### PR TITLE
Fix document of return value of TIMESTAMPADD method

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3500,7 +3500,7 @@ Use negative values to subtract units.
 addIntLong may be a long value when manipulating milliseconds,
 otherwise it's range is restricted to int.
 The same units as in the EXTRACT function are supported.
-This method returns a timestamp.
+DATEADD method returns a timestamp. TIMESTAMPADD method returns a long.
 ","
 DATEADD('MONTH', 1, DATE '2001-01-31')
 "


### PR DESCRIPTION
I found that this script fails with `Data conversion error converting "2016-08-15 15:17:22.961"; SQL statement:` error:

``` sql
drop table if exists t;
create table t (retry_at timestamp);
insert into t (retry_at) values ('2016-08-15 14:48:26.649');
update t set retry_at =
  case when retry_at = timestampadd('second', 0, now())
  then timestampadd('second', 1, retry_at)
  else timestampadd('second', 1, now()) end;
```

Replacing `timestamp` with `dateadd` fixed this issue. Thus I found that `timestampadd` is not strictly identical to `dateadd`.
This pull-request fixes the documents to reflect the actual behavior.
