### PR TITLE
In DateTimeUtils.getTimeTry(), Calendar instances used to evaluate Timestamps were only being cached if no timezone was specified. I've added code to reuse Calendar instances if the timezone specified matches the previous use.

### DIFF
--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -62,6 +62,12 @@ public class DateTimeUtils {
     private static final ThreadLocal<Calendar> CACHED_CALENDAR =
             new ThreadLocal<Calendar>();
 
+    /**
+     * A cached instance of Calendar used when a timezone is specified.
+     */
+    private static final ThreadLocal<Calendar> CACHED_CALENDAR_NON_DEFAULT_TIMEZONE =
+            new ThreadLocal<Calendar>();
+
     private DateTimeUtils() {
         // utility class
     }
@@ -78,6 +84,19 @@ public class DateTimeUtils {
         if (c == null) {
             c = Calendar.getInstance();
             CACHED_CALENDAR.set(c);
+        }
+        return c;
+    }
+
+    /**
+     * @param tz timezone for the calendar, is never null
+     * @return a calendar instance for the specified timezone. A cached instance is returned where possible
+     */
+    private static Calendar getCalendar(TimeZone tz) {
+        Calendar c = CACHED_CALENDAR_NON_DEFAULT_TIMEZONE.get();
+        if (c == null || !c.getTimeZone().equals(tz)) {
+            c = Calendar.getInstance(tz);
+            CACHED_CALENDAR_NON_DEFAULT_TIMEZONE.set(c);
         }
         return c;
     }
@@ -394,7 +413,7 @@ public class DateTimeUtils {
         if (tz == null) {
             c = getCalendar();
         } else {
-            c = Calendar.getInstance(tz);
+            c = getCalendar(tz);
         }
         c.clear();
         c.setLenient(lenient);


### PR DESCRIPTION
In DateTimeUtils.getTimeTry(), Calendar instances used to evaluate Timestamps were only being cached if no timezone was specified. I've added code to reuse Calendar instances if the timezone specified matches the previous use.

Profiling revealed that creating a new Calendar instance for each TimeStamp is a bottleneck. I've added caching of the most recently used Calendar instance, on the assumption that people almost always consistently use the same timezone.

The TestDate class already covers my code changes.

This only benefits people still using the page store. That's likely to be many users for a while, maybe.
