### PR TITLE
Cache Maven Local Repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,8 @@ jdk:
 before_script: cd h2
 
 script: ./build.sh jar testFast
+
+cache:
+  directories:
+    - $HOME/.m2/repository
+


### PR DESCRIPTION
Now that we're on the Travis CI container based infrastructure we can
use caching for the local Maven repository [1] in order to speed up the
build times and reduce the load on Maven Central.

 [1] https://docs.travis-ci.com/user/caching/