### PR TITLE
Fix DbContextRule.PROCEDURE in BNF

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2140,6 +2140,7 @@ value
     | ?[ int ]
     | NEXT VALUE FOR sequenceName
     | function
+    | procedure
     | { - | + } term
     | ( expression )
     | select

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -711,6 +711,7 @@ value
     | ?[ int ]
     | NEXT VALUE FOR sequenceName
     | function
+    | procedure
     | { - | + } term
     | ( expression )
     | select

--- a/h2/src/main/org/h2/server/web/WebSession.java
+++ b/h2/src/main/org/h2/server/web/WebSession.java
@@ -131,6 +131,9 @@ class WebSession {
                     new DbContextRule(contents, DbContextRule.SCHEMA);
             DbContextRule columnAliasRule =
                     new DbContextRule(contents, DbContextRule.COLUMN_ALIAS);
+            DbContextRule procedure =
+                    new DbContextRule(contents, DbContextRule.PROCEDURE);
+            newBnf.updateTopic("procedure", procedure);
             newBnf.updateTopic("column_name", columnRule);
             newBnf.updateTopic("new_table_alias", newAliasRule);
             newBnf.updateTopic("table_alias", aliasRule);

--- a/h2/src/test/org/h2/test/unit/TestBnf.java
+++ b/h2/src/test/org/h2/test/unit/TestBnf.java
@@ -136,12 +136,16 @@ public class TestBnf extends TestBase {
         DbContextRule columnRule = new
                 DbContextRule(dbContents, DbContextRule.COLUMN);
         bnf.updateTopic("column_name", columnRule);
-        bnf.updateTopic("expression", new
+        bnf.updateTopic("procedure", new
                 DbContextRule(dbContents, DbContextRule.PROCEDURE));
         bnf.linkStatements();
         // Test partial
         Map<String, String> tokens = bnf.getNextTokenList("SELECT CUSTOM_PR");
         assertTrue(tokens.values().contains("INT"));
+
+        // Test built-in function
+        tokens = bnf.getNextTokenList("SELECT LEAS");
+        assertTrue(tokens.values().contains("T"));
 
         // Test parameters
         tokens = bnf.getNextTokenList("SELECT CUSTOM_PRINT(");


### PR DESCRIPTION
This patch fix and test the auto-complete component DbContextRule.PROCEDURE that was commented back in time due to override of existing syntax tree node. A special node has been added for procedure defined in jdbc. (for auto-complete with postgresql for example or with user made functions)
