### PR TITLE
add support for "with"-subqueries into "join" & "sub-query" statements

### DIFF
--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -816,7 +816,10 @@ public class TableFilter implements ColumnResolver {
             }
             return buff.toString();
         }
-        buff.append(table.getSQL());
+        if ((table instanceof TableView) && ((TableView) table).isRecursive())
+            buff.append(table.getName());
+        else
+            buff.append(table.getSQL());
         if (table.isView() && ((TableView) table).isInvalid()) {
             throw DbException.get(ErrorCode.VIEW_IS_INVALID_2, table.getName(), "not compiled");
         }

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -579,6 +579,10 @@ public class TableView extends Table {
         return result;
     }
 
+    public boolean isRecursive() {
+        return recursive;
+    }
+
     @Override
     public boolean isDeterministic() {
         if (recursive || viewQuery == null) {

--- a/h2/src/test/org/h2/test/testScript.sql
+++ b/h2/src/test/org/h2/test/testScript.sql
@@ -10228,6 +10228,49 @@ select 0 from ((
 };
 > update count: 0
 
+explain with recursive r(n) as (
+    (select 1) union all (select n+1 from r where n < 3)
+)
+select n from r;
+> PLAN
+> -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+> WITH RECURSIVE R(N) AS ( (SELECT 1 FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX */) UNION ALL (SELECT (N + 1) FROM PUBLIC.R /* PUBLIC.R.tableScan */ WHERE N < 3) ) SELECT N FROM R /* null */
+> rows: 1
+
+select sum(n) from (
+    with recursive r(n) as (
+        (select 1) union all (select n+1 from r where n < 3)
+    )
+    select n from r
+);
+> SUM(N)
+> ------
+> 6
+> rows: 1
+
+select sum(n) from (select 0) join (
+    with recursive r(n) as (
+        (select 1) union all (select n+1 from r where n < 3)
+    )
+    select n from r
+) on 1=1;
+> SUM(N)
+> ------
+> 6
+> rows: 1
+
+select 0 from (
+    select 0 where 0 in (
+        with recursive r(n) as (
+            (select 1) union all (select n+1 from r where n < 3)
+        )
+        select n from r
+    )
+);
+> 0
+> -
+> rows: 0
+
 create table x(id int not null);
 > ok
 


### PR DESCRIPTION
Originally attempt using `with`-subqueries into `from` and `join` subqueries was failed.

Also fixed (as related issue):
- plan generation for `with`-subqueries
- `StackOverflowError` when using `with`-subqueries into deep-nested `in`-predicate (pull #253)
