### PR TITLE
Use System.nanoTime() to check timeouts

### DIFF
--- a/h2/src/main/org/h2/bnf/Sentence.java
+++ b/h2/src/main/org/h2/bnf/Sentence.java
@@ -54,7 +54,7 @@ public class Sentence {
      */
     private String queryUpper;
 
-    private long stopAt;
+    private long stopAtNs;
     private DbSchema lastMatchedSchema;
     private DbTableOrView lastMatchedTable;
     private DbTableOrView lastTable;
@@ -65,7 +65,7 @@ public class Sentence {
      * Start the timer to make sure processing doesn't take too long.
      */
     public void start() {
-        stopAt = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(MAX_PROCESSING_TIME);
+        stopAtNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(MAX_PROCESSING_TIME);
     }
 
     /**
@@ -74,7 +74,7 @@ public class Sentence {
      * If processing is stopped, this methods throws an IllegalStateException
      */
     public void stopIfRequired() {
-        if (System.nanoTime() > stopAt) {
+        if (System.nanoTime() > stopAtNs) {
             throw new IllegalStateException();
         }
     }

--- a/h2/src/main/org/h2/bnf/Sentence.java
+++ b/h2/src/main/org/h2/bnf/Sentence.java
@@ -7,6 +7,7 @@ package org.h2.bnf;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.bnf.context.DbSchema;
 import org.h2.bnf.context.DbTableOrView;
@@ -64,7 +65,7 @@ public class Sentence {
      * Start the timer to make sure processing doesn't take too long.
      */
     public void start() {
-        stopAt = System.currentTimeMillis() + MAX_PROCESSING_TIME;
+        stopAt = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(MAX_PROCESSING_TIME);
     }
 
     /**
@@ -73,7 +74,7 @@ public class Sentence {
      * If processing is stopped, this methods throws an IllegalStateException
      */
     public void stopIfRequired() {
-        if (System.currentTimeMillis() > stopAt) {
+        if (System.nanoTime() > stopAt) {
             throw new IllegalStateException();
         }
     }

--- a/h2/src/main/org/h2/command/dml/Optimizer.java
+++ b/h2/src/main/org/h2/command/dml/Optimizer.java
@@ -25,7 +25,7 @@ class Optimizer {
     private static final int MAX_BRUTE_FORCE_FILTERS = 7;
     private static final int MAX_BRUTE_FORCE = 2000;
     private static final int MAX_GENETIC = 500;
-    private long start;
+    private long startNs;
     private BitField switched;
 
     //  possible plans for filters, if using brute force:
@@ -80,7 +80,7 @@ class Optimizer {
         if (filters.length == 1 || session.isForceJoinOrder()) {
             testPlan(filters);
         } else {
-            start = System.nanoTime();
+            startNs = System.nanoTime();
             if (filters.length <= MAX_BRUTE_FORCE_FILTERS) {
                 calculateBruteForceAll();
             } else {
@@ -98,7 +98,7 @@ class Optimizer {
 
     private boolean canStop(int x) {
         if ((x & 127) == 0) {
-            long t = System.nanoTime() - start;
+            long t = System.nanoTime() - startNs;
             // don't calculate for simple queries (no rows or so)
             if (cost >= 0 && 10 * t > cost * TimeUnit.MILLISECONDS.toNanos(1)) {
                 return true;

--- a/h2/src/main/org/h2/command/dml/Optimizer.java
+++ b/h2/src/main/org/h2/command/dml/Optimizer.java
@@ -6,6 +6,8 @@
 package org.h2.command.dml;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.table.Plan;
@@ -78,7 +80,7 @@ class Optimizer {
         if (filters.length == 1 || session.isForceJoinOrder()) {
             testPlan(filters);
         } else {
-            start = System.currentTimeMillis();
+            start = System.nanoTime();
             if (filters.length <= MAX_BRUTE_FORCE_FILTERS) {
                 calculateBruteForceAll();
             } else {
@@ -96,9 +98,9 @@ class Optimizer {
 
     private boolean canStop(int x) {
         if ((x & 127) == 0) {
-            long t = System.currentTimeMillis() - start;
+            long t = System.nanoTime() - start;
             // don't calculate for simple queries (no rows or so)
-            if (cost >= 0 && 10 * t > cost) {
+            if (cost >= 0 && 10 * t > cost * TimeUnit.MILLISECONDS.toNanos(1)) {
                 return true;
             }
         }

--- a/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
@@ -23,6 +23,7 @@ import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import javax.sql.ConnectionEvent;
 import javax.sql.ConnectionEventListener;
@@ -190,7 +191,7 @@ public class JdbcConnectionPool implements DataSource, ConnectionEventListener,
      */
     @Override
     public Connection getConnection() throws SQLException {
-        long max = System.currentTimeMillis() + timeout * 1000;
+        long max = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeout);
         do {
             synchronized (this) {
                 if (activeConnections < maxConnections) {
@@ -202,7 +203,7 @@ public class JdbcConnectionPool implements DataSource, ConnectionEventListener,
                     // ignore
                 }
             }
-        } while (System.currentTimeMillis() <= max);
+        } while (System.nanoTime() <= max);
         throw new SQLException("Login timeout", "08001", 8001);
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.command.ddl.Analyze;
@@ -213,10 +215,10 @@ public class MVTable extends TableBase {
                 // check for deadlocks from now on
                 checkDeadlock = true;
             }
-            long now = System.currentTimeMillis();
+            long now = System.nanoTime();
             if (max == 0) {
                 // try at least one more time
-                max = now + session.getLockTimeout();
+                max = now + TimeUnit.MILLISECONDS.toNanos(session.getLockTimeout());
             } else if (now >= max) {
                 traceLock(session, exclusive,
                         "timeout after " + session.getLockTimeout());
@@ -235,7 +237,7 @@ public class MVTable extends TableBase {
                     }
                 }
                 // don't wait too long so that deadlocks are detected early
-                long sleep = Math.min(Constants.DEADLOCK_CHECK, max - now);
+                long sleep = Math.min(Constants.DEADLOCK_CHECK, TimeUnit.NANOSECONDS.toMillis(max - now));
                 if (sleep == 0) {
                     sleep = 1;
                 }

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.api.TableEngine;
@@ -349,12 +350,12 @@ public class MVTableEngine implements TableEngine {
          */
         public void compactFile(long maxCompactTime) {
             store.setRetentionTime(0);
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             while (store.compact(95, 16 * 1024 * 1024)) {
                 store.sync();
                 store.compactMoveChunks(95, 16 * 1024 * 1024);
-                long time = System.currentTimeMillis() - start;
-                if (time > maxCompactTime) {
+                long time = System.nanoTime() - start;
+                if (time > TimeUnit.MILLISECONDS.toNanos(maxCompactTime)) {
                     break;
                 }
             }

--- a/h2/src/main/org/h2/store/PageStore.java
+++ b/h2/src/main/org/h2/store/PageStore.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.CRC32;
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
@@ -506,7 +507,7 @@ public class PageStore implements CacheWriter {
         } finally {
             recoveryRunning = false;
         }
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         boolean isCompactFully = compactMode ==
                 CommandInterface.SHUTDOWN_COMPACT;
         boolean isDefrag = compactMode ==
@@ -537,8 +538,8 @@ public class PageStore implements CacheWriter {
                         }
                         if (compact(full, firstFree)) {
                             j++;
-                            long now = System.currentTimeMillis();
-                            if (now > start + maxCompactTime) {
+                            long now = System.nanoTime();
+                            if (now > start + TimeUnit.MILLISECONDS.toNanos(maxCompactTime)) {
                                 j = maxMove;
                                 break;
                             }

--- a/h2/src/main/org/h2/store/fs/FilePathNioMapped.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNioMapped.java
@@ -16,6 +16,7 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.NonWritableChannelException;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.engine.SysProperties;
 
@@ -98,9 +99,9 @@ class FileNioMapped extends FileBase {
             WeakReference<MappedByteBuffer> bufferWeakRef =
                     new WeakReference<MappedByteBuffer>(mapped);
             mapped = null;
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             while (bufferWeakRef.get() != null) {
-                if (System.currentTimeMillis() - start > GC_TIMEOUT_MS) {
+                if (System.nanoTime() - start > TimeUnit.MILLISECONDS.toNanos(GC_TIMEOUT_MS)) {
                     throw new IOException("Timeout (" + GC_TIMEOUT_MS
                             + " ms) reached while trying to GC mapped buffer");
                 }

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.command.ddl.Analyze;
@@ -500,10 +502,10 @@ public class RegularTable extends TableBase {
                 // check for deadlocks from now on
                 checkDeadlock = true;
             }
-            long now = System.currentTimeMillis();
+            long now = System.nanoTime();
             if (max == 0) {
                 // try at least one more time
-                max = now + session.getLockTimeout();
+                max = now + TimeUnit.MILLISECONDS.toNanos(session.getLockTimeout());
             } else if (now >= max) {
                 traceLock(session, exclusive, "timeout after " + session.getLockTimeout());
                 throw DbException.get(ErrorCode.LOCK_TIMEOUT_1, getName());
@@ -521,7 +523,7 @@ public class RegularTable extends TableBase {
                     }
                 }
                 // don't wait too long so that deadlocks are detected early
-                long sleep = Math.min(Constants.DEADLOCK_CHECK, max - now);
+                long sleep = Math.min(Constants.DEADLOCK_CHECK, TimeUnit.NANOSECONDS.toMillis(max - now));
                 if (sleep == 0) {
                     sleep = 1;
                 }

--- a/h2/src/main/org/h2/tools/ChangeFileEncryption.java
+++ b/h2/src/main/org/h2/tools/ChangeFileEncryption.java
@@ -11,6 +11,7 @@ import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.engine.Constants;
 import org.h2.message.DbException;
@@ -236,11 +237,11 @@ public class ChangeFileEncryption extends Tool {
             byte[] buffer = new byte[4 * 1024];
             long remaining = fileIn.size();
             long total = remaining;
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             while (remaining > 0) {
-                if (!quiet && System.currentTimeMillis() - time > 1000) {
+                if (!quiet && System.nanoTime() - time > TimeUnit.SECONDS.toNanos(1)) {
                     out.println(fileName + ": " + (100 - 100 * remaining / total) + "%");
-                    time = System.currentTimeMillis();
+                    time = System.nanoTime();
                 }
                 int len = (int) Math.min(buffer.length, remaining);
                 len = inStream.read(buffer, 0, len);
@@ -277,11 +278,11 @@ public class ChangeFileEncryption extends Tool {
         long total = remaining;
         in.seek(FileStore.HEADER_LENGTH);
         fileOut.seek(FileStore.HEADER_LENGTH);
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         while (remaining > 0) {
-            if (!quiet && System.currentTimeMillis() - time > 1000) {
+            if (!quiet && System.nanoTime() - time > TimeUnit.SECONDS.toNanos(1)) {
                 out.println(fileName + ": " + (100 - 100 * remaining / total) + "%");
-                time = System.currentTimeMillis();
+                time = System.nanoTime();
             }
             int len = (int) Math.min(buffer.length, remaining);
             in.readFully(buffer, 0, len);

--- a/h2/src/main/org/h2/tools/Console.java
+++ b/h2/src/main/org/h2/tools/Console.java
@@ -62,7 +62,7 @@ ShutdownHandler {
 //*/
     private Server web, tcp, pg;
     private boolean isWindows;
-    private long lastOpen;
+    private long lastOpenNs;
 
     /**
      * When running without options, -tcp, -web, -browser and -pg are started.
@@ -535,8 +535,8 @@ ShutdownHandler {
                 urlText.setText(url);
             }
             long now = System.nanoTime();
-            if (lastOpen == 0 || lastOpen + TimeUnit.MILLISECONDS.toNanos(100) < now) {
-                lastOpen = now;
+            if (lastOpenNs == 0 || lastOpenNs + TimeUnit.MILLISECONDS.toNanos(100) < now) {
+                lastOpenNs = now;
                 openBrowser(url);
             }
         }

--- a/h2/src/main/org/h2/tools/Console.java
+++ b/h2/src/main/org/h2/tools/Console.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.server.ShutdownHandler;
 import org.h2.util.JdbcUtils;
 import org.h2.util.Tool;
@@ -532,8 +534,8 @@ ShutdownHandler {
             if (urlText != null) {
                 urlText.setText(url);
             }
-            long now = System.currentTimeMillis();
-            if (lastOpen == 0 || lastOpen + 100 < now) {
+            long now = System.nanoTime();
+            if (lastOpen == 0 || lastOpen + TimeUnit.MILLISECONDS.toNanos(100) < now) {
                 lastOpen = now;
                 openBrowser(url);
             }

--- a/h2/src/main/org/h2/tools/RunScript.java
+++ b/h2/src/main/org/h2/tools/RunScript.java
@@ -16,6 +16,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
@@ -134,15 +135,15 @@ public class RunScript extends Tool {
             showUsage();
             throw new SQLException("URL not set");
         }
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         if (options != null) {
             processRunscript(url, user, password, script, options);
         } else {
             process(url, user, password, script, null, continueOnError);
         }
         if (showTime) {
-            time = System.currentTimeMillis() - time;
-            out.println("Done in " + time + " ms");
+            time = System.nanoTime() - time;
+            out.println("Done in " + TimeUnit.NANOSECONDS.toMillis(time) + " ms");
         }
     }
 

--- a/h2/src/main/org/h2/tools/Shell.java
+++ b/h2/src/main/org/h2/tools/Shell.java
@@ -19,6 +19,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.engine.Constants;
 import org.h2.server.web.ConnectionInfo;
 import org.h2.util.JdbcUtils;
@@ -447,20 +449,20 @@ public class Shell extends Tool implements Runnable {
         if (sql.trim().length() == 0) {
             return;
         }
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         try {
             ResultSet rs = null;
             try {
                 if (stat.execute(sql)) {
                     rs = stat.getResultSet();
                     int rowCount = printResult(rs, listMode);
-                    time = System.currentTimeMillis() - time;
+                    time = System.nanoTime() - time;
                     println("(" + rowCount + (rowCount == 1 ?
-                            " row, " : " rows, ") + time + " ms)");
+                            " row, " : " rows, ") + TimeUnit.NANOSECONDS.toMillis(time) + " ms)");
                 } else {
                     int updateCount = stat.getUpdateCount();
-                    time = System.currentTimeMillis() - time;
-                    println("(Update count: " + updateCount + ", " + time + " ms)");
+                    time = System.nanoTime() - time;
+                    println("(Update count: " + updateCount + ", " + TimeUnit.NANOSECONDS.toMillis(time) + " ms)");
                 }
             } finally {
                 JdbcUtils.closeSilently(rs);

--- a/h2/src/main/org/h2/util/NetUtils.java
+++ b/h2/src/main/org/h2/util/NetUtils.java
@@ -13,6 +13,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;
@@ -112,7 +113,7 @@ public class NetUtils {
      */
     public static Socket createSocket(InetAddress address, int port, boolean ssl)
             throws IOException {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         for (int i = 0;; i++) {
             try {
                 if (ssl) {
@@ -123,8 +124,8 @@ public class NetUtils {
                         SysProperties.SOCKET_CONNECT_TIMEOUT);
                 return socket;
             } catch (IOException e) {
-                if (System.currentTimeMillis() - start >=
-                        SysProperties.SOCKET_CONNECT_TIMEOUT) {
+                if (System.nanoTime() - start >=
+                        TimeUnit.MILLISECONDS.toNanos(SysProperties.SOCKET_CONNECT_TIMEOUT)) {
                     // either it was a connect timeout,
                     // or list of different exceptions
                     throw e;
@@ -250,9 +251,9 @@ public class NetUtils {
      * @return the local host address
      */
     public static synchronized String getLocalAddress() {
-        long now = System.currentTimeMillis();
+        long now = System.nanoTime();
         if (cachedLocalAddress != null) {
-            if (cachedLocalAddressTime + CACHE_MILLIS > now) {
+            if (cachedLocalAddressTime + TimeUnit.MILLISECONDS.toNanos(CACHE_MILLIS) > now) {
                 return cachedLocalAddress;
             }
         }

--- a/h2/src/main/org/h2/util/Profiler.java
+++ b/h2/src/main/org/h2/util/Profiler.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A simple CPU profiling tool similar to java -Xrunhprof. It can be used
@@ -135,15 +136,15 @@ public class Profiler implements Runnable {
             System.out.println(processes);
             return;
         }
-        start = System.currentTimeMillis();
+        start = System.nanoTime();
         if (args[0].matches("\\d+")) {
             pid = Integer.parseInt(args[0]);
             long last = 0;
             while (true) {
                 tick();
-                long t = System.currentTimeMillis();
-                if (t - last > 5000) {
-                    time = System.currentTimeMillis() - start;
+                long t = System.nanoTime();
+                if (t - last > TimeUnit.SECONDS.toNanos(5)) {
+                    time = System.nanoTime() - start;
                     System.out.println(getTopTraces(3));
                     last = t;
                 }
@@ -335,7 +336,7 @@ public class Profiler implements Runnable {
 
     @Override
     public void run() {
-        start = System.currentTimeMillis();
+        start = System.nanoTime();
         while (!stop) {
             try {
                 tick();
@@ -343,7 +344,7 @@ public class Profiler implements Runnable {
                 break;
             }
         }
-        time = System.currentTimeMillis() - start;
+        time = System.nanoTime() - start;
     }
 
     private void tick() {
@@ -462,7 +463,7 @@ public class Profiler implements Runnable {
         StringBuilder buff = new StringBuilder();
         buff.append("Profiler: top ").append(count).append(" stack trace(s) of ");
         if (time > 0) {
-            buff.append(" of ").append(time).append(" ms");
+            buff.append(" of ").append(TimeUnit.NANOSECONDS.toMillis(time)).append(" ms");
         }
         if (threadDumps > 0) {
             buff.append(" of ").append(threadDumps).append(" thread dumps");

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -9,6 +9,8 @@ import java.lang.ref.SoftReference;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
@@ -61,8 +63,8 @@ public class StringUtils {
         }
         // create a new cache at most every 5 seconds
         // so that out of memory exceptions are not delayed
-        long time = System.currentTimeMillis();
-        if (softCacheCreated != 0 && time - softCacheCreated < 5000) {
+        long time = System.nanoTime();
+        if (softCacheCreated != 0 && time - softCacheCreated < TimeUnit.SECONDS.toNanos(5)) {
             return null;
         }
         try {
@@ -70,7 +72,7 @@ public class StringUtils {
             softCache = new SoftReference<String[]>(cache);
             return cache;
         } finally {
-            softCacheCreated = System.currentTimeMillis();
+            softCacheCreated = System.nanoTime();
         }
     }
 

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -23,7 +23,7 @@ public class StringUtils {
 
     private static SoftReference<String[]> softCache =
             new SoftReference<String[]>(null);
-    private static long softCacheCreated;
+    private static long softCacheCreatedNs;
 
     private static final char[] HEX = "0123456789abcdef".toCharArray();
     private static final int[] HEX_DECODE = new int['f' + 1];
@@ -64,7 +64,7 @@ public class StringUtils {
         // create a new cache at most every 5 seconds
         // so that out of memory exceptions are not delayed
         long time = System.nanoTime();
-        if (softCacheCreated != 0 && time - softCacheCreated < TimeUnit.SECONDS.toNanos(5)) {
+        if (softCacheCreatedNs != 0 && time - softCacheCreatedNs < TimeUnit.SECONDS.toNanos(5)) {
             return null;
         }
         try {
@@ -72,7 +72,7 @@ public class StringUtils {
             softCache = new SoftReference<String[]>(cache);
             return cache;
         } finally {
-            softCacheCreated = System.nanoTime();
+            softCacheCreatedNs = System.nanoTime();
         }
     }
 

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -316,13 +317,13 @@ public class Utils {
     private static synchronized void collectGarbage() {
         Runtime runtime = Runtime.getRuntime();
         long total = runtime.totalMemory();
-        long time = System.currentTimeMillis();
-        if (lastGC + GC_DELAY < time) {
+        long time = System.nanoTime();
+        if (lastGC + TimeUnit.MILLISECONDS.toNanos(GC_DELAY) < time) {
             for (int i = 0; i < MAX_GC; i++) {
                 runtime.gc();
                 long now = runtime.totalMemory();
                 if (now == total) {
-                    lastGC = System.currentTimeMillis();
+                    lastGC = System.nanoTime();
                     break;
                 }
                 total = now;

--- a/h2/src/test/org/h2/samples/DirectInsert.java
+++ b/h2/src/test/org/h2/samples/DirectInsert.java
@@ -10,6 +10,8 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.tools.DeleteDbFiles;
 
 /**
@@ -42,10 +44,10 @@ public class DirectInsert {
         stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR)");
         PreparedStatement prep = conn.prepareStatement(
                 "INSERT INTO TEST VALUES(?, 'Test' || SPACE(100))");
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         for (int i = 0; i < len; i++) {
-            long now = System.currentTimeMillis();
-            if (now > time + 1000) {
+            long now = System.nanoTime();
+            if (now > time + TimeUnit.SECONDS.toNanos(1)) {
                 time = now;
                 System.out.println("Inserting " + (100L * i / len) + "%");
             }
@@ -66,10 +68,10 @@ public class DirectInsert {
         stat.execute("DROP TABLE IF EXISTS TEST2");
         System.out.println("CREATE TABLE ... AS SELECT " +
                 (optimize ? "(optimized)" : ""));
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         stat.execute("CREATE TABLE TEST2 AS SELECT * FROM TEST");
         System.out.printf("%.3f sec.\n",
-                (System.currentTimeMillis() - time) / 1000.0);
+                (double)(System.nanoTime() - time) / TimeUnit.SECONDS.toNanos(1));
         stat.execute("INSERT INTO TEST2 SELECT * FROM TEST2");
         stat.close();
         conn.close();

--- a/h2/src/test/org/h2/samples/ShowProgress.java
+++ b/h2/src/test/org/h2/samples/ShowProgress.java
@@ -10,6 +10,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.api.DatabaseEventListener;
 import org.h2.jdbc.JdbcConnection;
@@ -28,7 +29,7 @@ public class ShowProgress implements DatabaseEventListener {
      * Create a new instance of this class, and start the timer.
      */
     public ShowProgress() {
-        start = last = System.currentTimeMillis();
+        start = last = System.nanoTime();
     }
 
     /**
@@ -53,11 +54,11 @@ public class ShowProgress implements DatabaseEventListener {
         PreparedStatement prep = conn.prepareStatement(
                 "INSERT INTO TEST VALUES(?, 'Test' || SPACE(100))");
         long time;
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         int len = 1000;
         for (int i = 0; i < len; i++) {
-            long now = System.currentTimeMillis();
-            if (now > time + 1000) {
+            long now = System.nanoTime();
+            if (now > time + TimeUnit.SECONDS.toNanos(1)) {
                 time = now;
                 System.out.println("Inserting " + (100L * i / len) + "%");
             }
@@ -77,12 +78,12 @@ public class ShowProgress implements DatabaseEventListener {
         }
 
         System.out.println("Open connection...");
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         conn = DriverManager.getConnection(
                 "jdbc:h2:test;DATABASE_EVENT_LISTENER='" +
                 getClass().getName() + "'", "sa", "");
-        time = System.currentTimeMillis() - time;
-        System.out.println("Done after " + time + " ms");
+        time = System.nanoTime() - time;
+        System.out.println("Done after " + TimeUnit.NANOSECONDS.toMillis(time) + " ms");
         prep.close();
         stat.close();
         conn.close();
@@ -112,8 +113,8 @@ public class ShowProgress implements DatabaseEventListener {
      */
     @Override
     public void setProgress(int state, String name, int current, int max) {
-        long time = System.currentTimeMillis();
-        if (time < last + 5000) {
+        long time = System.nanoTime();
+        if (time < last + TimeUnit.SECONDS.toNanos(5)) {
             return;
         }
         last = time;
@@ -139,7 +140,7 @@ public class ShowProgress implements DatabaseEventListener {
         System.out.println("State: " + stateName + " " +
                 (100 * current / max) + "% (" +
                 current + " of " + max + ") "
-                + (time - start) + " ms");
+                + TimeUnit.NANOSECONDS.toMillis(time - start) + " ms");
     }
 
     /**

--- a/h2/src/test/org/h2/samples/ShowProgress.java
+++ b/h2/src/test/org/h2/samples/ShowProgress.java
@@ -22,14 +22,14 @@ import org.h2.jdbc.JdbcConnection;
  */
 public class ShowProgress implements DatabaseEventListener {
 
-    private final long start;
-    private long last;
+    private final long startNs;
+    private long lastNs;
 
     /**
-     * Create a new instance of this class, and start the timer.
+     * Create a new instance of this class, and startNs the timer.
      */
     public ShowProgress() {
-        start = last = System.nanoTime();
+        startNs = lastNs = System.nanoTime();
     }
 
     /**
@@ -114,10 +114,10 @@ public class ShowProgress implements DatabaseEventListener {
     @Override
     public void setProgress(int state, String name, int current, int max) {
         long time = System.nanoTime();
-        if (time < last + TimeUnit.SECONDS.toNanos(5)) {
+        if (time < lastNs + TimeUnit.SECONDS.toNanos(5)) {
             return;
         }
-        last = time;
+        lastNs = time;
         String stateName = "?";
         switch (state) {
         case STATE_SCAN_FILE:
@@ -140,7 +140,7 @@ public class ShowProgress implements DatabaseEventListener {
         System.out.println("State: " + stateName + " " +
                 (100 * current / max) + "% (" +
                 current + " of " + max + ") "
-                + TimeUnit.NANOSECONDS.toMillis(time - start) + " ms");
+                + TimeUnit.NANOSECONDS.toMillis(time - startNs) + " ms");
     }
 
     /**

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -10,6 +10,8 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Properties;
 import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.Driver;
 import org.h2.engine.Constants;
 import org.h2.store.fs.FilePathRec;
@@ -437,7 +439,7 @@ java org.h2.test.TestAll timer
 
     private static void run(String... args) throws Exception {
         SelfDestructor.startCountdown(4 * 60);
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         printSystemInfo();
 
         // use lower values, to better test those cases,
@@ -533,7 +535,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
             test.testAll();
         }
         System.out.println(TestBase.formatTime(
-                System.currentTimeMillis() - time) + " total");
+                TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time)) + " total");
     }
 
     private void testAll() throws Exception {

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -32,6 +32,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.SimpleTimeZone;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.jdbc.JdbcConnection;
 import org.h2.message.DbException;
 import org.h2.store.fs.FilePath;
@@ -144,7 +146,7 @@ public abstract class TestBase {
         }
         try {
             init(conf);
-            start = System.currentTimeMillis();
+            start = System.nanoTime();
             test();
             println("");
         } catch (Throwable e) {
@@ -519,10 +521,10 @@ public abstract class TestBase {
      * @param s the message
      */
     public void println(String s) {
-        long now = System.currentTimeMillis();
-        if (now > lastPrint + 1000) {
+        long now = System.nanoTime();
+        if (now > lastPrint + TimeUnit.SECONDS.toNanos(1)) {
             lastPrint = now;
-            long time = now - start;
+            long time = TimeUnit.NANOSECONDS.toMillis(now - start);
             printlnWithTime(time, getClass().getName() + " " + s);
         }
     }

--- a/h2/src/test/org/h2/test/bench/Database.java
+++ b/h2/src/test/org/h2/test/bench/Database.java
@@ -36,7 +36,7 @@ class Database {
     private String name, url, user, password;
     private final ArrayList<String[]> replace = new ArrayList<String[]>();
     private String currentAction;
-    private long startTime;
+    private long startTimeNs;
     private Connection conn;
     private Statement stat;
     private long lastTrace;
@@ -271,7 +271,7 @@ class Database {
      */
     void start(Bench bench, String action) {
         this.currentAction = bench.getName() + ": " + action;
-        this.startTime = System.nanoTime();
+        this.startTimeNs = System.nanoTime();
     }
 
     /**
@@ -279,7 +279,7 @@ class Database {
      * data.
      */
     void end() {
-        long time = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+        long time = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs);
         log(currentAction, "ms", (int) time);
         if (test.isCollect()) {
             totalTime += time;

--- a/h2/src/test/org/h2/test/bench/Database.java
+++ b/h2/src/test/org/h2/test/bench/Database.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.Random;
 import java.util.StringTokenizer;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.h2.test.TestBase;
 import org.h2.tools.Server;
@@ -270,7 +271,7 @@ class Database {
      */
     void start(Bench bench, String action) {
         this.currentAction = bench.getName() + ": " + action;
-        this.startTime = System.currentTimeMillis();
+        this.startTime = System.nanoTime();
     }
 
     /**
@@ -278,7 +279,7 @@ class Database {
      * data.
      */
     void end() {
-        long time = System.currentTimeMillis() - startTime;
+        long time = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
         log(currentAction, "ms", (int) time);
         if (test.isCollect()) {
             totalTime += time;
@@ -361,10 +362,10 @@ class Database {
      */
     void trace(String action, int i, int max) {
         if (TRACE) {
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             if (i == 0 || lastTrace == 0) {
                 lastTrace = time;
-            } else if (time > lastTrace + 1000) {
+            } else if (time > lastTrace + TimeUnit.SECONDS.toNanos(1)) {
                 System.out.println(action + ": " + ((100 * i / max) + "%"));
                 lastTrace = time;
             }
@@ -402,9 +403,9 @@ class Database {
      * @return the result set
      */
     ResultSet query(PreparedStatement prep) throws SQLException {
-        // long time = System.currentTimeMillis();
+        // long time = System.nanoTime();
         ResultSet rs = prep.executeQuery();
-        // time = System.currentTimeMillis() - time;
+        // time = System.nanoTime() - time;
         // if(time > 100) {
         //     System.out.println("time="+time);
         // }

--- a/h2/src/test/org/h2/test/coverage/Coverage.java
+++ b/h2/src/test/org/h2/test/coverage/Coverage.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.util.New;
 
 /**
@@ -127,10 +129,10 @@ public class Coverage {
 
     private void processAll() {
         int len = files.size();
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         for (int i = 0; i < len; i++) {
-            long t2 = System.currentTimeMillis();
-            if (t2 - time > 1000 || i >= len - 1) {
+            long t2 = System.nanoTime();
+            if (t2 - time > TimeUnit.SECONDS.toNanos(1) || i >= len - 1) {
                 System.out.println((i + 1) + " of " + len +
                         " " + (100 * i / len) + "%");
                 time = t2;

--- a/h2/src/test/org/h2/test/coverage/Profile.java
+++ b/h2/src/test/org/h2/test/coverage/Profile.java
@@ -27,7 +27,7 @@ public class Profile extends Thread {
     private boolean stop;
     private int maxIndex;
     private int lastIndex;
-    private long lastTime;
+    private long lastTimeNs;
     private BufferedWriter trace;
 
     private Profile() {
@@ -38,7 +38,7 @@ public class Profile extends Thread {
             maxIndex = r.getLineNumber();
             count = new int[maxIndex];
             time = new int[maxIndex];
-            lastTime = System.nanoTime();
+            lastTimeNs = System.nanoTime();
             Runtime.getRuntime().addShutdownHook(this);
         } catch (Exception e) {
             e.printStackTrace();
@@ -77,7 +77,7 @@ public class Profile extends Thread {
      */
     public static void startCollecting() {
         MAIN.stop = false;
-        MAIN.lastTime = System.nanoTime();
+        MAIN.lastTimeNs = System.nanoTime();
     }
 
     /**
@@ -111,7 +111,7 @@ public class Profile extends Thread {
         long now = System.nanoTime();
         if (TRACE) {
             if (trace != null) {
-                int duration = (int) TimeUnit.NANOSECONDS.toMillis(now - lastTime);
+                long duration = TimeUnit.NANOSECONDS.toMillis(now - lastTimeNs);
                 try {
                     trace.write(i + "\t" + duration + "\r\n");
                 } catch (Exception e) {
@@ -121,8 +121,8 @@ public class Profile extends Thread {
             }
         }
         count[i]++;
-        time[lastIndex] += (int) TimeUnit.NANOSECONDS.toMillis(now - lastTime);
-        lastTime = now;
+        time[lastIndex] += (int) TimeUnit.NANOSECONDS.toMillis(now - lastTimeNs);
+        lastTimeNs = now;
         lastIndex = i;
     }
 

--- a/h2/src/test/org/h2/test/coverage/Profile.java
+++ b/h2/src/test/org/h2/test/coverage/Profile.java
@@ -10,6 +10,8 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.LineNumberReader;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.util.IOUtils;
 
 /**
@@ -36,7 +38,7 @@ public class Profile extends Thread {
             maxIndex = r.getLineNumber();
             count = new int[maxIndex];
             time = new int[maxIndex];
-            lastTime = System.currentTimeMillis();
+            lastTime = System.nanoTime();
             Runtime.getRuntime().addShutdownHook(this);
         } catch (Exception e) {
             e.printStackTrace();
@@ -75,7 +77,7 @@ public class Profile extends Thread {
      */
     public static void startCollecting() {
         MAIN.stop = false;
-        MAIN.lastTime = System.currentTimeMillis();
+        MAIN.lastTime = System.nanoTime();
     }
 
     /**
@@ -106,10 +108,10 @@ public class Profile extends Thread {
         if (stop) {
             return;
         }
-        long now = System.currentTimeMillis();
+        long now = System.nanoTime();
         if (TRACE) {
             if (trace != null) {
-                int duration = (int) (now - lastTime);
+                int duration = (int) TimeUnit.NANOSECONDS.toMillis(now - lastTime);
                 try {
                     trace.write(i + "\t" + duration + "\r\n");
                 } catch (Exception e) {
@@ -119,7 +121,7 @@ public class Profile extends Thread {
             }
         }
         count[i]++;
-        time[lastIndex] += (int) (now - lastTime);
+        time[lastIndex] += (int) TimeUnit.NANOSECONDS.toMillis(now - lastTime);
         lastTime = now;
         lastIndex = i;
     }

--- a/h2/src/test/org/h2/test/db/TestBackup.java
+++ b/h2/src/test/org/h2/test/db/TestBackup.java
@@ -9,6 +9,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.h2.api.DatabaseEventListener;
@@ -64,7 +65,7 @@ public class TestBackup extends TestBase {
             @Override
             public void call() throws Exception {
                 while (!stop) {
-                    if (System.currentTimeMillis() < updateEnd.get()) {
+                    if (System.nanoTime() < updateEnd.get()) {
                         stat.execute("update test set name = 'Hallo'");
                         stat1.execute("checkpoint");
                         stat.execute("update test set name = 'Hello'");
@@ -82,7 +83,7 @@ public class TestBackup extends TestBase {
         Statement stat2 = conn2.createStatement();
         task.execute();
         for (int i = 0; i < 10; i++) {
-            updateEnd.set(System.currentTimeMillis() + 2000);
+            updateEnd.set(System.nanoTime() + TimeUnit.SECONDS.toNanos(2));
             stat2.execute("backup to '"+getBaseDir()+"/backup.zip'");
             stat2.execute("checkpoint");
             Restore.execute(getBaseDir() + "/backup.zip", getBaseDir() + "/t" + i, "backup");

--- a/h2/src/test/org/h2/test/db/TestBigDb.java
+++ b/h2/src/test/org/h2/test/db/TestBigDb.java
@@ -10,6 +10,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
 import org.h2.util.Utils;
@@ -86,11 +87,11 @@ public class TestBigDb extends TestBase {
         try {
             PreparedStatement prep = conn.prepareStatement(
                     "INSERT INTO TEST(PRD_CODE) VALUES('abc' || ?)");
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             for (int i = 0; i < len; i++) {
                 if ((i % 1000) == 0) {
-                    long t = System.currentTimeMillis();
-                    if (t - time > 1000) {
+                    long t = System.nanoTime();
+                    if (t - time > TimeUnit.SECONDS.toNanos(1)) {
                         time = t;
                         int free = Utils.getMemoryFree();
                         println("i: " + i + " free: " + free + " used: " + Utils.getMemoryUsed());

--- a/h2/src/test/org/h2/test/db/TestCases.java
+++ b/h2/src/test/org/h2/test/db/TestCases.java
@@ -18,6 +18,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
@@ -845,14 +846,14 @@ public class TestCases extends TestBase {
             @Override
             public void run() {
                 try {
-                    long time = System.currentTimeMillis();
+                    long time = System.nanoTime();
                     ResultSet rs = stat.executeQuery("SELECT MAX(T.ID) " +
                             "FROM TEST T, TEST, TEST, TEST, TEST, " +
                             "TEST, TEST, TEST, TEST, TEST, TEST");
                     rs.next();
-                    time = System.currentTimeMillis() - time;
+                    time = System.nanoTime() - time;
                     TestBase.logError("query was too quick; result: " +
-                            rs.getInt(1) + " time:" + time, null);
+                            rs.getInt(1) + " time:" + TimeUnit.NANOSECONDS.toMillis(time), null);
                 } catch (SQLException e) {
                     stopped[0] = e;
                     // ok
@@ -861,7 +862,7 @@ public class TestCases extends TestBase {
         });
         t.start();
         Thread.sleep(300);
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         conn.close();
         t.join(5000);
         if (stopped[0] == null) {
@@ -869,8 +870,8 @@ public class TestCases extends TestBase {
         } else {
             assertKnownException(stopped[0]);
         }
-        time = System.currentTimeMillis() - time;
-        if (time > 5000) {
+        time = System.nanoTime() - time;
+        if (time > TimeUnit.SECONDS.toNanos(5)) {
             if (!config.reopen) {
                 fail("closing took " + time);
             }

--- a/h2/src/test/org/h2/test/db/TestCsv.java
+++ b/h2/src/test/org/h2/test/db/TestCsv.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;
@@ -557,19 +558,19 @@ public class TestCsv extends TestBase {
             stat.execute("INSERT INTO TEST(NAME) VALUES('Ruebezahl')");
         }
         long time;
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         new Csv().write(conn, getBaseDir() + "/testRW.csv",
                 "SELECT X ID, 'Ruebezahl' NAME FROM SYSTEM_RANGE(1, " + len + ")", "UTF8");
-        trace("write: " + (System.currentTimeMillis() - time));
+        trace("write: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         ResultSet rs;
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         for (int i = 0; i < 30; i++) {
             rs = new Csv().read(getBaseDir() + "/testRW.csv", null, "UTF8");
             while (rs.next()) {
                 // ignore
             }
         }
-        trace("read: " + (System.currentTimeMillis() - time));
+        trace("read: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         rs = new Csv().read(getBaseDir() + "/testRW.csv", null, "UTF8");
         // stat.execute("CREATE ALIAS CSVREAD FOR \"org.h2.tools.Csv.read\"");
         ResultSetMetaData meta = rs.getMetaData();

--- a/h2/src/test/org/h2/test/db/TestDeadlock.java
+++ b/h2/src/test/org/h2/test/db/TestDeadlock.java
@@ -10,6 +10,8 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
 import org.h2.util.Task;
@@ -80,8 +82,8 @@ public class TestDeadlock extends TestBase {
             }
         };
         t.execute();
-        long start = System.currentTimeMillis();
-        while (System.currentTimeMillis() - start < 1000) {
+        long start = System.nanoTime();
+        while (System.nanoTime() - start < TimeUnit.SECONDS.toNanos(1)) {
             stat2.execute("insert into test values(1, 'Hello')");
             stat2.execute("delete from test");
         }
@@ -117,8 +119,8 @@ public class TestDeadlock extends TestBase {
             }
         };
         t.execute();
-        long start = System.currentTimeMillis();
-        while (System.currentTimeMillis() - start < 1000) {
+        long start = System.nanoTime();
+        while (System.nanoTime() - start < TimeUnit.SECONDS.toNanos(1)) {
             Reader r = rs2.getCharacterStream(2);
             char[] buff = new char[1024];
             while (true) {

--- a/h2/src/test/org/h2/test/db/TestFullText.java
+++ b/h2/src/test/org/h2/test/db/TestFullText.java
@@ -18,6 +18,8 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.fulltext.FullText;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
@@ -454,12 +456,12 @@ public class TestFullText extends TestBase {
                 "CREATE TABLE TEST AS SELECT * FROM INFORMATION_SCHEMA.HELP");
         stat.execute("ALTER TABLE TEST ALTER COLUMN ID INT NOT NULL");
         stat.execute("CREATE PRIMARY KEY ON TEST(ID)");
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         stat.execute("CALL " + prefix + "_CREATE_INDEX('PUBLIC', 'TEST', NULL)");
-        println("create " + prefix + ": " + (System.currentTimeMillis() - time));
+        println("create " + prefix + ": " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         PreparedStatement prep = conn.prepareStatement(
                 "SELECT * FROM " + prefix + "_SEARCH(?, 0, 0)");
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         ResultSet rs = stat.executeQuery("SELECT TEXT FROM TEST");
         int count = 0;
         while (rs.next()) {
@@ -480,7 +482,7 @@ public class TestFullText extends TestBase {
             }
         }
         println("search " + prefix + ": " +
-                (System.currentTimeMillis() - time) + " count: " + count);
+        		TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time) + " count: " + count);
         stat.execute("CALL " + prefix + "_DROP_ALL()");
         conn.close();
     }

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -79,15 +79,15 @@ public class TestIndex extends TestBase {
         testLargeIndex();
         testMultiColumnIndex();
         // long time;
-        // time = System.currentTimeMillis();
+        // time = System.nanoTime();
         testHashIndex(true, false);
 
         testHashIndex(false, false);
-        // System.out.println("b-tree="+(System.currentTimeMillis()-time));
-        // time = System.currentTimeMillis();
+        // System.out.println("b-tree="+TimeUnit.NANOSECONDS.toMillis(System.nanoTime()-time));
+        // time = System.nanoTime();
         testHashIndex(true, true);
         testHashIndex(false, true);
-        // System.out.println("hash="+(System.currentTimeMillis()-time));
+        // System.out.println("hash="+TimeUnit.NANOSECONDS.toMillis(System.nanoTime()-time));
 
         testMultiColumnHashIndex();
 

--- a/h2/src/test/org/h2/test/db/TestListener.java
+++ b/h2/src/test/org/h2/test/db/TestListener.java
@@ -10,6 +10,8 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.DatabaseEventListener;
 import org.h2.test.TestBase;
 
@@ -23,7 +25,7 @@ public class TestListener extends TestBase implements DatabaseEventListener {
     private String databaseUrl;
 
     public TestListener() {
-        start = last = System.currentTimeMillis();
+        start = last = System.nanoTime();
     }
 
     /**
@@ -67,8 +69,8 @@ public class TestListener extends TestBase implements DatabaseEventListener {
 
     @Override
     public void setProgress(int state, String name, int current, int max) {
-        long time = System.currentTimeMillis();
-        if (state == lastState && time < last + 1000) {
+        long time = System.nanoTime();
+        if (state == lastState && time < last + TimeUnit.SECONDS.toNanos(1)) {
             return;
         }
         if (state == STATE_STATEMENT_START ||
@@ -102,7 +104,7 @@ public class TestListener extends TestBase implements DatabaseEventListener {
             // ignore
         }
         printTime("state: " + stateName + " " +
-                (100 * current / max) + " " + (time - start));
+                (100 * current / max) + " " + TimeUnit.NANOSECONDS.toMillis(time - start));
     }
 
     @Override

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -23,6 +23,8 @@ import java.sql.SQLException;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;
 import org.h2.jdbc.JdbcConnection;
@@ -1133,7 +1135,7 @@ public class TestLob extends TestBase {
         conn.createStatement().execute("CREATE TABLE TEST(ID INT PRIMARY KEY, C CLOB)");
         PreparedStatement prep = conn.prepareStatement(
                 "INSERT INTO TEST VALUES(?, ?)");
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         int len = getSize(10, 40);
         if (config.networked && config.big) {
             len = 5;
@@ -1161,8 +1163,8 @@ public class TestLob extends TestBase {
                 }
             }
         }
-        time = System.currentTimeMillis() - time;
-        trace("time: " + time + " compress: " + compress);
+        time = System.nanoTime() - time;
+        trace("time: " + TimeUnit.NANOSECONDS.toMillis(time) + " compress: " + compress);
         conn.close();
         if (!config.memory) {
             long length = new File(getBaseDir() + "/lob.h2.db").length();
@@ -1285,12 +1287,12 @@ public class TestLob extends TestBase {
     }
 
     private Connection reconnect(Connection conn) throws SQLException {
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         if (conn != null) {
             JdbcUtils.closeSilently(conn);
         }
         conn = getConnection("lob");
-        trace("re-connect=" + (System.currentTimeMillis() - time));
+        trace("re-connect=" + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         return conn;
     }
 
@@ -1396,7 +1398,7 @@ public class TestLob extends TestBase {
             len = 100;
         }
 
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         prep = conn.prepareStatement("INSERT INTO TEST VALUES(?, ?)");
         for (int i = 0; i < len; i += i + i + 1) {
             prep.setInt(1, i);
@@ -1408,11 +1410,11 @@ public class TestLob extends TestBase {
             }
             prep.execute();
         }
-        trace("insert=" + (System.currentTimeMillis() - time));
+        trace("insert=" + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         traceMemory();
         conn = reconnect(conn);
 
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         prep = conn.prepareStatement("SELECT ID, VALUE FROM TEST");
         rs = prep.executeQuery();
         while (rs.next()) {
@@ -1438,18 +1440,18 @@ public class TestLob extends TestBase {
                         (InputStream) obj, -1);
             }
         }
-        trace("select=" + (System.currentTimeMillis() - time));
+        trace("select=" + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         traceMemory();
 
         conn = reconnect(conn);
 
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         prep = conn.prepareStatement("DELETE FROM TEST WHERE ID=?");
         for (int i = 0; i < len; i++) {
             prep.setInt(1, i);
             prep.executeUpdate();
         }
-        trace("delete=" + (System.currentTimeMillis() - time));
+        trace("delete=" + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         traceMemory();
         conn = reconnect(conn);
 

--- a/h2/src/test/org/h2/test/db/TestMemoryUsage.java
+++ b/h2/src/test/org/h2/test/db/TestMemoryUsage.java
@@ -11,6 +11,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.test.TestBase;
 import org.h2.util.Utils;
 
@@ -197,15 +199,15 @@ public class TestMemoryUsage extends TestBase {
         Connection conn1 = getConnection("memoryUsage");
         int len = getSize(1, 2000);
         printTimeMemory("start", 0);
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         for (int i = 0; i < len; i++) {
             Connection conn2 = getConnection("memoryUsage");
             conn2.close();
             if (i % 10000 == 0) {
-                printTimeMemory("connect", System.currentTimeMillis() - time);
+                printTimeMemory("connect", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
             }
         }
-        printTimeMemory("connect", System.currentTimeMillis() - time);
+        printTimeMemory("connect", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         conn1.close();
     }
 
@@ -215,14 +217,14 @@ public class TestMemoryUsage extends TestBase {
         int len = getSize(1, 2000);
 
         // insert
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         stat.execute("DROP TABLE IF EXISTS TEST");
-        trace("drop=" + (System.currentTimeMillis() - time));
+        trace("drop=" + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         stat.execute("CREATE CACHED TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR(255))");
         PreparedStatement prep = conn.prepareStatement(
                 "INSERT INTO TEST VALUES(?, 'Hello World')");
         printTimeMemory("start", 0);
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         for (int i = 0; i < len; i++) {
             prep.setInt(1, i);
             prep.execute();
@@ -230,10 +232,10 @@ public class TestMemoryUsage extends TestBase {
                 trace("  " + (100 * i / len) + "%");
             }
         }
-        printTimeMemory("insert", System.currentTimeMillis() - time);
+        printTimeMemory("insert", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
 
         // update
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         prep = conn.prepareStatement(
                 "UPDATE TEST SET NAME='Hallo Welt' || ID WHERE ID = ?");
         for (int i = 0; i < len; i++) {
@@ -243,10 +245,10 @@ public class TestMemoryUsage extends TestBase {
                 trace("  " + (100 * i / len) + "%");
             }
         }
-        printTimeMemory("update", System.currentTimeMillis() - time);
+        printTimeMemory("update", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
 
         // select
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         prep = conn.prepareStatement("SELECT * FROM TEST WHERE ID = ?");
         for (int i = 0; i < len; i++) {
             prep.setInt(1, i);
@@ -257,11 +259,11 @@ public class TestMemoryUsage extends TestBase {
                 trace("  " + (100 * i / len) + "%");
             }
         }
-        printTimeMemory("select", System.currentTimeMillis() - time);
+        printTimeMemory("select", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
 
         // select randomized
         Random random = new Random(1);
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         prep = conn.prepareStatement("SELECT * FROM TEST WHERE ID = ?");
         for (int i = 0; i < len; i++) {
             prep.setInt(1, random.nextInt(len));
@@ -272,10 +274,10 @@ public class TestMemoryUsage extends TestBase {
                 trace("  " + (100 * i / len) + "%");
             }
         }
-        printTimeMemory("select randomized", System.currentTimeMillis() - time);
+        printTimeMemory("select randomized", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
 
         // delete
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         prep = conn.prepareStatement("DELETE FROM TEST WHERE ID = ?");
         for (int i = 0; i < len; i++) {
             prep.setInt(1, random.nextInt(len));
@@ -284,7 +286,7 @@ public class TestMemoryUsage extends TestBase {
                 trace("  " + (100 * i / len) + "%");
             }
         }
-        printTimeMemory("delete", System.currentTimeMillis() - time);
+        printTimeMemory("delete", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
     }
 
 }

--- a/h2/src/test/org/h2/test/db/TestMultiDimension.java
+++ b/h2/src/test/org/h2/test/db/TestMultiDimension.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
 import org.h2.tools.MultiDimension;
@@ -106,11 +107,11 @@ public class TestMultiDimension extends TestBase {
         // the MultiDimension tool is faster for 4225 (65^2) points
         // the more the bigger the difference
         int max = getSize(30, 65);
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         for (int x = 0; x < max; x++) {
             for (int y = 0; y < max; y++) {
-                long t2 = System.currentTimeMillis();
-                if (t2 - time > 1000) {
+                long t2 = System.nanoTime();
+                if (t2 - time > TimeUnit.SECONDS.toNanos(1)) {
                     int percent = (int) (100.0 * ((double) x * max + y) /
                             ((double) max * max));
                     trace(percent + "%");
@@ -139,17 +140,17 @@ public class TestMultiDimension extends TestBase {
             int minX = rand.nextInt(max - size);
             int minY = rand.nextInt(max - size);
             int maxX = minX + size, maxY = minY + size;
-            time = System.currentTimeMillis();
+            time = System.nanoTime();
             ResultSet rs1 = multi.getResult(prepMulti,
                     new int[] { minX, minY }, new int[] { maxX, maxY });
-            timeMulti += System.currentTimeMillis() - time;
-            time = System.currentTimeMillis();
+            timeMulti += System.nanoTime() - time;
+            time = System.nanoTime();
             prepRegular.setInt(1, minX);
             prepRegular.setInt(2, maxX);
             prepRegular.setInt(3, minY);
             prepRegular.setInt(4, maxY);
             ResultSet rs2 = prepRegular.executeQuery();
-            timeRegular += System.currentTimeMillis() - time;
+            timeRegular += System.nanoTime() - time;
             while (rs1.next()) {
                 assertTrue(rs2.next());
                 assertEquals(rs1.getInt(1), rs2.getInt(1));
@@ -159,7 +160,7 @@ public class TestMultiDimension extends TestBase {
         }
         conn.close();
         deleteDb("multiDimension");
-        trace("2d: regular: " + timeRegular + " MultiDimension: " + timeMulti);
+        trace("2d: regular: " + TimeUnit.NANOSECONDS.toMillis(timeRegular) + " MultiDimension: " + TimeUnit.NANOSECONDS.toMillis(timeMulti));
     }
 
     private void testPerformance3d() throws SQLException {
@@ -179,12 +180,12 @@ public class TestMultiDimension extends TestBase {
         // the MultiDimension tool is faster for 8000 (20^3) points
         // the more the bigger the difference
         int max = getSize(10, 20);
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         for (int x = 0; x < max; x++) {
             for (int y = 0; y < max; y++) {
                 for (int z = 0; z < max; z++) {
-                    long t2 = System.currentTimeMillis();
-                    if (t2 - time > 1000) {
+                    long t2 = System.nanoTime();
+                    if (t2 - time > TimeUnit.SECONDS.toNanos(1)) {
                         int percent = (int) (100.0 * ((double) x * max + y) /
                                 ((double) max * max));
                         trace(percent + "%");
@@ -216,11 +217,11 @@ public class TestMultiDimension extends TestBase {
             int minY = rand.nextInt(max - size);
             int minZ = rand.nextInt(max - size);
             int maxX = minX + size, maxY = minY + size, maxZ = minZ + size;
-            time = System.currentTimeMillis();
+            time = System.nanoTime();
             ResultSet rs1 = multi.getResult(prepMulti, new int[] { minX, minY,
                     minZ }, new int[] { maxX, maxY, maxZ });
-            timeMulti += System.currentTimeMillis() - time;
-            time = System.currentTimeMillis();
+            timeMulti += System.nanoTime() - time;
+            time = System.nanoTime();
             prepRegular.setInt(1, minX);
             prepRegular.setInt(2, maxX);
             prepRegular.setInt(3, minY);
@@ -228,7 +229,7 @@ public class TestMultiDimension extends TestBase {
             prepRegular.setInt(5, minZ);
             prepRegular.setInt(6, maxZ);
             ResultSet rs2 = prepRegular.executeQuery();
-            timeRegular += System.currentTimeMillis() - time;
+            timeRegular += System.nanoTime() - time;
             while (rs1.next()) {
                 assertTrue(rs2.next());
                 assertEquals(rs1.getInt(1), rs2.getInt(1));
@@ -238,7 +239,7 @@ public class TestMultiDimension extends TestBase {
         }
         conn.close();
         deleteDb("multiDimension");
-        trace("3d: regular: " + timeRegular + " MultiDimension: " + timeMulti);
+        trace("3d: regular: " + TimeUnit.NANOSECONDS.toMillis(timeRegular) + " MultiDimension: " + TimeUnit.NANOSECONDS.toMillis(timeMulti));
     }
 
     /**

--- a/h2/src/test/org/h2/test/db/TestOpenClose.java
+++ b/h2/src/test/org/h2/test/db/TestOpenClose.java
@@ -13,6 +13,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
@@ -97,8 +99,8 @@ public class TestOpenClose extends TestBase {
         Connection conn = DriverManager.getConnection(url, user, password);
         conn.close();
         Thread.sleep(950);
-        long time = System.currentTimeMillis();
-        while (System.currentTimeMillis() - time < 100) {
+        long time = System.nanoTime();
+        while (System.nanoTime() - time < TimeUnit.MILLISECONDS.toNanos(100)) {
             conn = DriverManager.getConnection(url, user, password);
             conn.close();
         }

--- a/h2/src/test/org/h2/test/db/TestOptimizations.java
+++ b/h2/src/test/org/h2/test/db/TestOptimizations.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Random;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
@@ -802,16 +803,16 @@ public class TestOptimizations extends TestBase {
     private void testQuerySpeed(Statement stat, String sql) throws SQLException {
         stat.execute("set OPTIMIZE_REUSE_RESULTS 0");
         stat.execute(sql);
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         stat.execute(sql);
-        time = System.currentTimeMillis() - time;
+        time = System.nanoTime() - time;
         stat.execute("set OPTIMIZE_REUSE_RESULTS 1");
         stat.execute(sql);
-        long time2 = System.currentTimeMillis();
+        long time2 = System.nanoTime();
         stat.execute(sql);
-        time2 = System.currentTimeMillis() - time2;
+        time2 = System.nanoTime() - time2;
         if (time2 > time * 2) {
-            fail("not optimized: " + time + " optimized: " + time2 + " sql:" + sql);
+            fail("not optimized: " + TimeUnit.NANOSECONDS.toMillis(time) + " optimized: " + TimeUnit.NANOSECONDS.toMillis(time2) + " sql:" + sql);
         }
     }
 

--- a/h2/src/test/org/h2/test/db/TestSpeed.java
+++ b/h2/src/test/org/h2/test/db/TestSpeed.java
@@ -9,6 +9,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
 
@@ -55,7 +56,7 @@ public class TestSpeed extends TestBase {
         // stat.execute("CREATE TABLE TEST_A(ID INT PRIMARY KEY, NAME
         // VARCHAR(255))");
         // stat.execute("INSERT INTO TEST_A VALUES(0, 'Hello')");
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         // for(int i=1; i<8000; i*=2) {
         // stat.execute("INSERT INTO TEST_A SELECT ID+"+i+", NAME FROM TEST_A");
         //
@@ -68,7 +69,7 @@ public class TestSpeed extends TestBase {
         // rs.getString(2);
         // }
         // }
-        // System.out.println(System.currentTimeMillis()-time);
+        // System.out.println(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()-time));
 
         //
         // stat.execute("CREATE TABLE TEST_B(ID INT PRIMARY KEY, NAME
@@ -89,7 +90,7 @@ public class TestSpeed extends TestBase {
         // rs.getString("ID");
         // stat.execute("DROP TABLE TEST");
 
-        // long time = System.currentTimeMillis();
+        // long time = System.nanoTime();
 
         stat.execute("DROP TABLE IF EXISTS TEST");
         stat.execute("CREATE CACHED TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR(255))");
@@ -108,8 +109,8 @@ public class TestSpeed extends TestBase {
         // System.exit(0);
         // System.out.println("END "+Value.cacheHit+" "+Value.cacheMiss);
 
-        time = System.currentTimeMillis() - time;
-        trace(time + " insert");
+        time = System.nanoTime() - time;
+        trace(TimeUnit.NANOSECONDS.toMillis(time) + " insert");
 
         // if(true) return;
 
@@ -122,7 +123,7 @@ public class TestSpeed extends TestBase {
 
         // conn.close();
 
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
 
         prep = conn.prepareStatement("UPDATE TEST " +
                 "SET NAME='Another data row which is long' WHERE ID=?");
@@ -150,12 +151,13 @@ public class TestSpeed extends TestBase {
         // }
         // }
 
-        time = System.currentTimeMillis() - time;
-        trace(time + " update");
+        time = System.nanoTime() - time;
+        trace(TimeUnit.NANOSECONDS.toMillis(time) + " update");
 
+        time = System.nanoTime();
         conn.close();
-        time = System.currentTimeMillis() - time;
-        trace(time + " close");
+        time = System.nanoTime() - time;
+        trace(TimeUnit.NANOSECONDS.toMillis(time) + " close");
         deleteDb("speed");
     }
 

--- a/h2/src/test/org/h2/test/jdbcx/TestConnectionPool.java
+++ b/h2/src/test/org/h2/test/jdbcx/TestConnectionPool.java
@@ -11,6 +11,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
 import javax.sql.DataSource;
 
 import org.h2.jdbcx.JdbcConnectionPool;
@@ -95,7 +97,7 @@ public class TestConnectionPool extends TestBase {
             }
         };
         t.execute();
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         try {
             // connection 2 (of 1 or 2) may fail
             man.getConnection();
@@ -104,8 +106,8 @@ public class TestConnectionPool extends TestBase {
             fail();
         } catch (SQLException e) {
             assertContains(e.toString().toLowerCase(), "timeout");
-            time = System.currentTimeMillis() - time;
-            assertTrue("timeout after " + time + " ms", time > 1000);
+            time = System.nanoTime() - time;
+            assertTrue("timeout after " + TimeUnit.NANOSECONDS.toMillis(time) + " ms", time > TimeUnit.SECONDS.toNanos(1));
         } finally {
             conn.close();
             t.get();
@@ -151,17 +153,17 @@ public class TestConnectionPool extends TestBase {
         JdbcConnectionPool man = JdbcConnectionPool.create(url, user, password);
         Connection conn = man.getConnection();
         int len = 1000;
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         for (int i = 0; i < len; i++) {
             man.getConnection().close();
         }
         man.dispose();
-        trace((int) (System.currentTimeMillis() - time));
-        time = System.currentTimeMillis();
+        trace((int) TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
+        time = System.nanoTime();
         for (int i = 0; i < len; i++) {
             DriverManager.getConnection(url, user, password).close();
         }
-        trace((int) (System.currentTimeMillis() - time));
+        trace((int) TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         conn.close();
     }
 

--- a/h2/src/test/org/h2/test/poweroff/Listener.java
+++ b/h2/src/test/org/h2/test/poweroff/Listener.java
@@ -9,6 +9,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The listener application for the power off test.
@@ -60,7 +61,7 @@ public class Listener implements Runnable {
             Socket socket = serverSocket.accept();
             DataInputStream in = new DataInputStream(socket.getInputStream());
             System.out.println("Connected");
-            time = System.currentTimeMillis();
+            time = System.nanoTime();
             try {
                 while (true) {
                     int value = in.readInt();
@@ -72,8 +73,8 @@ public class Listener implements Runnable {
             } catch (IOException e) {
                 System.out.println("Closed with Exception: " + e);
             }
-            time = System.currentTimeMillis() - time;
-            int operationsPerSecond = (int) (1000 * maxValue / time);
+            time = System.nanoTime() - time;
+            int operationsPerSecond = (int) (TimeUnit.SECONDS.toNanos(1) * maxValue / time);
             System.out.println("Max=" + maxValue +
                     " operations/sec=" + operationsPerSecond);
         }

--- a/h2/src/test/org/h2/test/poweroff/TestWrite.java
+++ b/h2/src/test/org/h2/test/poweroff/TestWrite.java
@@ -13,6 +13,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This test shows the raw file access performance using various file modes.
@@ -57,7 +58,7 @@ public class TestWrite {
         RandomAccessFile file = new RandomAccessFile("test.txt", mode);
         file.setLength(0);
         FileDescriptor fd = file.getFD();
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         byte[] data = { 0 };
         file.write(data);
         int i = 0;
@@ -67,8 +68,8 @@ public class TestWrite {
                 file.write(data);
                 fd.sync();
                 if ((i & 15) == 0) {
-                    long time = System.currentTimeMillis() - start;
-                    if (time > 5000) {
+                    long time = System.nanoTime() - start;
+                    if (time > TimeUnit.SECONDS.toNanos(5)) {
                         break;
                     }
                 }
@@ -78,17 +79,17 @@ public class TestWrite {
                 file.seek(0);
                 file.write(data);
                 if ((i & 1023) == 0) {
-                    long time = System.currentTimeMillis() - start;
-                    if (time > 5000) {
+                    long time = System.nanoTime() - start;
+                    if (time > TimeUnit.SECONDS.toNanos(5)) {
                         break;
                     }
                 }
             }
         }
-        long time = System.currentTimeMillis() - start;
-        System.out.println("Time: " + time);
+        long time = System.nanoTime() - start;
+        System.out.println("Time: " + TimeUnit.NANOSECONDS.toMillis(time));
         System.out.println("Operations: " + i);
-        System.out.println("Operations/second: " + (i * 1000 / time));
+        System.out.println("Operations/second: " + (i * TimeUnit.SECONDS.toNanos(1) / time));
         System.out.println();
         file.close();
         new File("test.txt").delete();
@@ -108,23 +109,23 @@ public class TestWrite {
         stat.execute("CREATE TABLE TEST(ID INT)");
         PreparedStatement prep = conn.prepareStatement(
                 "INSERT INTO TEST VALUES(?)");
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         int i = 0;
         for (;; i++) {
             prep.setInt(1, i);
             // autocommit is on by default, so this commits as well
             prep.execute();
             if ((i & 15) == 0) {
-                long time = System.currentTimeMillis() - start;
-                if (time > 5000) {
+                long time = System.nanoTime() - start;
+                if (time > TimeUnit.SECONDS.toNanos(5)) {
                     break;
                 }
             }
         }
-        long time = System.currentTimeMillis() - start;
-        System.out.println("Time: " + time);
+        long time = System.nanoTime() - start;
+        System.out.println("Time: " + TimeUnit.NANOSECONDS.toMillis(time));
         System.out.println("Operations: " + i);
-        System.out.println("Operations/second: " + (i * 1000 / time));
+        System.out.println("Operations/second: " + (i * TimeUnit.SECONDS.toNanos(1) / time));
         System.out.println();
         stat.execute("DROP TABLE TEST");
         conn.close();

--- a/h2/src/test/org/h2/test/store/CalculateHashConstant.java
+++ b/h2/src/test/org/h2/test/store/CalculateHashConstant.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.h2.security.AES;
 
@@ -339,7 +340,7 @@ public class CalculateHashConstant implements Runnable {
         BitSet set = new BitSet();
         BitSet neg = new BitSet();
         long collisions = 0;
-        long t = System.currentTimeMillis();
+        long t = System.nanoTime();
         for (int i = Integer.MIN_VALUE; i != Integer.MAX_VALUE; i++) {
             int x = hash(i);
             if (x >= 0) {
@@ -357,8 +358,8 @@ public class CalculateHashConstant implements Runnable {
                 }
             }
             if ((i & 0xfffff) == 0) {
-                long n = System.currentTimeMillis();
-                if (n - t > 5000) {
+                long n = System.nanoTime();
+                if (n - t > TimeUnit.SECONDS.toNanos(5)) {
                     System.out.println(Integer.toHexString(constant) + " " +
                             Integer.toHexString(i) + " collisions: " + collisions);
                     t = n;

--- a/h2/src/test/org/h2/test/store/TestBenchmark.java
+++ b/h2/src/test/org/h2/test/store/TestBenchmark.java
@@ -10,6 +10,7 @@ import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.h2.mvstore.MVMap;
@@ -156,12 +157,12 @@ public class TestBenchmark extends TestBase {
             }
         }
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         // Profiler prof = new Profiler().startCollecting();
         stat.execute("create index on test(data)");
         // System.out.println(prof.getTop(5));
 
-        System.out.println((System.currentTimeMillis() - start) + " "
+        System.out.println(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) + " "
                 + (mvStore ? "mvstore" : "default"));
         conn.createStatement().execute("shutdown compact");
         conn.close();
@@ -191,7 +192,7 @@ public class TestBenchmark extends TestBase {
         int rowCount = 100;
         int readCount = 20 * rowCount;
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         for (int i = 0; i < rowCount; i++) {
             prep.setInt(1, i);
@@ -209,7 +210,7 @@ public class TestBenchmark extends TestBase {
             prep.executeQuery();
         }
 
-        System.out.println((System.currentTimeMillis() - start) + " "
+        System.out.println(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) + " "
                 + (mvStore ? "mvstore" : "default"));
         conn.close();
     }
@@ -249,7 +250,7 @@ public class TestBenchmark extends TestBase {
                 conn.commit();
             }
         }
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         prep = conn.prepareStatement("select * from test where id = ?");
         for (int i = 0; i < readCount; i++) {
@@ -257,7 +258,7 @@ public class TestBenchmark extends TestBase {
             prep.executeQuery();
         }
 
-        System.out.println((System.currentTimeMillis() - start) + " "
+        System.out.println(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) + " "
                 + (mvStore ? "mvstore" : "default"));
         conn.createStatement().execute("shutdown compact");
         conn.close();

--- a/h2/src/test/org/h2/test/store/TestConcurrentLinkedList.java
+++ b/h2/src/test/org/h2/test/store/TestConcurrentLinkedList.java
@@ -8,6 +8,7 @@ package org.h2.test.store;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.h2.mvstore.ConcurrentArrayList;
 import org.h2.test.TestBase;
@@ -46,7 +47,7 @@ public class TestConcurrentLinkedList extends TestBase {
 
     private static void testPerformance(final boolean stock) {
         System.out.print(stock ? "stock " : "custom ");
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         // final ConcurrentLinkedList<Integer> test =
         //     new ConcurrentLinkedList<Integer>();
         final ConcurrentArrayList<Integer> test =
@@ -104,7 +105,7 @@ public class TestConcurrentLinkedList extends TestBase {
             }
         }
         task.get();
-        System.out.println(System.currentTimeMillis() - start);
+        System.out.println(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
     }
 
     private void testConcurrent() {

--- a/h2/src/test/org/h2/test/store/TestFreeSpace.java
+++ b/h2/src/test/org/h2/test/store/TestFreeSpace.java
@@ -6,6 +6,7 @@
 package org.h2.test.store;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.mvstore.FreeSpaceBitSet;
 import org.h2.test.TestBase;
@@ -35,7 +36,7 @@ public class TestFreeSpace extends TestBase {
 
     private static void testPerformance() {
         for (int i = 0; i < 10; i++) {
-            long t = System.currentTimeMillis();
+            long t = System.nanoTime();
 
             FreeSpaceBitSet f = new FreeSpaceBitSet(0, 4096);
             // 75 ms
@@ -55,7 +56,7 @@ public class TestFreeSpace extends TestBase {
             for (int j = 0; j < 100000; j++) {
                 f.allocate(4096 * 2);
             }
-            System.out.println(System.currentTimeMillis() - t);
+            System.out.println(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));            
         }
     }
 

--- a/h2/src/test/org/h2/test/store/TestImmutableArray.java
+++ b/h2/src/test/org/h2/test/store/TestImmutableArray.java
@@ -8,6 +8,7 @@ package org.h2.test.store;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.dev.util.ImmutableArray2;
 import org.h2.test.TestBase;
@@ -48,7 +49,7 @@ public class TestImmutableArray extends TestBase {
 //        ArrayList time 361 dummy: 60000000
 
         System.out.print(immutable ? "immutable" : "ArrayList");
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         int count = 20000000;
         Integer x = 1;
         int sum = 0;
@@ -101,7 +102,7 @@ public class TestImmutableArray extends TestBase {
                 }
             }
         }
-        System.out.println(" time " + (System.currentTimeMillis() - start) +
+        System.out.println(" time " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) +
                 " dummy: " + sum);
     }
 

--- a/h2/src/test/org/h2/test/store/TestMVRTree.java
+++ b/h2/src/test/org/h2/test/store/TestMVRTree.java
@@ -151,7 +151,7 @@ public class TestMVRTree extends TestMVStore {
         // r.setQuadraticSplit(true);
         Random rand = new Random(1);
         int len = 1000;
-        // long t = System.currentTimeMillis();
+        // long t = System.nanoTime();
         // Profiler prof = new Profiler();
         // prof.startCollecting();
         for (int i = 0; i < len; i++) {
@@ -167,13 +167,13 @@ public class TestMVRTree extends TestMVStore {
             }
         }
         // System.out.println(prof.getTop(5));
-        // System.out.println("add: " + (System.currentTimeMillis() - t));
+        // System.out.println("add: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
         s.close();
         s = openStore(fileName);
         r = s.openMap("data",
                 new MVRTreeMap.Builder<String>().dimensions(2).
                 valueType(StringDataType.INSTANCE));
-        // t = System.currentTimeMillis();
+        // t = System.nanoTime();
         rand = new Random(1);
         for (int i = 0; i < len; i++) {
             float x = rand.nextFloat(), y = rand.nextFloat();
@@ -181,7 +181,7 @@ public class TestMVRTree extends TestMVStore {
             SpatialKey k = new SpatialKey(i, x - p, x + p, y - p, y + p);
             assertEquals("" + i, r.get(k));
         }
-        // System.out.println("query: " + (System.currentTimeMillis() - t));
+        // System.out.println("query: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
         assertEquals(len, r.size());
         int count = 0;
         for (SpatialKey k : r.keySet()) {
@@ -189,7 +189,7 @@ public class TestMVRTree extends TestMVStore {
             count++;
         }
         assertEquals(len, count);
-        // t = System.currentTimeMillis();
+        // t = System.nanoTime();
         // Profiler prof = new Profiler();
         // prof.startCollecting();
         rand = new Random(1);
@@ -202,7 +202,7 @@ public class TestMVRTree extends TestMVStore {
         assertEquals(0, r.size());
         s.close();
         // System.out.println(prof.getTop(5));
-        // System.out.println("remove: " + (System.currentTimeMillis() - t));
+        // System.out.println("remove: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
     }
 
     private void testSimple() {

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.h2.mvstore.Chunk;
@@ -659,16 +660,16 @@ public class TestMVStore extends TestBase {
         m.put(2, "World");
         s.commit();
         long v = s.getCurrentVersion();
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         m.put(3, "!");
 
         for (int i = 200; i > 0; i--) {
             if (s.getCurrentVersion() > v) {
                 break;
             }
-            long diff = System.currentTimeMillis() - time;
-            if (diff > 1000) {
-                fail("diff=" + diff);
+            long diff = System.nanoTime() - time;
+            if (diff > TimeUnit.SECONDS.toNanos(1)) {
+                fail("diff=" + TimeUnit.NANOSECONDS.toMillis(diff));
             }
             sleep(10);
         }
@@ -1265,7 +1266,7 @@ public class TestMVStore extends TestBase {
         String fileName = getBaseDir() + "/" + getTestName();
         FileUtils.delete(fileName);
         for (int k = 0; k < 1; k++) {
-            // long t = System.currentTimeMillis();
+            // long t = System.nanoTime();
             for (int j = 0; j < 3; j++) {
                 MVStore s = openStore(fileName);
                 Map<String, Integer> m = s.openMap("data");
@@ -1277,7 +1278,7 @@ public class TestMVStore extends TestBase {
                 s.close();
             }
             // System.out.println("open/close: " +
-            //         (System.currentTimeMillis() - t));
+            //        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
             // System.out.println("size: " + FileUtils.size(fileName));
         }
     }
@@ -1623,22 +1624,22 @@ public class TestMVStore extends TestBase {
             // TreeMap<Integer, String> m = new TreeMap<Integer, String>();
             // HashMap<Integer, String> m = New.hashMap();
             MVMap<Integer, String> m = s.openMap("data");
-            // t = System.currentTimeMillis();
+            // t = System.nanoTime();
             for (int i = 0; i < len; i++) {
                 assertNull(m.put(i, "Hello World"));
             }
-            // System.out.println("put: " + (System.currentTimeMillis() - t));
-            // t = System.currentTimeMillis();
+            // System.out.println("put: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
+            // t = System.nanoTime();
             for (int i = 0; i < len; i++) {
                 assertEquals("Hello World", m.get(i));
             }
-            // System.out.println("get: " + (System.currentTimeMillis() - t));
-            // t = System.currentTimeMillis();
+            // System.out.println("get: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
+            // t = System.nanoTime();
             for (int i = 0; i < len; i++) {
                 assertEquals("Hello World", m.remove(i));
             }
             // System.out.println("remove: " +
-            //         (System.currentTimeMillis() - t));
+            //         TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
             // System.out.println();
             assertEquals(null, m.get(0));
             assertEquals(0, m.size());
@@ -1662,7 +1663,7 @@ public class TestMVStore extends TestBase {
 
             // Profiler prof = new Profiler();
             // prof.startCollecting();
-            // long t = System.currentTimeMillis();
+            // long t = System.nanoTime();
             for (int i = 0; i < len;) {
                 Object[] o = new Object[3];
                 o[0] = i;
@@ -1677,7 +1678,7 @@ public class TestMVStore extends TestBase {
             s.close();
             // System.out.println(prof.getTop(5));
             // System.out.println("store time " +
-            //         (System.currentTimeMillis() - t));
+            //         TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
             // System.out.println("store size " +
             //         FileUtils.size(fileName));
         }
@@ -1694,18 +1695,18 @@ public class TestMVStore extends TestBase {
         int count = 2000;
         // Profiler p = new Profiler();
         // p.startCollecting();
-        // long t = System.currentTimeMillis();
+        // long t = System.nanoTime();
         for (int i = 0; i < count; i++) {
             assertNull(m.put(i, "hello " + i));
             assertEquals("hello " + i, m.get(i));
         }
-        // System.out.println("put: " + (System.currentTimeMillis() - t));
+        // System.out.println("put: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
         // System.out.println(p.getTop(5));
         // p = new Profiler();
         //p.startCollecting();
-        // t = System.currentTimeMillis();
+        // t = System.nanoTime();
         s.commit();
-        // System.out.println("store: " + (System.currentTimeMillis() - t));
+        // System.out.println("store: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t));
         // System.out.println(p.getTop(5));
         assertEquals("hello 0", m.remove(0));
         assertNull(m.get(0));
@@ -2032,14 +2033,14 @@ public class TestMVStore extends TestBase {
                 fileName(fileName).open();
         try {
             MVMap<Integer, String> map = store.openMap("test");
-            long last = System.currentTimeMillis();
+            long last = System.nanoTime();
             String data = new String(new char[2500]).replace((char) 0, 'x');
             for (int i = 0;; i++) {
                 map.put(i, data);
                 if (i % 10000 == 0) {
                     store.commit();
-                    long time = System.currentTimeMillis();
-                    if (time - last > 2000) {
+                    long time = System.nanoTime();
+                    if (time - last > TimeUnit.SECONDS.toNanos(2)) {
                         long mb = store.getFileStore().size() / 1024 / 1024;
                         trace(mb + "/4500");
                         if (mb > 4500) {

--- a/h2/src/test/org/h2/test/store/TestMVStoreBenchmark.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreBenchmark.java
@@ -12,6 +12,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.mvstore.MVStore;
 import org.h2.test.TestBase;
@@ -175,7 +176,7 @@ public class TestMVStoreBenchmark extends TestBase {
         System.gc();
         long time = 0;
         for (int t = 0; t < 3; t++) {
-            time = System.currentTimeMillis();
+            time = System.nanoTime();
             for (int b = 0; b < 3; b++) {
                 for (int i = 0; i < size; i++) {
                     map.put(i, "Hello World");
@@ -191,9 +192,9 @@ public class TestMVStoreBenchmark extends TestBase {
                 }
                 assertEquals(0, map.size());
             }
-            time = System.currentTimeMillis() - time;
+            time = System.nanoTime() - time;
         }
-        trace(map.getClass().getName() + ": " + time);
+        trace(map.getClass().getName() + ": " + TimeUnit.NANOSECONDS.toMillis(time));
         return time;
     }
 

--- a/h2/src/test/org/h2/test/store/TestMVStoreCachePerformance.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreCachePerformance.java
@@ -85,7 +85,7 @@ public class TestMVStoreCachePerformance extends TestBase {
             // System.out.println(prof.getTop(5));
             // System.out.println("  " + counter.get() / (i + 1) + " op/s");
         }
-        // long time = System.currentTimeMillis();
+        // long time = System.nanoTime();
         for (Task t : tasks) {
             t.get();
         }

--- a/h2/src/test/org/h2/test/synth/OutputCatcher.java
+++ b/h2/src/test/org/h2/test/synth/OutputCatcher.java
@@ -8,6 +8,7 @@ package org.h2.test.synth;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.util.IOUtils;
 
@@ -29,7 +30,7 @@ public class OutputCatcher extends Thread {
      * @return the line
      */
     public String readLine(long wait) {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         while (true) {
             synchronized (list) {
                 if (list.size() > 0) {
@@ -40,8 +41,8 @@ public class OutputCatcher extends Thread {
                 } catch (InterruptedException e) {
                     // ignore
                 }
-                long time = System.currentTimeMillis() - start;
-                if (time >= wait) {
+                long time = System.nanoTime() - start;
+                if (time >= TimeUnit.MILLISECONDS.toNanos(wait)) {
                     return null;
                 }
             }

--- a/h2/src/test/org/h2/test/synth/TestJoin.java
+++ b/h2/src/test/org/h2/test/synth/TestJoin.java
@@ -15,6 +15,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
 import org.h2.util.New;
@@ -97,12 +98,12 @@ public class TestJoin extends TestBase {
         execute("INSERT INTO TWO VALUES(3, 3)", null);
         execute("INSERT INTO TWO VALUES(4, NULL)", null);
         random = new Random();
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         for (int i = 0;; i++) {
             paramCount = 0;
             buff = new StringBuilder();
-            long time = System.currentTimeMillis();
-            if (time - startTime > 5000) {
+            long time = System.nanoTime();
+            if (time - startTime > TimeUnit.SECONDS.toNanos(5)) {
                 printTime("i:" + i);
                 startTime = time;
             }

--- a/h2/src/test/org/h2/test/synth/TestKillProcess.java
+++ b/h2/src/test/org/h2/test/synth/TestKillProcess.java
@@ -10,6 +10,8 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.util.ArrayList;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.store.FileLister;
 import org.h2.test.TestBase;
 import org.h2.test.utils.SelfDestructor;
@@ -45,11 +47,11 @@ public class TestKillProcess {
             PreparedStatement prep1b = conn1.prepareStatement(
                     "UPDATE ACCOUNT SET SUM=SUM+? WHERE ID=?");
             conn1.setAutoCommit(false);
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             String d = null;
             for (int i = 0;; i++) {
-                long t = System.currentTimeMillis();
-                if (t > time + 1000) {
+                long t = System.nanoTime();
+                if (t > time + TimeUnit.SECONDS.toNanos(1)) {
                     ArrayList<String> list = FileLister.getDatabaseFiles(
                             baseDir, "kill", true);
                     System.out.println("inserting... i:" + i + " d:" + d +

--- a/h2/src/test/org/h2/test/synth/TestTimer.java
+++ b/h2/src/test/org/h2/test/synth/TestTimer.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
 import org.h2.tools.Backup;
@@ -47,7 +48,7 @@ public class TestTimer extends TestBase {
         Random random = new Random();
         int max = 0;
         int count = 0;
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         while (true) {
             int action = random.nextInt(10);
             int x = max == 0 ? 0 : random.nextInt(max);
@@ -81,8 +82,8 @@ public class TestTimer extends TestBase {
                 rs.next();
                 int c = rs.getInt(1);
                 assertEquals(count, c);
-                long time = System.currentTimeMillis();
-                if (time > startTime + 5000) {
+                long time = System.nanoTime();
+                if (time > startTime + TimeUnit.SECONDS.toNanos(5)) {
                     println("rows: " + count);
                     startTime = time;
                 }

--- a/h2/src/test/org/h2/test/todo/TestTempTableCrash.java
+++ b/h2/src/test/org/h2/test/todo/TestTempTableCrash.java
@@ -9,6 +9,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.store.fs.FilePathRec;
 import org.h2.test.unit.TestReopen;
 import org.h2.tools.DeleteDbFiles;
@@ -48,10 +50,10 @@ public class TestTempTableCrash {
         stat = conn.createStatement();
 
         Random random = new Random(1);
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         for (int i = 0; i < 10000; i++) {
-            long now = System.currentTimeMillis();
-            if (now > start + 1000) {
+            long now = System.nanoTime();
+            if (now > start + TimeUnit.SECONDS.toNanos(1)) {
                 System.out.println("i: " + i);
                 start = now;
             }

--- a/h2/src/test/org/h2/test/todo/TestUndoLogLarge.java
+++ b/h2/src/test/org/h2/test/todo/TestUndoLogLarge.java
@@ -10,6 +10,8 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.tools.DeleteDbFiles;
 
 /**
@@ -37,13 +39,13 @@ public class TestUndoLogLarge {
         conn.setAutoCommit(false);
         PreparedStatement prep = conn.prepareStatement(
                 "insert into test(name) values(space(1024*1024))");
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         for (int i = 0; i < 2500; i++) {
             prep.execute();
-            long now = System.currentTimeMillis();
-            if (now > time + 5000) {
+            long now = System.nanoTime();
+            if (now > time + TimeUnit.SECONDS.toNanos(5)) {
                 System.out.println(i);
-                time = now + 5000;
+                time = now + TimeUnit.SECONDS.toNanos(5);
             }
         }
         conn.rollback();

--- a/h2/src/test/org/h2/test/unit/TestBinaryArithmeticStream.java
+++ b/h2/src/test/org/h2/test/unit/TestBinaryArithmeticStream.java
@@ -91,7 +91,7 @@ public class TestBinaryArithmeticStream extends TestBase {
 
     private void testPerformance() throws IOException {
         Random r = new Random();
-        // long time = System.currentTimeMillis();
+        // long time = System.nanoTime();
         // Profiler prof = new Profiler().startCollecting();
         for (int seed = 0; seed < 10000; seed++) {
             r.setSeed(seed);
@@ -114,8 +114,8 @@ public class TestBinaryArithmeticStream extends TestBase {
                 assertEquals(expected, in.readBit(prob));
             }
         }
-        // time = System.currentTimeMillis() - time;
-        // System.out.println("time: " + time);
+        // time = System.nanoTime() - time;
+        // System.out.println("time: " + TimeUnit.NANOSECONDS.toMillis(time));
         // System.out.println(prof.getTop(5));
     }
 

--- a/h2/src/test/org/h2/test/unit/TestCompress.java
+++ b/h2/src/test/org/h2/test/unit/TestCompress.java
@@ -17,6 +17,8 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.compress.CompressLZF;
 import org.h2.compress.Compressor;
 import org.h2.engine.Constants;
@@ -159,7 +161,7 @@ public class TestCompress extends TestBase {
         byte[] test = new byte[2 * pageSize];
         compress.compress(buff2, pageSize, test, 0);
         for (int j = 0; j < 4; j++) {
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             for (int i = 0; i < 1000; i++) {
                 InputStream in = FileUtils.newInputStream("memFS:compress.h2.db");
                 while (true) {
@@ -171,7 +173,7 @@ public class TestCompress extends TestBase {
                 }
                 in.close();
             }
-            System.out.println("compress: " + (System.currentTimeMillis() - time) + " ms");
+            System.out.println("compress: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time) + " ms");
         }
 
         for (int j = 0; j < 4; j++) {
@@ -189,14 +191,14 @@ public class TestCompress extends TestBase {
             }
             in.close();
             byte[] result = new byte[pageSize];
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             for (int i = 0; i < 1000; i++) {
                 for (int k = 0; k < comp.size(); k++) {
                     byte[] data = comp.get(k);
                     compress.expand(data, 0, data.length, result, 0, pageSize);
                 }
             }
-            System.out.println("expand: " + (System.currentTimeMillis() - time) + " ms");
+            System.out.println("expand: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time) + " ms");
         }
     }
 
@@ -242,12 +244,12 @@ public class TestCompress extends TestBase {
             // level 9 is highest, strategy 2 is huffman only
             for (String a : new String[] { "LZF", "No",
                     "Deflate", "Deflate level 9 strategy 2" }) {
-                long time = System.currentTimeMillis();
+                long time = System.nanoTime();
                 byte[] out = utils.compress(b, a);
                 byte[] test = utils.expand(out);
                 if (testPerformance) {
                     System.out.println("p:" + pattern + " len: " + out.length +
-                            " time: " + (System.currentTimeMillis() - time) + " " + a);
+                            " time: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time) + " " + a);
                 }
                 assertEquals(b.length, test.length);
                 assertEquals(b, test);

--- a/h2/src/test/org/h2/test/unit/TestDataPage.java
+++ b/h2/src/test/org/h2/test/unit/TestDataPage.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Types;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.api.JavaObjectSerializer;
 import org.h2.store.Data;
@@ -73,7 +74,7 @@ public class TestDataPage extends TestBase implements DataHandler {
     private static void testPerformance() {
         Data data = Data.create(null, 1024);
         for (int j = 0; j < 4; j++) {
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             for (int i = 0; i < 100000; i++) {
                 data.reset();
                 for (int k = 0; k < 30; k++) {
@@ -92,10 +93,10 @@ public class TestDataPage extends TestBase implements DataHandler {
             //                    data.writeVarInt(k * k);
             //                }
             //            }
-            System.out.println("write: " + (System.currentTimeMillis() - time) + " ms");
+            System.out.println("write: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time) + " ms");
         }
         for (int j = 0; j < 4; j++) {
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             for (int i = 0; i < 1000000; i++) {
                 data.reset();
                 for (int k = 0; k < 30; k++) {
@@ -114,7 +115,7 @@ public class TestDataPage extends TestBase implements DataHandler {
             //                    data.readInt();
             //                }
             //            }
-            System.out.println("read: " + (System.currentTimeMillis() - time) + " ms");
+            System.out.println("read: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time) + " ms");
         }
     }
 

--- a/h2/src/test/org/h2/test/unit/TestFileLockSerialized.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLockSerialized.java
@@ -13,6 +13,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.ErrorCode;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.store.fs.FileUtils;
@@ -359,7 +361,7 @@ public class TestFileLockSerialized extends TestBase {
                 "create table test(id int auto_increment, id2 int)");
         conn.close();
 
-        final long endTime = System.currentTimeMillis() + runTime;
+        final long endTime = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(runTime);
         final Exception[] ex = { null };
         final Connection[] connList = new Connection[howManyThreads];
         final boolean[] stop = { false };
@@ -412,7 +414,7 @@ public class TestFileLockSerialized extends TestBase {
             t.start();
             threads[i] = t;
         }
-        while ((ex[0] == null) && (System.currentTimeMillis() < endTime)) {
+        while ((ex[0] == null) && (System.nanoTime() < endTime)) {
             Thread.sleep(10);
         }
 
@@ -443,7 +445,7 @@ public class TestFileLockSerialized extends TestBase {
         conn.createStatement().execute("insert into test values(1)");
         conn.close();
 
-        final long endTime = System.currentTimeMillis() + runTime;
+        final long endTime = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(runTime);
         final Exception[] ex = { null };
         final Connection[] connList = new Connection[howManyThreads];
         final boolean[] stop = { false };
@@ -484,7 +486,7 @@ public class TestFileLockSerialized extends TestBase {
             t.start();
             threads[i] = t;
         }
-        while ((ex[0] == null) && (System.currentTimeMillis() < endTime)) {
+        while ((ex[0] == null) && (System.nanoTime() < endTime)) {
             Thread.sleep(10);
         }
 

--- a/h2/src/test/org/h2/test/unit/TestIntPerfectHash.java
+++ b/h2/src/test/org/h2/test/unit/TestIntPerfectHash.java
@@ -10,6 +10,7 @@ import java.util.BitSet;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.dev.hash.IntPerfectHash;
 import org.h2.dev.hash.IntPerfectHash.BitArray;
@@ -39,11 +40,11 @@ public class TestIntPerfectHash extends TestBase {
         int size = 10000;
         test(size / 10);
         int s;
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         s = test(size);
-        time = System.currentTimeMillis() - time;
+        time = System.nanoTime() - time;
         System.out.println((double) s / size + " bits/key in " +
-                time + " ms");
+                TimeUnit.NANOSECONDS.toMillis(time) + " ms");
 
     }
 

--- a/h2/src/test/org/h2/test/unit/TestPageStore.java
+++ b/h2/src/test/org/h2/test/unit/TestPageStore.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.result.Row;
@@ -307,13 +309,13 @@ public class TestPageStore extends TestBase {
         stat.execute("set max_log_size 1");
         conn.setAutoCommit(false);
         stat.execute("insert into test select space(1000) from system_range(1, 1000)");
-        long before = System.currentTimeMillis();
+        long before = System.nanoTime();
         stat.execute("select nextval('SEQ') from system_range(1, 100000)");
-        long after = System.currentTimeMillis();
+        long after = System.nanoTime();
         // it's hard to test - basically it shouldn't checkpoint too often
-        if (after - before > 20000) {
+        if (after - before > TimeUnit.SECONDS.toNanos(20)) {
             if (!config.reopen) {
-                fail("Checkpoint took " + (after - before) + " ms");
+                fail("Checkpoint took " + TimeUnit.NANOSECONDS.toMillis(after - before) + " ms");
             }
         }
         stat.execute("drop table test");

--- a/h2/src/test/org/h2/test/unit/TestPerfectHash.java
+++ b/h2/src/test/org/h2/test/unit/TestPerfectHash.java
@@ -12,6 +12,8 @@ import java.util.BitSet;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.dev.hash.MinimalPerfectHash;
 import org.h2.dev.hash.MinimalPerfectHash.LongHash;
 import org.h2.dev.hash.MinimalPerfectHash.StringHash;
@@ -78,10 +80,10 @@ public class TestPerfectHash extends TestBase {
         }
         System.out.println("file: " + s);
         System.out.println("size: " + set.size());
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         byte[] desc = MinimalPerfectHash.generate(set, hf);
-        time = System.currentTimeMillis() - time;
-        System.out.println("millis: " + time);
+        time = System.nanoTime() - time;
+        System.out.println("millis: " + TimeUnit.NANOSECONDS.toMillis(time));
         System.out.println("len: " + desc.length);
         int bits = desc.length * 8;
         System.out.println(((double) bits / set.size()) + " bits/key");
@@ -94,29 +96,29 @@ public class TestPerfectHash extends TestBase {
         int size = 1000000;
         testMinimal(size / 10);
         int s;
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         s = testMinimal(size);
-        time = System.currentTimeMillis() - time;
+        time = System.nanoTime() - time;
         System.out.println((double) s / size + " bits/key (minimal) in " +
-                time + " ms");
+                TimeUnit.NANOSECONDS.toMillis(time) + " ms");
 
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         s = testMinimalWithString(size);
-        time = System.currentTimeMillis() - time;
+        time = System.nanoTime() - time;
         System.out.println((double) s / size +
                 " bits/key (minimal; String keys) in " +
-                time + " ms");
+                TimeUnit.NANOSECONDS.toMillis(time) + " ms");
 
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         s = test(size, true);
-        time = System.currentTimeMillis() - time;
+        time = System.nanoTime() - time;
         System.out.println((double) s / size + " bits/key (minimal old) in " +
-                time + " ms");
-        time = System.currentTimeMillis();
+        		TimeUnit.NANOSECONDS.toMillis(time) + " ms");
+        time = System.nanoTime();
         s = test(size, false);
-        time = System.currentTimeMillis() - time;
+        time = System.nanoTime() - time;
         System.out.println((double) s / size + " bits/key (not minimal) in " +
-                time + " ms");
+        		TimeUnit.NANOSECONDS.toMillis(time) + " ms");
     }
 
     @Override

--- a/h2/src/test/org/h2/test/unit/TestReopen.java
+++ b/h2/src/test/org/h2/test/unit/TestReopen.java
@@ -8,6 +8,7 @@ package org.h2.test.unit;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.ConnectionInfo;
@@ -58,12 +59,12 @@ public class TestReopen extends TestBase implements Recorder {
         FilePathRec.setRecorder(this);
         config.reopen = true;
 
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         Profiler p = new Profiler();
         p.startCollecting();
         new TestPageStoreCoverage().init(config).test();
         System.out.println(p.getTop(3));
-        System.out.println(System.currentTimeMillis() - time);
+        System.out.println(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time));
         System.out.println("counter: " + writeCount);
     }
 

--- a/h2/src/test/org/h2/test/unit/TestSort.java
+++ b/h2/src/test/org/h2/test/unit/TestSort.java
@@ -91,14 +91,14 @@ public class TestSort extends TestBase {
     private void  test(String type) throws Exception {
         compareCount.set(0);
 
-        // long t = System.currentTimeMillis();
+        // long t = System.nanoTime();
 
         clazz.getMethod("sort", Object[].class, Comparator.class).invoke(null,
                 array, comp);
 
         // System.out.printf(
         //    "%4d ms; %10d comparisons order: %s data: %s\n",
-        //    (System.currentTimeMillis() - t),
+        //    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t),
         //    compareCount.get(), clazz, type);
 
         verify(array);

--- a/h2/src/test/org/h2/test/unit/TestStringCache.java
+++ b/h2/src/test/org/h2/test/unit/TestStringCache.java
@@ -7,6 +7,8 @@ package org.h2.test.unit;
 
 import java.util.Locale;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.test.TestBase;
 import org.h2.util.StringUtils;
 
@@ -56,24 +58,24 @@ public class TestStringCache extends TestBase {
         }
         int repeat = 100000;
         int testLen = 0;
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         for (int a = 0; a < repeat; a++) {
             for (String x : test) {
                 String y = StringUtils.toUpperEnglish(x);
                 testLen += y.length();
             }
         }
-        time = System.currentTimeMillis() - time;
-        System.out.println("cache " + time);
-        time = System.currentTimeMillis();
+        time = System.nanoTime() - time;
+        System.out.println("cache " + TimeUnit.NANOSECONDS.toMillis(time));
+        time = System.nanoTime();
         for (int a = 0; a < repeat; a++) {
             for (String x : test) {
                 String y = x.toUpperCase(Locale.ENGLISH);
                 testLen -= y.length();
             }
         }
-        time = System.currentTimeMillis() - time;
-        System.out.println("toUpperCase " + time);
+        time = System.nanoTime() - time;
+        System.out.println("toUpperCase " + TimeUnit.NANOSECONDS.toMillis(time));
         assertEquals(0, testLen);
     }
 
@@ -100,10 +102,10 @@ public class TestStringCache extends TestBase {
         testToUpperCache();
         for (int i = 0; i < 6; i++) {
             useIntern = (i % 2) == 0;
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             testSingleThread(100000);
-            time = System.currentTimeMillis() - time;
-            System.out.println(time + " ms (useIntern=" + useIntern + ")");
+            time = System.nanoTime() - time;
+            System.out.println(TimeUnit.NANOSECONDS.toMillis(time) + " ms (useIntern=" + useIntern + ")");
         }
 
     }

--- a/h2/src/test/org/h2/test/unit/TestUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestUtils.java
@@ -175,10 +175,10 @@ public class TestUtils extends TestBase {
 
     private void testReflectionUtils() throws Exception {
         // Static method call
-        long currentTimeMillis1 = System.currentTimeMillis();
-        long currentTimeMillis2 = (Long) Utils.callStaticMethod(
-                "java.lang.System.currentTimeMillis");
-        assertTrue(currentTimeMillis1 <= currentTimeMillis2);
+        long currentTimeNanos1 = System.nanoTime();
+        long currentTimeNanos2 = (Long) Utils.callStaticMethod(
+                "java.lang.System.nanoTime");
+        assertTrue(currentTimeNanos1 <= currentTimeNanos2);
         // New Instance
         Object instance = Utils.newInstance("java.lang.StringBuilder");
         // New Instance with int parameter

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -14,6 +14,8 @@ import java.net.Socket;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.build.code.SwitchSource;
 import org.h2.build.doc.XMLParser;
 
@@ -961,7 +963,7 @@ public class Build extends BuildBase {
     @Description(summary = "Test the local network of this machine.")
     public void testNetwork() {
         try {
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             System.out.println("localhost:");
             System.out.println("  " + InetAddress.getByName("localhost"));
             for (InetAddress address : InetAddress.getAllByName("localhost")) {
@@ -985,7 +987,7 @@ public class Build extends BuildBase {
             System.out.println(serverSocket);
             int port = serverSocket.getLocalPort();
             final ServerSocket accept = serverSocket;
-            start = System.currentTimeMillis();
+            start = System.nanoTime();
             Thread thread = new Thread() {
                 @Override
                 public void run() {
@@ -1007,9 +1009,9 @@ public class Build extends BuildBase {
                 }
             };
             thread.start();
-            System.out.println("time: " + (System.currentTimeMillis() - start));
+            System.out.println("time: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
             Thread.sleep(1000);
-            start = System.currentTimeMillis();
+            start = System.nanoTime();
             final Socket socket = new Socket();
             socket.setSoTimeout(2000);
             final InetSocketAddress socketAddress = new InetSocketAddress(address, port);
@@ -1034,21 +1036,21 @@ public class Build extends BuildBase {
                             + socketAddress);
                     socket.connect(localhostAddress, 2000);
                 }
-                System.out.println("time: " + (System.currentTimeMillis() - start));
+                System.out.println("time: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
                 Thread.sleep(200);
-                start = System.currentTimeMillis();
+                start = System.nanoTime();
                 System.out.println("client:" + socket.toString());
                 socket.getOutputStream().write(123);
-                System.out.println("time: " + (System.currentTimeMillis() - start));
+                System.out.println("time: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
                 Thread.sleep(100);
-                start = System.currentTimeMillis();
+                start = System.nanoTime();
                 System.out.println("client read:" + socket.getInputStream().read());
                 socket.close();
             } catch (Throwable t) {
                 t.printStackTrace();
             }
             thread.join(5000);
-            System.out.println("time: " + (System.currentTimeMillis() - start));
+            System.out.println("time: " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
             if (thread.isAlive()) {
                 System.out.println("thread is still alive, interrupting");
                 thread.interrupt();

--- a/h2/src/tools/org/h2/build/BuildBase.java
+++ b/h2/src/tools/org/h2/build/BuildBase.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.JarOutputStream;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
@@ -192,7 +193,7 @@ public class BuildBase {
      * @param args the command line parameters
      */
     protected void run(String... args) {
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         if (args.length == 0) {
             all();
         } else {
@@ -220,7 +221,7 @@ public class BuildBase {
                 }
             }
         }
-        println("Done in " + (System.currentTimeMillis() - time) + " ms");
+        println("Done in " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time) + " ms");
     }
 
     private boolean runTarget(String target) {
@@ -254,13 +255,13 @@ public class BuildBase {
             } else if (line.length() == 0) {
                 line = last;
             }
-            long time = System.currentTimeMillis();
+            long time = System.nanoTime();
             try {
                 runTarget(line);
             } catch (Exception e) {
                 System.out.println(e);
             }
-            println("Done in " + (System.currentTimeMillis() - time) + " ms");
+            println("Done in " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - time) + " ms");
             last = line;
         }
     }
@@ -660,11 +661,11 @@ public class BuildBase {
             println("Downloading " + fileURL);
             URL url = new URL(fileURL);
             InputStream in = new BufferedInputStream(url.openStream());
-            long last = System.currentTimeMillis();
+            long last = System.nanoTime();
             int len = 0;
             while (true) {
-                long now = System.currentTimeMillis();
-                if (now > last + 1000) {
+                long now = System.nanoTime();
+                if (now > last + TimeUnit.SECONDS.toNanos(1)) {
                     println("Downloaded " + len + " bytes");
                     last = now;
                 }

--- a/h2/src/tools/org/h2/dev/fs/ArchiveToolStore.java
+++ b/h2/src/tools/org/h2/dev/fs/ArchiveToolStore.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 import java.util.Random;
 import org.h2.mvstore.Cursor;
 import org.h2.mvstore.DataUtils;
@@ -276,13 +277,13 @@ public class ArchiveToolStore {
     }
 
     private void start() {
-        this.start = System.currentTimeMillis();
+        this.start = System.nanoTime();
         this.lastTime = start;
     }
 
     private void printProgress(int low, int high, long current, long total) {
-        long now = System.currentTimeMillis();
-        if (now - lastTime > 5000) {
+        long now = System.nanoTime();
+        if (now - lastTime > TimeUnit.SECONDS.toNanos(5)) {
             System.out.print((low + (high - low) * current / total) + "% ");
             lastTime = now;
         }
@@ -290,7 +291,7 @@ public class ArchiveToolStore {
 
     private void printDone() {
         System.out.println("Done in " +
-                (System.currentTimeMillis() - start) / 1000 +
+                TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start) +
                 " seconds");
     }
 

--- a/h2/src/tools/org/h2/dev/util/Base64.java
+++ b/h2/src/tools/org/h2/dev/util/Base64.java
@@ -6,6 +6,7 @@
 package org.h2.dev.util;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class converts binary to base64 and vice versa.
@@ -68,7 +69,7 @@ public class Base64 {
 
     private static void test(boolean fast, int len) {
         Random random = new Random(10);
-        long time = System.currentTimeMillis();
+        long time = System.nanoTime();
         byte[] bin = new byte[len];
         random.nextBytes(bin);
         for (int i = 0; i < len; i++) {
@@ -82,8 +83,8 @@ public class Base64 {
             }
             test(bin, dec);
         }
-        time = System.currentTimeMillis() - time;
-        System.out.println("fast=" + fast + " time=" + time);
+        time = System.nanoTime() - time;
+        System.out.println("fast=" + fast + " time=" + TimeUnit.NANOSECONDS.toMillis(time));
     }
 
     private static void test(byte[] in, byte[] out) {

--- a/h2/src/tools/org/h2/dev/util/FileViewer.java
+++ b/h2/src/tools/org/h2/dev/util/FileViewer.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 
 import org.h2.message.DbException;
 import org.h2.util.Tool;
@@ -129,7 +130,7 @@ public class FileViewer extends Tool {
         long length = file.length();
         int bufferSize = 4 * 1024;
         byte[] data = new byte[bufferSize * 2];
-        long last = System.currentTimeMillis();
+        long last = System.nanoTime();
         while (pos < length) {
             System.arraycopy(data, bufferSize, data, 0, bufferSize);
             if (pos + bufferSize > length) {
@@ -137,8 +138,8 @@ public class FileViewer extends Tool {
                 return find(data, find, (int) (bufferSize + length - pos - find.length));
             }
             if (!quiet) {
-                long now = System.currentTimeMillis();
-                if (now > last + 5000) {
+                long now = System.nanoTime();
+                if (now > last + TimeUnit.SECONDS.toNanos(5)) {
                     System.out.println((100 * pos / length) + "%");
                     last = now;
                 }

--- a/h2/src/tools/org/h2/dev/util/Migrate.java
+++ b/h2/src/tools/org/h2/dev/util/Migrate.java
@@ -16,6 +16,8 @@ import java.io.RandomAccessFile;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeUnit;
+
 import org.h2.engine.Constants;
 import org.h2.tools.RunScript;
 
@@ -124,11 +126,11 @@ public class Migrate {
             println("Downloading " + fileURL);
             URL url = new URL(fileURL);
             InputStream in = new BufferedInputStream(url.openStream());
-            long last = System.currentTimeMillis();
+            long last = System.nanoTime();
             int len = 0;
             while (true) {
-                long now = System.currentTimeMillis();
-                if (now > last + 1000) {
+                long now = System.nanoTime();
+                if (now > last + TimeUnit.SECONDS.toNanos(1)) {
                     println("Downloaded " + len + " bytes");
                     last = now;
                 }


### PR DESCRIPTION
System.currentTimeMillis() is influenced by system time corrections
whereas System.nanoTime() is strongly sequential. So it is better to use
System.nanoTime() when checking for timeouts and elapsed time.