### PR TITLE
Fix for date-handling error in "Europe/Moscow" timezone with Java 1.8.0_60

### DIFF
--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -91,6 +91,7 @@ public class DateTimeUtils {
             c = Calendar.getInstance();
             CACHED_CALENDAR.set(c);
         }
+        c.clear();
         return c;
     }
 
@@ -106,6 +107,7 @@ public class DateTimeUtils {
             c = Calendar.getInstance(tz);
             CACHED_CALENDAR_NON_DEFAULT_TIMEZONE.set(c);
         }
+        c.clear();
         return c;
     }
 
@@ -423,7 +425,6 @@ public class DateTimeUtils {
         } else {
             c = getCalendar(tz);
         }
-        c.clear();
         c.setLenient(lenient);
         setCalendarFields(c, year, month, day, hour, minute, second, millis);
         return c.getTime().getTime();
@@ -490,7 +491,8 @@ public class DateTimeUtils {
      * @return the milliseconds
      */
     public static long getTimeLocalWithoutDst(java.util.Date d) {
-        return d.getTime() + getCalendar().get(Calendar.ZONE_OFFSET);
+        Calendar calendar = getCalendar();
+        return d.getTime() + calendar.get(Calendar.ZONE_OFFSET);
     }
 
     /**
@@ -501,11 +503,7 @@ public class DateTimeUtils {
      * @return the number of milliseconds in UTC
      */
     public static long getTimeUTCWithoutDst(long millis) {
-        Calendar calendar = getCalendar();
-        // clearing calendar is work-around for bug with "Europe/Moscow" timezone with Java 1.8.0_60
-        // if calendar is not cleared, then subsequent calls to this method with the same input return different values.
-        calendar.clear();
-        return millis - calendar.get(Calendar.ZONE_OFFSET);
+        return millis - getCalendar().get(Calendar.ZONE_OFFSET);
     }
     /**
      * Return the day of week according to the ISO 8601 specification. Week
@@ -775,7 +773,6 @@ public class DateTimeUtils {
      */
     public static long dateValueFromDate(long ms) {
         Calendar cal = getCalendar();
-        cal.clear();
         cal.setTimeInMillis(ms);
         return dateValueFromCalendar(cal);
     }
@@ -803,7 +800,6 @@ public class DateTimeUtils {
      */
     public static long nanosFromDate(long ms) {
         Calendar cal = getCalendar();
-        cal.clear();
         cal.setTimeInMillis(ms);
         return nanosFromCalendar(cal);
     }

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -501,9 +501,12 @@ public class DateTimeUtils {
      * @return the number of milliseconds in UTC
      */
     public static long getTimeUTCWithoutDst(long millis) {
-        return millis - getCalendar().get(Calendar.ZONE_OFFSET);
+        Calendar calendar = getCalendar();
+        // clearing calendar is work-around for bug with "Europe/Moscow" timezone with Java 1.8.0_60
+        // if calendar is not cleared, then subsequent calls to this method with the same input return different values.
+        calendar.clear();
+        return millis - calendar.get(Calendar.ZONE_OFFSET);
     }
-
     /**
      * Return the day of week according to the ISO 8601 specification. Week
      * starts at Monday. See also http://en.wikipedia.org/wiki/ISO_8601

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -473,6 +473,12 @@ public class TestDate extends TestBase {
                 ts2.getTimestamp(), Calendar.getInstance());
         assertEquals("-999-08-07 13:14:15.16", ts1a.getString());
         assertEquals("19999-08-07 13:14:15.16", ts2a.getString());
+
+        // test for bug on Java 1.8.0_60 in "Europe/Moscow" timezone. Doesn't affect most other timezones
+        long millis = 1407437460000L;
+        long result1 = DateTimeUtils.nanosFromDate(DateTimeUtils.getTimeUTCWithoutDst(millis));
+        long result2 = DateTimeUtils.nanosFromDate(DateTimeUtils.getTimeUTCWithoutDst(millis));
+        assertEquals(result1, result2);
     }
 
 }


### PR DESCRIPTION
I spent two days figuring out why I've been getting a spate of recent error reports from Russian customers showing H2 errors. It is a problem exposed on recent Java 1.8 releases with Calendar. It breaks the PageStore's binary searching of indexes. This manifested itself during UPDATE statements with what appeared to a corrupt database but actually was not.

To reproduce the problem, make sure you are using Java 1.8.0_60 or Java 1.8.0_66 (and possibly other Java 8 updates). This problem is on both Windows and OS X.

Set your computer to Europe/Moscow or launch Java with a timezone override:

java -Duser.timezone=Europe/Moscow ...

and execute the following code:

```
import org.h2.util.DateTimeUtils;

public class ScratchSpace {

    public static void main(String[] args) {
        long millis = 1407437460000L;

        System.out.println(millis + " " + getNanosFromMillis(millis));
        System.out.println(millis + " " + getNanosFromMillis(millis));
    }

    private static long getNanosFromMillis(long millis) {
        return DateTimeUtils.nanosFromDate(DateTimeUtils.getTimeUTCWithoutDst(millis));
    }

}
```

Notice that a different result occurs each time for what should be a deterministic function.
