### PR TITLE
Optimized column vs constant comparisons

### DIFF
--- a/h2/src/main/org/h2/expression/Comparison.java
+++ b/h2/src/main/org/h2/expression/Comparison.java
@@ -194,6 +194,13 @@ public class Comparison extends Condition {
                             return ValueExpression.getNull();
                         }
                     }
+                    int colType = left.getType();
+                    int constType = r.getType();
+                    int resType = Value.getHigherOrder(colType, constType);
+                    // If not the column values will need to be promoted
+                    // to constant type, but vise versa, then let's do this here once.
+                    if (constType != resType)
+                        right = ValueExpression.get(r.convertTo(resType));
                 } else if (right instanceof Parameter) {
                     ((Parameter) right).setColumn(
                             ((ExpressionColumn) left).getColumn());

--- a/h2/src/test/org/h2/test/db/TestOptimizations.java
+++ b/h2/src/test/org/h2/test/db/TestOptimizations.java
@@ -58,6 +58,7 @@ public class TestOptimizations extends TestBase {
         testNestedIn();
         testConstantIn1();
         testConstantIn2();
+        testConstantTypeConversionToColumnType();
         testNestedInSelectAndLike();
         testNestedInSelect();
         testInSelectJoin();
@@ -459,6 +460,25 @@ public class TestOptimizations extends TestBase {
         resultSet = stat.executeQuery(
                 "SELECT x FROM testValues WHERE x IN ('FOO','bar')");
         assertTrue(resultSet.next());
+
+        conn.close();
+    }
+
+    private void testConstantTypeConversionToColumnType() throws SQLException {
+        deleteDb("optimizations");
+        Connection conn = getConnection("optimizations;IGNORECASE=TRUE");
+        Statement stat = conn.createStatement();
+
+        stat.executeUpdate("CREATE TABLE test (x int)");
+        ResultSet resultSet;
+        resultSet = stat.executeQuery(
+            "EXPLAIN SELECT x FROM test WHERE x = '5'");
+
+        assertTrue(resultSet.next());
+        // String constant '5' has been converted to int constant 5 on optimization
+        assertTrue(resultSet.getString(1).endsWith("X = 5"));
+
+        stat.execute("drop table test");
 
         conn.close();
     }

--- a/h2/src/test/org/h2/test/testScript.sql
+++ b/h2/src/test/org/h2/test/testScript.sql
@@ -8172,9 +8172,9 @@ select * from s;
 > rows: 1
 
 select some(y>10), every(y>10), min(y), max(y) from t;
-> BOOL_OR(Y > 10) BOOL_AND(Y > 10) MIN(Y) MAX(Y)
-> --------------- ---------------- ------ ------
-> null            null             null   null
+> BOOL_OR(Y > 10.0) BOOL_AND(Y > 10.0) MIN(Y) MAX(Y)
+> ----------------- ------------------ ------ ------
+> null              null               null   null
 > rows: 1
 
 insert into t values(1000000004, 4);
@@ -8230,9 +8230,9 @@ stddev_pop(distinct y) s_py, stddev_samp(distinct y) s_sy, var_pop(distinct y) v
 > rows: 1
 
 select some(y>10), every(y>10), min(y), max(y) from t;
-> BOOL_OR(Y > 10) BOOL_AND(Y > 10) MIN(Y) MAX(Y)
-> --------------- ---------------- ------ ------
-> TRUE            FALSE            4.0    16.0
+> BOOL_OR(Y > 10.0) BOOL_AND(Y > 10.0) MIN(Y) MAX(Y)
+> ----------------- ------------------ ------ ------
+> TRUE              FALSE              4.0    16.0
 > rows: 1
 
 drop view s;


### PR DESCRIPTION
In some cases, say, when a column value is compared to a constant, we can promote constant to column's type once instead of repeating this (each time the same) conversion for each row - for example, converting int constant to long on each row condition check may be avoided.