### PR TITLE
Add external metadata type support

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -769,8 +769,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     }
 
     /**
-     * Gets the list of table types. This call returns a result set with three
-     * records: "SYSTEM TABLE", "TABLE", "and "VIEW".
+     * Gets the list of table types. This call returns a result set with five
+     * records: "SYSTEM TABLE", "TABLE", "VIEW", "TABLE LINK" and "EXTERNAL".
      * The result set is sorted by TABLE_TYPE.
      *
      * <ul>
@@ -3131,7 +3131,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     /**
      * [Not supported]
      */
-    /*## Java 1.7 ##
+    //## Java 1.7 ##
     @Override
     public boolean generatedKeyAlwaysReturned() {
         return true;
@@ -3149,7 +3149,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * @param columnNamePattern null (to get all objects) or a column name
      *            (uppercase for unquoted names)
      */
-    /*## Java 1.7 ##
+    //## Java 1.7 ##
     @Override
     public ResultSet getPseudoColumns(String catalog, String schemaPattern,
             String tableNamePattern, String columnNamePattern) {

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -888,11 +888,12 @@ public class MetaTable extends Table {
             }
             break;
         }
-        case TABLE_TYPES: {
+        case TABLE_TYPES: {            
             add(rows, Table.TABLE);
             add(rows, Table.TABLE_LINK);
             add(rows, Table.SYSTEM_TABLE);
             add(rows, Table.VIEW);
+            add(rows, Table.EXTERNAL_TABLE_ENGINE);
             break;
         }
         case CATALOGS: {

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1019,6 +1019,9 @@ public class TestMetaData extends TestBase {
 
         rs = meta.getTableTypes();
         rs.next();
+        
+        assertEquals("EXTERNAL", rs.getString("TABLE_TYPE"));
+        assertFalse(rs.next());        
         assertEquals("SYSTEM TABLE", rs.getString("TABLE_TYPE"));
         rs.next();
         assertEquals("TABLE", rs.getString("TABLE_TYPE"));
@@ -1027,6 +1030,8 @@ public class TestMetaData extends TestBase {
         rs.next();
         assertEquals("VIEW", rs.getString("TABLE_TYPE"));
         assertFalse(rs.next());
+        
+        
 
         rs = meta.getTables(null, Constants.SCHEMA_MAIN,
                 null, new String[] { "TABLE" });


### PR DESCRIPTION
Dear Thomas,

This PR add support to external type in INFORMATION_SCHEMA.TABLE_TYPES.

Now It's possible to display external (FILE TABLE) in any JDBC clients like libreoffice ;-).

Cheers.

Erwan