### PR TITLE
make trace system more parallel capable

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -518,6 +518,16 @@ public class Database implements DataHandler {
     public Trace getTrace(String module) {
         return traceSystem.getTrace(module);
     }
+    
+    /**
+     * Get the trace object for the given module id.
+     *
+     * @param moduleId the module id
+     * @return the trace object
+     */
+    public Trace getTrace(int moduleId) {
+        return traceSystem.getTrace(moduleId);
+    }
 
     @Override
     public FileStore openFile(String name, String openMode, boolean mustExist) {

--- a/h2/src/main/org/h2/engine/DbObjectBase.java
+++ b/h2/src/main/org/h2/engine/DbObjectBase.java
@@ -40,12 +40,12 @@ public abstract class DbObjectBase implements DbObject {
      * @param db the database
      * @param objectId the object id
      * @param name the name
-     * @param traceModule the trace module name
+     * @param traceModuleId the trace module id
      */
     protected void initDbObjectBase(Database db, int objectId, String name,
-            String traceModule) {
+            int traceModuleId) {
         this.database = db;
-        this.trace = db.getTrace(traceModule);
+        this.trace = db.getTrace(traceModuleId);
         this.id = objectId;
         this.objectName = name;
         this.modificationId = db.getModificationMetaId();

--- a/h2/src/main/org/h2/engine/RightOwner.java
+++ b/h2/src/main/org/h2/engine/RightOwner.java
@@ -26,8 +26,8 @@ public abstract class RightOwner extends DbObjectBase {
     private HashMap<DbObject, Right> grantedRights;
 
     protected RightOwner(Database database, int id, String name,
-            String traceModule) {
-        initDbObjectBase(database, id, name, traceModule);
+            int traceModuleId) {
+        initDbObjectBase(database, id, name, traceModuleId);
     }
 
     /**

--- a/h2/src/main/org/h2/jdbcx/JdbcDataSourceFactory.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcDataSourceFactory.java
@@ -34,7 +34,7 @@ public class JdbcDataSourceFactory implements ObjectFactory {
      * The public constructor to create new factory objects.
      */
     public JdbcDataSourceFactory() {
-        trace = getTraceSystem().getTrace("JDBCX");
+        trace = getTraceSystem().getTrace(Trace.JDBCX);
     }
 
     /**

--- a/h2/src/main/org/h2/message/Trace.java
+++ b/h2/src/main/org/h2/message/Trace.java
@@ -20,84 +20,115 @@ import org.h2.value.Value;
 public class Trace {
 
     /**
-     * The trace module name for commands.
+     * The trace module id for commands.
      */
-    public static final String COMMAND = "command";
+    public static final int COMMAND = 0;
 
     /**
-     * The trace module name for constraints.
+     * The trace module id for constraints.
      */
-    public static final String CONSTRAINT = "constraint";
+    public static final int CONSTRAINT = 1;
 
     /**
-     * The trace module name for databases.
+     * The trace module id for databases.
      */
-    public static final String DATABASE = "database";
+    public static final int DATABASE = 2;
 
     /**
-     * The trace module name for functions.
+     * The trace module id for functions.
      */
-    public static final String FUNCTION = "function";
+    public static final int FUNCTION = 3;
 
     /**
-     * The trace module name for file locks.
+     * The trace module id for file locks.
      */
-    public static final String FILE_LOCK = "fileLock";
+    public static final int FILE_LOCK = 4;
 
     /**
-     * The trace module name for indexes.
+     * The trace module id for indexes.
      */
-    public static final String INDEX = "index";
+    public static final int INDEX = 5;
 
     /**
-     * The trace module name for the JDBC API.
+     * The trace module id for the JDBC API.
      */
-    public static final String JDBC = "jdbc";
+    public static final int JDBC = 6;
 
     /**
-     * The trace module name for locks.
+     * The trace module id for locks.
      */
-    public static final String LOCK = "lock";
+    public static final int LOCK = 7;
 
     /**
-     * The trace module name for schemas.
+     * The trace module id for schemas.
      */
-    public static final String SCHEMA = "schema";
+    public static final int SCHEMA = 8;
 
     /**
-     * The trace module name for sequences.
+     * The trace module id for sequences.
      */
-    public static final String SEQUENCE = "sequence";
+    public static final int SEQUENCE = 9;
 
     /**
-     * The trace module name for settings.
+     * The trace module id for settings.
      */
-    public static final String SETTING = "setting";
+    public static final int SETTING = 10;
 
     /**
-     * The trace module name for tables.
+     * The trace module id for tables.
      */
-    public static final String TABLE = "table";
+    public static final int TABLE = 11;
 
     /**
-     * The trace module name for triggers.
+     * The trace module id for triggers.
      */
-    public static final String TRIGGER = "trigger";
+    public static final int TRIGGER = 12;
 
     /**
-     * The trace module name for users.
+     * The trace module id for users.
      */
-    public static final String USER = "user";
+    public static final int USER = 13;
 
     /**
-     * The trace module name for the page store.
+     * The trace module id for the page store.
      */
-    public static final String PAGE_STORE = "pageStore";
+    public static final int PAGE_STORE = 14;
+    
+    /**
+     * The trace module id for the JDBCX API
+     */
+    public static final int JDBCX = 15;
 
+    /**
+     * Module names by their ids as array indexes.
+     */
+    public static final String[] MODULE_NAMES = {
+        "command", 
+        "constraint",
+        "database",
+        "function",
+        "fileLock",
+        "index",
+        "jdbc",
+        "lock",
+        "schema",
+        "sequence",
+        "setting",
+        "table",
+        "trigger",
+        "user",
+        "pageStore",
+        "JDBCX"
+    };
+    
     private final TraceWriter traceWriter;
     private final String module;
     private final String lineSeparator;
     private int traceLevel = TraceSystem.PARENT;
+
+    Trace(TraceWriter traceWriter, int moduleId) {
+        this(traceWriter, MODULE_NAMES[moduleId]);
+    }
 
     Trace(TraceWriter traceWriter, String module) {
         this.traceWriter = traceWriter;

--- a/h2/src/main/org/h2/message/TraceSystem.java
+++ b/h2/src/main/org/h2/message/TraceSystem.java
@@ -10,14 +10,12 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.text.SimpleDateFormat;
-import java.util.HashMap;
-
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.jdbc.JdbcSQLException;
 import org.h2.store.fs.FileUtils;
 import org.h2.util.IOUtils;
-import org.h2.util.New;
 
 /**
  * The trace mechanism is the logging facility of this database. There is
@@ -83,7 +81,7 @@ public class TraceSystem implements TraceWriter {
     private int levelMax;
     private int maxFileSize = DEFAULT_MAX_FILE_SIZE;
     private String fileName;
-    private HashMap<String, Trace> traces;
+    private final AtomicReferenceArray<Trace> traces = new AtomicReferenceArray<Trace>(Trace.MODULE_NAMES.length);
     private SimpleDateFormat dateFormat;
     private Writer fileWriter;
     private PrintWriter printWriter;
@@ -117,26 +115,30 @@ public class TraceSystem implements TraceWriter {
     }
 
     /**
-     * Get or create a trace object for this module. Trace modules with names
-     * such as "JDBC[1]" are not cached (modules where the name ends with "]").
-     * All others are cached.
+     * Get or create a trace object for this module id. Trace modules with id are cached.
+     * 
+     * @param moduleId module id
+     * @return the trace object
+     */
+    public Trace getTrace(int moduleId) {
+        Trace t = traces.get(moduleId);
+        if (t == null) {
+            t = new Trace(writer, moduleId);
+            if (!traces.compareAndSet(moduleId, null, t)) {
+                t = traces.get(moduleId);
+            }
+        }
+        return t;
+    }
+    
+    /**
+     * Create a trace object for this module. Trace modules with names are not cached.
      *
      * @param module the module name
      * @return the trace object
      */
-    public synchronized Trace getTrace(String module) {
-        if (module.endsWith("]")) {
-            return new Trace(writer, module);
-        }
-        if (traces == null) {
-            traces = New.hashMap(16);
-        }
-        Trace t = traces.get(module);
-        if (t == null) {
-            t = new Trace(writer, module);
-            traces.put(module, t);
-        }
-        return t;
+    public Trace getTrace(String module) {
+        return new Trace(writer, module);
     }
 
     @Override
@@ -214,6 +216,11 @@ public class TraceSystem implements TraceWriter {
         return dateFormat.format(System.currentTimeMillis()) + module + ": " + s;
     }
 
+    @Override
+    public void write(int level, int moduleId, String s, Throwable t) {
+        write(level, Trace.MODULE_NAMES[moduleId], s, t);
+    };
+    
     @Override
     public void write(int level, String module, String s, Throwable t) {
         if (level <= levelSystemOut || level > this.levelMax) {

--- a/h2/src/main/org/h2/message/TraceWriter.java
+++ b/h2/src/main/org/h2/message/TraceWriter.java
@@ -31,6 +31,17 @@ interface TraceWriter {
     void write(int level, String module, String s, Throwable t);
 
     /**
+     * Write a message.
+     *
+     * @param level the trace level
+     * @param moduleId the id of the module
+     * @param s the message
+     * @param t the exception (may be null)
+     */
+    void write(int level, int moduleId, String s, Throwable t);
+
+    
+    /**
      * Check the given trace / log level is enabled.
      *
      * @param level the level

--- a/h2/src/main/org/h2/message/TraceWriterAdapter.java
+++ b/h2/src/main/org/h2/message/TraceWriterAdapter.java
@@ -44,6 +44,11 @@ public class TraceWriterAdapter implements TraceWriter {
             return false;
         }
     }
+    
+    @Override
+    public void write(int level, int moduleId, String s, Throwable t) {
+        write(level, Trace.MODULE_NAMES[moduleId], s, t);
+    };
 
     @Override
     public void write(int level, String module, String s, Throwable t) {

--- a/h2/src/main/org/h2/schema/SchemaObjectBase.java
+++ b/h2/src/main/org/h2/schema/SchemaObjectBase.java
@@ -21,11 +21,11 @@ public abstract class SchemaObjectBase extends DbObjectBase implements
      * @param newSchema the schema
      * @param id the object id
      * @param name the name
-     * @param traceModule the trace module name
+     * @param traceModuleId the trace module id
      */
     protected void initSchemaObjectBase(Schema newSchema, int id, String name,
-            String traceModule) {
-        initDbObjectBase(newSchema.getDatabase(), id, name, traceModule);
+            int traceModuleId) {
+        initDbObjectBase(newSchema.getDatabase(), id, name, traceModuleId);
         this.schema = newSchema;
     }
 


### PR DESCRIPTION
Currently TraceSystem.getTrace is synchronized and becomes a bottleneck for multithreaded queries.
