### PR TITLE
Table alias get lost on joins

### DIFF
--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -249,13 +249,9 @@ public class ExpressionColumn extends Expression {
 
     @Override
     public String getAlias() {
-        if (column != null) {
-            return column.getName();
-        }
-        if (tableAlias != null) {
-            return tableAlias + "." + columnName;
-        }
-        return columnName;
+        String table = tableAlias == null ? "" : tableAlias + ".";
+        String columnName = column == null ? this.columnName : column.getName();
+        return table + columnName;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -108,6 +108,7 @@ import org.h2.test.jdbcx.TestConnectionPool;
 import org.h2.test.jdbcx.TestDataSource;
 import org.h2.test.jdbcx.TestXA;
 import org.h2.test.jdbcx.TestXASimple;
+import org.h2.test.lostalias.LostAliasTest;
 import org.h2.test.mvcc.TestMvcc1;
 import org.h2.test.mvcc.TestMvcc2;
 import org.h2.test.mvcc.TestMvcc3;
@@ -795,6 +796,9 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestQueryCache());
         addTest(new TestUrlJavaObjectSerializer());
         addTest(new TestWeb());
+        
+        // #392: Table alias get lost
+        addTest(new LostAliasTest());
 
         runAddedTests(1);
 

--- a/h2/src/test/org/h2/test/lostalias/LostAliasTest.java
+++ b/h2/src/test/org/h2/test/lostalias/LostAliasTest.java
@@ -1,0 +1,48 @@
+package org.h2.test.lostalias;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.h2.test.TestBase;
+import org.h2.tools.DeleteDbFiles;
+
+public class LostAliasTest extends TestBase {
+
+    public static void main(final String[] args) throws Exception {
+        TestBase.createCaller().init().test();
+    }
+
+    @Override
+    public void test() throws Exception {
+        shouldNotLostAlias();
+    }
+
+    private void shouldNotLostAlias() throws SQLException {
+        DeleteDbFiles.execute(getBaseDir(), "lostalias", true);
+        Connection conn = getConnection("lostalias");
+
+        Statement stat = conn.createStatement();
+
+        stat.execute("create table entry(id int, region int, author int)");
+        stat.execute("create table meta(id int, type varchar(255), value varchar(255))");
+        stat.execute("create table person(id int, name varchar(255))");
+        stat.execute("insert into person(id, name) values(3, 'edgar')");
+        stat.execute("insert into meta(id, type, value) values(2, 'Region', 'LATAM')");
+        stat.execute("insert into entry(id, region, author) values(1, 2, 3)");
+
+        ResultSet rs = stat.executeQuery("select entry.*, region.*, author.* from entry entry join meta region on entry.region=region.id join person author on entry.author=author.id");
+        while (rs.next()) {
+            assertEquals(1, rs.getInt("entry.id"));
+            assertEquals(2, rs.getInt("region.id"));
+            assertEquals("Region", rs.getString("region.type"));
+            assertEquals("LATAM", rs.getString("region.value"));
+            assertEquals(3, rs.getInt("author.id"));
+            assertEquals("edgar", rs.getString("author.name"));
+        }
+        rs.close();
+        stat.close();
+        conn.close();
+    }
+}


### PR DESCRIPTION
Stacktrace:

```
Exception in thread "main" org.h2.jdbc.JdbcSQLException: Column "region.id" not found [42122-193]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:345)
	at org.h2.message.DbException.get(DbException.java:179)
	at org.h2.message.DbException.get(DbException.java:155)
	at org.h2.jdbc.JdbcResultSet.getColumnIndex(JdbcResultSet.java:3146)
	at org.h2.jdbc.JdbcResultSet.get(JdbcResultSet.java:3234)
	at org.h2.jdbc.JdbcResultSet.getInt(JdbcResultSet.java:344)
	at org.h2.test.lostalias.LostAliasTest.shouldNotLostAlias(LostAliasTest.java:38)
	at org.h2.test.lostalias.LostAliasTest.test(LostAliasTest.java:19)
	at org.h2.test.lostalias.LostAliasTest.main(LostAliasTest.java:14)
```