### PR TITLE
Support for BEFORE and AFTER clauses when using multiple columns in A…

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -226,8 +226,8 @@ ALTER SEQUENCE SEQ_ID RESTART WITH 1000
 
 "Commands (DDL)","ALTER TABLE ADD","
 ALTER TABLE [ IF EXISTS ] tableName ADD [ COLUMN ]
-{ [ IF NOT EXISTS ] columnDefinition [ { BEFORE | AFTER } columnName ]
-    | ( { columnDefinition } [,...] ) }
+{ [ IF NOT EXISTS ] columnDefinition | ( { columnDefinition } [,...] ) }
+[ { BEFORE | AFTER } columnName ]
 ","
 Adds a new column to a table.
 This command commits an open transaction in this connection.

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -5719,7 +5719,11 @@ public class Parser {
                 columnsToAdd.add(column);
             } while (readIf(","));
             read(")");
-            command.setNewColumns(columnsToAdd);
+            if (readIf("BEFORE")) {
+                command.setAddBefore(readColumnIdentifier());
+            } else if (readIf("AFTER")) {
+                command.setAddAfter(readColumnIdentifier());
+            }
         } else {
             boolean ifNotExists = readIfNotExists();
             command.setIfNotExists(ifNotExists);

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -84,8 +84,8 @@ ALTER SEQUENCE [ IF EXISTS ] sequenceName [ RESTART WITH long ] [ INCREMENT BY l
 Changes the parameters of a sequence."
 "Commands (DDL)","ALTER TABLE ADD","
 ALTER TABLE [ IF EXISTS ] tableName ADD [ COLUMN ]
-{ [ IF NOT EXISTS ] columnDefinition [ { BEFORE | AFTER } columnName ]
-    | ( { columnDefinition } [,...] ) }
+{ [ IF NOT EXISTS ] columnDefinition | ( { columnDefinition } [,...] ) }
+[ { BEFORE | AFTER } columnName ]
 ","
 Adds a new column to a table."
 "Commands (DDL)","ALTER TABLE ADD CONSTRAINT","

--- a/h2/src/test/org/h2/test/db/TestAlter.java
+++ b/h2/src/test/org/h2/test/db/TestAlter.java
@@ -48,6 +48,8 @@ public class TestAlter extends TestBase {
         testAlterTableAlterColumn2();
         testAlterTableAddColumnBefore();
         testAlterTableAddColumnAfter();
+        testAlterTableAddMultipleColumnsBefore();
+        testAlterTableAddMultipleColumnsAfter();
         testAlterTableModifyColumn();
         conn.close();
         deleteDb(getTestName());
@@ -204,6 +206,38 @@ public class TestAlter extends TestBase {
         stat.execute("create table t(x varchar) as select 'x'");
         stat.execute("alter table t add (y int)");
         stat.execute("drop table t");
+    }
+
+    // column and field names must be upper-case due to getMetaData sensitivity
+    private void testAlterTableAddMultipleColumnsBefore() throws SQLException {
+        stat.execute("create table T(X varchar)");
+        stat.execute("alter table T add (Y int, Z int) before X");
+        DatabaseMetaData dbMeta = conn.getMetaData();
+        ResultSet rs = dbMeta.getColumns(null, null, "T", null);
+        assertTrue(rs.next());
+        assertEquals("Y", rs.getString("COLUMN_NAME"));
+        assertTrue(rs.next());
+        assertEquals("Z", rs.getString("COLUMN_NAME"));
+        assertTrue(rs.next());
+        assertEquals("X", rs.getString("COLUMN_NAME"));
+        assertFalse(rs.next());
+        stat.execute("drop table T");
+    }
+
+    // column and field names must be upper-case due to getMetaData sensitivity
+    private void testAlterTableAddMultipleColumnsAfter() throws SQLException {
+        stat.execute("create table T(X varchar)");
+        stat.execute("alter table T add (Y int, Z int) after X");
+        DatabaseMetaData dbMeta = conn.getMetaData();
+        ResultSet rs = dbMeta.getColumns(null, null, "T", null);
+        assertTrue(rs.next());
+        assertEquals("X", rs.getString("COLUMN_NAME"));
+        assertTrue(rs.next());
+        assertEquals("Y", rs.getString("COLUMN_NAME"));
+        assertTrue(rs.next());
+        assertEquals("Z", rs.getString("COLUMN_NAME"));
+        assertFalse(rs.next());
+        stat.execute("drop table T");
     }
 
     // column and field names must be upper-case due to getMetaData sensitivity


### PR DESCRIPTION
…LTER TABLE ADD.

As discussed in [Quickly adding multiple columns at a certain position](https://groups.google.com/forum/#!topic/h2-database/1m32ZgtciqU), I implemented `BEFORE` and `AFTER` clauses for `ALTER TABLE ADD` with multiple columns.

I had some issue building and testing, but the relevant tests seem to have run through successfully.

Please let me know, if this works for you.

Thanks.
