### PR TITLE
fix compare TIMESTAMP WITH TIMEZONE

### DIFF
--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -290,15 +290,21 @@ public class ValueTimestampTimeZone extends Value {
     @Override
     protected int compareSecure(Value o, CompareMode mode) {
         ValueTimestampTimeZone t = (ValueTimestampTimeZone) o;
-        int c = MathUtils.compareLong(dateValue, t.dateValue);
+        long a = DateTimeUtils.convertDateValueToMillis(TimeZone.getTimeZone("UTC"), dateValue) / ( 1000L * 60L );
+        long ma = timeNanos / ( 1000L * 1000L * 1000L * 60L );
+        a += ma;
+        a -= timeZoneOffsetMins;
+        long b = DateTimeUtils.convertDateValueToMillis(TimeZone.getTimeZone("UTC"), t.dateValue) / ( 1000L * 60L );
+        long mb = t.timeNanos / ( 1000L * 1000L * 1000L * 60L );
+        b += mb;
+        b -= t.timeZoneOffsetMins;
+        int c = MathUtils.compareLong(a, b);
         if (c != 0) {
             return c;
         }
-        c = MathUtils.compareLong(timeNanos, t.timeNanos);
-        if (c != 0) {
-            return c;
-        }
-        return MathUtils.compareInt(timeZoneOffsetMins, t.timeZoneOffsetMins);
+        long na = timeNanos - ( ma * 1000L * 1000L * 1000L * 60L );
+        long nb = t.timeNanos - ( mb * 1000L * 1000L * 1000L * 60L );
+        return MathUtils.compareLong(na, nb);
     }
 
     @Override

--- a/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
+++ b/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.TimestampWithTimeZone;
 import org.h2.test.TestBase;
+import org.h2.value.ValueTimestampTimeZone;
 
 /**
  */
@@ -29,6 +30,10 @@ public class TestTimeStampWithTimeZone extends TestBase {
     public void test() throws SQLException {
         deleteDb(getTestName());
         test1();
+        test2();
+        test3();
+        test4();
+        testOrder();
         deleteDb(getTestName());
     }
 
@@ -78,6 +83,39 @@ public class TestTimeStampWithTimeZone extends TestBase {
         assertEquals(31, ts.getDay());
         rs.close();
         stat.close();
+        conn.close();
+    }
+
+    private void test2() {
+    	ValueTimestampTimeZone a = ValueTimestampTimeZone.parse("1970-01-01 12:00:00.00+00:15");
+    	ValueTimestampTimeZone b = ValueTimestampTimeZone.parse("1970-01-01 12:00:01.00+01:15");
+    	int c= a.compareTo(b, null);
+    	assertEquals(c, 1);
+    }
+    
+    private void test3() {
+    	ValueTimestampTimeZone a = ValueTimestampTimeZone.parse("1970-01-02 00:00:02.00+01:15");
+    	ValueTimestampTimeZone b = ValueTimestampTimeZone.parse("1970-01-01 23:00:01.00+00:15");
+    	int c= a.compareTo(b, null);
+    	assertEquals(c, 1);
+    }
+
+    private void test4() {
+    	ValueTimestampTimeZone a = ValueTimestampTimeZone.parse("1970-01-02 00:00:01.00+01:15");
+    	ValueTimestampTimeZone b = ValueTimestampTimeZone.parse("1970-01-01 23:00:01.00+00:15");
+    	int c= a.compareTo(b, null);
+    	assertEquals(c, 0);
+    }
+
+    private void testOrder() throws SQLException {
+        Connection conn = getConnection(getTestName());
+        Statement stat = conn.createStatement();
+        stat.execute("create table test_order(id identity, t1 timestamp with timezone)");
+        stat.execute("insert into test_order(t1) values('1970-01-01 12:00:00.00+00:15')");
+        stat.execute("insert into test_order(t1) values('1970-01-01 12:00:01.00+01:15')");
+        ResultSet rs = stat.executeQuery("select t1 from test_order order by t1");
+        rs.next();
+        assertEquals("1970-01-01 12:00:01.0+01:15", rs.getString(1));
         conn.close();
     }
 


### PR DESCRIPTION
I`m found bug in compare timestamp with timezone.
Normal sorting (PostgreSQL 9.4):
postgres=# create table t ( id serial, dt timestamp with time zone );
CREATE TABLE
postgres=# insert into t (dt) values ('2016-01-01 12:00:00+03:00');
INSERT 0 1
postgres=# insert into t (dt) values ('2016-01-01 12:00:01+04:00');
INSERT 0 1
postgres=# insert into t (dt) values ('2016-01-01 12:00:02+02:00');
INSERT 0 1
postgres=# select \* from t order by dt;
 id |           dt  
----+------------------------
  2 | 2016-01-01 11:00:01+03
  1 | 2016-01-01 12:00:00+03
  3 | 2016-01-01 13:00:02+03
(3 rows)

Invalid sorting (h2-1.4.192):
mem:=> create table t ( id serial, dt timestamp with timezone );
UPDATE 0
mem:=> insert into t (dt) values ('2016-01-01 12:00:00+03:00');
INSERT 0 1
mem:=> insert into t (dt) values ('2016-01-01 12:00:01+04:00');
INSERT 0 1
mem:=> insert into t (dt) values ('2016-01-01 12:00:02+02:00');
INSERT 0 1
mem:=> select \* from t order by dt;
 id |            dt  
----+--------------------------
  1 | 2016-01-01 12:00:00.0+03
  2 | 2016-01-01 12:00:01.0+04
  3 | 2016-01-01 12:00:02.0+02
(3 rows)
