### PR TITLE
fixed: parameters index clash

### DIFF
--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -260,8 +260,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
         } else {
             len = 0;
         }
-        int idx = originalParameters == null ? 0 : originalParameters.size();
-        idx += view.getParameterOffset();
+        int idx = view.getParameterOffset(originalParameters);
         for (int i = 0; i < len; i++) {
             int mask = indexMasks[i];
             if ((mask & IndexCondition.EQUALITY) != 0) {
@@ -313,9 +312,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
         if (!q.allowGlobalConditions()) {
             return q;
         }
-        int firstIndexParam = originalParameters == null ?
-                0 : originalParameters.size();
-        firstIndexParam += view.getParameterOffset();
+        int firstIndexParam = view.getParameterOffset(originalParameters);
         IntArray paramIndex = new IntArray();
         int indexColumnCount = 0;
         for (int i = 0; i < masks.length; i++) {

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -557,8 +557,20 @@ public class TableView extends Table {
         return 0;
     }
 
-    public int getParameterOffset() {
-        return topQuery == null ? 0 : topQuery.getParameters().size();
+    public int getParameterOffset(ArrayList<Parameter> additionalParameters) {
+        int result = topQuery == null ? -1 : getMaxParameterIndex(topQuery.getParameters());
+        if (additionalParameters != null) {
+            result = Math.max(result, getMaxParameterIndex(additionalParameters));
+        }
+        return result + 1;
+    }
+
+    private int getMaxParameterIndex(ArrayList<Parameter> parameters) {
+        int result = -1;
+        for (Parameter p : parameters) {
+            result = Math.max(result, p.getIndex());
+        }
+        return result;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/testScript.sql
+++ b/h2/src/test/org/h2/test/testScript.sql
@@ -10181,3 +10181,19 @@ create table test(id int, name varchar);
 insert into test values(5, 'b'), (5, 'b'), (20, 'a');
 > update count: 3
 
+select 0 from ((
+  select 0 as f from dual u1 where null in (?, ?, ?, ?, ?)
+) union all (
+  select u2.f from (
+    select 0 as f from (
+      select 0 from dual u2f1f1 where now() = ?
+    ) u2f1
+  ) u2
+)) where f = 12345;
+{
+11, 22, 33, 44, 55, null
+> 0
+> -
+> rows: 0
+};
+> update count: 0


### PR DESCRIPTION
Originally parameter from `now() = ?`-condition may clashing with auto-propagated parameter for `12345`-value.
This causes the `Cannot parse "TIMESTAMP" constant "12345"` error.
