### PR TITLE
ISSUE-207 - CREATE ALIAS tests fail on Java 7 because of TestAnnotati…

### DIFF
--- a/h2/src/test/org/h2/test/ap/TestAnnotationProcessor.java
+++ b/h2/src/test/org/h2/test/ap/TestAnnotationProcessor.java
@@ -45,7 +45,7 @@ public class TestAnnotationProcessor extends AbstractProcessor {
     }
 
     public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.RELEASE_6;
+        return SourceVersion.latest();
     }
 
     @Override

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -1782,49 +1782,6 @@ public class TestFunctions extends TestBase implements AggregateFunction {
     }
 
     private void testAnnotationProcessorsOutput() throws SQLException {
-        testAnnotationProcessorsOutput_emptyKey();
-        testAnnotationProcessorsOutput_invalidKey();
-        testAnnotationProcessorsOutput_oneInvalidKey();
-        testAnnotationProcessorsOutput_warnAndError();
-    }
-
-    private void testAnnotationProcessorsOutput_emptyKey() throws SQLException {
-        try {
-            System.setProperty(TestAnnotationProcessor.MESSAGES_KEY, "");
-            callCompiledFunction("test_atp_empty_key");
-        } finally {
-            System.clearProperty(TestAnnotationProcessor.MESSAGES_KEY);
-        }
-    }
-
-    private void testAnnotationProcessorsOutput_invalidKey() throws SQLException {
-        try {
-            System.setProperty(TestAnnotationProcessor.MESSAGES_KEY, "invalid");
-            callCompiledFunction("test_atp_invalid_key");
-            fail();
-        } catch (JdbcSQLException e) {
-            assertEquals(ErrorCode.SYNTAX_ERROR_1, e.getErrorCode());
-            assertContains(e.getMessage(), "'invalid'");
-        } finally {
-            System.clearProperty(TestAnnotationProcessor.MESSAGES_KEY);
-        }
-    }
-
-    private void testAnnotationProcessorsOutput_oneInvalidKey() throws SQLException {
-        try {
-            System.setProperty(TestAnnotationProcessor.MESSAGES_KEY, "invalid,foo");
-            callCompiledFunction("test_atp_one_invalid_key");
-            fail();
-        } catch (JdbcSQLException e) {
-            assertEquals(ErrorCode.SYNTAX_ERROR_1, e.getErrorCode());
-            assertContains(e.getMessage(), "enum");
-            assertContains(e.getMessage(), "Kind.invalid");
-        } finally {
-            System.clearProperty(TestAnnotationProcessor.MESSAGES_KEY);
-        }
-    }
-
-    private void testAnnotationProcessorsOutput_warnAndError() throws SQLException {
         try {
             System.setProperty(TestAnnotationProcessor.MESSAGES_KEY, "WARNING,foo1|ERROR,foo2");
             callCompiledFunction("test_atp_warn_and_error");


### PR DESCRIPTION
…onProcessor

Hi, I have fixed regression. Could @svladykin test it in his environment. I have tested Java 6, 7 and 8. Bug was introduced because of JavaC internal API exception handling between Java 6 and 7 (and maybe later) - sorry for this. Few tests on Java 7, 8 stopped making sense.
Ivos
