### PR TITLE
Fix JDBC type of TIMESTAMP WITH TIME ZONE

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,9 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li><strong>[API CHANGE]</strong> #439: the JDBC type of TIMESTAMP WITH TIME ZONE
+changed from Types.OTHER (1111) to Types.TIMESTAMP_WITH_TIMEZONE (2014)
+</li>
 <li>#430: Subquery not cached if number of rows exceeds MAX_MEMORY_ROWS
 </li>
 <li>#411: "TIMEZONE" should be "TIME ZONE" in type "TIMESTAMP WITH TIMEZONE"

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -315,7 +315,11 @@ public class DataType {
                 // 24 for ValueTimestamp, 32 for java.sql.Timestamp
                 56
         );
-        add(Value.TIMESTAMP_TZ, Types.OTHER, "TimestampTimeZone",
+        // 2014 is the value of Types.TIMESTAMP_WITH_TIMEZONE
+        // use the value instead of the reference because the code has to compile
+        // on Java 1.7
+        // can be replaced with Types.TIMESTAMP_WITH_TIMEZONE once Java 1.8 is required
+        add(Value.TIMESTAMP_TZ, 2014, "TimestampTimeZone",
                 createDate(ValueTimestampTimeZone.PRECISION, "TIMESTAMP_TZ",
                         ValueTimestampTimeZone.DEFAULT_SCALE, ValueTimestampTimeZone.DISPLAY_SIZE),
                 new String[]{"TIMESTAMP WITH TIME ZONE"},

--- a/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
+++ b/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
@@ -7,6 +7,7 @@ package org.h2.test.unit;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.TimestampWithTimeZone;
@@ -102,6 +103,15 @@ public class TestTimeStampWithTimeZone extends TestBase {
             assertEquals("2015-12-31T19:00-10:00", rs.getObject(1,
                             LocalDateTimeUtils.getOffsetDateTimeClass()).toString());
         }
+
+        ResultSetMetaData metaData = rs.getMetaData();
+        int columnType = metaData.getColumnType(1);
+        // 2014 is the value of Types.TIMESTAMP_WITH_TIMEZONE
+        // use the value instead of the reference because the code has to compile
+        // on Java 1.7
+        // can be replaced with Types.TIMESTAMP_WITH_TIMEZONE once Java 1.8 is required
+        assertEquals(2014, columnType);
+
         rs.close();
         stat.close();
         conn.close();


### PR DESCRIPTION
Currently the JDBC type of TIMESTAMP WITH TIME ZONE is Types.OTHER.
JDBC 4.2 has a dedicated type for this Types.TIMESTAMP_WITH_TIMEZONE.

Unfortunately this type is only available in JDBC 4.2/Java 1.8 so I
hard code the constant value instead of the constant reference.