### PR TITLE
Server: use xdg-open to open the WebConsole in the user's preferred browser on Linux

### DIFF
--- a/h2/src/main/org/h2/tools/Server.java
+++ b/h2/src/main/org/h2/tools/Server.java
@@ -670,9 +670,9 @@ public class Server extends Tool implements Runnable, ShutdownHandler {
                 // Mac OS: to open a page with Safari, use "open -a Safari"
                 Runtime.getRuntime().exec(new String[] { "open", url });
             } else {
-                String[] browsers = { "chromium", "google-chrome", "firefox",
-                        "mozilla-firefox", "mozilla", "konqueror", "netscape",
-                        "opera", "midori" };
+                String[] browsers = { "xdg-open", "chromium", "google-chrome",
+                        "firefox", "mozilla-firefox", "mozilla", "konqueror",
+                        "netscape", "opera", "midori" };
                 boolean ok = false;
                 for (String b : browsers) {
                     try {


### PR DESCRIPTION
Use xdg-open if available to open the WebConsole.

[xdg-open](https://portland.freedesktop.org/doc/xdg-open.html) is a standard tool on Linux distributions to open URL or files with the user's preferred applications, in this case his preferred Web Browser.
