### PR TITLE
Added missing source encoding. Assuming UTF-8.

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -37,6 +37,7 @@
     <derby.version>10.10.1.1</derby.version>
     <osgi.version>4.2.0</osgi.version>
     <slf4j.version>1.6.0</slf4j.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fix for:

```
[WARNING] File encoding has not been set, using platform encoding US-ASCII, i.e. build is platform dependent!
```

as mentioned in [Maven build issues](https://groups.google.com/d/msg/h2-database/J0XFc8LcFAk/LEZhSkUlBAAJ).
