### PR TITLE
Support byte[] in getObject

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3757,6 +3757,8 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             return type.cast(value.getTimestamp());
         } else if (type == UUID.class) {
             return type.cast(value.getObject());
+        } else if (type == byte[].class) {
+            return type.cast(value.getBytes());
         } else if (type == TimestampWithTimeZone.class) {
             return type.cast(value.getObject());
         } else if (type.isAssignableFrom(Geometry.class)) {

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1227,10 +1227,18 @@ public class TestResultSet extends TestBase {
                 (byte) 0x01, (byte) 0x01 },
                 rs.getBytes(2));
         assertTrue(!rs.wasNull());
+        assertEqualsWithNull(new byte[] { (byte) 0x01, (byte) 0x01,
+                (byte) 0x01, (byte) 0x01 },
+                ((JdbcResultSetBackwardsCompat) rs).getObject(2, byte[].class));
+        assertTrue(!rs.wasNull());
         rs.next();
         assertEqualsWithNull(new byte[] { (byte) 0x02, (byte) 0x02,
                 (byte) 0x02, (byte) 0x02 },
                 rs.getBytes("value"));
+        assertTrue(!rs.wasNull());
+        assertEqualsWithNull(new byte[] { (byte) 0x02, (byte) 0x02,
+                (byte) 0x02, (byte) 0x02 },
+                ((JdbcResultSetBackwardsCompat) rs).getObject("value", byte[].class));
         assertTrue(!rs.wasNull());
         rs.next();
         assertEqualsWithNull(new byte[] { (byte) 0x00 },


### PR DESCRIPTION
The current implementation of getObject does not support byte[]. This
is an issue for some people [1].

 [1] https://groups.google.com/forum/#!topic/h2-database/InWprFw2B0o
