### PR TITLE
Document recursive common table expressions

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -192,6 +192,24 @@ Lists the schemas, tables, or the columns of a table.
 SHOW TABLES
 "
 
+"Commands (DML)","WITH","
+WITH [ RECURSIVE ] name ( columnName [,...] )
+    AS ( select )
+    select
+","
+Can be used to create a recursive query. The first select has to be a UNION.
+Currently only one result set can be referred to by name.
+","
+WITH RECURSIVE t(n) AS (
+        SELECT 1
+    UNION ALL
+        SELECT n + 1
+        FROM t
+        WHERE n < 100
+)
+SELECT sum(n) FROM t;
+"
+
 "Commands (DDL)","ALTER INDEX RENAME","
 ALTER INDEX [ IF EXISTS ] indexName RENAME TO newIndexName
 ","


### PR DESCRIPTION
H2 supports recursive common table expressions. Unfortunately they are
not covered in the official grammar documentation so some people don't
know about it.

I had to reverse engineer the syntax by looking at the parser source so
it may contain errors. This commit does contain maybe not the greatest
documentation ever but I feel it's an improvement over the current
situation.

<img width="496" alt="with-recursive" src="https://cloud.githubusercontent.com/assets/471021/24373132/a5dd8ec6-1330-11e7-8bb0-87a851082e86.png">