### PR TITLE
Migrate to Travis container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: java
 
 jdk:


### PR DESCRIPTION
Sine we're not using sudo we can migrate to the container-based Travis
build infrastructure [1]. This has the following advantages:

 - Builds start in seconds
 - More available resources
 - Better network capacity, availability and throughput
 - Caching available for open source projects

The builds will still fail due to an `OutOfMemoryError` but that's a
different issue.

 [1] https://docs.travis-ci.com/user/migrating-from-legacy/