### PR TITLE
Fix fetch first rows only grammar

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -7,7 +7,7 @@ SELECT [ TOP term ] [ DISTINCT | ALL ] selectExpression [,...]
 FROM tableExpression [,...] [ WHERE expression ]
 [ GROUP BY expression [,...] ] [ HAVING expression ]
 [ { UNION [ ALL ] | MINUS | EXCEPT | INTERSECT } select ] [ ORDER BY order [,...] ]
-[ { { LIMIT expression } | { FETCH { FIRST | NEXT } expression { ROW | ROWS } ONLY } } [ OFFSET expression ] [ SAMPLE_SIZE rowCountInt ] ]
+[ { LIMIT expression [ OFFSET expression ] [ SAMPLE_SIZE rowCountInt ] } | { [ OFFSET expression { ROW | ROWS } ] [ { FETCH { FIRST | NEXT } expression { ROW | ROWS } ONLY } ] } ]
 [ FOR UPDATE ]
 ","
 Selects data from a table or multiple tables.


### PR DESCRIPTION
After some additional test for #476 and more checking with the source
code I found out that I make a mistake in the grammar. The
MySQL/Postgres and the Derby/Oracle syntax should be different
productions.

<img width="627" alt="grammar" src="https://cloud.githubusercontent.com/assets/471021/24330429/ea76144a-121d-11e7-92f5-7125ad1227f3.png">