### PR TITLE
Problem: org.h2.mvstore.db is not exported (OSGi)

### DIFF
--- a/h2/src/main/META-INF/MANIFEST.MF
+++ b/h2/src/main/META-INF/MANIFEST.MF
@@ -55,6 +55,7 @@ Export-Package: org.h2;version="${version}",
  org.h2.bnf;version="${version}",
  org.h2.bnf.context;version="${version}",
  org.h2.mvstore;version="${version}",
+ org.h2.mvstore.db;version="${version}",
  org.h2.mvstore.type;version="${version}",
  org.h2.mvstore.rtree;version="${version}"
 Premain-Class: org.h2.util.Profiler


### PR DESCRIPTION
This causes an ability to deploy applications that use classes like TransactionStore.

Solution: add  org.h2.mvstore.db to MANIFEST.MF
