### PR TITLE
Fix linked table with geometry field

### DIFF
--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -150,12 +150,13 @@ public class TableLink extends Table {
             String n = rs.getString("COLUMN_NAME");
             n = convertColumnName(n);
             int sqlType = rs.getInt("DATA_TYPE");
+            String sqlTypeName = rs.getString("TYPE_NAME");
             long precision = rs.getInt("COLUMN_SIZE");
             precision = convertPrecision(sqlType, precision);
             int scale = rs.getInt("DECIMAL_DIGITS");
             scale = convertScale(sqlType, scale);
             int displaySize = MathUtils.convertLongToInt(precision);
-            int type = DataType.convertSQLTypeToValueType(sqlType);
+            int type = DataType.convertSQLTypeToValueType(sqlType, sqlTypeName);
             Column col = new Column(n, type, precision, scale, displaySize);
             col.setTable(this, i++);
             columnList.add(col);

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -782,7 +782,7 @@ public class DataType {
      * @param sqlTypeName the SQL type name
      * @return the value type
      */
-    private static int convertSQLTypeToValueType(int sqlType, String sqlTypeName) {
+    public static int convertSQLTypeToValueType(int sqlType, String sqlTypeName) {
         switch (sqlType) {
             case Types.OTHER:
             case Types.JAVA_OBJECT:

--- a/h2/src/test/org/h2/test/db/TestLinkedTable.java
+++ b/h2/src/test/org/h2/test/db/TestLinkedTable.java
@@ -18,6 +18,7 @@ import java.sql.Timestamp;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.value.DataType;
 
 /**
  * Tests the linked table feature (CREATE LINKED TABLE).
@@ -52,7 +53,7 @@ public class TestLinkedTable extends TestBase {
         testLinkTwoTables();
         testCachingResults();
         testLinkedTableInReadOnlyDb();
-
+        testGeometry();
         deleteDb("linkedTable");
     }
 
@@ -693,4 +694,34 @@ public class TestLinkedTable extends TestBase {
         deleteDb("testLinkedTableInReadOnlyDb");
     }
 
+    private void testGeometry() throws SQLException {
+        if (!config.mvStore && config.mvcc) {
+            return;
+        }
+        if (config.memory && config.mvcc) {
+            return;
+        }
+        if (DataType.GEOMETRY_CLASS != null) {
+            org.h2.Driver.load();
+            Connection ca = DriverManager.getConnection("jdbc:h2:mem:one", "sa", "sa");
+            Connection cb = DriverManager.getConnection("jdbc:h2:mem:two", "sa", "sa");
+            Statement sa = ca.createStatement();
+            Statement sb = cb.createStatement();
+            sa.execute("CREATE TABLE TEST(ID SERIAL, the_geom geometry)");
+            sa.execute("INSERT INTO TEST(THE_GEOM) VALUES('POINT (1 1)')");
+            String sql = "CREATE LINKED TABLE T(NULL, " +
+                    "'jdbc:h2:mem:one', 'sa', 'sa', 'TEST') READONLY";
+            sb.execute(sql);
+            ResultSet rs = sb.executeQuery("SELECT * FROM T");
+            try {
+                assertTrue(rs.next());
+                assertEquals("POINT (1 1)", rs.getString("THE_GEOM"));
+            } finally {
+                rs.close();
+            }
+            sb.execute("DROP TABLE T");
+            ca.close();
+            cb.close();
+        }
+    }
 }


### PR DESCRIPTION
Linked table (by providing only table name) does not work for geometry columns as it only use sqlType for defining column type.

This fix has a unit test and have been also tested (externally) with PostGIS.

If you have some recommendation you can write it here in comments (In this case I add more commits), or add your modifications as a pull request on my branch (that will automatically add up here) 

I've been somewhat "sad" when the last time you closed my pr and you do the commit separately :cry: 

Thank you !
