### PR TITLE
Added Eclipse resources to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+/.settings/
+/.classpath
+/.project


### PR DESCRIPTION
When working with Eclipse, some meta project files and directories are created, which shouldn't be part of the H2 project.

This change will help users ignore these resources, which facilitates further pull requests
