### PR TITLE
Batched index lookups for sub-query

### DIFF
--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -69,6 +69,11 @@ public abstract class Command implements CommandInterface {
     public abstract boolean isQuery();
 
     /**
+     * Prepare join batching.
+     */
+    public abstract void prepareJoinBatch();
+
+    /**
      * Get the list of parameters.
      *
      * @return the list of parameters

--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -7,6 +7,7 @@ package org.h2.command;
 
 import java.util.ArrayList;
 import org.h2.api.DatabaseEventListener;
+import org.h2.command.dml.Query;
 import org.h2.expression.Parameter;
 import org.h2.expression.ParameterInterface;
 import org.h2.result.ResultInterface;
@@ -44,6 +45,13 @@ public class CommandContainer extends Command {
         return prepared.isQuery();
     }
 
+    @Override
+    public void prepareJoinBatch() {
+        if (session.isJoinBatchEnabled() && prepared.isQuery()) {
+            ((Query) prepared).prepareJoinBatch();
+        }
+    }
+
     private void recompileIfRequired() {
         if (prepared.needRecompile()) {
             // TODO test with 'always recompile'
@@ -65,6 +73,7 @@ public class CommandContainer extends Command {
             }
             prepared.prepare();
             prepared.setModificationMetaId(mod);
+            prepareJoinBatch();
         }
     }
 

--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -7,6 +7,7 @@ package org.h2.command;
 
 import java.util.ArrayList;
 import org.h2.api.DatabaseEventListener;
+import org.h2.command.dml.Explain;
 import org.h2.command.dml.Query;
 import org.h2.expression.Parameter;
 import org.h2.expression.ParameterInterface;
@@ -47,8 +48,18 @@ public class CommandContainer extends Command {
 
     @Override
     public void prepareJoinBatch() {
-        if (session.isJoinBatchEnabled() && prepared.isQuery()) {
-            ((Query) prepared).prepareJoinBatch();
+        if (session.isJoinBatchEnabled()) {
+            prepareJoinBatch(prepared);
+        }
+    }
+
+    private static void prepareJoinBatch(Prepared prepared) {
+        if (prepared.isQuery()) {
+            if (prepared.getType() == CommandInterface.SELECT) {
+                ((Query) prepared).prepareJoinBatch();
+            } else if (prepared.getType() == CommandInterface.EXPLAIN) {
+                prepareJoinBatch(((Explain) prepared).getCommand());
+            }
         }
     }
 

--- a/h2/src/main/org/h2/command/CommandList.java
+++ b/h2/src/main/org/h2/command/CommandList.java
@@ -45,6 +45,11 @@ class CommandList extends Command {
     }
 
     @Override
+    public void prepareJoinBatch() {
+        command.prepareJoinBatch();
+    }
+
+    @Override
     public ResultInterface query(int maxrows) {
         ResultInterface result = command.query(maxrows);
         executeRemaining();

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -294,6 +294,9 @@ public class AlterTableAddConstraint extends SchemaCommand {
     }
 
     private static Index getUniqueIndex(Table t, IndexColumn[] cols) {
+        if (t.getIndexes() == null) {
+            return null;
+        }
         for (Index idx : t.getIndexes()) {
             if (canUseUniqueIndex(idx, t, cols)) {
                 return idx;
@@ -303,6 +306,9 @@ public class AlterTableAddConstraint extends SchemaCommand {
     }
 
     private static Index getIndex(Table t, IndexColumn[] cols, boolean moreColumnOk) {
+        if (t.getIndexes() == null) {
+            return null;
+        }
         for (Index idx : t.getIndexes()) {
             if (canUseIndex(idx, t, cols, moreColumnOk)) {
                 return idx;

--- a/h2/src/main/org/h2/command/dml/Delete.java
+++ b/h2/src/main/org/h2/command/dml/Delete.java
@@ -132,7 +132,7 @@ public class Delete extends Prepared {
         }
         PlanItem item = tableFilter.getBestPlanItem(session, new TableFilter[]{tableFilter}, 0);
         tableFilter.setPlanItem(item);
-        tableFilter.prepare();
+        tableFilter.prepare(false);
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/Delete.java
+++ b/h2/src/main/org/h2/command/dml/Delete.java
@@ -132,7 +132,7 @@ public class Delete extends Prepared {
         }
         PlanItem item = tableFilter.getBestPlanItem(session, new TableFilter[]{tableFilter}, 0);
         tableFilter.setPlanItem(item);
-        tableFilter.prepare(false);
+        tableFilter.prepare();
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/Explain.java
+++ b/h2/src/main/org/h2/command/dml/Explain.java
@@ -40,6 +40,10 @@ public class Explain extends Prepared {
         this.command = command;
     }
 
+    public Prepared getCommand() {
+        return command;
+    }
+
     @Override
     public void prepare() {
         command.prepare();

--- a/h2/src/main/org/h2/command/dml/NoOperation.java
+++ b/h2/src/main/org/h2/command/dml/NoOperation.java
@@ -25,11 +25,6 @@ public class NoOperation extends Prepared {
     }
 
     @Override
-    public boolean isQuery() {
-        return false;
-    }
-
-    @Override
     public boolean isTransactional() {
         return true;
     }

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -71,6 +71,8 @@ public abstract class Query extends Prepared {
         super(session);
     }
 
+    public abstract boolean isUnion();
+
     /**
      * Execute the query without checking the cache. If a target is specified,
      * the results are written to it, and the method returns null. If no target

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -71,7 +71,17 @@ public abstract class Query extends Prepared {
         super(session);
     }
 
+    /**
+     * Check if this is a UNION query.
+     * 
+     * @return {@code true} if this is a UNION query
+     */
     public abstract boolean isUnion();
+
+    /**
+     * Prepare join batching.
+     */
+    public abstract void prepareJoinBatch();
 
     /**
      * Execute the query without checking the cache. If a target is specified,

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -87,6 +87,11 @@ public class Select extends Query {
         super(session);
     }
 
+    @Override
+    public boolean isUnion() {
+        return false;
+    }
+
     /**
      * Add a table to the query.
      *
@@ -942,7 +947,9 @@ public class Select extends Query {
         }
         expressionArray = new Expression[expressions.size()];
         expressions.toArray(expressionArray);
-        topTableFilter.prepareBatch(0);
+        if (!session.isParsingView()) {
+            topTableFilter.prepareBatch(0);
+        }
         isPrepared = true;
     }
 

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -948,7 +948,7 @@ public class Select extends Query {
         expressionArray = new Expression[expressions.size()];
         expressions.toArray(expressionArray);
         if (!session.isParsingView()) {
-            topTableFilter.prepareBatch(0);
+            topTableFilter.prepareJoinBatch(0);
         }
         isPrepared = true;
     }

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -1010,9 +1010,7 @@ public class Select extends Query {
 
         setEvaluatableRecursive(topTableFilter);
 
-        if (!parse) {
-            topTableFilter.prepare();
-        }
+        topTableFilter.prepare(parse);
         return planCost;
     }
 

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -1010,7 +1010,9 @@ public class Select extends Query {
 
         setEvaluatableRecursive(topTableFilter);
 
-        topTableFilter.prepare(parse);
+        if (!parse) {
+            topTableFilter.prepare();
+        }
         return planCost;
     }
 

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.command.CommandInterface;
@@ -36,6 +35,7 @@ import org.h2.result.SortOrder;
 import org.h2.table.Column;
 import org.h2.table.ColumnResolver;
 import org.h2.table.IndexColumn;
+import org.h2.table.JoinBatch;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
 import org.h2.util.New;
@@ -942,7 +942,12 @@ public class Select extends Query {
         }
         expressionArray = new Expression[expressions.size()];
         expressions.toArray(expressionArray);
+        topTableFilter.prepareBatch(0);
         isPrepared = true;
+    }
+
+    public JoinBatch getJoinBatch() {
+        return getTopTableFilter().getJoinBatch();
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -76,6 +76,12 @@ public class SelectUnion extends Query {
         return true;
     }
 
+    @Override
+    public void prepareJoinBatch() {
+        left.prepareJoinBatch();
+        right.prepareJoinBatch();
+    }
+
     public void setUnionType(int type) {
         this.unionType = type;
     }

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -7,7 +7,6 @@ package org.h2.command.dml;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.engine.Session;
@@ -70,6 +69,11 @@ public class SelectUnion extends Query {
     public SelectUnion(Session session, Query query) {
         super(session);
         this.left = query;
+    }
+
+    @Override
+    public boolean isUnion() {
+        return true;
     }
 
     public void setUnionType(int type) {

--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -497,6 +497,15 @@ public class Set extends Prepared {
             database.setRowFactory(rowFactory);
             break;
         }
+        case SetTypes.BATCH_JOINS: {
+            int value = getIntValue();
+            if (value != 0 && value != 1) {
+                throw DbException.getInvalidValueException("BATCH_JOINS",
+                        getIntValue());
+            }
+            session.setJoinBatchEnabled(value == 1);
+            break;
+        }
         default:
             DbException.throwInternalError("type="+type);
         }

--- a/h2/src/main/org/h2/command/dml/SetTypes.java
+++ b/h2/src/main/org/h2/command/dml/SetTypes.java
@@ -228,6 +228,11 @@ public class SetTypes {
      */
     public static final int ROW_FACTORY = 43;
 
+    /**
+     * The type of SET BATCH_JOINS statement.
+     */
+    public static final int BATCH_JOINS = 44;
+
     private static final ArrayList<String> TYPES = New.arrayList();
 
     private SetTypes() {
@@ -280,6 +285,7 @@ public class SetTypes {
         list.add(QUERY_STATISTICS, "QUERY_STATISTICS");
         list.add(QUERY_STATISTICS_MAX_ENTRIES, "QUERY_STATISTICS_MAX_ENTRIES");
         list.add(ROW_FACTORY, "ROW_FACTORY");
+        list.add(BATCH_JOINS, "BATCH_JOINS");
     }
 
     /**

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -189,7 +189,7 @@ public class Update extends Prepared {
         }
         PlanItem item = tableFilter.getBestPlanItem(session, new TableFilter[] {tableFilter}, 0);
         tableFilter.setPlanItem(item);
-        tableFilter.prepare();
+        tableFilter.prepare(false);
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -189,7 +189,7 @@ public class Update extends Prepared {
         }
         PlanItem item = tableFilter.getBestPlanItem(session, new TableFilter[] {tableFilter}, 0);
         tableFilter.setPlanItem(item);
-        tableFilter.prepare(false);
+        tableFilter.prepare();
     }
 
     @Override

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -30,12 +30,14 @@ import org.h2.mvstore.db.TransactionStore.Change;
 import org.h2.mvstore.db.TransactionStore.Transaction;
 import org.h2.result.LocalResult;
 import org.h2.result.Row;
+import org.h2.result.SortOrder;
 import org.h2.schema.Schema;
 import org.h2.store.DataHandler;
 import org.h2.store.InDoubtTransaction;
 import org.h2.store.LobStorageFrontend;
 import org.h2.table.SubQueryInfo;
 import org.h2.table.Table;
+import org.h2.table.TableFilter;
 import org.h2.util.New;
 import org.h2.util.SmallLRUCache;
 import org.h2.value.Value;
@@ -115,6 +117,7 @@ public class Session extends SessionWithState {
     private int parsingView;
     private volatile SmallLRUCache<Object, ViewIndex> viewIndexCache;
     private HashMap<Object, ViewIndex> subQueryIndexCache;
+    private boolean joinBatchEnabled;
 
     /**
      * Temporary LOBs from result sets. Those are kept for some time. The
@@ -148,12 +151,25 @@ public class Session extends SessionWithState {
         this.currentSchemaName = Constants.SCHEMA_MAIN;
     }
 
+    public void setJoinBatchEnabled(boolean joinBatchEnabled) {
+        this.joinBatchEnabled = joinBatchEnabled;
+    }
+
+    public boolean isJoinBatchEnabled() {
+        return joinBatchEnabled;
+    }
+
     public Row createRow(Value[] data, int memory) {
         return database.createRow(data, memory);
     }
 
-    public void setSubQueryInfo(SubQueryInfo subQueryInfo) {
-        this.subQueryInfo = subQueryInfo;
+    public void pushSubQueryInfo(int[] masks, TableFilter[] filters, int filter,
+            SortOrder sortOrder) {
+        subQueryInfo = new SubQueryInfo(subQueryInfo, masks, filters, filter, sortOrder);
+    }
+
+    public void popSubQueryInfo() {
+        subQueryInfo = subQueryInfo.getUpper();
     }
 
     public SubQueryInfo getSubQueryInfo() {
@@ -492,6 +508,7 @@ public class Session extends SessionWithState {
             // we can't reuse sub-query indexes, so just drop the whole cache
             subQueryIndexCache = null;
         }
+        command.prepareJoinBatch();
         if (queryCache != null) {
             if (command.isCacheable()) {
                 queryCache.put(sql, command);

--- a/h2/src/main/org/h2/index/IndexLookupBatch.java
+++ b/h2/src/main/org/h2/index/IndexLookupBatch.java
@@ -52,6 +52,13 @@ public interface IndexLookupBatch {
     List<Future<Cursor>> find();
 
     /**
+     * Get plan for EXPLAIN.
+     *
+     * @return plan
+     */
+    String getPlanSQL();
+
+    /**
      * Reset this batch to clear state. This method will be called before each query execution.
      */
     void reset();

--- a/h2/src/main/org/h2/index/IndexLookupBatch.java
+++ b/h2/src/main/org/h2/index/IndexLookupBatch.java
@@ -17,7 +17,7 @@ import org.h2.result.SearchRow;
  * Note that a single instance of {@link IndexLookupBatch} can be reused for multiple 
  * sequential batched lookups.
  * 
- * @see Index#createLookupBatch(TableFilter)
+ * @see Index#createLookupBatch(org.h2.table.TableFilter)
  * @author Sergi Vladykin
  */
 public interface IndexLookupBatch {

--- a/h2/src/main/org/h2/index/IndexLookupBatch.java
+++ b/h2/src/main/org/h2/index/IndexLookupBatch.java
@@ -27,9 +27,11 @@ public interface IndexLookupBatch {
      * 
      * @param first the first row, or null for no limit
      * @param last the last row, or null for no limit
+     * @return {@code false} if this search row pair is known to produce no results
+     *          and thus the given row pair was not added
      * @see Index#find(TableFilter, SearchRow, SearchRow)
      */
-    void addSearchRows(SearchRow first, SearchRow last);
+    boolean addSearchRows(SearchRow first, SearchRow last);
 
     /**
      * Check if this batch is full.

--- a/h2/src/main/org/h2/index/IndexLookupBatch.java
+++ b/h2/src/main/org/h2/index/IndexLookupBatch.java
@@ -15,7 +15,8 @@ import org.h2.result.SearchRow;
  * method {@link #isBatchFull()}} will return {@code true} or there are no more
  * search rows to add. Then method {@link #find()} will be called to execute batched lookup.
  * Note that a single instance of {@link IndexLookupBatch} can be reused for multiple 
- * sequential batched lookups.
+ * sequential batched lookups, moreover it can be reused for multiple queries for
+ * the same prepared statement.
  * 
  * @see Index#createLookupBatch(org.h2.table.TableFilter)
  * @author Sergi Vladykin
@@ -47,4 +48,9 @@ public interface IndexLookupBatch {
      * @return List of future cursors for collected search rows.
      */
     List<Future<Cursor>> find();
+
+    /**
+     * Reset this batch to clear state. This method will be called before each query execution.
+     */
+    void reset();
 }

--- a/h2/src/main/org/h2/index/MultiVersionIndex.java
+++ b/h2/src/main/org/h2/index/MultiVersionIndex.java
@@ -6,8 +6,6 @@
 package org.h2.index;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Future;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Database;
 import org.h2.engine.DbObject;

--- a/h2/src/main/org/h2/index/ViewCursor.java
+++ b/h2/src/main/org/h2/index/ViewCursor.java
@@ -24,7 +24,7 @@ public class ViewCursor implements Cursor {
     private final SearchRow first, last;
     private Row current;
 
-    ViewCursor(ViewIndex index, LocalResult result, SearchRow first,
+    public ViewCursor(ViewIndex index, LocalResult result, SearchRow first,
             SearchRow last) {
         this.table = index.getTable();
         this.index = index;

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -22,7 +22,6 @@ import org.h2.result.SortOrder;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
 import org.h2.table.JoinBatch;
-import org.h2.table.SubQueryInfo;
 import org.h2.table.TableFilter;
 import org.h2.table.TableView;
 import org.h2.util.IntArray;
@@ -209,14 +208,11 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
             TableFilter[] filters, int filter, SortOrder sortOrder, boolean preliminary) {
         assert filters != null;
         Prepared p;
-        SubQueryInfo upper = session.getSubQueryInfo();
-        SubQueryInfo info = new SubQueryInfo(upper,
-                masks, filters, filter, sortOrder, preliminary);
-        session.setSubQueryInfo(info);
+        session.pushSubQueryInfo(masks, filters, filter, sortOrder);
         try {
             p = session.prepare(sql, true);
         } finally {
-            session.setSubQueryInfo(upper);
+            session.popSubQueryInfo();
         }
         return (Query) p;
     }

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -347,6 +347,10 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
         param.setValue(v);
     }
 
+    public Query getQuery() {
+        return query;
+    }
+
     private Query getQuery(Session session, int[] masks,
             TableFilter[] filters, int filter, SortOrder sortOrder) {
         Query q = prepareSubQuery(querySQL, session, masks, filters, filter, sortOrder, true);

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -119,7 +119,8 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
             // our sub-query itself is not batched, will run usual way
             return null;
         }
-        return joinBatch.getLookupBatch(0);
+        // TODO wrap the join batch into lookup batch
+        return null;
     }
 
     private IndexLookupBatch createLookupBatchUnion(SelectUnion union) {

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import org.h2.api.ErrorCode;
 import org.h2.command.Prepared;
 import org.h2.command.dml.Query;
-import org.h2.command.dml.Select;
 import org.h2.command.dml.SelectUnion;
 import org.h2.engine.Constants;
 import org.h2.engine.Session;
@@ -101,19 +100,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
             // we do not support batching for recursive queries
             return null;
         }
-        // currently do not support unions
-        return query.isUnion() ? null : createLookupBatchSimple((Select) query);
-    }
-
-    private IndexLookupBatch createLookupBatchSimple(Select select) {
-        // here we have already prepared plan for our sub-query,
-        // thus select already contains join batch for it (if it has to)
-        JoinBatch joinBatch = select.getJoinBatch();
-        if (joinBatch == null) {
-            // our sub-query itself is not batched, will run usual way
-            return null;
-        }
-        return joinBatch.asViewIndexLookupBatch(this);
+        return JoinBatch.createViewIndexLookupBatch(this);
     }
 
     public Session getSession() {

--- a/h2/src/main/org/h2/table/JoinBatch.java
+++ b/h2/src/main/org/h2/table/JoinBatch.java
@@ -83,11 +83,23 @@ public final class JoinBatch {
     }
 
     /**
+     * Check if the index at the given table filter really supports batching in this query.
+     *
      * @param joinFilterId joined table filter id
      * @return {@code true} if index really supports batching in this query
      */
     public boolean isBatchedIndex(int joinFilterId) {
         return filters[joinFilterId].isBatched();
+    }
+
+    /**
+     * Get the lookup batch for the given table filter.
+     *
+     * @param joinFilterId joined table filter id
+     * @return lookup batch
+     */
+    public IndexLookupBatch getLookupBatch(int joinFilterId) {
+        return filters[joinFilterId].lookupBatch;
     }
 
     /**

--- a/h2/src/main/org/h2/table/JoinBatch.java
+++ b/h2/src/main/org/h2/table/JoinBatch.java
@@ -1,0 +1,613 @@
+/*
+ * Copyright 2004-2014 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.table;
+
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+import org.h2.index.Cursor;
+import org.h2.index.IndexCursor;
+import org.h2.index.IndexLookupBatch;
+import org.h2.message.DbException;
+import org.h2.result.Row;
+import org.h2.result.SearchRow;
+import org.h2.util.DoneFuture;
+import org.h2.value.Value;
+import org.h2.value.ValueLong;
+
+/**
+ * Support for asynchronous batched index lookups on joins.
+ * 
+ * @see org.h2.index.Index#createLookupBatch(TableFilter)
+ * @see IndexLookupBatch
+ * @author Sergi Vladykin
+ */
+public final class JoinBatch {
+    
+    private static final Cursor EMPTY_CURSOR = new Cursor() {
+        @Override
+        public boolean previous() {
+            return false;
+        }
+        
+        @Override
+        public boolean next() {
+            return false;
+        }
+        
+        @Override
+        public SearchRow getSearchRow() {
+            return null;
+        }
+        
+        @Override
+        public Row get() {
+            return null;
+        }
+        
+        @Override
+        public String toString() {
+            return "EMPTY_CURSOR";
+        }
+    }; 
+    
+    private int filtersCount;
+    private JoinFilter[] filters;
+    private JoinFilter top;
+    
+    private boolean started;
+    
+    private JoinRow current;
+    private boolean found;
+    
+    /**
+     * This filter joined after this batched join and can be used normally.
+     */
+    private final TableFilter additionalFilter;
+    
+    /**
+     * @param additionalFilter table filter after this batched join.
+     */
+    public JoinBatch(TableFilter additionalFilter) {
+        this.additionalFilter = additionalFilter;
+    }
+    
+    /**
+     * @param filter table filter
+     * @param lookupBatch lookup batch
+     */
+    public void register(TableFilter filter, IndexLookupBatch lookupBatch) {
+        assert filter != null;
+        filtersCount++;
+        top = new JoinFilter(lookupBatch, filter, top);
+    }
+    
+    /**
+     * @param filterId table filter id
+     * @param column column
+     * @return column value for current row
+     */
+    public Value getValue(int filterId, Column column) {
+        Object x = current.row(filterId);
+        assert x != null;
+        Row row = current.isRow(filterId) ? (Row) x : ((Cursor) x).get();
+        int columnId = column.getColumnId();
+        if (columnId == -1) {
+            return ValueLong.get(row.getKey());
+        }
+        Value value = row.getValue(column.getColumnId());
+        if (value == null) {
+            throw DbException.throwInternalError("value is null: " + column + " " + row);
+        }
+        return value;
+    }
+
+    private void start() {
+        if (filtersCount > 32) {
+            // This is because we store state in a 64 bit field, 2 bits per joined table.
+            throw DbException.getUnsupportedException("Too many tables in join (at most 32 supported).");
+        }
+
+        // fill filters
+        filters = new JoinFilter[filtersCount];
+        JoinFilter jf = top;
+        for (int i = 0; i < filtersCount; i++) {
+            jf.id = jf.filter.joinFilterId = i;
+            filters[i] = jf;
+            jf = jf.join;
+        }
+        // initialize current row
+        current = new JoinRow(new Object[filtersCount]);
+        current.updateRow(top.id, top.filter.getIndexCursor(), JoinRow.S_NULL, JoinRow.S_CURSOR);
+
+        // initialize top cursor
+        top.filter.getIndexCursor().find(top.filter.getSession(), top.filter.getIndexConditions());
+
+        // we need fake first row because batchedNext always will move to the next row
+        JoinRow fake = new JoinRow(null);
+        fake.next = current;
+        current = fake;
+    }
+
+    /**
+     * Get next row from the join batch.
+     * 
+     * @return
+     */
+    public boolean next() {
+        if (!started) {
+            start();
+            started = true;
+        }
+        if (additionalFilter == null) {
+            if (batchedNext()) {
+                assert current.isComplete();
+                return true;
+            }
+            return false;
+        }
+        for (;;) {
+            if (!found) {
+                if (!batchedNext()) {
+                    return false;
+                }
+                assert current.isComplete();
+                found = true;
+                additionalFilter.reset();
+            }
+            // we call furtherFilter in usual way outside of this batch because it is more effective
+            if (additionalFilter.next()) {
+                return true;
+            }
+            found = false;
+        }
+    }
+    
+    private static Cursor get(Future<Cursor> f) {
+        try {
+            return f.get();
+        } catch (Exception e) {
+            throw DbException.convert(e);
+        }
+    }
+    
+    private boolean batchedNext() {
+        if (current == null) {
+            // after last
+            return false;
+        }
+        // go next
+        current = current.next;
+        if (current == null) {
+            return false;
+        }
+        current.prev = null;
+    
+        final int lastJfId = filtersCount - 1;
+        
+        int jfId = lastJfId;
+        while (current.row(jfId) == null) {
+            // lookup for the first non fetched filter for the current row
+            jfId--;
+        }
+        
+        for (;;) {
+            fetchCurrent(jfId);
+            
+            if (!current.isDropped()) {
+                // if current was not dropped then it must be fetched successfully
+                if (jfId == lastJfId) {
+                    // the whole join row is ready to be returned
+                    return true;
+                }
+                JoinFilter join = filters[jfId + 1];
+                if (join.isBatchFull()) {
+                    // get future cursors for join and go right to fetch them
+                    current = join.find(current);
+                }
+                if (current.row(join.id) != null) {
+                    // either find called or outer join with null row
+                    jfId = join.id;
+                    continue;
+                }
+            }
+            // we have to go down and fetch next cursors for jfId if it is possible
+            if (current.next == null) {
+                // either dropped or null-row
+                if (current.isDropped()) {
+                    current = current.prev;
+                    if (current == null) {
+                        return false;
+                    }
+                }
+                assert !current.isDropped();
+                assert jfId != lastJfId;
+                
+                jfId = 0;
+                while (current.row(jfId) != null) {
+                    jfId++;
+                }
+                // force find on half filled batch (there must be either searchRows 
+                // or Cursor.EMPTY set for null-rows)
+                current = filters[jfId].find(current);
+            } else {
+                // here we don't care if the current was dropped
+                current = current.next;
+                assert !current.isRow(jfId);
+                while (current.row(jfId) == null) {
+                    assert jfId != top.id;
+                    // need to go left and fetch more search rows
+                    jfId--;
+                    assert !current.isRow(jfId);
+                }
+            }
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void fetchCurrent(final int jfId) {
+        assert current.prev == null || current.prev.isRow(jfId) : "prev must be already fetched";
+        assert jfId == 0 || current.isRow(jfId - 1) : "left must be already fetched";
+
+        assert !current.isRow(jfId) : "double fetching";
+
+        Object x = current.row(jfId);
+        assert x != null : "x null";
+
+        final JoinFilter jf = filters[jfId];
+        // in case of outer join we don't have any future around empty cursor
+        boolean newCursor = x == EMPTY_CURSOR;
+
+        if (!newCursor && current.isFuture(jfId)) {
+            // get cursor from a future
+            x = get((Future<Cursor>) x);
+            current.updateRow(jfId, x, JoinRow.S_FUTURE, JoinRow.S_CURSOR);
+            newCursor = true;
+        }
+
+        Cursor c = (Cursor) x;
+        assert c != null;
+        JoinFilter join = jf.join;
+
+        for (;;) {
+            if (c == null || !c.next()) {
+                if (newCursor && jf.isOuterJoin()) {
+                    // replace cursor with null-row
+                    current.updateRow(jfId, jf.getNullRow(), JoinRow.S_CURSOR, JoinRow.S_ROW);
+                    c = null;
+                    newCursor = false;
+                } else {
+                    // cursor is done, drop it
+                    current.drop();
+                    return;
+                }
+            }
+            if (!jf.isOk(c == null)) {
+                // try another row from the cursor
+                continue;
+            }
+            boolean joinEmpty = false;
+            if (join != null && !join.collectSearchRows()) {
+                if (join.isOuterJoin()) {
+                    joinEmpty = true;
+                } else {
+                    // join will fail, try next row in the cursor
+                    continue;
+                }
+            }
+            if (c != null) {
+                current = current.copyBehind(jfId);
+                // get current row from cursor
+                current.updateRow(jfId, c.get(), JoinRow.S_CURSOR, JoinRow.S_ROW);
+            }
+            if (joinEmpty) {
+                current.updateRow(join.id, EMPTY_CURSOR, JoinRow.S_NULL, JoinRow.S_CURSOR);
+            }
+            return;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "JoinBatch->\nprev->" + (current == null ? null : current.prev) +
+                "\ncurr->" + current + 
+                "\nnext->" + (current == null ? null : current.next);
+    }
+    
+    /**
+     * Table filter participating in batched join.
+     */
+    private static final class JoinFilter {
+        final TableFilter filter;
+        final JoinFilter join;
+        int id;
+        
+        IndexLookupBatch lookupBatch;
+        
+        private JoinFilter(IndexLookupBatch lookupBatch, TableFilter filter, JoinFilter join) {
+            this.filter = filter;
+            this.join = join;
+            this.lookupBatch = lookupBatch != null ? lookupBatch : new FakeLookupBatch(filter);
+        }
+        
+        public Row getNullRow() {
+            return filter.getTable().getNullRow();
+        }
+
+        private boolean isOuterJoin() {
+            return filter.isJoinOuter();
+        }
+
+        private boolean isBatchFull() {
+            return lookupBatch.isBatchFull();
+        }
+
+        private boolean isOk(boolean ignoreJoinCondition) {
+            boolean filterOk = filter.isOk(filter.getFilterCondition());
+            boolean joinOk = filter.isOk(filter.getJoinCondition());
+
+            return filterOk && (ignoreJoinCondition || joinOk);
+        }
+        
+        private boolean collectSearchRows() {
+            assert !isBatchFull();
+            IndexCursor c = filter.getIndexCursor();
+            c.prepare(filter.getSession(), filter.getIndexConditions());
+            if (c.isAlwaysFalse()) {
+                return false;
+            }
+            lookupBatch.addSearchRows(c.getStart(), c.getEnd());
+            return true;
+        }
+        
+        private JoinRow find(JoinRow current) {
+            assert current != null;
+
+            // lookupBatch is allowed to be empty when we have some null-rows and forced find call
+            List<Future<Cursor>> result = lookupBatch.find();
+
+            // go backwards and assign futures
+            for (int i = result.size(); i > 0;) {
+                assert current.isRow(id - 1);
+                if (current.row(id) == EMPTY_CURSOR) {
+                    // outer join support - skip row with existing empty cursor
+                    current = current.prev;
+                    continue;
+                }
+                assert current.row(id) == null;
+                Future<Cursor> future = result.get(--i);
+                if (future == null) {
+                    current.updateRow(id, EMPTY_CURSOR, JoinRow.S_NULL, JoinRow.S_CURSOR);
+                } else {
+                    current.updateRow(id, future, JoinRow.S_NULL, JoinRow.S_FUTURE);
+                }
+                if (current.prev == null || i == 0) {
+                    break;
+                }
+                current = current.prev;
+            }
+
+            // handle empty cursors (because of outer joins) at the beginning
+            while (current.prev != null && current.prev.row(id) == EMPTY_CURSOR) {
+                current = current.prev;
+            }
+            assert current.prev == null || current.prev.isRow(id);
+            assert current.row(id) != null;
+            assert !current.isRow(id);
+
+            // the last updated row
+            return current;
+        }
+        
+        @Override
+        public String toString() {
+            return "JoinFilter->" + filter;
+        }
+    }
+    
+    /**
+     * Linked row in batched join.
+     */
+    private static final class JoinRow {
+        private static final long S_NULL = 0;
+        private static final long S_FUTURE = 1;
+        private static final long S_CURSOR = 2;
+        private static final long S_ROW = 3;
+
+        private static final long S_MASK = 3;
+
+        /**
+         * May contain one of the following:
+         * <br/>- {@code null}: means that we need to get future cursor for this row
+         * <br/>- {@link Future}: means that we need to get a new {@link Cursor} from the {@link Future}
+         * <br/>- {@link Cursor}: means that we need to fetch {@link Row}s from the {@link Cursor}
+         * <br/>- {@link Row}: the {@link Row} is already fetched and is ready to be used
+         */
+        private Object[] row;
+        private long state;
+
+        private JoinRow prev;
+        private JoinRow next;
+
+        /**
+         * @param row Row.
+         */
+        private JoinRow(Object[] row) {
+            this.row = row;
+        }
+
+        /**
+         * @param joinFilterId Join filter id.
+         * @return Row state.
+         */
+        private long getState(int joinFilterId) {
+            return (state >>> (joinFilterId << 1)) & S_MASK;
+        }
+
+        /**
+         * Allows to do a state transition in the following order:
+         * 0. Slot contains {@code null} ({@link #S_NULL}).
+         * 1. Slot contains {@link Future} ({@link #S_FUTURE}).
+         * 2. Slot contains {@link Cursor} ({@link #S_CURSOR}).
+         * 3. Slot contains {@link Row} ({@link #S_ROW}).
+         *
+         * @param joinFilterId {@link JoinRow} filter id.
+         * @param i Increment by this number of moves.
+         */
+        private void incrementState(int joinFilterId, long i) {
+            assert i > 0 : i;
+            state += i << (joinFilterId << 1);
+        }
+
+        private void updateRow(int joinFilterId, Object x, long oldState, long newState) {
+            assert getState(joinFilterId) == oldState : "old state: " + getState(joinFilterId);
+            row[joinFilterId] = x;
+            incrementState(joinFilterId, newState - oldState);
+            assert getState(joinFilterId) == newState : "new state: " + getState(joinFilterId);
+        }
+
+        private Object row(int joinFilterId) {
+            return row[joinFilterId];
+        }
+
+        private boolean isRow(int joinFilterId) {
+            return getState(joinFilterId) == S_ROW;
+        }
+
+        private boolean isFuture(int joinFilterId) {
+            return getState(joinFilterId) == S_FUTURE;
+        }
+
+        private boolean isCursor(int joinFilterId) {
+            return getState(joinFilterId) == S_CURSOR;
+        }
+
+        private boolean isComplete() {
+            return isRow(row.length - 1);
+        }
+
+        private boolean isDropped() {
+            return row == null;
+        }
+
+        private void drop() {
+            if (prev != null) {
+                prev.next = next;
+            }
+            if (next != null) {
+                next.prev = prev;
+            }
+            row = null;
+        }
+        
+        /**
+         * Copy this JoinRow behind itself in linked list of all in progress rows.
+         *
+         * @param jfId The last fetched filter id.
+         * @return The copy.
+         */
+        private JoinRow copyBehind(int jfId) {
+            assert isCursor(jfId);
+            assert jfId + 1 == row.length || row[jfId + 1] == null;
+            
+            Object[] r = new Object[row.length];
+            if (jfId != 0) {
+                System.arraycopy(row, 0, r, 0, jfId);
+            }
+            JoinRow copy = new JoinRow(r);
+            copy.state = state;
+            
+            if (prev != null) {
+                copy.prev = prev;
+                prev.next = copy;
+            }
+            prev = copy;
+            copy.next = this;
+            
+            return copy;
+        }
+        
+        @Override
+        public String toString() {
+            return "JoinRow->" + Arrays.toString(row);
+        }
+    }
+
+    /**
+     * Fake Lookup batch for indexes which do not support batching but have to participate 
+     * in batched joins.
+     */
+    private static final class FakeLookupBatch implements IndexLookupBatch {
+        private final TableFilter filter;
+
+        private SearchRow first;
+        private SearchRow last;
+
+        private boolean full;
+
+        private final List<Future<Cursor>> result = new SingletonList<Future<Cursor>>();
+
+        /**
+         * @param index Index.
+         */
+        public FakeLookupBatch(TableFilter filter) {
+            this.filter = filter;
+        }
+
+        @Override
+        public void addSearchRows(SearchRow first, SearchRow last) {
+            assert !full;
+            this.first = first;
+            this.last = last;
+            full = true;
+        }
+
+        @Override
+        public boolean isBatchFull() {
+            return full;
+        }
+
+        @Override
+        public List<Future<Cursor>> find() {
+            if (!full) {
+                return Collections.emptyList();
+            }
+            Cursor c = filter.getIndex().find(filter, first, last);
+            result.set(0, new DoneFuture<Cursor>(c));
+            full = false;
+            first = last = null;
+            return result;
+        }
+    }
+
+    /**
+     * Simple singleton list.
+     */
+    private static final class SingletonList<E> extends AbstractList<E> {
+        private E element;
+
+        @Override
+        public E get(int index) {
+            assert index == 0;
+            return element;
+        }
+
+        @Override
+        public E set(int index, E element) {
+            assert index == 0;
+            this.element = element;
+            return null;
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+    }
+}
+

--- a/h2/src/main/org/h2/table/JoinBatch.java
+++ b/h2/src/main/org/h2/table/JoinBatch.java
@@ -60,7 +60,7 @@ public final class JoinBatch {
 
     private static final Future<Cursor> PLACEHOLDER = new DoneFuture<Cursor>(null);
 
-    private ViewIndexLookupBatch lookupBatchWrapper;
+    private ViewIndexLookupBatch viewIndexLookupBatch;
 
     private JoinFilter[] filters;
     private JoinFilter top;
@@ -156,7 +156,7 @@ public final class JoinBatch {
     private void start() {
         // initialize current row
         current = new JoinRow(new Object[filters.length]);
-        if (lookupBatchWrapper == null) {
+        if (viewIndexLookupBatch == null) {
             current.updateRow(top.id, top.filter.getIndexCursor(), JoinRow.S_NULL, JoinRow.S_CURSOR);
             // initialize top cursor
             top.filter.getIndexCursor().find(top.filter.getSession(), top.filter.getIndexConditions());
@@ -352,10 +352,10 @@ public final class JoinBatch {
      * @return Adapter to allow joining to this batch in sub-queries.
      */
     public IndexLookupBatch asViewIndexLookupBatch(ViewIndex viewIndex) {
-        if (lookupBatchWrapper == null) {
-            lookupBatchWrapper = new ViewIndexLookupBatch(viewIndex);
+        if (viewIndexLookupBatch == null) {
+            viewIndexLookupBatch = new ViewIndexLookupBatch(viewIndex);
         }
-        return lookupBatchWrapper;
+        return viewIndexLookupBatch;
     }
 
     @Override
@@ -685,6 +685,7 @@ public final class JoinBatch {
         private final ViewIndex viewIndex;
         private final ArrayList<Future<Cursor>> result = New.arrayList();
         private boolean findCalled;
+        private boolean full;
 
         private ViewIndexLookupBatch(ViewIndex viewIndex) {
             this.viewIndex = viewIndex;
@@ -706,6 +707,10 @@ public final class JoinBatch {
                 result.add(null);
             }
         }
+        
+        private void fetch() {
+            
+        }
 
         @Override
         public boolean isBatchFull() {
@@ -715,15 +720,6 @@ public final class JoinBatch {
 
         @Override
         public List<Future<Cursor>> find() {
-            JoinBatch jb = JoinBatch.this;
-            List<Future<Cursor>> topCursors = top.find();
-            for (int i = 0; i < topCursors.size(); i++) {
-//                jb.setCursor
-                
-                while (jb.next()) {
-                    // collect result
-                }
-            }
             findCalled = true;
             return result;
         }

--- a/h2/src/main/org/h2/table/JoinBatch.java
+++ b/h2/src/main/org/h2/table/JoinBatch.java
@@ -323,11 +323,11 @@ public final class JoinBatch {
      * Table filter participating in batched join.
      */
     private static final class JoinFilter {
-        final TableFilter filter;
-        final JoinFilter join;
-        int id;
+        private final TableFilter filter;
+        private final JoinFilter join;
+        private int id;
         
-        IndexLookupBatch lookupBatch;
+        private final IndexLookupBatch lookupBatch;
         
         private JoinFilter(IndexLookupBatch lookupBatch, TableFilter filter, JoinFilter join) {
             this.filter = filter;

--- a/h2/src/main/org/h2/table/SubQueryInfo.java
+++ b/h2/src/main/org/h2/table/SubQueryInfo.java
@@ -19,7 +19,6 @@ public class SubQueryInfo {
     private TableFilter[] filters;
     private int filter;
     private SortOrder sortOrder;
-    private boolean preliminary;
     private SubQueryInfo upper;
 
     /**
@@ -28,17 +27,14 @@ public class SubQueryInfo {
      * @param filters table filters
      * @param filter current filter
      * @param sortOrder sort order
-     * @param preliminary if this is a preliminary query optimization 
-     *          without global conditions
      */
     public SubQueryInfo(SubQueryInfo upper, int[] masks, TableFilter[] filters, int filter,
-            SortOrder sortOrder, boolean preliminary) {
+            SortOrder sortOrder) {
         this.upper = upper;
         this.masks = masks;
         this.filters = filters;
         this.filter = filter;
         this.sortOrder = sortOrder;
-        this.preliminary = preliminary;
     }
 
     public SubQueryInfo getUpper() {
@@ -59,9 +55,5 @@ public class SubQueryInfo {
 
     public SortOrder getSortOrder() {
         return sortOrder;
-    }
-
-    public boolean isPreliminary() {
-        return preliminary;
     }
 }

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -127,6 +127,10 @@ public abstract class Table extends SchemaObjectBase {
         }
     }
 
+    public boolean isView() {
+        return false;
+    }
+
     /**
      * Lock the table for the given session.
      * This method waits until the lock is granted.

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -269,10 +269,8 @@ public class TableFilter implements ColumnResolver {
     /**
      * Prepare reading rows. This method will remove all index conditions that
      * can not be used, and optimize the conditions.
-     * 
-     * @param parse if we are parsing sub-query
      */
-    public void prepare(boolean parse) {
+    public void prepare() {
         // forget all unused index conditions
         // the indexConditions list may be modified here
         for (int i = 0; i < indexConditions.size(); i++) {
@@ -291,21 +289,19 @@ public class TableFilter implements ColumnResolver {
             if (SysProperties.CHECK && nestedJoin == this) {
                 DbException.throwInternalError("self join");
             }
-            nestedJoin.prepare(parse);
+            nestedJoin.prepare();
         }
         if (join != null) {
             if (SysProperties.CHECK && join == this) {
                 DbException.throwInternalError("self join");
             }
-            join.prepare(parse);
+            join.prepare();
         }
-        if (!parse) {
-            if (filterCondition != null) {
-                filterCondition = filterCondition.optimize(session);
-            }
-            if (joinCondition != null) {
-                joinCondition = joinCondition.optimize(session);
-            }
+        if (filterCondition != null) {
+            filterCondition = filterCondition.optimize(session);
+        }
+        if (joinCondition != null) {
+            joinCondition = joinCondition.optimize(session);
         }
     }
 

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -5,12 +5,7 @@
  */
 package org.h2.table;
 
-import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.Future;
 import org.h2.command.Parser;
 import org.h2.command.dml.Select;
 import org.h2.engine.Right;
@@ -21,7 +16,6 @@ import org.h2.expression.Comparison;
 import org.h2.expression.ConditionAndOr;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
-import org.h2.index.Cursor;
 import org.h2.index.Index;
 import org.h2.index.IndexLookupBatch;
 import org.h2.index.IndexCondition;
@@ -30,7 +24,6 @@ import org.h2.message.DbException;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.result.SortOrder;
-import org.h2.util.DoneFuture;
 import org.h2.util.New;
 import org.h2.util.StatementBuilder;
 import org.h2.util.StringUtils;
@@ -48,33 +41,6 @@ public class TableFilter implements ColumnResolver {
     private static final int BEFORE_FIRST = 0, FOUND = 1, AFTER_LAST = 2,
             NULL_ROW = 3;
 
-    private static final Cursor EMPTY_CURSOR = new Cursor() {
-        @Override
-        public boolean previous() {
-            return false;
-        }
-        
-        @Override
-        public boolean next() {
-            return false;
-        }
-        
-        @Override
-        public SearchRow getSearchRow() {
-            return null;
-        }
-        
-        @Override
-        public Row get() {
-            return null;
-        }
-        
-        @Override
-        public String toString() {
-            return "EMPTY_CURSOR";
-        }
-    }; 
-    
     /**
      * Whether this is a direct or indirect (nested) outer join
      */
@@ -94,8 +60,8 @@ public class TableFilter implements ColumnResolver {
      * Batched join support.
      */
     private JoinBatch joinBatch;
-    private JoinFilter joinFilter;
-    
+    int joinFilterId = -1;
+
     /**
      * Indicates that this filter is used in the plan.
      */
@@ -166,6 +132,10 @@ public class TableFilter implements ColumnResolver {
             session.getUser().checkRight(table, Right.SELECT);
         }
         hashCode = session.nextObjectId();
+    }
+
+    public IndexCursor getIndexCursor() {
+        return cursor;
     }
 
     @Override
@@ -342,7 +312,7 @@ public class TableFilter implements ColumnResolver {
      */
     public JoinBatch startQuery(Session s) {
         joinBatch = null;
-        joinFilter = null;
+        joinFilterId = -1;
         this.session = s;
         scanCount = 0;
         if (nestedJoin != null) {
@@ -367,7 +337,7 @@ public class TableFilter implements ColumnResolver {
                 lookupBatch = index.createLookupBatch(this);
             }
             joinBatch = batch;
-            joinFilter = batch.register(this, lookupBatch);
+            batch.register(this, lookupBatch);
         }
         return batch;
     }
@@ -505,7 +475,7 @@ public class TableFilter implements ColumnResolver {
         // scanCount);
     }
 
-    private boolean isOk(Expression condition) {
+    boolean isOk(Expression condition) {
         if (condition == null) {
             return true;
         }
@@ -964,7 +934,7 @@ public class TableFilter implements ColumnResolver {
     @Override
     public Value getValue(Column column) {
         if (joinBatch != null) {
-            return joinBatch.getValue(joinFilter, column);
+            return joinBatch.getValue(joinFilterId, column);
         }
         if (currentSearchRow == null) {
             return null;
@@ -1113,563 +1083,5 @@ public class TableFilter implements ColumnResolver {
          * @param f the filter
          */
         void accept(TableFilter f);
-    }
-
-    /**
-     * Support for asynchronous batched index lookups on joins.
-     * 
-     * @see Index#findBatched(TableFilter, java.util.Collection)
-     * @see Index#getPreferedLookupBatchSize()
-     * 
-     * @author Sergi Vladykin
-     */
-    private static final class JoinBatch {
-        int filtersCount;
-        JoinFilter[] filters;
-        JoinFilter top;
-        
-        boolean started;
-        
-        JoinRow current;
-        boolean found;
-        
-        /**
-         * This filter joined after this batched join and can be used normally.
-         */
-        final TableFilter additionalFilter;
-        
-        /**
-         * @param additionalFilter table filter after this batched join.
-         */
-        private JoinBatch(TableFilter additionalFilter) {
-            this.additionalFilter = additionalFilter;
-        }
-        
-        /**
-         * @param filter table filter
-         * @param lookupBatch lookup batch
-         */
-        private JoinFilter register(TableFilter filter, IndexLookupBatch lookupBatch) {
-            assert filter != null;
-            filtersCount++;
-            return top = new JoinFilter(lookupBatch, filter, top);
-        }
-        
-        /**
-         * @param filterId table filter id
-         * @param column column
-         * @return column value for current row
-         */
-        private Value getValue(JoinFilter filter, Column column) {
-            Object x = current.row(filter.id);
-            assert x != null;
-            Row row = current.isRow(filter.id) ? (Row) x : ((Cursor) x).get();
-            int columnId = column.getColumnId();
-            if (columnId == -1) {
-                return ValueLong.get(row.getKey());
-            }
-            Value value = row.getValue(column.getColumnId());
-            if (value == null) {
-                throw DbException.throwInternalError("value is null: " + column + " " + row);
-            }
-            return value;
-        }
-        
-        private void start() {
-            if (filtersCount > 32) {
-                // This is because we store state in a 64 bit field, 2 bits per joined table.
-                throw DbException.getUnsupportedException("Too many tables in join (at most 32 supported).");
-            }
-
-            // fill filters
-            filters = new JoinFilter[filtersCount];
-            JoinFilter jf = top;
-            for (int i = 0; i < filtersCount; i++) {
-                filters[jf.id = i] = jf;
-                jf = jf.join;
-            }
-            // initialize current row
-            current = new JoinRow(new Object[filtersCount]);
-            current.updateRow(top.id, top.filter.cursor, JoinRow.S_NULL, JoinRow.S_CURSOR);
-
-            // initialize top cursor
-            top.filter.cursor.find(top.filter.session, top.filter.indexConditions);
-
-            // we need fake first row because batchedNext always will move to the next row
-            JoinRow fake = new JoinRow(null);
-            fake.next = current;
-            current = fake;
-        }
-
-        private boolean next() {
-            if (!started) {
-                start();
-                started = true;
-            }
-            if (additionalFilter == null) {
-                if (batchedNext()) {
-                    assert current.isComplete();
-                    return true;
-                }
-                return false;
-            }
-            for (;;) {
-                if (!found) {
-                    if (!batchedNext()) {
-                        return false;
-                    }
-                    assert current.isComplete();
-                    found = true;
-                    additionalFilter.reset();
-                }
-                // we call furtherFilter in usual way outside of this batch because it is more effective
-                if (additionalFilter.next()) {
-                    return true;
-                }
-                found = false;
-            }
-        }
-        
-        private static Cursor get(Future<Cursor> f) {
-            try {
-                return f.get();
-            } catch (Exception e) {
-                throw DbException.convert(e);
-            }
-        }
-        
-        private boolean batchedNext() {
-            if (current == null) {
-                // after last
-                return false;
-            }
-            // go next
-            current = current.next;
-            if (current == null) {
-                return false;
-            }
-            current.prev = null;
-        
-            final int lastJfId = filtersCount - 1;
-            
-            int jfId = lastJfId;
-            while (current.row(jfId) == null) {
-                // lookup for the first non fetched filter for the current row
-                jfId--;
-            }
-            
-            for (;;) {
-                fetchCurrent(jfId);
-                
-                if (!current.isDropped()) {
-                    // if current was not dropped then it must be fetched successfully
-                    if (jfId == lastJfId) {
-                        // the whole join row is ready to be returned
-                        return true;
-                    }
-                    JoinFilter join = filters[jfId + 1];
-                    if (join.isBatchFull()) {
-                        // get future cursors for join and go right to fetch them
-                        current = join.find(current);
-                    }
-                    if (current.row(join.id) != null) {
-                        // either find called or outer join with null row
-                        jfId = join.id;
-                        continue;
-                    }
-                }
-                // we have to go down and fetch next cursors for jfId if it is possible
-                if (current.next == null) {
-                    // either dropped or null-row
-                    if (current.isDropped()) {
-                        current = current.prev;
-                        if (current == null) {
-                            return false;
-                        }
-                    }
-                    assert !current.isDropped();
-                    assert jfId != lastJfId;
-                    
-                    jfId = 0;
-                    while (current.row(jfId) != null) {
-                        jfId++;
-                    }
-                    // force find on half filled batch (there must be either searchRows 
-                    // or Cursor.EMPTY set for null-rows)
-                    current = filters[jfId].find(current);
-                } else {
-                    // here we don't care if the current was dropped
-                    current = current.next;
-                    assert !current.isRow(jfId);
-                    while (current.row(jfId) == null) {
-                        assert jfId != top.id;
-                        // need to go left and fetch more search rows
-                        jfId--;
-                        assert !current.isRow(jfId);
-                    }
-                }
-            }
-        }
-        
-        @SuppressWarnings("unchecked")
-        private void fetchCurrent(final int jfId) {
-            assert current.prev == null || current.prev.isRow(jfId) : "prev must be already fetched";
-            assert jfId == 0 || current.isRow(jfId - 1) : "left must be already fetched";
-
-            assert !current.isRow(jfId) : "double fetching";
-
-            Object x = current.row(jfId);
-            assert x != null : "x null";
-
-            final JoinFilter jf = filters[jfId];
-            // in case of outer join we don't have any future around empty cursor
-            boolean newCursor = x == EMPTY_CURSOR;
-
-            if (!newCursor && current.isFuture(jfId)) {
-                // get cursor from a future
-                x = get((Future<Cursor>) x);
-                current.updateRow(jfId, x, JoinRow.S_FUTURE, JoinRow.S_CURSOR);
-                newCursor = true;
-            }
-
-            Cursor c = (Cursor) x;
-            assert c != null;
-            JoinFilter join = jf.join;
-
-            for (;;) {
-                if (c == null || !c.next()) {
-                    if (newCursor && jf.isOuterJoin()) {
-                        // replace cursor with null-row
-                        current.updateRow(jfId, jf.getNullRow(), JoinRow.S_CURSOR, JoinRow.S_ROW);
-                        c = null;
-                        newCursor = false;
-                    } else {
-                        // cursor is done, drop it
-                        current.drop();
-                        return;
-                    }
-                }
-                if (!jf.isOk(c == null)) {
-                    // try another row from the cursor
-                    continue;
-                }
-                boolean joinEmpty = false;
-                if (join != null && !join.collectSearchRows()) {
-                    if (join.isOuterJoin()) {
-                        joinEmpty = true;
-                    } else {
-                        // join will fail, try next row in the cursor
-                        continue;
-                    }
-                }
-                if (c != null) {
-                    current = current.copyBehind(jfId);
-                    // get current row from cursor
-                    current.updateRow(jfId, c.get(), JoinRow.S_CURSOR, JoinRow.S_ROW);
-                }
-                if (joinEmpty) {
-                    current.updateRow(join.id, EMPTY_CURSOR, JoinRow.S_NULL, JoinRow.S_CURSOR);
-                }
-                return;
-            }
-        }
-
-        @Override
-        public String toString() {
-            return "JoinBatch->\nprev->" + (current == null ? null : current.prev) +
-                    "\ncurr->" + current + 
-                    "\nnext->" + (current == null ? null : current.next);
-        }
-    }
-    
-    /**
-     * Table filter participating in batched join.
-     */
-    private static final class JoinFilter {
-        final TableFilter filter;
-        final JoinFilter join;
-        int id;
-        
-        IndexLookupBatch lookupBatch;
-        
-        private JoinFilter(IndexLookupBatch lookupBatch, TableFilter filter, JoinFilter join) {
-            this.filter = filter;
-            this.join = join;
-            this.lookupBatch = lookupBatch != null ? lookupBatch : new FakeLookupBatch(filter);
-        }
-        
-        public Row getNullRow() {
-            return filter.table.getNullRow();
-        }
-
-        private boolean isOuterJoin() {
-            return filter.joinOuter;
-        }
-
-        private boolean isBatchFull() {
-            return lookupBatch.isBatchFull();
-        }
-
-        private boolean isOk(boolean ignoreJoinCondition) {
-            boolean filterOk = filter.isOk(filter.filterCondition);
-            boolean joinOk = filter.isOk(filter.joinCondition);
-
-            return filterOk && (ignoreJoinCondition || joinOk);
-        }
-        
-        private boolean collectSearchRows() {
-            assert !isBatchFull();
-            IndexCursor c = filter.cursor;
-            c.prepare(filter.session, filter.indexConditions);
-            if (c.isAlwaysFalse()) {
-                return false;
-            }
-            lookupBatch.addSearchRows(c.getStart(), c.getEnd());
-            return true;
-        }
-        
-        private JoinRow find(JoinRow current) {
-            assert current != null;
-
-            // lookupBatch is allowed to be empty when we have some null-rows and forced find call
-            List<Future<Cursor>> result = lookupBatch.find();
-
-            // go backwards and assign futures
-            for (int i = result.size(); i > 0;) {
-                assert current.isRow(id - 1);
-                if (current.row(id) == EMPTY_CURSOR) {
-                    // outer join support - skip row with existing empty cursor
-                    current = current.prev;
-                    continue;
-                }
-                assert current.row(id) == null;
-                Future<Cursor> future = result.get(--i);
-                if (future == null) {
-                    current.updateRow(id, EMPTY_CURSOR, JoinRow.S_NULL, JoinRow.S_CURSOR);
-                } else {
-                    current.updateRow(id, future, JoinRow.S_NULL, JoinRow.S_FUTURE);
-                }
-                if (current.prev == null || i == 0) {
-                    break;
-                }
-                current = current.prev;
-            }
-
-            // handle empty cursors (because of outer joins) at the beginning
-            while (current.prev != null && current.prev.row(id) == EMPTY_CURSOR) {
-                current = current.prev;
-            }
-            assert current.prev == null || current.prev.isRow(id);
-            assert current.row(id) != null;
-            assert !current.isRow(id);
-
-            // the last updated row
-            return current;
-        }
-        
-        @Override
-        public String toString() {
-            return "JoinFilter->" + filter;
-        }
-    }
-    
-    /**
-     * Linked row in batched join.
-     */
-    private static final class JoinRow {
-        private static final long S_NULL = 0;
-        private static final long S_FUTURE = 1;
-        private static final long S_CURSOR = 2;
-        private static final long S_ROW = 3;
-
-        private static final long S_MASK = 3;
-
-        /**
-         * May contain one of the following:
-         * <br/>- {@code null}: means that we need to get future cursor for this row
-         * <br/>- {@link Future}: means that we need to get a new {@link Cursor} from the {@link Future}
-         * <br/>- {@link Cursor}: means that we need to fetch {@link Row}s from the {@link Cursor}
-         * <br/>- {@link Row}: the {@link Row} is already fetched and is ready to be used
-         */
-        Object[] row;
-        long state;
-
-        JoinRow prev;
-        JoinRow next;
-
-        /**
-         * @param row Row.
-         */
-        private JoinRow(Object[] row) {
-            this.row = row;
-        }
-
-        /**
-         * @param joinFilterId Join filter id.
-         * @return Row state.
-         */
-        private long getState(int joinFilterId) {
-            return (state >>> (joinFilterId << 1)) & S_MASK;
-        }
-
-        /**
-         * Allows to do a state transition in the following order:
-         * 0. Slot contains {@code null} ({@link #S_NULL}).
-         * 1. Slot contains {@link Future} ({@link #S_FUTURE}).
-         * 2. Slot contains {@link Cursor} ({@link #S_CURSOR}).
-         * 3. Slot contains {@link Row} ({@link #S_ROW}).
-         *
-         * @param joinFilterId {@link JoinRow} filter id.
-         * @param i Increment by this number of moves.
-         */
-        private void incrementState(int joinFilterId, long i) {
-            assert i > 0 : i;
-            state += i << (joinFilterId << 1);
-        }
-
-        private void updateRow(int joinFilterId, Object x, long oldState, long newState) {
-            assert getState(joinFilterId) == oldState : "old state: " + getState(joinFilterId);
-            row[joinFilterId] = x;
-            incrementState(joinFilterId, newState - oldState);
-            assert getState(joinFilterId) == newState : "new state: " + getState(joinFilterId);
-        }
-
-        private Object row(int joinFilterId) {
-            return row[joinFilterId];
-        }
-
-        private boolean isRow(int joinFilterId) {
-            return getState(joinFilterId) == S_ROW;
-        }
-
-        private boolean isFuture(int joinFilterId) {
-            return getState(joinFilterId) == S_FUTURE;
-        }
-
-        private boolean isCursor(int joinFilterId) {
-            return getState(joinFilterId) == S_CURSOR;
-        }
-
-        private boolean isComplete() {
-            return isRow(row.length - 1);
-        }
-
-        private boolean isDropped() {
-            return row == null;
-        }
-
-        private void drop() {
-            if (prev != null) {
-                prev.next = next;
-            }
-            if (next != null) {
-                next.prev = prev;
-            }
-            row = null;
-        }
-        
-        /**
-         * Copy this JoinRow behind itself in linked list of all in progress rows.
-         *
-         * @param jfId The last fetched filter id.
-         * @return The copy.
-         */
-        private JoinRow copyBehind(int jfId) {
-            assert isCursor(jfId);
-            assert jfId + 1 == row.length || row[jfId + 1] == null;
-            
-            Object[] r = new Object[row.length];
-            if (jfId != 0) {
-                System.arraycopy(row, 0, r, 0, jfId);
-            }
-            JoinRow copy = new JoinRow(r);
-            copy.state = state;
-            
-            if (prev != null) {
-                copy.prev = prev;
-                prev.next = copy;
-            }
-            prev = copy;
-            copy.next = this;
-            
-            return copy;
-        }
-        
-        @Override
-        public String toString() {
-            return "JoinRow->" + Arrays.toString(row);
-        }
-    }
-
-    /**
-     * Fake Lookup batch for indexes which do not support batching but have to participate 
-     * in batched joins.
-     */
-    private static class FakeLookupBatch implements IndexLookupBatch {
-        final TableFilter filter;
-
-        SearchRow first;
-        SearchRow last;
-
-        boolean full;
-
-        final List<Future<Cursor>> result = new SingletonList<Future<Cursor>>();
-
-        /**
-         * @param index Index.
-         */
-        public FakeLookupBatch(TableFilter filter) {
-            this.filter = filter;
-        }
-
-        @Override
-        public void addSearchRows(SearchRow first, SearchRow last) {
-            assert !full;
-            this.first = first;
-            this.last = last;
-            full = true;
-        }
-
-        @Override
-        public boolean isBatchFull() {
-            return full;
-        }
-
-        @Override
-        public List<Future<Cursor>> find() {
-            if (!full) {
-                return Collections.emptyList();
-            }
-            Cursor c = filter.getIndex().find(filter, first, last);
-            result.set(0, new DoneFuture<Cursor>(c));
-            full = false;
-            first = last = null;
-            return result;
-        }
-    }
-
-    /**
-     * Simple singleton list.
-     */
-    private static class SingletonList<E> extends AbstractList<E> {
-        private E element;
-
-        @Override
-        public E get(int index) {
-            assert index == 0;
-            return element;
-        }
-
-        @Override
-        public E set(int index, E element) {
-            assert index == 0;
-            this.element = element;
-            return null;
-        }
-
-        @Override
-        public int size() {
-            return 1;
-        }
     }
 }

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -218,6 +218,11 @@ public class TableView extends Table {
         }
     }
 
+    @Override
+    public boolean isView() {
+        return true;
+    }
+
     /**
      * Check if this view is currently invalid.
      *

--- a/h2/src/main/org/h2/util/LazyFuture.java
+++ b/h2/src/main/org/h2/util/LazyFuture.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2004-2014 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.util;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.h2.message.DbException;
+
+/**
+ * Single threaded lazy future. 
+ * 
+ * @param <T>
+ * @author Sergi Vladykin
+ */
+public abstract class LazyFuture<T> implements Future<T> {
+
+    private static final int S_READY = 0;
+    private static final int S_DONE = 1;
+    private static final int S_ERROR = 2;
+    private static final int S_CANCELED = 3;
+    
+    private int state = S_READY;
+    private T result;
+    private Exception error;
+
+    /**
+     * Reset this future to the initial state.
+     * 
+     * @return {@code false} if it was already in initial state 
+     */
+    public boolean reset() {
+        if (state == S_READY) {
+            return false;
+        }
+        state = S_READY;
+        result = null;
+        error = null;
+        return true;
+    }
+
+    /**
+     * Run computation and produce the result.
+     * 
+     * @return the result of computation
+     */
+    protected abstract T run() throws Exception;
+    
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if (state != S_READY) {
+            return false;
+        }
+        state = S_CANCELED;
+        return true;
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        switch (state) {
+        case S_READY:
+            try {
+                result = run();
+                state = S_DONE;
+            } catch (Exception e) {
+                error = e;
+                if (e instanceof InterruptedException) {
+                    throw (InterruptedException) e;
+                }
+                throw new ExecutionException(e);
+            } finally {
+                if (state != S_DONE) {
+                    state = S_ERROR;
+                }
+            }
+            return result;
+        case S_DONE:
+            return result;
+        case S_ERROR:
+            throw new ExecutionException(error);
+        case S_CANCELED:
+            throw new CancellationException();
+        default:
+            throw DbException.throwInternalError();
+        }
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException {
+        return get();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return state == S_CANCELED;
+    }
+
+    @Override
+    public boolean isDone() {
+        return state == S_DONE;
+    }
+}

--- a/h2/src/main/org/h2/util/LazyFuture.java
+++ b/h2/src/main/org/h2/util/LazyFuture.java
@@ -101,6 +101,6 @@ public abstract class LazyFuture<T> implements Future<T> {
 
     @Override
     public boolean isDone() {
-        return state == S_DONE;
+        return state != S_READY;
     }
 }

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -1160,10 +1160,11 @@ public class TestTableEngines extends TestBase {
                 }
 
                 @Override
-                public void addSearchRows(SearchRow first, SearchRow last) {
+                public boolean addSearchRows(SearchRow first, SearchRow last) {
                     assert !isBatchFull();
                     searchRows.add(first);
                     searchRows.add(last);
+                    return true;
                 }
 
                 @Override

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -1118,6 +1118,11 @@ public class TestTableEngines extends TestBase {
                     searchRows.add(first);
                     searchRows.add(last);
                 }
+
+                @Override
+                public void reset() {
+                    searchRows.clear();
+                }
             };
         }
 


### PR DESCRIPTION
In this PR:
- `JoinBatch` and almost all the related logic moved to the top level from `TableFilter` (this is more convenient and will allow to drop it easily when some better replacement will appear).
-  Join batching initialization has been moved to `Session.prepareLocal` so that it happens when everything else is prepared.
- Join batching now works only when session scope `BATCH_JOINS` property is enabled (by default it is disabled)
- Join batches now are visible in EXPLAIN (as it was suggested by Noel)
- Added support for batched joins with sub-queries/views
- API of `IndexLookupBatch` a bit changed: added `getPlanSQL()` and `reset()` methods.
