### PR TITLE
fix recursive queries: support parameters

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -220,6 +220,7 @@ public class Parser {
     private boolean recompileAlways;
     private ArrayList<Parameter> indexedParameterList;
     private int orderInFrom;
+    private ArrayList<Parameter> suppliedParameterList;
 
     public Parser(Session session) {
         this.database = session.getDatabase();
@@ -311,7 +312,7 @@ public class Parser {
         currentPrepared = null;
         createView = null;
         recompileAlways = false;
-        indexedParameterList = null;
+        indexedParameterList = suppliedParameterList;
         read();
         return parsePrepared();
     }
@@ -4757,7 +4758,7 @@ public class Parser {
         }
         int id = database.allocateObjectId();
         TableView view = new TableView(schema, id, tempViewName, querySQL,
-                null, cols, session, true);
+                parameters, cols, session, true);
         view.setTableExpression(true);
         view.setTemporary(true);
         session.addLocalTempTable(view);
@@ -6097,6 +6098,10 @@ public class Parser {
 
     public void setRightsChecked(boolean rightsChecked) {
         this.rightsChecked = rightsChecked;
+    }
+
+    public void setSuppliedParameterList(ArrayList<Parameter> suppliedParameterList) {
+        this.suppliedParameterList = suppliedParameterList;
     }
 
     /**

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 import org.h2.api.ErrorCode;
+import org.h2.command.Parser;
 import org.h2.command.Prepared;
 import org.h2.command.dml.Query;
 import org.h2.command.dml.SelectUnion;
@@ -184,7 +185,10 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
             return new ViewCursor(this, recResult, first, last);
         }
         if (query == null) {
-            query = (Query) createSession.prepare(querySQL, true);
+            Parser parser = new Parser(createSession);
+            parser.setRightsChecked(true);
+            parser.setSuppliedParameterList(originalParameters);
+            query = (Query) parser.prepare(querySQL);
         }
         if (!query.isUnion()) {
             throw DbException.get(ErrorCode.SYNTAX_ERROR_2,

--- a/h2/src/test/org/h2/test/db/TestRecursiveQueries.java
+++ b/h2/src/test/org/h2/test/db/TestRecursiveQueries.java
@@ -123,6 +123,21 @@ public class TestRecursiveQueries extends TestBase {
         assertEquals(103, rs.getInt(1));
         assertFalse(rs.next());
 
+        prep = conn.prepareStatement("with recursive t(n) as " +
+                "(select ? union all select n+? from t where n<?) " +
+                "select * from t");
+        prep.setInt(1, 10);
+        prep.setInt(2, 2);
+        prep.setInt(3, 14);
+        rs = prep.executeQuery();
+        assertResultSetOrdered(rs, new String[][]{{"10"}, {"12"}, {"14"}});
+
+        prep.setInt(1, 100);
+        prep.setInt(2, 3);
+        prep.setInt(3, 103);
+        rs = prep.executeQuery();
+        assertResultSetOrdered(rs, new String[][]{{"100"}, {"103"}});
+
         conn.close();
         deleteDb("recursiveQueries");
     }


### PR DESCRIPTION
Originally "with"-subquery was added duplicated parameters.
Now "with"-subquery uses parameters from main query (through `suppliedParametersList`).
