### PR TITLE
pg: send RowDescription in response to Describe (statement variant)

### DIFF
--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -209,6 +209,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.14.0.jar" +
+                File.pathSeparator + "ext/postgresql-8.3-603.jdbc3.jar" +
                 File.pathSeparator + javaToolsJar;
         FileList files;
         if (clientOnly) {
@@ -317,6 +318,9 @@ public class Build extends BuildBase {
         downloadOrVerify("ext/junit-4.12.jar",
                 "junit", "junit", "4.12",
                 "2973d150c0dc1fefe998f834810d68f278ea58ec", offline);
+        downloadOrVerify("ext/postgresql-8.3-603.jdbc3.jar",
+                "postgresql", "postgresql", "8.3-603.jdbc3",
+                "33d531c3c53055ddcbea3d88bfa093466ffef924", offline);
     }
 
     private void downloadOrVerify(String target, String group, String artifact,


### PR DESCRIPTION
According to https://www.postgresql.org/docs/9.1/static/protocol-flow.html

  The Describe message (statement variant) specifies the name of an
  existing prepared statement (or an empty string for the unnamed
  prepared statement). The response is a ParameterDescription message
  describing the parameters needed by the statement, followed by a
  RowDescription message describing the rows that will be returned when
  the statement is eventually executed (or a NoData message if the
  statement will not return rows)
