### PR TITLE
ignore call to setQueryTimeout

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -594,7 +594,7 @@ public class JdbcStatement extends TraceObject implements Statement {
             if (seconds < 0) {
                 throw DbException.getInvalidValueException("seconds", seconds);
             }
-            conn.setQueryTimeout(seconds);
+            // conn.setQueryTimeout(seconds); //TODO see issue 243
         } catch (Exception e) {
             throw logAndConvert(e);
         }


### PR DESCRIPTION
connection.setQueryTimeout() is misleading. public JDBC API  do not have such method for connection.
ignoring call that sets query time out for the session.
see https://github.com/h2database/h2database/issues/243
