### PR TITLE
Add support for MySQL's utf8mb4 charset in CREATE TABLE

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -5904,7 +5904,9 @@ public class Parser {
         readIf("DEFAULT");
         if (readIf("CHARSET")) {
             read("=");
-            read("UTF8");
+            if (!readIf("UTF8")) {
+                read("UTF8MB4");
+            }
         }
         if (temp) {
             if (readIf("ON")) {


### PR DESCRIPTION
Makes CREATE TABLE compatible with MySQL DDLs that use utf8mb4 as table charset.
