### PR TITLE
Sub-query or view cost could be wrong for cached ViewIndex

### DIFF
--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -141,22 +141,6 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
         throw DbException.getUnsupportedException("VIEW");
     }
 
-    /**
-     * A calculated cost value.
-     */
-    static class CostElement {
-
-        /**
-         * The time in milliseconds when this cost was calculated.
-         */
-        long evaluatedAt;
-
-        /**
-         * The cost.
-         */
-        double cost;
-    }
-
     @Override
     public double getCost(Session session, int[] masks,
             TableFilter[] filters, int filter, SortOrder sortOrder) {

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -235,15 +235,15 @@ public class TableView extends Table {
     @Override
     public PlanItem getBestPlanItem(Session session, int[] masks,
             TableFilter[] filters, int filter, SortOrder sortOrder) {
-        PlanItem item = new PlanItem();
-        item.cost = index.getCost(session, masks, filters, filter, sortOrder);
         final CacheKey cacheKey = new CacheKey(masks, this);
         Map<Object, ViewIndex> indexCache = session.getViewIndexCache(topQuery != null);
         ViewIndex i = indexCache.get(cacheKey);
-        if (i == null) {
+        if (i == null || i.isExpired()) {
             i = new ViewIndex(this, index, session, masks, filters, filter, sortOrder);
             indexCache.put(cacheKey, i);
         }
+        PlanItem item = new PlanItem();
+        item.cost = i.getCost(session, masks, filters, filter, sortOrder);
         item.setIndex(i);
         return item;
     }

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -394,13 +394,15 @@ public class TestTableEngines extends TestBase {
     }
     
     private void testBatchedJoin() throws SQLException {
+        if (config.networked) {
+            // networked test is disabled because it relies on OptimizerHints which is ThreadLocal
+            return;
+        }
         deleteDb("testBatchedJoin");
         Connection conn = getConnection("testBatchedJoin;OPTIMIZE_REUSE_RESULTS=0;BATCH_JOINS=1");
         Statement stat = conn.createStatement();
-        if (!config.networked) {
-            Session s = (Session) ((JdbcConnection) conn).getSession();
-            assertTrue(s.isJoinBatchEnabled());
-        }
+        Session s = (Session) ((JdbcConnection) conn).getSession();
+        assertTrue(s.isJoinBatchEnabled());
         setBatchingEnabled(stat, false);
         setBatchingEnabled(stat, true);
         


### PR DESCRIPTION
Actually the cost will be correct, but the actual cached `ViewIndex` instance, which will be used in query execution, can be outdated (use wrong indexes and join order in cached query plan) and have other cost than it was returned by `getCost`.

In this PR I return cost from cached `ViewIndex` (just taking it from the prepared query) and expire these indexes instead of `CostElement`. This should not affect performance since cost recalculation was basically the same thing as creation of new cached `ViewIndex` instance.

Also switched to `System.nanoTime()` for expiration to avoid time travel effects of `System.currentTimeMillis()`
