### PR TITLE
Synchronized on database when unlock tables

### DIFF
--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -923,12 +923,14 @@ public class Session extends SessionWithState {
             }
         }
         if (locks.size() > 0) {
-            // don't use the enhanced for loop to save memory
-            for (int i = 0, size = locks.size(); i < size; i++) {
-                Table t = locks.get(i);
-                t.unlock(this);
+            synchronized (database) {
+                // don't use the enhanced for loop to save memory
+                for (int i = 0, size = locks.size(); i < size; i++) {
+                    Table t = locks.get(i);
+                    t.unlock(this);
+                }
+                locks.clear();
             }
-            locks.clear();
         }
         savepoints = null;
         sessionStateChanged = true;

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -923,14 +923,12 @@ public class Session extends SessionWithState {
             }
         }
         if (locks.size() > 0) {
-            synchronized (database) {
-                // don't use the enhanced for loop to save memory
-                for (int i = 0, size = locks.size(); i < size; i++) {
-                    Table t = locks.get(i);
-                    t.unlock(this);
-                }
-                locks.clear();
+            // don't use the enhanced for loop to save memory
+            for (int i = 0, size = locks.size(); i < size; i++) {
+                Table t = locks.get(i);
+                t.unlock(this);
             }
+            locks.clear();
         }
         savepoints = null;
         sessionStateChanged = true;

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -670,10 +670,10 @@ public class RegularTable extends TableBase {
             if (lockExclusiveSession == s) {
                 lockExclusiveSession = null;
             }
-            if (lockSharedSessions.size() > 0) {
-                lockSharedSessions.remove(s);
-            }
             synchronized (database) {
+                if (lockSharedSessions.size() > 0) {
+                    lockSharedSessions.remove(s);
+                }
                 if (!waitingSessions.isEmpty()) {
                     database.notifyAll();
                 }

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -266,7 +266,7 @@ java org.h2.test.TestAll timer
     /**
      * Whether the MVStore storage is used.
      */
-    public final boolean mvStore = Constants.VERSION_MINOR >= 4;
+    public boolean mvStore = Constants.VERSION_MINOR >= 4;
 
     /**
      * If the test should run with many rows.
@@ -297,6 +297,11 @@ java org.h2.test.TestAll timer
      * If the multi version concurrency control mode should be used.
      */
     public boolean mvcc = mvStore;
+
+    /**
+     * If the multi-threaded mode should be used.
+     */
+    public boolean multiThreaded;
 
     /**
      * The cipher to use (null for unencrypted).

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -280,6 +280,8 @@ public abstract class TestBase {
         if (config.mvStore) {
             url = addOption(url, "MV_STORE", "true");
             // url = addOption(url, "MVCC", "true");
+        } else {
+            url = addOption(url, "MV_STORE", "false");
         }
         if (!config.memory) {
             if (config.smallLog && admin) {
@@ -309,6 +311,9 @@ public abstract class TestBase {
         }
         if (config.mvcc) {
             url = addOption(url, "MVCC", "TRUE");
+        }
+        if (config.multiThreaded) {
+            url = addOption(url, "MULTI_THREADED", "TRUE");
         }
         if (config.cacheType != null && admin) {
             url = addOption(url, "CACHE_TYPE", config.cacheType);

--- a/h2/src/test/org/h2/test/synth/TestReleaseSelectLock.java
+++ b/h2/src/test/org/h2/test/synth/TestReleaseSelectLock.java
@@ -1,0 +1,80 @@
+package org.h2.test.synth;
+
+import org.h2.test.TestBase;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Tests lock releasing for concurrent select statements
+ */
+public class TestReleaseSelectLock extends TestBase {
+
+    private static final String TEST_DB_NAME = "releaseSelectLock";
+
+    /**
+     * Run just this test.
+     *
+     * @param a ignored
+     */
+    public static void main(String... a) throws Exception {
+        TestBase.createCaller().init().test();
+    }
+
+    @Override
+    public void test() throws Exception {
+        config.mvStore = false;
+        config.mvcc = false;
+        config.multiThreaded = true;
+
+        deleteDb(TEST_DB_NAME);
+
+        Connection conn = getConnection(TEST_DB_NAME);
+        final Statement statement = conn.createStatement();
+        statement.execute("create table test(id int primary key)");
+
+        runConcurrentSelects();
+
+        // check that all locks have been released by dropping the test table
+        statement.execute("drop table test");
+
+        statement.close();
+        conn.close();
+        deleteDb(TEST_DB_NAME);
+    }
+
+    private void runConcurrentSelects() throws InterruptedException {
+        int tryCount = 500;
+        int threadsCount = getSize(2, 4);
+        for (int tryNumber = 0; tryNumber < tryCount; tryNumber++) {
+            final CountDownLatch allFinished = new CountDownLatch(threadsCount);
+
+            for (int i = 0; i < threadsCount; i++) {
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            Connection conn = getConnection(TEST_DB_NAME);
+                            PreparedStatement stmt = conn.prepareStatement("select id from test");
+                            ResultSet rs = stmt.executeQuery();
+                            while (rs.next()) {
+                                rs.getInt(1);
+                            }
+                            stmt.close();
+                            conn.close();
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            allFinished.countDown();
+                        }
+                    }
+                }).start();
+            }
+
+            allFinished.await();
+        }
+    }
+}


### PR DESCRIPTION
I found a problem with table locking under heavy load. The error "Timeout trying to lock table T" happened when I try to drop a table. I made some tests in debug mode and found a cause of the problem: after multiple concurrent table reading variable  RegularTable.lockSharedSessions becomes corrupted (size = 1 but no elements inside) so every next drop attempt fails. In Session.unlockAll there is no synchronizing  on database section as it is in other similar methods.

I use h2 with  MULTI_THREADED=1 and MV_STORE=FALSE properties because we only read from tables after they were created. 

Also I found a workaround - set autocommit=false for select queries. In this case session invoke unlockReadLocks methods where  synchronized (database) is present.
