### PR TITLE
EXISTS predicate should not evaluate SELECT list

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2110,6 +2110,7 @@ public class Parser {
         if (readIf("EXISTS")) {
             read("(");
             Query query = parseSelect();
+            query.setExistsSubquery(true);
             // can not reduce expression because it might be a union except
             // query with distinct
             read(")");

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -224,7 +224,7 @@ public abstract class Query extends Prepared {
     public abstract void fireBeforeSelectTriggers();
 
     /**
-     * Indicate to this query that it is an exists subquery.
+     * Indicate to this query that it is wrapped inside an EXISTS().
      */
     public abstract void setExistsSubquery(boolean isExistsSubquery);
 

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -224,6 +224,11 @@ public abstract class Query extends Prepared {
     public abstract void fireBeforeSelectTriggers();
 
     /**
+     * Indicate to this query that it is an exists subquery.
+     */
+    public abstract void setExistsSubquery(boolean isExistsSubquery);
+
+    /**
      * Set the distinct flag.
      *
      * @param b the new value
@@ -565,5 +570,4 @@ public abstract class Query extends Prepared {
         isEverything(visitor);
         return visitor.getMaxDataModificationId();
     }
-
 }

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -82,6 +82,10 @@ public class Select extends Query {
     private boolean sortUsingIndex;
     private SortOrder sort;
     private int currentGroupRowId;
+
+    /**
+     * Indicate to this query that it is wrapped inside an EXISTS().
+     */
     private boolean isExistsSubquery;
 
     public Select(Session session) {

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -463,6 +463,10 @@ public class SelectUnion extends Query {
     }
 
     @Override
+    public void setExistsSubquery(boolean isExistsSubquery) {
+    }
+
+    @Override
     public int getType() {
         return CommandInterface.SELECT;
     }

--- a/h2/src/test/org/h2/test/testScript.sql
+++ b/h2/src/test/org/h2/test/testScript.sql
@@ -3,6 +3,30 @@
 -- Initial Developer: H2 Group
 --
 --- special grammar and test cases ---------------------------------------------------------------------------------------------
+select 1 a where exists (select 1 / 0);
+> A
+> -
+> 1
+> rows: 1
+
+select 1 a where exists (select 1 order by 1 / 0);
+> A
+> -
+> 1
+> rows (ordered): 1
+
+select 1 a where exists (select 1 / 0 union select 1 / 0);
+> exception
+
+select 1 a where exists (select 1 / 0 union all select 1 / 0);
+> exception
+
+select 1 a where exists (select 1 / 0 except select 1 / 0);
+> exception
+
+select 1 a where exists (select 1 / 0 intersect select 1 / 0);
+> exception
+
 create table test(id int) as select 1;
 > ok
 
@@ -10449,3 +10473,9 @@ create table z.z (id int);
 
 drop schema z;
 > ok
+
+select 1 a where exists (select 1 / 0);
+> A
+> -
+> 1
+> rows: 1

--- a/h2/src/test/org/h2/test/testScript.sql
+++ b/h2/src/test/org/h2/test/testScript.sql
@@ -10473,9 +10473,3 @@ create table z.z (id int);
 
 drop schema z;
 > ok
-
-select 1 a where exists (select 1 / 0);
-> A
-> -
-> 1
-> rows: 1


### PR DESCRIPTION
Most other databases optimise this. It would be reasonable for H2 to also optimise `EXISTS()` predicates by not evaluating the subquery's `SELECT` list.

The implementation suggested in this PR simply:
- Skips the optimisation step in `Select.prepare()`
- Skips calculating the results for the `SELECT` clause (unless there's a set operation, which makes things more complicated)

I can imagine other optimisations, too, such as avoiding `GROUP BY` or `ORDER BY` but I left them out to keep things simple for now.
