### PR TITLE
Remove Java 6 backwards compatibility

### DIFF
--- a/h2/src/main/org/h2/JdbcDriverBackwardsCompat.java
+++ b/h2/src/main/org/h2/JdbcDriverBackwardsCompat.java
@@ -5,12 +5,9 @@
  */
 package org.h2;
 
-import java.util.logging.Logger;
-
 /**
  * Allows us to compile on older platforms, while still implementing the methods from the newer JDBC API.
  */
 public interface JdbcDriverBackwardsCompat {
 
-    Logger getParentLogger();
 }

--- a/h2/src/main/org/h2/jdbc/JdbcCallableStatementBackwardsCompat.java
+++ b/h2/src/main/org/h2/jdbc/JdbcCallableStatementBackwardsCompat.java
@@ -5,14 +5,9 @@
  */
 package org.h2.jdbc;
 
-import java.sql.SQLException;
-
 /**
  * Allows us to compile on older platforms, while still implementing the methods from the newer JDBC API.
  */
 public interface JdbcCallableStatementBackwardsCompat {
 
-    <T> T getObject(int parameterIndex, Class<T> type) throws SQLException;
-
-    <T> T getObject(String parameterName, Class<T> type) throws SQLException;
 }

--- a/h2/src/main/org/h2/jdbc/JdbcConnectionBackwardsCompat.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnectionBackwardsCompat.java
@@ -5,21 +5,9 @@
  */
 package org.h2.jdbc;
 
-import java.sql.SQLException;
-import java.util.concurrent.Executor;
-
 /**
  * Allows us to compile on older platforms, while still implementing the methods from the newer JDBC API.
  */
 public interface JdbcConnectionBackwardsCompat {
 
-    void setSchema(String schema) throws SQLException;
-
-    String getSchema() throws SQLException;
-
-    void abort(Executor executor) throws SQLException;
-
-    void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException;
-
-    int getNetworkTimeout() throws SQLException;
 }

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaDataBackwardsCompat.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaDataBackwardsCompat.java
@@ -5,17 +5,10 @@
  */
 package org.h2.jdbc;
 
-import java.sql.ResultSet;
-
 /**
  * Allows us to compile on older platforms, while still implementing the methods
  * from the newer JDBC API.
  */
 public interface JdbcDatabaseMetaDataBackwardsCompat {
-
-    boolean generatedKeyAlwaysReturned();
-
-    ResultSet getPseudoColumns(String catalog, String schemaPattern,
-            String tableNamePattern, String columnNamePattern);
 
 }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSetBackwardsCompat.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSetBackwardsCompat.java
@@ -5,14 +5,9 @@
  */
 package org.h2.jdbc;
 
-import java.sql.SQLException;
-
 /**
  * Allows us to compile on older platforms, while still implementing the methods from the newer JDBC API.
  */
 public interface JdbcResultSetBackwardsCompat {
 
-    public abstract <T> T getObject(int columnIndex, Class<T> type) throws SQLException;
-
-    public abstract <T> T getObject(String columnName, Class<T> type) throws SQLException;
 }

--- a/h2/src/main/org/h2/jdbc/JdbcStatementBackwardsCompat.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatementBackwardsCompat.java
@@ -10,7 +10,4 @@ package org.h2.jdbc;
  */
 public interface JdbcStatementBackwardsCompat {
 
-    void closeOnCompletion();
-
-    boolean isCloseOnCompletion();
 }

--- a/h2/src/main/org/h2/jdbcx/JdbcConnectionPoolBackwardsCompat.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcConnectionPoolBackwardsCompat.java
@@ -5,12 +5,9 @@
  */
 package org.h2.jdbcx;
 
-import java.util.logging.Logger;
-
 /**
  * Allows us to compile on older platforms, while still implementing the methods from the newer JDBC API.
  */
 public interface JdbcConnectionPoolBackwardsCompat {
 
-    Logger getParentLogger();
 }

--- a/h2/src/main/org/h2/jdbcx/JdbcDataSourceBackwardsCompat.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcDataSourceBackwardsCompat.java
@@ -5,12 +5,9 @@
  */
 package org.h2.jdbcx;
 
-import java.util.logging.Logger;
-
 /**
  * Allows us to compile on older platforms, while still implementing the methods from the newer JDBC API.
  */
 public interface JdbcDataSourceBackwardsCompat {
 
-    Logger getParentLogger();
 }

--- a/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
@@ -23,7 +23,6 @@ import java.sql.Types;
 import java.util.Collections;
 
 import org.h2.api.ErrorCode;
-import org.h2.jdbc.JdbcCallableStatementBackwardsCompat;
 import org.h2.test.TestBase;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.IOUtils;
@@ -148,7 +147,7 @@ public class TestCallableStatement extends TestBase {
         assertEquals(1, call.getLong(1));
         assertEquals(1, call.getByte(1));
         assertEquals(1, ((Long) call.getObject(1)).longValue());
-        assertEquals(1, ((JdbcCallableStatementBackwardsCompat) call).getObject(1, Long.class).longValue());
+        assertEquals(1, call.getObject(1, Long.class).longValue());
         assertFalse(call.wasNull());
 
         call.setFloat(2, 1.1f);

--- a/h2/src/test/org/h2/test/jdbc/TestConnection.java
+++ b/h2/src/test/org/h2/test/jdbc/TestConnection.java
@@ -6,7 +6,6 @@
 package org.h2.test.jdbc;
 
 import org.h2.api.ErrorCode;
-import org.h2.jdbc.JdbcConnectionBackwardsCompat;
 import org.h2.test.TestBase;
 import java.sql.Connection;
 import java.sql.SQLClientInfoException;
@@ -97,18 +96,17 @@ public class TestConnection extends TestBase {
         Statement s = conn.createStatement();
         s.executeUpdate("create schema my_test_schema");
         s.executeUpdate("create table my_test_schema.my_test_table(id uuid, nave varchar)");
-        JdbcConnectionBackwardsCompat connx = (JdbcConnectionBackwardsCompat) conn;
-        assertEquals("PUBLIC", connx.getSchema());
+        assertEquals("PUBLIC", conn.getSchema());
         assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, s, "select * from my_test_table");
-        assertThrows(ErrorCode.SCHEMA_NOT_FOUND_1, connx).setSchema("my_test_table");
-        connx.setSchema("MY_TEST_SCHEMA");
-        assertEquals("MY_TEST_SCHEMA", connx.getSchema());
+        assertThrows(ErrorCode.SCHEMA_NOT_FOUND_1, conn).setSchema("my_test_table");
+        conn.setSchema("MY_TEST_SCHEMA");
+        assertEquals("MY_TEST_SCHEMA", conn.getSchema());
         s.executeQuery("select * from my_test_table");
-        assertThrows(ErrorCode.SCHEMA_NOT_FOUND_1, connx).setSchema("NON_EXISTING_SCHEMA");
-        assertEquals("MY_TEST_SCHEMA", connx.getSchema());
+        assertThrows(ErrorCode.SCHEMA_NOT_FOUND_1, conn).setSchema("NON_EXISTING_SCHEMA");
+        assertEquals("MY_TEST_SCHEMA", conn.getSchema());
         s.executeUpdate("create schema \"otheR_schEma\"");
-        connx.setSchema("otheR_schEma");
-        assertEquals("otheR_schEma", connx.getSchema());
+        conn.setSchema("otheR_schEma");
+        assertEquals("otheR_schEma", conn.getSchema());
         s.close();
         conn.close();
     }

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.TimeZone;
 
 import org.h2.api.ErrorCode;
-import org.h2.jdbc.JdbcResultSetBackwardsCompat;
 import org.h2.test.TestBase;
 import org.h2.util.IOUtils;
 
@@ -671,7 +670,7 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof Integer);
         assertTrue(((Integer) o).intValue() == -1);
-        o = ((JdbcResultSetBackwardsCompat) rs).getObject("value", Integer.class);
+        o = rs.getObject("value", Integer.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof Integer);
         assertTrue(((Integer) o).intValue() == -1);
@@ -679,7 +678,7 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof Integer);
         assertTrue(((Integer) o).intValue() == -1);
-        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, Integer.class);
+        o = rs.getObject(2, Integer.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof Integer);
         assertTrue(((Integer) o).intValue() == -1);
@@ -730,7 +729,7 @@ public class TestResultSet extends TestBase {
         o = rs.getObject(2);
         assertTrue(o == null);
         assertTrue(rs.wasNull());
-        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, Integer.class);
+        o = rs.getObject(2, Integer.class);
         assertTrue(o == null);
         assertTrue(rs.wasNull());
         assertFalse(rs.next());
@@ -792,7 +791,7 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof String);
         assertTrue(o.toString().equals("Hi"));
-        o = ((JdbcResultSetBackwardsCompat) rs).getObject("value", String.class);
+        o = rs.getObject("value", String.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof String);
         assertTrue(o.equals("Hi"));
@@ -861,7 +860,7 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof BigDecimal);
         assertTrue(((BigDecimal) o).compareTo(new BigDecimal("-1.00")) == 0);
-        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, BigDecimal.class);
+        o = rs.getObject(2, BigDecimal.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof BigDecimal);
         assertTrue(((BigDecimal) o).compareTo(new BigDecimal("-1.00")) == 0);
@@ -925,7 +924,7 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof Double);
         assertTrue(((Double) o).compareTo(new Double("-1.00")) == 0);
-        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, Double.class);
+        o = rs.getObject(2, Double.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof Double);
         assertTrue(((Double) o).compareTo(new Double("-1.00")) == 0);
@@ -933,7 +932,7 @@ public class TestResultSet extends TestBase {
         trace(o.getClass().getName());
         assertTrue(o instanceof Float);
         assertTrue(((Float) o).compareTo(new Float("-1.00")) == 0);
-        o = ((JdbcResultSetBackwardsCompat) rs).getObject(3, Float.class);
+        o = rs.getObject(3, Float.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof Float);
         assertTrue(((Float) o).compareTo(new Float("-1.00")) == 0);
@@ -1037,7 +1036,7 @@ public class TestResultSet extends TestBase {
         assertTrue(((java.sql.Timestamp) o).equals(
                 java.sql.Timestamp.valueOf("2011-11-11 00:00:00.0")));
         assertFalse(rs.wasNull());
-        o = ((JdbcResultSetBackwardsCompat) rs).getObject(2, java.sql.Timestamp.class);
+        o = rs.getObject(2, java.sql.Timestamp.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof java.sql.Timestamp);
         assertTrue(((java.sql.Timestamp) o).equals(
@@ -1082,9 +1081,9 @@ public class TestResultSet extends TestBase {
         assertEquals("2001-02-03", date.toString());
         assertEquals("14:15:16", time.toString());
         assertEquals("2007-08-09 10:11:12.141516171", ts.toString());
-        date = ((JdbcResultSetBackwardsCompat) rs).getObject(1, Date.class);
-        time = ((JdbcResultSetBackwardsCompat) rs).getObject(2, Time.class);
-        ts = ((JdbcResultSetBackwardsCompat) rs).getObject(3, Timestamp.class);
+        date = rs.getObject(1, Date.class);
+        time = rs.getObject(2, Time.class);
+        ts = rs.getObject(3, Timestamp.class);
         assertEquals("2001-02-03", date.toString());
         assertEquals("14:15:16", time.toString());
         assertEquals("2007-08-09 10:11:12.141516171", ts.toString());
@@ -1229,7 +1228,7 @@ public class TestResultSet extends TestBase {
         assertTrue(!rs.wasNull());
         assertEqualsWithNull(new byte[] { (byte) 0x01, (byte) 0x01,
                 (byte) 0x01, (byte) 0x01 },
-                ((JdbcResultSetBackwardsCompat) rs).getObject(2, byte[].class));
+                rs.getObject(2, byte[].class));
         assertTrue(!rs.wasNull());
         rs.next();
         assertEqualsWithNull(new byte[] { (byte) 0x02, (byte) 0x02,
@@ -1238,7 +1237,7 @@ public class TestResultSet extends TestBase {
         assertTrue(!rs.wasNull());
         assertEqualsWithNull(new byte[] { (byte) 0x02, (byte) 0x02,
                 (byte) 0x02, (byte) 0x02 },
-                ((JdbcResultSetBackwardsCompat) rs).getObject("value", byte[].class));
+                rs.getObject("value", byte[].class));
         assertTrue(!rs.wasNull());
         rs.next();
         assertEqualsWithNull(new byte[] { (byte) 0x00 },


### PR DESCRIPTION
Since we now require at least Java 6 we can remove the Java 6 backwards
compatibility layer.

I can also remove the compatibility interfaces. For now I thought I leave
them for future JDBC versions. Let me know if you want them removed as
well.
