### PR TITLE
Change getters in TimestampWithTimeZone to int

### DIFF
--- a/h2/src/main/org/h2/api/TimestampWithTimeZone.java
+++ b/h2/src/main/org/h2/api/TimestampWithTimeZone.java
@@ -46,15 +46,15 @@ public class TimestampWithTimeZone implements Serializable, Cloneable {
         return dateValue;
     }
 
-    public long getYear() {
+    public int getYear() {
         return DateTimeUtils.yearFromDateValue(dateValue);
     }
 
-    public long getMonth() {
+    public int getMonth() {
         return DateTimeUtils.monthFromDateValue(dateValue);
     }
 
-    public long getDay() {
+    public int getDay() {
         return DateTimeUtils.dayFromDateValue(dateValue);
     }
 


### PR DESCRIPTION
The convenience accessors getYear getMonth and getDay in
TimestampWithTimeZone return long even though their values fall within
the range of int. This makes them a bit inconvenient to work with as
most APIs (Calendar, LocalDateTime) take int for such values.

This commit contains the following changes
- change TimestampWithTimeZone#getYear() to return an int instead of
  a long
- change TimestampWithTimeZone#getMonth() to return an int instead of
  a long
- change TimestampWithTimeZone#getDay() to return an int instead of
  a long
