### PR TITLE
fix recursive queries: infer column data types

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4746,6 +4746,7 @@ public class Parser {
         recursiveTable = schema.createTable(data);
         session.addLocalTempTable(recursiveTable);
         String querySQL;
+        Column[] columnTemplates = new Column[cols.length];
         try {
             read("AS");
             read("(");
@@ -4753,12 +4754,16 @@ public class Parser {
             read(")");
             withQuery.prepare();
             querySQL = StringUtils.fromCacheOrNew(withQuery.getPlanSQL());
+            ArrayList<Expression> withExpressions = withQuery.getExpressions();
+            for (int i = 0; i < cols.length; ++i) {
+                columnTemplates[i] = new Column(cols[i], withExpressions.get(i).getType());
+            }
         } finally {
             session.removeLocalTempTable(recursiveTable);
         }
         int id = database.allocateObjectId();
         TableView view = new TableView(schema, id, tempViewName, querySQL,
-                parameters, cols, session, true);
+                parameters, columnTemplates, session, true);
         view.setTableExpression(true);
         view.setTemporary(true);
         session.addLocalTempTable(view);

--- a/h2/src/main/org/h2/command/ddl/CreateView.java
+++ b/h2/src/main/org/h2/command/ddl/CreateView.java
@@ -16,8 +16,10 @@ import org.h2.engine.Session;
 import org.h2.expression.Parameter;
 import org.h2.message.DbException;
 import org.h2.schema.Schema;
+import org.h2.table.Column;
 import org.h2.table.Table;
 import org.h2.table.TableView;
+import org.h2.value.Value;
 
 /**
  * This class represents the statement
@@ -104,8 +106,15 @@ public class CreateView extends SchemaCommand {
             if (view == null) {
                 Schema schema = session.getDatabase().getSchema(session.getCurrentSchemaName());
                 sysSession.setCurrentSchema(schema);
+                Column[] columnTemplates = null;
+                if (columnNames != null) {
+                    columnTemplates = new Column[columnNames.length];
+                    for (int i = 0; i < columnNames.length; ++i) {
+                        columnTemplates[i] = new Column(columnNames[i], Value.UNKNOWN);
+                    }
+                }
                 view = new TableView(getSchema(), id, viewName, querySQL, null,
-                        columnNames, sysSession, false);
+                        columnTemplates, sysSession, false);
             } else {
                 view.replace(querySQL, columnNames, sysSession, false, force);
                 view.setModified();

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -95,7 +95,7 @@ public class Column {
             int displaySize) {
         this.name = name;
         this.type = type;
-        if (precision == -1 && scale == -1 && displaySize == -1) {
+        if (precision == -1 && scale == -1 && displaySize == -1 && type != Value.UNKNOWN) {
             DataType dt = DataType.getDataType(type);
             precision = dt.defaultPrecision;
             scale = dt.defaultScale;

--- a/h2/src/test/org/h2/test/db/TestRecursiveQueries.java
+++ b/h2/src/test/org/h2/test/db/TestRecursiveQueries.java
@@ -9,6 +9,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Types;
 import org.h2.test.TestBase;
 
 /**
@@ -137,6 +138,14 @@ public class TestRecursiveQueries extends TestBase {
         prep.setInt(3, 103);
         rs = prep.executeQuery();
         assertResultSetOrdered(rs, new String[][]{{"100"}, {"103"}});
+
+        rs = stat.executeQuery("with recursive t(i, s, d) as "
+                + "(select 1, '.', now() union all"
+                + " select i+1, s||'.', d from t where i<3)"
+                + " select * from t");
+        assertResultSetMeta(rs, 3, new String[]{ "I", "S", "D" },
+                new int[]{ Types.INTEGER, Types.VARCHAR, Types.TIMESTAMP },
+                null, null);
 
         conn.close();
         deleteDb("recursiveQueries");


### PR DESCRIPTION
Originally all columns of "with"-subquery are of type `VARCHAR`.
Now data types of columns are inferred using `withQuery.getExpressions().get(...).getType()`
