### PR TITLE
Make Row an interface

### DIFF
--- a/h2/src/main/org/h2/result/Row.java
+++ b/h2/src/main/org/h2/result/Row.java
@@ -11,10 +11,10 @@ import org.h2.value.Value;
 /**
  * Represents a row in a table.
  */
-public abstract class Row implements SearchRow {
+public interface Row extends SearchRow {
 
-    public static final int MEMORY_CALCULATE = -1;
-    public static final Row[] EMPTY_ARRAY = {};
+    int MEMORY_CALCULATE = -1;
+    Row[] EMPTY_ARRAY = {};
 
     /**
      * Get a copy of the row that is distinct from (not equal to) this row.
@@ -22,14 +22,14 @@ public abstract class Row implements SearchRow {
      *
      * @return a new row with the same data
      */
-    public abstract Row getCopy();
+    Row getCopy();
 
     /**
      * Set version.
      *
      * @param version row version
      */
-    public abstract void setVersion(int version);
+    void setVersion(int version);
 
     /**
      * Get the number of bytes required for the data.
@@ -37,52 +37,52 @@ public abstract class Row implements SearchRow {
      * @param dummy the template buffer
      * @return the number of bytes
      */
-    public abstract int getByteCount(Data dummy);
+    int getByteCount(Data dummy);
 
     /**
      * Check if this is an empty row.
      *
      * @return {@code true} if the row is empty
      */
-    public abstract boolean isEmpty();
+    boolean isEmpty();
 
     /**
      * Mark the row as deleted.
      *
      * @param deleted deleted flag
      */
-    public abstract void setDeleted(boolean deleted);
+    void setDeleted(boolean deleted);
 
     /**
      * Set session id.
      *
      * @param sessionId the session id
      */
-    public abstract void setSessionId(int sessionId);
+    void setSessionId(int sessionId);
 
     /**
      * Get session id.
      *
      * @return the session id
      */
-    public abstract int getSessionId();
+    int getSessionId();
 
     /**
      * This record has been committed. The session id is reset.
      */
-    public abstract void commit();
+    void commit();
 
     /**
      * Check if the row is deleted.
      *
      * @return {@code true} if the row is deleted
      */
-    public abstract boolean isDeleted();
+    boolean isDeleted();
 
     /**
      * Get values.
      *
      * @return values
      */
-    public abstract Value[] getValueList();
+    Value[] getValueList();
 }

--- a/h2/src/main/org/h2/result/RowImpl.java
+++ b/h2/src/main/org/h2/result/RowImpl.java
@@ -14,7 +14,7 @@ import org.h2.value.ValueLong;
 /**
  * Default row implementation.
  */
-public class RowImpl extends Row {
+public class RowImpl implements Row {
     private long key;
     private final Value[] data;
     private int memory;


### PR DESCRIPTION
I ran benchmark [1] multiple times and it seems that there is no difference in performance (only a statistical deviation). This change will simplify embedding of H2 database engine.

Delta = (6292.681 - 6287.418) / 6292.681 = 0.0008 

=== Row class ===
Result "testSelect":
  6292.681 ±(99.9%) 79.794 ops/s Average
  min, avg, max = (5214.375, 6292.681, 6835.945), stdev = 337.855
  CI (99.9%): 6212.886, 6372.475 (assumes normal distribution)

Run complete. Total time: 00:06:49

Benchmark                   Mode  Cnt     Score    Error  Units
FullScanSelect.testSelect  thrpt  200  6292.681 ± 79.794  ops/s

=== Row interface ===
Result "testSelect":
  6287.418 ±(99.9%) 79.108 ops/s [Average]
  min, avg, max = (5133.814, 6287.418, 6972.724), stdev = 334.947
  CI (99.9%): 6208.310, 6366.526 (assumes normal distribution)

Run complete. Total time: 00:06:49

Benchmark                   Mode  Cnt     Score    Error  Units
FullScanSelect.testSelect  thrpt  200  6287.418 ± 79.108  ops/s

[1] https://github.com/svladykin/h2benchmarks/blob/master/src/main/java/org/h2/benchmarks/FullScanSelect.java
