### PR TITLE
Add support for converting JAVA_OBJECT to UUID

### DIFF
--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -910,6 +910,14 @@ public abstract class Value {
                 case BYTES:
                     return ValueUuid.get(getBytesNoCopy());
                 case JAVA_OBJECT:
+                    Object object = JdbcUtils.deserialize(getBytesNoCopy(), getDataHandler());
+                    if (object instanceof java.util.UUID) {
+                        java.util.UUID uuid = (java.util.UUID) object;
+                        return ValueUuid.get(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+                    }
+                    else {
+                        throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, getString());
+                    }
                 case TIMESTAMP_TZ:
                     throw DbException.get(
                             ErrorCode.DATA_CONVERSION_ERROR_1, getString());

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -314,9 +314,9 @@ public abstract class Value {
             return 40;
         case BLOB:
             return 41;
-        case UUID:
-            return 42;
         case JAVA_OBJECT:
+            return 42;
+        case UUID:
             return 43;
         case GEOMETRY:
             return 44;

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -58,6 +58,7 @@ public class TestPreparedStatement extends TestBase {
         testExecuteUpdateCall(conn);
         testPrepareExecute(conn);
         testUUID(conn);
+        testUUIDAsJavaObject(conn);
         testScopedGeneratedKey(conn);
         testLobTempFiles(conn);
         testExecuteErrorTwice(conn);
@@ -449,6 +450,22 @@ public class TestPreparedStatement extends TestBase {
         PreparedStatement prep = conn.prepareStatement(
                 "insert into test_uuid values(?)");
         prep.setObject(1, uuid);
+        prep.execute();
+        ResultSet rs = stat.executeQuery("select * from test_uuid");
+        rs.next();
+        assertEquals("ffffffff-ffff-fffe-ffff-ffffffffffff", rs.getString(1));
+        Object o = rs.getObject(1);
+        assertEquals("java.util.UUID", o.getClass().getName());
+        stat.execute("drop table test_uuid");
+    }
+
+    private void testUUIDAsJavaObject(Connection conn) throws SQLException {
+        Statement stat = conn.createStatement();
+        stat.execute("create table test_uuid(id uuid primary key)");
+        UUID uuid = new UUID(-2, -1);
+        PreparedStatement prep = conn.prepareStatement(
+                "insert into test_uuid values(?)");
+        prep.setObject(1, uuid, java.sql.Types.JAVA_OBJECT);
         prep.execute();
         ResultSet rs = stat.executeQuery("select * from test_uuid");
         rs.next();

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -470,7 +470,7 @@ public class TestPreparedStatement extends TestBase {
         prep.execute();
 
         prep = conn.prepareStatement("select * from test_uuid where id=?");
-        prep.setObject(1, origUUID);
+        prep.setObject(1, origUUID, java.sql.Types.JAVA_OBJECT);
         ResultSet rs = prep.executeQuery();
         rs.next();
         Object o = rs.getObject(1);

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -286,11 +286,13 @@ public class TestValue extends TestBase {
         assertEquals("00000000-0000-4000-8000-000000000000", min.getString());
 
         // Test conversion from ValueJavaObject to ValueUuid
-        UUID origUUID = UUID.fromString("12345678-1234-4321-8765-123456789012");
+        String uuidStr = "12345678-1234-4321-8765-123456789012";
+
+        UUID origUUID = UUID.fromString(uuidStr);
         ValueJavaObject valObj = ValueJavaObject.getNoCopy(origUUID, null, null);
         Value valUUID = valObj.convertTo(Value.UUID);
         assertTrue(valUUID instanceof ValueUuid);
-        assertTrue((valUUID.getString().equals("12345678-1234-4321-8765-123456789012")));
+        assertTrue((valUUID.getString().equals(uuidStr)));
         assertTrue(valUUID.getObject().equals(origUUID));
 
         ValueJavaObject vo_string = ValueJavaObject.getNoCopy(new String("This is not a ValueUuid object"), null, null);

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -286,8 +286,10 @@ public class TestValue extends TestBase {
         assertEquals("00000000-0000-4000-8000-000000000000", min.getString());
 
         // Test conversion from ValueJavaObject to ValueUuid
-        ValueJavaObject vo_uuid = ValueJavaObject.getNoCopy(UUID.randomUUID(), null, null);
-        assertTrue(vo_uuid.convertTo(Value.UUID) instanceof ValueUuid);
+        ValueJavaObject valObj = ValueJavaObject.getNoCopy(UUID.fromString("12345678-1234-4321-8765-123456789012"), null, null);
+        Value valUUID = valObj.convertTo(Value.UUID);
+        assertTrue(valUUID instanceof ValueUuid);
+        assertTrue((valUUID.getString().equals("12345678-1234-4321-8765-123456789012")));
 
         ValueJavaObject vo_string = ValueJavaObject.getNoCopy(new String("This is not a ValueUuid object"), null, null);
         assertThrows(DbException.class, vo_string).convertTo(Value.UUID);

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -285,8 +285,12 @@ public class TestValue extends TestBase {
         ValueUuid min = ValueUuid.get(minHigh, minLow);
         assertEquals("00000000-0000-4000-8000-000000000000", min.getString());
 
-        ValueJavaObject vo = ValueJavaObject.getNoCopy(UUID.randomUUID(), null, null);
-        assertThrows(DbException.class, vo).convertTo(Value.UUID);
+        // Test conversion from ValueJavaObject to ValueUuid
+        ValueJavaObject vo_uuid = ValueJavaObject.getNoCopy(UUID.randomUUID(), null, null);
+        assertTrue(vo_uuid.convertTo(Value.UUID) instanceof ValueUuid);
+
+        ValueJavaObject vo_string = ValueJavaObject.getNoCopy(new String("This is not a ValueUuid object"), null, null);
+        assertThrows(DbException.class, vo_string).convertTo(Value.UUID);
     }
 
     private void testModulusDouble() {

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -286,10 +286,12 @@ public class TestValue extends TestBase {
         assertEquals("00000000-0000-4000-8000-000000000000", min.getString());
 
         // Test conversion from ValueJavaObject to ValueUuid
-        ValueJavaObject valObj = ValueJavaObject.getNoCopy(UUID.fromString("12345678-1234-4321-8765-123456789012"), null, null);
+        UUID origUUID = UUID.fromString("12345678-1234-4321-8765-123456789012");
+        ValueJavaObject valObj = ValueJavaObject.getNoCopy(origUUID, null, null);
         Value valUUID = valObj.convertTo(Value.UUID);
         assertTrue(valUUID instanceof ValueUuid);
         assertTrue((valUUID.getString().equals("12345678-1234-4321-8765-123456789012")));
+        assertTrue(valUUID.getObject().equals(origUUID));
 
         ValueJavaObject vo_string = ValueJavaObject.getNoCopy(new String("This is not a ValueUuid object"), null, null);
         assertThrows(DbException.class, vo_string).convertTo(Value.UUID);


### PR DESCRIPTION
I added support for converting from a JAVA_OBJECT to a UUID for better compatibility with the way Postgres handles things.

I tried to modify TestPgServer.java to test the use of UUIDs, but the Postgres driver requires the back-end server to be at least v8.3 to support UUIDs correctly.  Currently, H2 only emulates v8.1.4.  As an experiment, I changed the reported server version to 8.3, but other things started breaking in TestPgServer, so presumably the Postgres driver was expecting additional behaviour that is not implemented by H2.  When that behaviour is implemented later, we can add in proper UUID testing in TestPgServer.java.
