### PR TITLE
Improve compatibility with oracle to_date RRRR

### DIFF
--- a/h2/src/main/org/h2/util/ToDateTokenizer.java
+++ b/h2/src/main/org/h2/util/ToDateTokenizer.java
@@ -37,10 +37,14 @@ class ToDateTokenizer {
     static final Pattern PATTERN_NUMBER = Pattern.compile("^([+-]?[0-9]+)");
 
     /**
-     * The pattern for for digits (typically a year).
+     * The pattern for four digits (typically a year).
      */
     static final Pattern PATTERN_FOUR_DIGITS = Pattern.compile("^([+-]?[0-9]{4})");
 
+    /**
+     * The pattern 2-4 digits (e.g. for RRRR).
+     */
+    static final Pattern PATTERN_TWO_TO_FOUR_DIGITS = Pattern.compile("^([+-]?[0-9]{2,4})");
     /**
      * The pattern for three digits.
      */
@@ -142,6 +146,8 @@ class ToDateTokenizer {
                     dateNr = Integer.parseInt(inputFragmentStr);
                     // Gregorian calendar does not have a year 0.
                     // 0 = 0001 BC, -1 = 0002 BC, ... so we adjust
+                    if (dateNr==0)
+                        throwException(params, "Year may not be zero");
                     result.set(Calendar.YEAR, dateNr >= 0 ? dateNr : dateNr + 1);
                     break;
                 case YYY:
@@ -155,9 +161,16 @@ class ToDateTokenizer {
                     break;
                 case RRRR:
                     inputFragmentStr = matchStringOrThrow(
-                            PATTERN_TWO_DIGITS, params, formatTokenEnum);
+                            PATTERN_TWO_TO_FOUR_DIGITS, params, formatTokenEnum);
                     dateNr = Integer.parseInt(inputFragmentStr);
-                    dateNr += dateNr < 50 ? 2000 : 1900;
+                    if (inputFragmentStr.length() < 4) {
+                        if (dateNr < 50)
+                            dateNr += 2000;
+                        else if (dateNr < 100)
+                            dateNr += 1900;
+                    }
+                    if (dateNr==0)
+                        throwException(params, "Year may not be zero");
                     result.set(Calendar.YEAR, dateNr);
                     break;
                 case RR:

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -1288,6 +1288,11 @@ public class TestFunctions extends TestBase implements AggregateFunction {
         } catch (Exception e) {
             assertEquals(DbException.class.getSimpleName(), e.getClass().getSimpleName());
         }
+
+        try {
+            ToDateParser.toDate("1-DEC-0000","DD-MON-RRRR");
+            fail("Oracle to_date should reject year 0 (ORA-01841)");
+        } catch (Exception e) { }
     }
 
     private void testToDate() throws ParseException {
@@ -1400,6 +1405,22 @@ public class TestFunctions extends TestBase implements AggregateFunction {
 
         date = new SimpleDateFormat("yyyy-MM-dd").parse("2013-01-29");
         assertEquals(date, ToDateParser.toDate("113029", "J"));
+
+        date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse("9999-12-31T23:59:59");
+        assertEquals(date, ToDateParser.toDate("31-DEC-9999 23:59:59","DD-MON-YYYY HH24:MI:SS"));
+        assertEquals(date, ToDateParser.toDate("31-DEC-9999 23:59:59","DD-MON-RRRR HH24:MI:SS"));
+
+
+        SimpleDateFormat ymd = new SimpleDateFormat("yyyy-MM-dd");
+        assertEquals(ymd.parse("0001-03-01"), ToDateParser.toDate("1-MAR-0001","DD-MON-RRRR"));
+        assertEquals(ymd.parse("9999-03-01"), ToDateParser.toDate("1-MAR-9999","DD-MON-RRRR"));
+        assertEquals(ymd.parse("2000-03-01"), ToDateParser.toDate("1-MAR-000","DD-MON-RRRR"));
+        assertEquals(ymd.parse("1999-03-01"), ToDateParser.toDate("1-MAR-099","DD-MON-RRRR"));
+        assertEquals(ymd.parse("0100-03-01"), ToDateParser.toDate("1-MAR-100","DD-MON-RRRR"));
+        assertEquals(ymd.parse("2000-03-01"), ToDateParser.toDate("1-MAR-00","DD-MON-RRRR"));
+        assertEquals(ymd.parse("2049-03-01"), ToDateParser.toDate("1-MAR-49","DD-MON-RRRR"));
+        assertEquals(ymd.parse("1950-03-01"), ToDateParser.toDate("1-MAR-50","DD-MON-RRRR"));
+        assertEquals(ymd.parse("1999-03-01"), ToDateParser.toDate("1-MAR-99","DD-MON-RRRR"));
     }
 
     private static void setMonth(Date date, int month) {


### PR DESCRIPTION
I tried the new oracle to_date support, but encountered a bug when I used this code: `to_date('31-DEC-9999 23:59:59','DD-MON-RRRR HH24:MI:SS')` (it produced a date in the year 1999)

RRRR is a bit of a weird design - if you provide a 2-digit year it calculates the century, if you provide a 3- or 4-digit year it treats that as absolute.

This change makes the RRRR behaviour more oracle-like.
