### PR TITLE
Added support to define last IDENTIFIER on a Trigger.

### DIFF
--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -78,6 +78,7 @@ public class Session extends SessionWithState {
     private int lockTimeout;
     private Value lastIdentity = ValueLong.get(0);
     private Value lastScopeIdentity = ValueLong.get(0);
+    private Value lastTriggerIdentity = null;
     private int firstUncommittedLog = Session.LOG_WRITTEN;
     private int firstUncommittedPos = Session.LOG_WRITTEN;
     private HashMap<String, Savepoint> savepoints;
@@ -998,6 +999,14 @@ public class Session extends SessionWithState {
 
     public Value getLastScopeIdentity() {
         return lastScopeIdentity;
+    }
+
+    public void setLastTriggerIdentity(Value last) {
+        this.lastTriggerIdentity = last;
+    }
+
+    public Value getLastTriggerIdentity() {
+        return lastTriggerIdentity;
     }
 
     /**

--- a/h2/src/main/org/h2/schema/TriggerObject.java
+++ b/h2/src/main/org/h2/schema/TriggerObject.java
@@ -262,7 +262,12 @@ public class TriggerObject extends SchemaObjectBase {
                 throw DbException.convert(e);
             }
         } finally {
-            session.setLastScopeIdentity(identity);
+            if (session.getLastTriggerIdentity() != null) {
+                session.setLastScopeIdentity(session.getLastTriggerIdentity());
+                session.setLastTriggerIdentity(null);
+            } else {
+                session.setLastScopeIdentity(identity);
+            }
             session.setCommitOrRollbackDisabled(oldDisabled);
             session.setAutoCommit(old);
         }

--- a/h2/src/main/org/h2/schema/TriggerObject.java
+++ b/h2/src/main/org/h2/schema/TriggerObject.java
@@ -167,7 +167,12 @@ public class TriggerObject extends SchemaObjectBase {
             throw DbException.get(ErrorCode.ERROR_EXECUTING_TRIGGER_3, e, getName(),
                     triggerClassName != null ? triggerClassName : "..source..", e.toString());
         } finally {
-            session.setLastScopeIdentity(identity);
+            if (session.getLastTriggerIdentity() != null) {
+                session.setLastScopeIdentity(session.getLastTriggerIdentity());
+                session.setLastTriggerIdentity(null);
+            } else {
+                session.setLastScopeIdentity(identity);
+            }
             if (type != Trigger.SELECT) {
                 session.setCommitOrRollbackDisabled(old);
             }

--- a/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
+++ b/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
@@ -337,14 +337,13 @@ public class TestTriggersConstraints extends TestBase implements Trigger {
         public void init(Connection conn, String schemaName,
                 String triggerName, String tableName, boolean before, int type)
                 throws SQLException {
-            prepInsert = conn.prepareStatement("insert into test values(?)", Statement.RETURN_GENERATED_KEYS);
+            prepInsert = conn.prepareStatement("insert into test values()", Statement.RETURN_GENERATED_KEYS);
         }
 
         @Override
         public void fire(Connection conn, Object[] oldRow, Object[] newRow)
                 throws SQLException {
             if (newRow != null) {
-                prepInsert.setInt(1, (Integer) newRow[0]);
                 prepInsert.execute();
                 ResultSet rs = prepInsert.getGeneratedKeys();
                 if (rs.next()) {

--- a/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
+++ b/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
@@ -15,9 +15,12 @@ import java.util.HashSet;
 
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
+import org.h2.engine.Session;
+import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestBase;
 import org.h2.tools.TriggerAdapter;
 import org.h2.util.Task;
+import org.h2.value.ValueLong;
 
 /**
  * Tests for trigger and constraints.
@@ -44,6 +47,7 @@ public class TestTriggersConstraints extends TestBase implements Trigger {
         testTriggerAdapter();
         testTriggerSelectEachRow();
         testViewTrigger();
+        testViewTriggerGeneratedKeys();
         testTriggerBeforeSelect();
         testTriggerAlterTable();
         testTriggerAsSource();
@@ -202,6 +206,44 @@ public class TestTriggersConstraints extends TestBase implements Trigger {
         stat.execute("drop table test");
         conn.close();
     }
+    
+    private void testViewTriggerGeneratedKeys() throws SQLException {
+        Connection conn;
+        Statement stat;
+        conn = getConnection("trigger");
+        stat = conn.createStatement();
+        stat.execute("drop table if exists test");
+        stat.execute("create table test(id int identity)");
+        stat.execute("create view test_view as select * from test");
+        stat.execute("create trigger test_view_insert " +
+                "instead of insert on test_view for each row call \"" +
+                TestViewGeneratedKeys.class.getName() + "\"");
+        if (!config.memory) {
+            conn.close();
+            conn = getConnection("trigger");
+            stat = conn.createStatement();
+        }
+        
+        PreparedStatement pstat;
+        pstat = conn.prepareStatement("insert into test_view values()", Statement.RETURN_GENERATED_KEYS);
+        int count = pstat.executeUpdate();
+        assertEquals(1, count);
+        
+        ResultSet gkRs;
+        gkRs = pstat.getGeneratedKeys();
+        
+        assertTrue(gkRs.next());
+        assertEquals(1, gkRs.getInt(1));
+        assertFalse(gkRs.next());
+        
+        ResultSet rs;
+        rs = stat.executeQuery("select * from test");
+        assertTrue(rs.next());
+        assertFalse(rs.next());
+        stat.execute("drop view test_view");
+        stat.execute("drop table test");
+        conn.close();
+    }
 
     /**
      * A test trigger adapter implementation.
@@ -272,6 +314,44 @@ public class TestTriggersConstraints extends TestBase implements Trigger {
             if (newRow != null) {
                 prepInsert.setInt(1, (Integer) newRow[0]);
                 prepInsert.execute();
+            }
+        }
+
+        @Override
+        public void close() {
+            // ignore
+        }
+
+        @Override
+        public void remove() {
+            // ignore
+        }
+
+    }
+    
+    public static class TestViewGeneratedKeys implements Trigger {
+
+        PreparedStatement prepInsert;
+
+        @Override
+        public void init(Connection conn, String schemaName,
+                String triggerName, String tableName, boolean before, int type)
+                throws SQLException {
+            prepInsert = conn.prepareStatement("insert into test values(?)", Statement.RETURN_GENERATED_KEYS);
+        }
+
+        @Override
+        public void fire(Connection conn, Object[] oldRow, Object[] newRow)
+                throws SQLException {
+            if (newRow != null) {
+                prepInsert.setInt(1, (Integer) newRow[0]);
+                prepInsert.execute();
+                ResultSet rs = prepInsert.getGeneratedKeys();
+                if (rs.next()) {
+                    JdbcConnection jconn = (JdbcConnection) conn;
+                    Session session = (Session) jconn.getSession();
+                    session.setLastTriggerIdentity(ValueLong.get(rs.getLong(1)));
+                }
             }
         }
 


### PR DESCRIPTION
Using a new variable holder on session we can maintain compatibility with current version without break any code in use.
This new variable holder, if defined inside a trigger, is used a last IDENTIFIER.
It is very useful if you are implementing a VIEW with support to INSERT and needs Statement.RETURN_GENERATED_KEYS value.
