### PR TITLE
Add support for getObject(int|String, Class)

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcCallableStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcCallableStatement.java
@@ -1571,7 +1571,7 @@ public class JdbcCallableStatement extends JdbcPreparedStatement implements
      */
     @Override
     public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
-        throw unsupported("getObject");
+        return getOpenResultSet().getObject(parameterIndex, type);
     }
 
     /**
@@ -1582,7 +1582,7 @@ public class JdbcCallableStatement extends JdbcPreparedStatement implements
      */
     @Override
     public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
-        throw unsupported("getObject");
+        return getObject(getIndexForName(parameterName), type);
     }
 
     private ResultSetMetaData getCheckedMetaData() throws SQLException {

--- a/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
@@ -23,6 +23,7 @@ import java.sql.Types;
 import java.util.Collections;
 
 import org.h2.api.ErrorCode;
+import org.h2.jdbc.JdbcCallableStatementBackwardsCompat;
 import org.h2.test.TestBase;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.IOUtils;
@@ -147,6 +148,7 @@ public class TestCallableStatement extends TestBase {
         assertEquals(1, call.getLong(1));
         assertEquals(1, call.getByte(1));
         assertEquals(1, ((Long) call.getObject(1)).longValue());
+        assertEquals(1, ((JdbcCallableStatementBackwardsCompat) call).getObject(1, Long.class).longValue());
         assertFalse(call.wasNull());
 
         call.setFloat(2, 1.1f);

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.TimeZone;
 
 import org.h2.api.ErrorCode;
+import org.h2.jdbc.JdbcResultSetBackwardsCompat;
 import org.h2.test.TestBase;
 import org.h2.util.IOUtils;
 
@@ -670,7 +671,15 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof Integer);
         assertTrue(((Integer) o).intValue() == -1);
+        o = ((JdbcResultSetBackwardsCompat) rs).getObject("value", Integer.class);
+        trace(o.getClass().getName());
+        assertTrue(o instanceof Integer);
+        assertTrue(((Integer) o).intValue() == -1);
         o = rs.getObject(2);
+        trace(o.getClass().getName());
+        assertTrue(o instanceof Integer);
+        assertTrue(((Integer) o).intValue() == -1);
+        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, Integer.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof Integer);
         assertTrue(((Integer) o).intValue() == -1);
@@ -719,6 +728,9 @@ public class TestResultSet extends TestBase {
         assertTrue(rs.getString(1).equals("6") && !rs.wasNull());
         assertTrue(rs.getString(2) == null && rs.wasNull());
         o = rs.getObject(2);
+        assertTrue(o == null);
+        assertTrue(rs.wasNull());
+        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, Integer.class);
         assertTrue(o == null);
         assertTrue(rs.wasNull());
         assertFalse(rs.next());
@@ -780,6 +792,10 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof String);
         assertTrue(o.toString().equals("Hi"));
+        o = ((JdbcResultSetBackwardsCompat) rs).getObject("value", String.class);
+        trace(o.getClass().getName());
+        assertTrue(o instanceof String);
+        assertTrue(o.equals("Hi"));
         rs.next();
         value = rs.getString(2);
         trace("Value: <" + value + "> (should be: < Hi >)");
@@ -845,6 +861,10 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof BigDecimal);
         assertTrue(((BigDecimal) o).compareTo(new BigDecimal("-1.00")) == 0);
+        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, BigDecimal.class);
+        trace(o.getClass().getName());
+        assertTrue(o instanceof BigDecimal);
+        assertTrue(((BigDecimal) o).compareTo(new BigDecimal("-1.00")) == 0);
 
         rs.next();
         assertTrue(rs.getInt(1) == 2);
@@ -905,7 +925,15 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof Double);
         assertTrue(((Double) o).compareTo(new Double("-1.00")) == 0);
+        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, Double.class);
+        trace(o.getClass().getName());
+        assertTrue(o instanceof Double);
+        assertTrue(((Double) o).compareTo(new Double("-1.00")) == 0);
         o = rs.getObject(3);
+        trace(o.getClass().getName());
+        assertTrue(o instanceof Float);
+        assertTrue(((Float) o).compareTo(new Float("-1.00")) == 0);
+        o = ((JdbcResultSetBackwardsCompat) rs).getObject(3, Float.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof Float);
         assertTrue(((Float) o).compareTo(new Float("-1.00")) == 0);
@@ -1009,6 +1037,12 @@ public class TestResultSet extends TestBase {
         assertTrue(((java.sql.Timestamp) o).equals(
                 java.sql.Timestamp.valueOf("2011-11-11 00:00:00.0")));
         assertFalse(rs.wasNull());
+        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, java.sql.Timestamp.class);
+        trace(o.getClass().getName());
+        assertTrue(o instanceof java.sql.Timestamp);
+        assertTrue(((java.sql.Timestamp) o).equals(
+                        java.sql.Timestamp.valueOf("2011-11-11 00:00:00.0")));
+        assertFalse(rs.wasNull());
         rs.next();
 
         date = rs.getDate("VALUE");
@@ -1045,6 +1079,12 @@ public class TestResultSet extends TestBase {
         date = (Date) rs.getObject(1);
         time = (Time) rs.getObject(2);
         ts = (Timestamp) rs.getObject(3);
+        assertEquals("2001-02-03", date.toString());
+        assertEquals("14:15:16", time.toString());
+        assertEquals("2007-08-09 10:11:12.141516171", ts.toString());
+        date = ((JdbcResultSetBackwardsCompat) rs).getObject(1, Date.class);
+        time = ((JdbcResultSetBackwardsCompat) rs).getObject(2, Time.class);
+        ts = ((JdbcResultSetBackwardsCompat) rs).getObject(3, Timestamp.class);
         assertEquals("2001-02-03", date.toString());
         assertEquals("14:15:16", time.toString());
         assertEquals("2007-08-09 10:11:12.141516171", ts.toString());


### PR DESCRIPTION
Both JdbcResultSet and JdbcCallableStatement currently do not support
getObject(int, Class) and getObject(String, Class) but support is easy
to add.

This commits contains the following changes:
- add support for getObject(int, Class) and getObject(String, Class)
  with the following types: BigDecimal, String, Boolean, Byte, Short,
  Integer, Long, Float, Double, Date, Time, Timestamp, UUID,
  TimestampWithTimeZone and Geometry subclasses
- extend the existing getObject tests to cover these new methods

Most notably missing is support for LOBs and arrays including primitive
arrays but this can always be added later.
