### PR TITLE
Add index hints

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2141,6 +2141,7 @@ ID + 20
 
 "Other Grammar","Table Expression","
 { [ schemaName. ] tableName | ( select ) | valuesExpression } [ [ AS ] newTableAlias ]
+[ USE INDEX ([ indexName [,...] ]) ]
 [ { { LEFT | RIGHT } [ OUTER ] | [ INNER ] | CROSS | NATURAL }
     JOIN tableExpression [ ON expression ] ]
 ","

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Added index hints: SELECT * FROM TEST USE INDEX (idx1, idx2)
+</li>
 <li>Add a test case to ensure that spatial index is used with and order by command by Fortin N
 </li>
 <li>Fix multi-threaded mode update exception "NullPointerException", test case by Anatolii K

--- a/h2/src/docsrc/html/performance.html
+++ b/h2/src/docsrc/html/performance.html
@@ -707,6 +707,14 @@ For queries of the form <code>SELECT * FROM TEST GROUP BY ID ORDER BY ID</code>,
 <code>/* group sorted */</code> to indicate there is no separate sorting required.
 </p>
 
+<h3>Index Hints</h3>
+<p>
+If you have determined that H2 is not using the optimal index for your query, you can use index hints to force
+H2 to use a specific index.
+</p>
+<pre>
+SELECT * FROM TEST USE INDEX (index_name) WHERE X=1
+</pre>
 <h2 id="storage_and_indexes">How Data is Stored and How Indexes Work</h2>
 <p>
 Internally, each row in a table is identified by a unique number, the row id.

--- a/h2/src/docsrc/html/performance.html
+++ b/h2/src/docsrc/html/performance.html
@@ -371,6 +371,22 @@ Indexes are also created for foreign key constraints, if required.
 For other columns, indexes need to be created manually using the <code>CREATE INDEX</code> statement.
 </p>
 
+<h3>Index Hints</h3>
+<p>
+If you have determined that H2 is not using the optimal index for your query, you can use index hints to force
+H2 to use specific indexes.
+</p>
+<pre>
+SELECT * FROM TEST USE INDEX (index_name_1, index_name_2) WHERE X=1
+</pre>
+<p>Only indexes in the list will be used when choosing an index to use on the given table. There
+is no significance to order in this list.
+</p><p>
+It is possible that no index in the list is chosen, in which case a full table scan will be used.
+</p>
+<p>An empty list of index names forces a full table scan to be performed.</p>
+<p>Each index in the list must exist.</p>
+
 <h3>How Data is Stored Internally</h3>
 <p>
 For persistent databases, if a table is created with a single column primary key of type <code>BIGINT, INT, SMALLINT, TINYINT</code>,
@@ -707,14 +723,6 @@ For queries of the form <code>SELECT * FROM TEST GROUP BY ID ORDER BY ID</code>,
 <code>/* group sorted */</code> to indicate there is no separate sorting required.
 </p>
 
-<h3>Index Hints</h3>
-<p>
-If you have determined that H2 is not using the optimal index for your query, you can use index hints to force
-H2 to use a specific index.
-</p>
-<pre>
-SELECT * FROM TEST USE INDEX (index_name) WHERE X=1
-</pre>
 <h2 id="storage_and_indexes">How Data is Stored and How Indexes Work</h2>
 <p>
 Internally, each row in a table is identified by a unique number, the row id.

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1262,7 +1262,6 @@ public class Parser {
             alias = readFromAlias(alias);
         }
         IndexHints indexHints = parseIndexHints();
-        System.out.println("indexHints = " + indexHints);
         return new TableFilter(session, table, alias, rightsChecked,
                 currentSelect, orderInFrom++, indexHints);
     }
@@ -1276,11 +1275,13 @@ public class Parser {
         read("INDEX");
         read("(");
 
-        ArrayList<String> indexNameList = New.arrayList();
-        do {
-            indexNameList.add(readIdentifierWithSchema());
-        } while (readIf(","));
-        read(")");
+        HashSet<String> indexNameList = New.hashSet();
+        if (!readIf(")")) {
+            do {
+                indexNameList.add(readIdentifierWithSchema());
+            } while (readIf(","));
+            read(")");
+        }
 
         return IndexHints.createUseIndexHints(indexNameList);
     }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -796,7 +796,7 @@ public class Parser {
             }
         }
         return new TableFilter(session, table, alias, rightsChecked,
-                currentSelect, orderInFrom, IndexHints.NONE);
+                currentSelect, orderInFrom, IndexHints.createNoHints());
     }
 
     private Delete parseDelete() {
@@ -1269,7 +1269,7 @@ public class Parser {
 
     private IndexHints parseIndexHints() {
         if (!readIf("USE")) {
-            return IndexHints.NONE;
+            return IndexHints.createNoHints();
         }
 
         read("INDEX");
@@ -1657,7 +1657,8 @@ public class Parser {
     private TableFilter getNested(TableFilter n) {
         String joinTable = Constants.PREFIX_JOIN + parseIndex;
         TableFilter top = new TableFilter(session, getDualTable(true),
-                joinTable, rightsChecked, currentSelect, n.getOrderInFrom(), IndexHints.NONE);
+                joinTable, rightsChecked, currentSelect, n.getOrderInFrom(),
+                IndexHints.createNoHints());
         top.addJoin(n, false, true, null);
         return top;
     }
@@ -2063,7 +2064,8 @@ public class Parser {
                 // SYSTEM_RANGE(1,1)
                 Table dual = getDualTable(false);
                 TableFilter filter = new TableFilter(session, dual, null,
-                        rightsChecked, currentSelect, 0, IndexHints.NONE);
+                        rightsChecked, currentSelect, 0,
+                        IndexHints.createNoHints());
                 command.addTableFilter(filter, true);
             } else {
                 parseSelectSimpleFromPart(command);
@@ -4510,7 +4512,8 @@ public class Parser {
         tf.doneWithParameters();
         Table table = new FunctionTable(mainSchema, session, tf, tf);
         TableFilter filter = new TableFilter(session, table, null,
-                rightsChecked, currentSelect, orderInFrom, IndexHints.NONE);
+                rightsChecked, currentSelect, orderInFrom,
+                IndexHints.createNoHints());
         return filter;
     }
 

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.command.ddl.AlterIndexRename;
@@ -1284,15 +1285,15 @@ public class Parser {
     private IndexHints parseUseIndexList() {
         read("(");
 
-        HashSet<String> indexNameList = New.hashSet();
+        LinkedHashSet<String> indexNames = new LinkedHashSet<>();
         if (!readIf(")")) {
             do {
-                indexNameList.add(readIdentifierWithSchema());
+                indexNames.add(readIdentifierWithSchema());
             } while (readIf(","));
             read(")");
         }
 
-        return IndexHints.createUseIndexHints(indexNameList);
+        return IndexHints.createUseIndexHints(indexNames);
     }
 
     private String readFromAlias(String alias) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -796,7 +796,7 @@ public class Parser {
             }
         }
         return new TableFilter(session, table, alias, rightsChecked,
-                currentSelect, orderInFrom, IndexHints.createNoHints());
+                currentSelect, orderInFrom, null);
     }
 
     private Delete parseDelete() {
@@ -1269,7 +1269,7 @@ public class Parser {
 
     private IndexHints parseIndexHints() {
         if (!readIf("USE")) {
-            return IndexHints.createNoHints();
+            return null;
         }
 
         read("INDEX");
@@ -1658,7 +1658,7 @@ public class Parser {
         String joinTable = Constants.PREFIX_JOIN + parseIndex;
         TableFilter top = new TableFilter(session, getDualTable(true),
                 joinTable, rightsChecked, currentSelect, n.getOrderInFrom(),
-                IndexHints.createNoHints());
+                null);
         top.addJoin(n, false, true, null);
         return top;
     }
@@ -2065,7 +2065,7 @@ public class Parser {
                 Table dual = getDualTable(false);
                 TableFilter filter = new TableFilter(session, dual, null,
                         rightsChecked, currentSelect, 0,
-                        IndexHints.createNoHints());
+                        null);
                 command.addTableFilter(filter, true);
             } else {
                 parseSelectSimpleFromPart(command);
@@ -4513,7 +4513,7 @@ public class Parser {
         Table table = new FunctionTable(mainSchema, session, tf, tf);
         TableFilter filter = new TableFilter(session, table, null,
                 rightsChecked, currentSelect, orderInFrom,
-                IndexHints.createNoHints());
+                null);
         return filter;
     }
 

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -25,6 +25,7 @@ import org.h2.message.DbException;
 import org.h2.schema.Schema;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
+import org.h2.table.IndexHints;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
 import org.h2.util.New;
@@ -186,7 +187,7 @@ public class AlterTableAddConstraint extends SchemaCommand {
             int id = getObjectId();
             String name = generateConstraintName(table);
             ConstraintCheck check = new ConstraintCheck(getSchema(), id, name, table);
-            TableFilter filter = new TableFilter(session, table, null, false, null, 0);
+            TableFilter filter = new TableFilter(session, table, null, false, null, 0, IndexHints.NONE);
             checkExpression.mapColumns(filter, 0);
             checkExpression = checkExpression.optimize(session);
             check.setExpression(checkExpression);

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -187,7 +187,7 @@ public class AlterTableAddConstraint extends SchemaCommand {
             int id = getObjectId();
             String name = generateConstraintName(table);
             ConstraintCheck check = new ConstraintCheck(getSchema(), id, name, table);
-            TableFilter filter = new TableFilter(session, table, null, false, null, 0, IndexHints.NONE);
+            TableFilter filter = new TableFilter(session, table, null, false, null, 0, IndexHints.createNoHints());
             checkExpression.mapColumns(filter, 0);
             checkExpression = checkExpression.optimize(session);
             check.setExpression(checkExpression);

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -25,7 +25,6 @@ import org.h2.message.DbException;
 import org.h2.schema.Schema;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.IndexHints;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
 import org.h2.util.New;
@@ -187,7 +186,7 @@ public class AlterTableAddConstraint extends SchemaCommand {
             int id = getObjectId();
             String name = generateConstraintName(table);
             ConstraintCheck check = new ConstraintCheck(getSchema(), id, name, table);
-            TableFilter filter = new TableFilter(session, table, null, false, null, 0, IndexHints.createNoHints());
+            TableFilter filter = new TableFilter(session, table, null, false, null, 0, null);
             checkExpression.mapColumns(filter, 0);
             checkExpression = checkExpression.optimize(session);
             check.setExpression(checkExpression);

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -705,6 +705,7 @@ factor [ { { + | - } factor } [...] ]
 A value or a numeric sum."
 "Other Grammar","Table Expression","
 { [ schemaName. ] tableName | ( select ) | valuesExpression } [ [ AS ] newTableAlias ]
+[ USE INDEX ([ indexName [,...] ]) ]
 [ { { LEFT | RIGHT } [ OUTER ] | [ INNER ] | CROSS | NATURAL }
     JOIN tableExpression [ ON expression ] ]
 ","

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -406,7 +406,7 @@ public class Column {
     public void prepareExpression(Session session) {
         if (defaultExpression != null) {
             computeTableFilter = new TableFilter(session, table, null, false, null, 0,
-                    IndexHints.createNoHints());
+                    null);
             defaultExpression.mapColumns(computeTableFilter, 0);
             defaultExpression = defaultExpression.optimize(session);
         }

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -405,7 +405,7 @@ public class Column {
      */
     public void prepareExpression(Session session) {
         if (defaultExpression != null) {
-            computeTableFilter = new TableFilter(session, table, null, false, null, 0);
+            computeTableFilter = new TableFilter(session, table, null, false, null, 0, IndexHints.NONE);
             defaultExpression.mapColumns(computeTableFilter, 0);
             defaultExpression = defaultExpression.optimize(session);
         }

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -405,7 +405,8 @@ public class Column {
      */
     public void prepareExpression(Session session) {
         if (defaultExpression != null) {
-            computeTableFilter = new TableFilter(session, table, null, false, null, 0, IndexHints.NONE);
+            computeTableFilter = new TableFilter(session, table, null, false, null, 0,
+                    IndexHints.createNoHints());
             defaultExpression.mapColumns(computeTableFilter, 0);
             defaultExpression = defaultExpression.optimize(session);
         }

--- a/h2/src/main/org/h2/table/IndexHints.java
+++ b/h2/src/main/org/h2/table/IndexHints.java
@@ -7,6 +7,7 @@ package org.h2.table;
 
 import org.h2.index.Index;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -19,26 +20,26 @@ import java.util.Set;
  **/
 public final class IndexHints {
 
-    private final Set<String> indexList;
+    private final LinkedHashSet<String> allowedIndexes;
 
-    private IndexHints(Set<String> indexList) {
-        this.indexList = indexList;
+    private IndexHints(LinkedHashSet<String> allowedIndexes) {
+        this.allowedIndexes = allowedIndexes;
     }
 
-    public static IndexHints createUseIndexHints(Set<String> indexList) {
-        return new IndexHints(indexList);
+    public static IndexHints createUseIndexHints(LinkedHashSet<String> allowedIndexes) {
+        return new IndexHints(allowedIndexes);
     }
 
-    public Set<String> getIndexList() {
-        return indexList;
+    public Set<String> getAllowedIndexes() {
+        return allowedIndexes;
     }
 
     @Override
     public String toString() {
-        return "IndexHints{indexList=" + indexList + '}';
+        return "IndexHints{allowedIndexes=" + allowedIndexes + '}';
     }
 
     public boolean allowIndex(Index index) {
-        return indexList.contains(index.getName());
+        return allowedIndexes.contains(index.getName());
     }
 }

--- a/h2/src/main/org/h2/table/IndexHints.java
+++ b/h2/src/main/org/h2/table/IndexHints.java
@@ -1,0 +1,52 @@
+package org.h2.table;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Contains the hints for which index to use for a specific table. Currently allows no hints to be specified, or
+ * a list of "use indexes" to be specified.
+ * <p>
+ * Use IndexHints.NONE for the most common case of table having no index hints. This instance can be safely reused.
+ * <p>
+ * Use factory method IndexHints.createUseIndexHints(listOfIndexes) to limit the query planner to only use
+ * specific indexes when determining which index to use for a table
+ * <p>
+ * Currently handles "USE INDEX" syntax only, but allows adding of other syntax such as "IGNORE INDEX" and "FORCE INDEX".
+ **/
+public final class IndexHints {
+
+    public static final IndexHints NONE = new IndexHints();
+
+    private final boolean useOnlySpecifiedIndexes;
+    private final List<String> useIndexList;
+
+    private IndexHints() {
+        this(false, Collections.<String>emptyList());
+    }
+
+    private IndexHints(boolean useOnlySpecifiedIndexes, List<String> useIndexList) {
+        this.useOnlySpecifiedIndexes = useOnlySpecifiedIndexes;
+        this.useIndexList = useIndexList;
+    }
+
+    public boolean isUseOnlySpecifiedIndexes() {
+        return useOnlySpecifiedIndexes;
+    }
+
+    public List<String> getUseIndexList() {
+        return useIndexList;
+    }
+
+    public static IndexHints createUseIndexHints(List<String> useIndexList) {
+        return new IndexHints(true, useIndexList);
+    }
+
+    @Override
+    public String toString() {
+        return "IndexHints{" +
+                "useOnlySpecifiedIndexes=" + useOnlySpecifiedIndexes +
+                ", useIndexList=" + useIndexList +
+                '}';
+    }
+}

--- a/h2/src/main/org/h2/table/IndexHints.java
+++ b/h2/src/main/org/h2/table/IndexHints.java
@@ -7,39 +7,26 @@ package org.h2.table;
 
 import org.h2.index.Index;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**
  * Contains the hints for which index to use for a specific table. Currently
- * allows no hints to be specified, or a list of "use indexes" to be specified.
+ * allows a list of "use indexes" to be specified.
  * <p>
- * Use IndexHints.NONE for the most common case of table having no index hints.
- * This instance can be safely reused.
- * <p>
- * Use factory method IndexHints.createUseIndexHints(listOfIndexes) to limit
+ * Use the factory method IndexHints.createUseIndexHints(listOfIndexes) to limit
  * the query planner to only use specific indexes when determining which index
  * to use for a table
  * <p>
- * Currently handles "USE INDEX" syntax only, but allows adding of other
- * syntax such as "IGNORE INDEX" and "FORCE INDEX".
+ * Currently supports "USE INDEX" syntax.
  **/
 public final class IndexHints {
 
     private final boolean useOnlySpecifiedIndexes;
     private final Set<String> useIndexList;
 
-    private IndexHints() {
-        this(false, Collections.<String>emptySet());
-    }
-
     private IndexHints(boolean useOnlySpecifiedIndexes, Set<String> useIndexList) {
         this.useOnlySpecifiedIndexes = useOnlySpecifiedIndexes;
         this.useIndexList = useIndexList;
-    }
-
-    public static IndexHints createNoHints() {
-        return new IndexHints();
     }
 
     public static IndexHints createUseIndexHints(Set<String> useIndexList) {

--- a/h2/src/main/org/h2/table/IndexHints.java
+++ b/h2/src/main/org/h2/table/IndexHints.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2004-2014 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
 package org.h2.table;
 
 import org.h2.index.Index;

--- a/h2/src/main/org/h2/table/IndexHints.java
+++ b/h2/src/main/org/h2/table/IndexHints.java
@@ -1,7 +1,9 @@
 package org.h2.table;
 
+import org.h2.index.Index;
+
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Contains the hints for which index to use for a specific table. Currently allows no hints to be specified, or
@@ -19,26 +21,22 @@ public final class IndexHints {
     public static final IndexHints NONE = new IndexHints();
 
     private final boolean useOnlySpecifiedIndexes;
-    private final List<String> useIndexList;
+    private final Set<String> useIndexList;
 
     private IndexHints() {
-        this(false, Collections.<String>emptyList());
+        this(false, Collections.<String>emptySet());
     }
 
-    private IndexHints(boolean useOnlySpecifiedIndexes, List<String> useIndexList) {
+    private IndexHints(boolean useOnlySpecifiedIndexes, Set<String> useIndexList) {
         this.useOnlySpecifiedIndexes = useOnlySpecifiedIndexes;
         this.useIndexList = useIndexList;
     }
 
-    public boolean isUseOnlySpecifiedIndexes() {
-        return useOnlySpecifiedIndexes;
-    }
-
-    public List<String> getUseIndexList() {
+    public Set<String> getUseIndexList() {
         return useIndexList;
     }
 
-    public static IndexHints createUseIndexHints(List<String> useIndexList) {
+    public static IndexHints createUseIndexHints(Set<String> useIndexList) {
         return new IndexHints(true, useIndexList);
     }
 
@@ -48,5 +46,9 @@ public final class IndexHints {
                 "useOnlySpecifiedIndexes=" + useOnlySpecifiedIndexes +
                 ", useIndexList=" + useIndexList +
                 '}';
+    }
+
+    public boolean allowIndex(Index index) {
+        return !useOnlySpecifiedIndexes || useIndexList.contains(index.getName());
     }
 }

--- a/h2/src/main/org/h2/table/IndexHints.java
+++ b/h2/src/main/org/h2/table/IndexHints.java
@@ -26,8 +26,6 @@ import java.util.Set;
  **/
 public final class IndexHints {
 
-    public static final IndexHints NONE = new IndexHints();
-
     private final boolean useOnlySpecifiedIndexes;
     private final Set<String> useIndexList;
 
@@ -38,6 +36,10 @@ public final class IndexHints {
     private IndexHints(boolean useOnlySpecifiedIndexes, Set<String> useIndexList) {
         this.useOnlySpecifiedIndexes = useOnlySpecifiedIndexes;
         this.useIndexList = useIndexList;
+    }
+
+    public static IndexHints createNoHints() {
+        return new IndexHints();
     }
 
     public static IndexHints createUseIndexHints(Set<String> useIndexList) {

--- a/h2/src/main/org/h2/table/IndexHints.java
+++ b/h2/src/main/org/h2/table/IndexHints.java
@@ -6,15 +6,18 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * Contains the hints for which index to use for a specific table. Currently allows no hints to be specified, or
- * a list of "use indexes" to be specified.
+ * Contains the hints for which index to use for a specific table. Currently
+ * allows no hints to be specified, or a list of "use indexes" to be specified.
  * <p>
- * Use IndexHints.NONE for the most common case of table having no index hints. This instance can be safely reused.
+ * Use IndexHints.NONE for the most common case of table having no index hints.
+ * This instance can be safely reused.
  * <p>
- * Use factory method IndexHints.createUseIndexHints(listOfIndexes) to limit the query planner to only use
- * specific indexes when determining which index to use for a table
+ * Use factory method IndexHints.createUseIndexHints(listOfIndexes) to limit
+ * the query planner to only use specific indexes when determining which index
+ * to use for a table
  * <p>
- * Currently handles "USE INDEX" syntax only, but allows adding of other syntax such as "IGNORE INDEX" and "FORCE INDEX".
+ * Currently handles "USE INDEX" syntax only, but allows adding of other
+ * syntax such as "IGNORE INDEX" and "FORCE INDEX".
  **/
 public final class IndexHints {
 
@@ -32,12 +35,12 @@ public final class IndexHints {
         this.useIndexList = useIndexList;
     }
 
-    public Set<String> getUseIndexList() {
-        return useIndexList;
-    }
-
     public static IndexHints createUseIndexHints(Set<String> useIndexList) {
         return new IndexHints(true, useIndexList);
+    }
+
+    public Set<String> getUseIndexList() {
+        return useIndexList;
     }
 
     @Override

--- a/h2/src/main/org/h2/table/IndexHints.java
+++ b/h2/src/main/org/h2/table/IndexHints.java
@@ -16,36 +16,29 @@ import java.util.Set;
  * Use the factory method IndexHints.createUseIndexHints(listOfIndexes) to limit
  * the query planner to only use specific indexes when determining which index
  * to use for a table
- * <p>
- * Currently supports "USE INDEX" syntax.
  **/
 public final class IndexHints {
 
-    private final boolean useOnlySpecifiedIndexes;
-    private final Set<String> useIndexList;
+    private final Set<String> indexList;
 
-    private IndexHints(boolean useOnlySpecifiedIndexes, Set<String> useIndexList) {
-        this.useOnlySpecifiedIndexes = useOnlySpecifiedIndexes;
-        this.useIndexList = useIndexList;
+    private IndexHints(Set<String> indexList) {
+        this.indexList = indexList;
     }
 
-    public static IndexHints createUseIndexHints(Set<String> useIndexList) {
-        return new IndexHints(true, useIndexList);
+    public static IndexHints createUseIndexHints(Set<String> indexList) {
+        return new IndexHints(indexList);
     }
 
-    public Set<String> getUseIndexList() {
-        return useIndexList;
+    public Set<String> getIndexList() {
+        return indexList;
     }
 
     @Override
     public String toString() {
-        return "IndexHints{" +
-                "useOnlySpecifiedIndexes=" + useOnlySpecifiedIndexes +
-                ", useIndexList=" + useIndexList +
-                '}';
+        return "IndexHints{indexList=" + indexList + '}';
     }
 
     public boolean allowIndex(Index index) {
-        return !useOnlySpecifiedIndexes || useIndexList.contains(index.getName());
+        return indexList.contains(index.getName());
     }
 }

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -721,7 +721,7 @@ public abstract class Table extends SchemaObjectBase {
 
     private IndexHints getIndexHints(Session session, TableFilter[] filters, int filter) {
         IndexHints indexHints = filters == null
-                ? IndexHints.NONE
+                ? IndexHints.createNoHints()
                 : filters[filter].getIndexHints();
         // check all index names in hints are valid indexes
         for (String indexName : indexHints.getUseIndexList()) {

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -720,7 +720,9 @@ public abstract class Table extends SchemaObjectBase {
     }
 
     private IndexHints getIndexHints(Session session, TableFilter[] filters, int filter) {
-        IndexHints indexHints = filters == null ? IndexHints.NONE : filters[filter].getIndexHints();
+        IndexHints indexHints = filters == null
+                ? IndexHints.NONE
+                : filters[filter].getIndexHints();
         // check all index names in hints are valid indexes
         for (String indexName : indexHints.getUseIndexList()) {
             Index index = getSchema().findIndex(session, indexName);

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -732,7 +732,7 @@ public abstract class Table extends SchemaObjectBase {
             return null;
         }
         // check all index names in hints are valid indexes
-        for (String indexName : indexHints.getUseIndexList()) {
+        for (String indexName : indexHints.getIndexList()) {
             Index index = getSchema().findIndex(session, indexName);
             if (index == null) {
                 throw DbException.get(ErrorCode.INDEX_NOT_FOUND_1, indexName);

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -732,7 +732,7 @@ public abstract class Table extends SchemaObjectBase {
             return null;
         }
         // check all index names in hints are valid indexes
-        for (String indexName : indexHints.getIndexList()) {
+        for (String indexName : indexHints.getAllowedIndexes()) {
             Index index = getSchema().findIndex(session, indexName);
             if (index == null) {
                 throw DbException.get(ErrorCode.INDEX_NOT_FOUND_1, indexName);

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -832,7 +832,7 @@ public class TableFilter implements ColumnResolver {
         if (indexHints != null) {
             buff.append(" USE INDEX (");
             boolean first = true;
-            for (String index : indexHints.getIndexList()) {
+            for (String index : indexHints.getAllowedIndexes()) {
                 if (!first) {
                     buff.append(", ");
                 } else {

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -55,7 +55,7 @@ public class TableFilter implements ColumnResolver {
     private final Select select;
     private String alias;
     private Index index;
-    private IndexHints indexHints;
+    private final IndexHints indexHints;
     private int[] masks;
     private int scanCount;
     private boolean evaluatable;
@@ -1193,6 +1193,10 @@ public class TableFilter implements ColumnResolver {
 
     public Session getSession() {
         return session;
+    }
+
+    public IndexHints getIndexHints() {
+        return indexHints;
     }
 
     /**

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -129,7 +129,7 @@ public class TableFilter implements ColumnResolver {
      * @param indexHints the index hints to be used by the query planner
      */
     public TableFilter(Session session, Table table, String alias,
-                       boolean rightsChecked, Select select, int orderInFrom, IndexHints indexHints) {
+            boolean rightsChecked, Select select, int orderInFrom, IndexHints indexHints) {
         this.session = session;
         this.table = table;
         this.alias = alias;

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -829,6 +829,19 @@ public class TableFilter implements ColumnResolver {
         if (alias != null) {
             buff.append(' ').append(Parser.quoteIdentifier(alias));
         }
+        if (indexHints != null) {
+            buff.append(" USE INDEX (");
+            boolean first = true;
+            for (String index : indexHints.getIndexList()) {
+                if (!first) {
+                    buff.append(", ");
+                } else {
+                    first = false;
+                }
+                buff.append(index);
+            }
+            buff.append(")");
+        }
         if (index != null) {
             buff.append('\n');
             StatementBuilder planBuff = new StatementBuilder();

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -55,6 +55,7 @@ public class TableFilter implements ColumnResolver {
     private final Select select;
     private String alias;
     private Index index;
+    private IndexHints indexHints;
     private int[] masks;
     private int scanCount;
     private boolean evaluatable;
@@ -125,10 +126,10 @@ public class TableFilter implements ColumnResolver {
      * @param rightsChecked true if rights are already checked
      * @param select the select statement
      * @param orderInFrom original order number (index) of this table filter in
-     *            FROM clause (0, 1, 2,...)
+     * @param indexHints the index hints to be used by the query planner
      */
     public TableFilter(Session session, Table table, String alias,
-            boolean rightsChecked, Select select, int orderInFrom) {
+                       boolean rightsChecked, Select select, int orderInFrom, IndexHints indexHints) {
         this.session = session;
         this.table = table;
         this.alias = alias;
@@ -139,6 +140,7 @@ public class TableFilter implements ColumnResolver {
         }
         hashCode = session.nextObjectId();
         this.orderInFrom = orderInFrom;
+        this.indexHints = indexHints;
     }
 
     /**

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -37,6 +37,7 @@ import org.h2.test.db.TestFullText;
 import org.h2.test.db.TestFunctionOverload;
 import org.h2.test.db.TestFunctions;
 import org.h2.test.db.TestIndex;
+import org.h2.test.db.TestIndexHints;
 import org.h2.test.db.TestLargeBlob;
 import org.h2.test.db.TestLinkedTable;
 import org.h2.test.db.TestListener;
@@ -707,6 +708,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestFunctions());
         addTest(new TestInit());
         addTest(new TestIndex());
+        addTest(new TestIndexHints());
         addTest(new TestLargeBlob());
         addTest(new TestLinkedTable());
         addTest(new TestListener());

--- a/h2/src/test/org/h2/test/db/TestIndexHints.java
+++ b/h2/src/test/org/h2/test/db/TestIndexHints.java
@@ -46,7 +46,8 @@ public class TestIndexHints extends TestBase {
     private void testWithSingleIndexName() throws SQLException {
         Connection conn = getConnection("indexhints");
         Statement stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("explain analyze select * from test use index(idx2) where x=1 and y=1");
+        ResultSet rs = stat.executeQuery("explain analyze select * " +
+                "from test use index(idx2) where x=1 and y=1");
         rs.next();
         String result = rs.getString(1);
         assertTrue(result.contains("/* PUBLIC.IDX2:"));
@@ -56,7 +57,8 @@ public class TestIndexHints extends TestBase {
     private void testWithTableAlias() throws SQLException {
         Connection conn = getConnection("indexhints");
         Statement stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("explain analyze select * from test t use index(idx2) where x=1 and y=1");
+        ResultSet rs = stat.executeQuery("explain analyze select * " +
+                "from test t use index(idx2) where x=1 and y=1");
         rs.next();
         String result = rs.getString(1);
         assertTrue(result.contains("/* PUBLIC.IDX2:"));
@@ -66,7 +68,8 @@ public class TestIndexHints extends TestBase {
     private void testWithMultipleIndexNames() throws SQLException {
         Connection conn = getConnection("indexhints");
         Statement stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("explain analyze select * from test use index(idx1, idx2) where x=1 and y=1");
+        ResultSet rs = stat.executeQuery("explain analyze select * " +
+                "from test use index(idx1, idx2) where x=1 and y=1");
         rs.next();
         String result = rs.getString(1);
         assertTrue(result.contains("/* PUBLIC.IDX2:"));
@@ -76,7 +79,8 @@ public class TestIndexHints extends TestBase {
     private void testWithEmptyIndexHintsList() throws SQLException {
         Connection conn = getConnection("indexhints");
         Statement stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("explain analyze select * from test use index () where x=1 and y=1");
+        ResultSet rs = stat.executeQuery("explain analyze select * " +
+                "from test use index () where x=1 and y=1");
         rs.next();
         String result = rs.getString(1);
         assertTrue(result.contains("/* PUBLIC.TEST.tableScan"));
@@ -87,8 +91,10 @@ public class TestIndexHints extends TestBase {
         Connection conn = getConnection("indexhints");
         Statement stat = conn.createStatement();
         try {
-            stat.executeQuery("explain analyze select * from test use index(idx_doesnt_exist) where x=1 and y=1");
-            fail("Expected exception: " + "Index \"IDX_DOESNT_EXIST\" not found");
+            stat.executeQuery("explain analyze select * " +
+                    "from test use index(idx_doesnt_exist) where x=1 and y=1");
+            fail("Expected exception: "
+                    + "Index \"IDX_DOESNT_EXIST\" not found");
         } catch (SQLException e) {
             assert(e.getErrorCode() == 1);
         } finally {

--- a/h2/src/test/org/h2/test/db/TestIndexHints.java
+++ b/h2/src/test/org/h2/test/db/TestIndexHints.java
@@ -32,6 +32,7 @@ public class TestIndexHints extends TestBase {
         testWithInvalidIndexName();
         testWithMultipleIndexNames();
         testWithTableAlias();
+        testWithTableAliasCalledUse();
         deleteDb("indexhints");
     }
 
@@ -62,6 +63,16 @@ public class TestIndexHints extends TestBase {
         rs.next();
         String result = rs.getString(1);
         assertTrue(result.contains("/* PUBLIC.IDX2:"));
+        conn.close();
+    }
+
+    private void testWithTableAliasCalledUse() throws SQLException {
+        // make sure that while adding new syntax for table hints, code
+        // that uses "USE" as a table alias still works
+        Connection conn = getConnection("indexhints");
+        Statement stat = conn.createStatement();
+        stat.executeQuery("explain analyze select * " +
+                "from test use where use.x=1 and use.y=1");
         conn.close();
     }
 

--- a/h2/src/test/org/h2/test/db/TestIndexHints.java
+++ b/h2/src/test/org/h2/test/db/TestIndexHints.java
@@ -31,6 +31,7 @@ public class TestIndexHints extends TestBase {
         testWithEmptyIndexHintsList();
         testWithInvalidIndexName();
         testWithMultipleIndexNames();
+        testPlanSqlHasIndexesInCorrectOrder();
         testWithTableAlias();
         testWithTableAliasCalledUse();
         deleteDb("indexhints");
@@ -84,6 +85,17 @@ public class TestIndexHints extends TestBase {
         rs.next();
         String result = rs.getString(1);
         assertTrue(result.contains("/* PUBLIC.IDX2:"));
+        conn.close();
+    }
+
+    private void testPlanSqlHasIndexesInCorrectOrder() throws SQLException {
+        Connection conn = getConnection("indexhints");
+        Statement stat = conn.createStatement();
+        ResultSet rs = stat.executeQuery("explain analyze select * " +
+                "from test use index(idx1, idx2) where x=1 and y=1");
+        rs.next();
+        String result = rs.getString(1);
+        assertTrue(result.contains("USE INDEX (IDX1, IDX2)"));
         conn.close();
     }
 

--- a/h2/src/test/org/h2/test/db/TestIndexHints.java
+++ b/h2/src/test/org/h2/test/db/TestIndexHints.java
@@ -7,7 +7,10 @@ package org.h2.test.db;
 
 import org.h2.test.TestBase;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 /**
  * Tests the index hints feature of this database.
@@ -90,12 +93,16 @@ public class TestIndexHints extends TestBase {
 
     private void testPlanSqlHasIndexesInCorrectOrder() throws SQLException {
         Connection conn = getConnection("indexhints");
-        Statement stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("explain analyze select * " +
+        ResultSet rs = conn.createStatement().executeQuery("explain analyze select * " +
                 "from test use index(idx1, idx2) where x=1 and y=1");
         rs.next();
-        String result = rs.getString(1);
-        assertTrue(result.contains("USE INDEX (IDX1, IDX2)"));
+        assertTrue(rs.getString(1).contains("USE INDEX (IDX1, IDX2)"));
+
+        ResultSet rs2 = conn.createStatement().executeQuery("explain analyze select * " +
+                "from test use index(idx2, idx1) where x=1 and y=1");
+        rs2.next();
+        assertTrue(rs2.getString(1).contains("USE INDEX (IDX2, IDX1)"));
+
         conn.close();
     }
 

--- a/h2/src/test/org/h2/test/db/TestIndexHints.java
+++ b/h2/src/test/org/h2/test/db/TestIndexHints.java
@@ -48,10 +48,10 @@ public class TestIndexHints extends TestBase {
         Connection conn = getConnection("indexhints");
         Statement stat = conn.createStatement();
         ResultSet rs = stat.executeQuery("explain analyze select * " +
-                "from test use index(idx2) where x=1 and y=1");
+                "from test use index(idx1) where x=1 and y=1");
         rs.next();
         String result = rs.getString(1);
-        assertTrue(result.contains("/* PUBLIC.IDX2:"));
+        assertTrue(result.contains("/* PUBLIC.IDX1:"));
         conn.close();
     }
 

--- a/h2/src/test/org/h2/test/db/TestIndexHints.java
+++ b/h2/src/test/org/h2/test/db/TestIndexHints.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2004-2017 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.test.db;
+
+import org.h2.test.TestBase;
+
+import java.sql.*;
+
+/**
+ * Tests the index hints feature of this database.
+ */
+public class TestIndexHints extends TestBase {
+
+    /**
+     * Run just this test.
+     *
+     * @param a ignored
+     */
+    public static void main(String... a) throws Exception {
+        TestBase.createCaller().init().test();
+    }
+
+    @Override
+    public void test() throws Exception {
+        deleteDb("indexhints");
+        createDb();
+        testWithSingleIndexName();
+        testWithEmptyIndexHintsList();
+        testWithInvalidIndexName();
+        testWithMultipleIndexNames();
+        testWithTableAlias();
+        deleteDb("indexhints");
+    }
+
+    private void createDb() throws SQLException {
+        Connection conn = getConnection("indexhints");
+        Statement stat = conn.createStatement();
+        stat.execute("create table test (x int, y int)");
+        stat.execute("create index idx1 on test (x)");
+        stat.execute("create index idx2 on test (x, y)");
+    }
+
+    private void testWithSingleIndexName() throws SQLException {
+        Connection conn = getConnection("indexhints");
+        Statement stat = conn.createStatement();
+        ResultSet rs = stat.executeQuery("explain analyze select * from test use index(idx2) where x=1 and y=1");
+        rs.next();
+        String result = rs.getString(1);
+        assertTrue(result.contains("/* PUBLIC.IDX2:"));
+        conn.close();
+    }
+
+    private void testWithTableAlias() throws SQLException {
+        Connection conn = getConnection("indexhints");
+        Statement stat = conn.createStatement();
+        ResultSet rs = stat.executeQuery("explain analyze select * from test t use index(idx2) where x=1 and y=1");
+        rs.next();
+        String result = rs.getString(1);
+        assertTrue(result.contains("/* PUBLIC.IDX2:"));
+        conn.close();
+    }
+
+    private void testWithMultipleIndexNames() throws SQLException {
+        Connection conn = getConnection("indexhints");
+        Statement stat = conn.createStatement();
+        ResultSet rs = stat.executeQuery("explain analyze select * from test use index(idx1, idx2) where x=1 and y=1");
+        rs.next();
+        String result = rs.getString(1);
+        assertTrue(result.contains("/* PUBLIC.IDX2:"));
+        conn.close();
+    }
+
+    private void testWithEmptyIndexHintsList() throws SQLException {
+        Connection conn = getConnection("indexhints");
+        Statement stat = conn.createStatement();
+        ResultSet rs = stat.executeQuery("explain analyze select * from test use index () where x=1 and y=1");
+        rs.next();
+        String result = rs.getString(1);
+        assertTrue(result.contains("/* PUBLIC.TEST.tableScan"));
+        conn.close();
+    }
+
+    private void testWithInvalidIndexName() throws SQLException {
+        Connection conn = getConnection("indexhints");
+        Statement stat = conn.createStatement();
+        try {
+            stat.executeQuery("explain analyze select * from test use index(idx_doesnt_exist) where x=1 and y=1");
+            fail("Expected exception: " + "Index \"IDX_DOESNT_EXIST\" not found");
+        } catch (SQLException e) {
+            assert(e.getErrorCode() == 1);
+        } finally {
+            conn.close();
+
+        }
+    }
+
+}


### PR DESCRIPTION
Please review this code. It is a simple implementation of index hints, based on MySQL's implementation.

Syntax:
SELECT * FROM TEST USE INDEX (idx1, idx2)

With table alias:
SELECT * FROM TEST AS t USE INDEX (idx1, idx2)

This could break existing code that uses a table alias called "USE".
