### PR TITLE
dropped nestedJoins test config property

### DIFF
--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -326,11 +326,6 @@ java org.h2.test.TestAll timer
     public boolean splitFileSystem;
 
     /**
-     * Support nested joins.
-     */
-    public boolean nestedJoins;
-
-    /**
      * If only fast tests should be run. If enabled, SSL is not tested.
      */
     public boolean fast;

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -323,9 +323,6 @@ public abstract class TestBase {
         if (config.defrag) {
             url = addOption(url, "DEFRAG_ALWAYS", "TRUE");
         }
-        if (config.nestedJoins) {
-            url = addOption(url, "NESTED_JOINS", "TRUE");
-        }
         return "jdbc:h2:" + url;
     }
 

--- a/h2/src/test/org/h2/test/synth/TestLimit.java
+++ b/h2/src/test/org/h2/test/synth/TestLimit.java
@@ -25,7 +25,6 @@ public class TestLimit extends TestBase {
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
         // test.config.traceTest = true;
-        test.config.nestedJoins = true;
         test.test();
     }
 

--- a/h2/src/test/org/h2/test/synth/TestNestedJoins.java
+++ b/h2/src/test/org/h2/test/synth/TestNestedJoins.java
@@ -36,15 +36,11 @@ public class TestNestedJoins extends TestBase {
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
         // test.config.traceTest = true;
-        test.config.nestedJoins = true;
         test.test();
     }
 
     @Override
     public void test() throws Exception {
-        if (!config.nestedJoins) {
-            return;
-        }
         deleteDb("nestedJoins");
         // testCases2();
         testCases();

--- a/h2/src/test/org/h2/test/synth/TestOuterJoins.java
+++ b/h2/src/test/org/h2/test/synth/TestOuterJoins.java
@@ -35,15 +35,11 @@ public class TestOuterJoins extends TestBase {
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
         test.config.traceTest = true;
-        test.config.nestedJoins = true;
         test.test();
     }
 
     @Override
     public void test() throws Exception {
-        if (!config.nestedJoins) {
-            return;
-        }
         deleteDb("outerJoins");
         testCases();
         testRandom();


### PR DESCRIPTION
dropped nestedJoins test config property since it must be always enabled now because NESTED_JOINS setting is true by default
