### PR TITLE
Handle LocalTime with nanosecond resolution

### DIFF
--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -639,7 +639,7 @@ public class TestPreparedStatement extends TestBase {
         prep.setObject(1, localDateTime);
         ResultSet rs = prep.executeQuery();
         rs.next();
-        Object localDateTime2 = rs.getObject(1, LocalDateTimeUtils.getLocalDateClass());
+        Object localDateTime2 = rs.getObject(1, LocalDateTimeUtils.getLocalDateTimeClass());
         assertEquals(localDateTime, localDateTime2);
         rs.close();
     }

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -621,6 +621,13 @@ public class TestPreparedStatement extends TestBase {
         Object localTime2 = rs.getObject(1, LocalDateTimeUtils.getLocalTimeClass());
         assertEquals(localTime, localTime2);
         rs.close();
+        localTime = LocalDateTimeUtils.parseLocalTime("04:05:06.123456789");
+        prep.setObject(1, localTime);
+        rs = prep.executeQuery();
+        rs.next();
+        localTime2 = rs.getObject(1, LocalDateTimeUtils.getLocalTimeClass());
+        assertEquals(localTime, localTime2);
+        rs.close();
     }
 
     private void testDateTime8(Connection conn) throws SQLException {


### PR DESCRIPTION
Intertal TIME representation in H2 and LocalTime both provide nanosecond resolution, but java.sql.Time limits it to milliseconds, and Time<->LocalTime conversions limit it just to seconds (not H2 bug).

This patch replaces ValueTime->Time->LocalTime and vice versa conversions with direct ValueTime<->LocalTime conversions.

Please notice that diff looks quite ugly due to inlining of timeToLocalTime(). Method dateToLocalDate() is not really changed.