### PR TITLE
Lazy query execution support

### DIFF
--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -21,7 +21,6 @@ import org.h2.util.MathUtils;
  * Represents a SQL statement. This object is only used on the server side.
  */
 public abstract class Command implements CommandInterface {
-
     /**
      * The session.
      */
@@ -44,7 +43,7 @@ public abstract class Command implements CommandInterface {
 
     private final String sql;
 
-    private boolean canReuse;
+    private volatile boolean canReuse;
 
     Command(Parser parser, String sql) {
         this.session = parser.getSession();
@@ -147,7 +146,8 @@ public abstract class Command implements CommandInterface {
         }
     }
 
-    private void stop() {
+    @Override
+    public void stop() {
         session.endStatement();
         session.setCurrentCommand(null);
         if (!isTransactional()) {
@@ -198,7 +198,9 @@ public abstract class Command implements CommandInterface {
                 while (true) {
                     database.checkPowerOff();
                     try {
-                        return query(maxrows);
+                        ResultInterface result = query(maxrows);
+                        callStop = !result.isLazy();
+                        return result;
                     } catch (DbException e) {
                         start = filterConcurrentUpdate(e, start);
                     } catch (OutOfMemoryError e) {

--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -43,7 +43,7 @@ public abstract class Command implements CommandInterface {
 
     private final String sql;
 
-    private volatile boolean canReuse;
+    private boolean canReuse;
 
     Command(Parser parser, String sql) {
         this.session = parser.getSession();

--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -111,7 +111,7 @@ public class CommandContainer extends Command {
         start();
         prepared.checkParameters();
         ResultInterface result = prepared.query(maxrows);
-        prepared.trace(startTimeNanos, result.getRowCount());
+        prepared.trace(startTimeNanos, result.isLazy() ? 0 : result.getRowCount());
         setProgress(DatabaseEventListener.STATE_STATEMENT_END);
         return result;
     }

--- a/h2/src/main/org/h2/command/CommandInterface.java
+++ b/h2/src/main/org/h2/command/CommandInterface.java
@@ -504,6 +504,11 @@ public interface CommandInterface {
     int executeUpdate();
 
     /**
+     * Stop the command execution, release all locks and resources
+     */
+    void stop();
+
+    /**
      * Close the statement.
      */
     void close();

--- a/h2/src/main/org/h2/command/CommandRemote.java
+++ b/h2/src/main/org/h2/command/CommandRemote.java
@@ -54,6 +54,12 @@ public class CommandRemote implements CommandInterface {
         created = session.getLastReconnect();
     }
 
+    @Override
+    public void stop() {
+        // Must never be called, because remote result is not lazy.
+        throw DbException.throwInternalError();
+    }
+
     private void prepare(SessionRemote s, boolean createParams) {
         id = s.getNextId();
         for (int i = 0, count = 0; i < transferList.size(); i++) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -224,6 +224,7 @@ public class Parser {
     private ArrayList<Parameter> indexedParameterList;
     private int orderInFrom;
     private ArrayList<Parameter> suppliedParameterList;
+    private boolean hasRecursive;
 
     public Parser(Session session) {
         this.database = session.getDatabase();
@@ -300,6 +301,9 @@ public class Parser {
         }
         p.setPrepareAlways(recompileAlways);
         p.setParameterList(parameters);
+        if (hasRecursive && p.isQuery() && p instanceof Query) {
+            ((Query) p).setNeverLazy(true);
+        }
         return p;
     }
 
@@ -4833,6 +4837,7 @@ public class Parser {
     }
 
     private Query parseWith() {
+        hasRecursive = true;
         readIf("RECURSIVE");
         String tempViewName = readIdentifierWithSchema();
         Schema schema = getSchema();

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2240,6 +2240,9 @@ public class Parser {
                 } else {
                     if (isSelect()) {
                         Query query = parseSelect();
+                        // can not be lazy because we have to call
+                        // method ResultInterface.containsDistinct
+                        // which is not supported for lazy execution
                         query.setNeverLazy(true);
                         r = new ConditionInSelect(database, r, query, false,
                                 Comparison.EQUAL);

--- a/h2/src/main/org/h2/command/dml/Explain.java
+++ b/h2/src/main/org/h2/command/dml/Explain.java
@@ -38,6 +38,9 @@ public class Explain extends Prepared {
 
     public void setCommand(Prepared command) {
         this.command = command;
+        if (command instanceof Query) {
+            ((Query) command).setNeverLazy(true);
+        }
     }
 
     public Prepared getCommand() {

--- a/h2/src/main/org/h2/command/dml/Explain.java
+++ b/h2/src/main/org/h2/command/dml/Explain.java
@@ -38,9 +38,6 @@ public class Explain extends Prepared {
 
     public void setCommand(Prepared command) {
         this.command = command;
-        if (command instanceof Query) {
-            ((Query) command).setNeverLazy(true);
-        }
     }
 
     public Prepared getCommand() {

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -60,14 +60,13 @@ public abstract class Query extends Prepared {
      */
     protected boolean randomAccessResult;
 
-    protected boolean neverLazy;
-
     private boolean noCache;
     private int lastLimit;
     private long lastEvaluated;
     private ResultInterface lastResult;
     private Value[] lastParameters;
     private boolean cacheableChecked;
+    private boolean neverLazy;
 
     Query(Session session) {
         super(session);
@@ -75,6 +74,10 @@ public abstract class Query extends Prepared {
 
     public void setNeverLazy(boolean b) {
         this.neverLazy = b;
+    }
+
+    public boolean isNeverLazy() {
+        return neverLazy;
     }
 
     /**

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -17,6 +17,7 @@ import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.Parameter;
 import org.h2.expression.ValueExpression;
 import org.h2.message.DbException;
+import org.h2.result.LazyResult;
 import org.h2.result.LocalResult;
 import org.h2.result.ResultInterface;
 import org.h2.result.ResultTarget;
@@ -148,7 +149,7 @@ public class SelectUnion extends Query {
     }
 
     @Override
-    protected LocalResult queryWithoutCache(int maxRows, ResultTarget target) {
+    protected ResultInterface queryWithoutCache(int maxRows, ResultTarget target) {
         if (maxRows != 0) {
             // maxRows is set (maxRows 0 means no limit)
             int l;
@@ -177,6 +178,25 @@ public class SelectUnion extends Query {
             }
         }
         int columnCount = left.getColumnCount();
+        if (session.isLazyQueryExecution() && unionType == UNION_ALL && !distinct &&
+                sort == null && !randomAccessResult && !isForUpdate &&
+                offsetExpr == null && isReadOnly()) {
+            int limit = -1;
+            if (limitExpr != null) {
+                Value v = limitExpr.getValue(session);
+                if (v != ValueNull.INSTANCE) {
+                    limit = v.getInt();
+                }
+            }
+            // limit 0 means no rows
+            if (limit != 0) {
+                LazyResultUnion lazyResult = new LazyResultUnion(expressionArray, columnCount);
+                if (limit > 0) {
+                    lazyResult.setLimit(limit);
+                }
+                return lazyResult;
+            }
+        }
         LocalResult result = new LocalResult(session, expressionArray, columnCount);
         if (sort != null) {
             result.setSortOrder(sort);
@@ -205,8 +225,8 @@ public class SelectUnion extends Query {
         default:
             DbException.throwInternalError("type=" + unionType);
         }
-        LocalResult l = left.query(0);
-        LocalResult r = right.query(0);
+        ResultInterface l = left.query(0);
+        ResultInterface r = right.query(0);
         l.reset();
         r.reset();
         switch (unionType) {
@@ -435,10 +455,10 @@ public class SelectUnion extends Query {
     }
 
     @Override
-    public LocalResult query(int limit, ResultTarget target) {
+    public ResultInterface query(int limit, ResultTarget target) {
         // union doesn't always know the parameter list of the left and right
         // queries
-        return queryWithoutCache(limit, target);
+        return queryWithoutCache0(limit, target);
     }
 
     @Override
@@ -473,4 +493,75 @@ public class SelectUnion extends Query {
         return left.allowGlobalConditions() && right.allowGlobalConditions();
     }
 
+    /**
+     * Lazy execution for this union.
+     */
+    private final class LazyResultUnion extends LazyResult {
+
+        int columnCount;
+        ResultInterface l;
+        ResultInterface r;
+        boolean leftDone;
+        boolean rightDone;
+
+        LazyResultUnion(Expression[] expressions, int columnCount) {
+            super(expressions);
+            this.columnCount = columnCount;
+        }
+
+        @Override
+        public int getVisibleColumnCount() {
+            return columnCount;
+        }
+
+        @Override
+        protected Value[] fetchNextRow() {
+            if (rightDone) {
+                return null;
+            }
+            if (!leftDone) {
+                if (l == null) {
+                    l = left.query(0);
+                    l.reset();
+                }
+                if (l.next()) {
+                    return l.currentRow();
+                }
+                leftDone = true;
+            }
+            if (r == null) {
+                r = right.query(0);
+                r.reset();
+            }
+            if (r.next()) {
+                return r.currentRow();
+            }
+            rightDone = true;
+            return null;
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            if (l != null) {
+                l.close();
+            }
+            if (r != null) {
+                r.close();
+            }
+        }
+
+        @Override
+        public void reset() {
+            super.reset();
+            if (l != null) {
+                l.reset();
+            }
+            if (r != null) {
+                r.reset();
+            }
+            leftDone = false;
+            rightDone = false;
+        }
+    }
 }

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -455,13 +455,6 @@ public class SelectUnion extends Query {
     }
 
     @Override
-    public ResultInterface query(int limit, ResultTarget target) {
-        // union doesn't always know the parameter list of the left and right
-        // queries
-        return queryWithoutCache0(limit, target);
-    }
-
-    @Override
     public boolean isEverything(ExpressionVisitor visitor) {
         return left.isEverything(visitor) && right.isEverything(visitor);
     }

--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -510,9 +510,18 @@ public class Set extends Prepared {
             int value = getIntValue();
             if (value != 0 && value != 1) {
                 throw DbException.getInvalidValueException("FORCE_JOIN_ORDER",
-                        getIntValue());
+                        value);
             }
             session.setForceJoinOrder(value == 1);
+            break;
+        }
+        case SetTypes.LAZY_QUERY_EXECUTION: {
+            int value = getIntValue();
+            if (value != 0 && value != 1) {
+                throw DbException.getInvalidValueException("LAZY_QUERY_EXECUTION",
+                        value);
+            }
+            session.setLazyQueryExecution(value == 1);
             break;
         }
         default:

--- a/h2/src/main/org/h2/command/dml/SetTypes.java
+++ b/h2/src/main/org/h2/command/dml/SetTypes.java
@@ -214,7 +214,7 @@ public class SetTypes {
     public static final int RETENTION_TIME = 40;
 
     /**
-     * The type of a SET QUERY_STATISTICS_ACTIVE statement.
+     * The type of a SET QUERY_STATISTICS statement.
      */
     public static final int QUERY_STATISTICS = 41;
 
@@ -237,6 +237,11 @@ public class SetTypes {
      * The type of SET FORCE_JOIN_ORDER statement.
      */
     public static final int FORCE_JOIN_ORDER = 45;
+
+    /**
+     * The type of SET LAZY_QUERY_EXECUTION statement.
+     */
+    public static final int LAZY_QUERY_EXECUTION = 46;
 
     private static final ArrayList<String> TYPES = New.arrayList();
 
@@ -292,6 +297,7 @@ public class SetTypes {
         list.add(ROW_FACTORY, "ROW_FACTORY");
         list.add(BATCH_JOINS, "BATCH_JOINS");
         list.add(FORCE_JOIN_ORDER, "FORCE_JOIN_ORDER");
+        list.add(LAZY_QUERY_EXECUTION, "LAZY_QUERY_EXECUTION");
     }
 
     /**

--- a/h2/src/main/org/h2/expression/ConditionExists.java
+++ b/h2/src/main/org/h2/expression/ConditionExists.java
@@ -7,7 +7,7 @@ package org.h2.expression;
 
 import org.h2.command.dml.Query;
 import org.h2.engine.Session;
-import org.h2.result.LocalResult;
+import org.h2.result.ResultInterface;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.util.StringUtils;
@@ -28,9 +28,9 @@ public class ConditionExists extends Condition {
     @Override
     public Value getValue(Session session) {
         query.setSession(session);
-        LocalResult result = query.query(1);
+        ResultInterface result = query.query(1);
         session.addTemporaryResult(result);
-        boolean r = result.getRowCount() > 0;
+        boolean r = result.hasNext();
         return ValueBoolean.get(r);
     }
 

--- a/h2/src/main/org/h2/expression/ConditionInSelect.java
+++ b/h2/src/main/org/h2/expression/ConditionInSelect.java
@@ -11,7 +11,7 @@ import org.h2.engine.Database;
 import org.h2.engine.Session;
 import org.h2.index.IndexCondition;
 import org.h2.message.DbException;
-import org.h2.result.LocalResult;
+import org.h2.result.ResultInterface;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.util.StringUtils;
@@ -38,6 +38,7 @@ public class ConditionInSelect extends Condition {
         this.query = query;
         this.all = all;
         this.compareType = compareType;
+        query.setNeverLazy(true);
     }
 
     @Override
@@ -46,9 +47,9 @@ public class ConditionInSelect extends Condition {
         if (!query.hasOrder()) {
             query.setDistinct(true);
         }
-        LocalResult rows = query.query(0);
+        ResultInterface rows = query.query(0);
         Value l = left.getValue(session);
-        if (rows.getRowCount() == 0) {
+        if (!rows.hasNext()) {
             return ValueBoolean.get(all);
         } else if (l == ValueNull.INSTANCE) {
             return l;
@@ -74,7 +75,7 @@ public class ConditionInSelect extends Condition {
         return ValueBoolean.get(false);
     }
 
-    private Value getValueSlow(LocalResult rows, Value l) {
+    private Value getValueSlow(ResultInterface rows, Value l) {
         // this only returns the correct result if the result has at least one
         // row, and if l is not null
         boolean hasNull = false;

--- a/h2/src/main/org/h2/expression/ConditionInSelect.java
+++ b/h2/src/main/org/h2/expression/ConditionInSelect.java
@@ -38,7 +38,6 @@ public class ConditionInSelect extends Condition {
         this.query = query;
         this.all = all;
         this.compareType = compareType;
-        query.setNeverLazy(true);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/Subquery.java
+++ b/h2/src/main/org/h2/expression/Subquery.java
@@ -34,20 +34,18 @@ public class Subquery extends Expression {
     public Value getValue(Session session) {
         query.setSession(session);
         try (ResultInterface result = query.query(2)) {
-            int rowcount = result.getRowCount();
-            if (rowcount > 1) {
-                throw DbException.get(ErrorCode.SCALAR_SUBQUERY_CONTAINS_MORE_THAN_ONE_ROW);
-            }
             Value v;
-            if (rowcount <= 0) {
+            if (!result.next()) {
                 v = ValueNull.INSTANCE;
             } else {
-                result.next();
                 Value[] values = result.currentRow();
                 if (result.getVisibleColumnCount() == 1) {
                     v = values[0];
                 } else {
                     v = ValueArray.get(values);
+                }
+                if (result.hasNext()) {
+                    throw DbException.get(ErrorCode.SCALAR_SUBQUERY_CONTAINS_MORE_THAN_ONE_ROW);
                 }
             }
             return v;

--- a/h2/src/main/org/h2/expression/TableFunction.java
+++ b/h2/src/main/org/h2/expression/TableFunction.java
@@ -12,7 +12,6 @@ import org.h2.engine.Database;
 import org.h2.engine.Session;
 import org.h2.message.DbException;
 import org.h2.result.LocalResult;
-import org.h2.result.ResultInterface;
 import org.h2.table.Column;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.MathUtils;
@@ -131,7 +130,7 @@ public class TableFunction extends Function {
         return vr;
     }
 
-    private static SimpleResultSet getSimpleResultSet(ResultInterface rs,
+    private static SimpleResultSet getSimpleResultSet(LocalResult rs,
             int maxrows) {
         int columnCount = rs.getVisibleColumnCount();
         SimpleResultSet simple = new SimpleResultSet();

--- a/h2/src/main/org/h2/index/ViewCursor.java
+++ b/h2/src/main/org/h2/index/ViewCursor.java
@@ -6,7 +6,7 @@
 package org.h2.index;
 
 import org.h2.message.DbException;
-import org.h2.result.LocalResult;
+import org.h2.result.ResultInterface;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.table.Table;
@@ -20,11 +20,11 @@ public class ViewCursor implements Cursor {
 
     private final Table table;
     private final ViewIndex index;
-    private final LocalResult result;
+    private final ResultInterface result;
     private final SearchRow first, last;
     private Row current;
 
-    public ViewCursor(ViewIndex index, LocalResult result, SearchRow first,
+    public ViewCursor(ViewIndex index, ResultInterface result, SearchRow first,
             SearchRow last) {
         this.table = index.getTable();
         this.index = index;

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -192,7 +192,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
             parser.setRightsChecked(true);
             parser.setSuppliedParameterList(originalParameters);
             query = (Query) parser.prepare(querySQL);
-            query.setNeverLazy(true);
+            assert query.isNeverLazy();
         }
         if (!query.isUnion()) {
             throw DbException.get(ErrorCode.SYNTAX_ERROR_2,

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -192,7 +192,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
             parser.setRightsChecked(true);
             parser.setSuppliedParameterList(originalParameters);
             query = (Query) parser.prepare(querySQL);
-            assert query.isNeverLazy();
+            query.setNeverLazy(true);
         }
         if (!query.isUnion()) {
             throw DbException.get(ErrorCode.SYNTAX_ERROR_2,

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -1548,7 +1548,7 @@ public class JdbcConnection extends TraceObject implements Connection,
                 "SELECT SCOPE_IDENTITY() " +
                 "WHERE SCOPE_IDENTITY() IS NOT NULL", getGeneratedKeys);
         ResultInterface result = getGeneratedKeys.executeQuery(0, false);
-        ResultSet rs = new JdbcResultSet(this, stat, result, id, false, true, false);
+        ResultSet rs = new JdbcResultSet(this, stat, getGeneratedKeys, result, id, false, true, false);
         return rs;
     }
 

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -102,16 +102,18 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             synchronized (session) {
                 checkClosed();
                 closeOldResultSet();
-                ResultInterface result;
+                ResultInterface result = null;
                 boolean scrollable = resultSetType != ResultSet.TYPE_FORWARD_ONLY;
                 boolean updatable = resultSetConcurrency == ResultSet.CONCUR_UPDATABLE;
                 try {
                     setExecutingStatement(command);
                     result = command.executeQuery(maxRows, scrollable);
                 } finally {
-                    setExecutingStatement(null);
+                    if (result == null || !result.isLazy()) {
+                        setExecutingStatement(null);
+                    }
                 }
-                resultSet = new JdbcResultSet(conn, this, result, id,
+                resultSet = new JdbcResultSet(conn, this, command, result, id,
                         closedByResultSet, scrollable, updatable, cachedColumnLabelMap);
             }
             return resultSet;
@@ -186,6 +188,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
                 boolean returnsResultSet;
                 synchronized (conn.getSession()) {
                     closeOldResultSet();
+                    boolean lazy = false;
                     try {
                         setExecutingStatement(command);
                         if (command.isQuery()) {
@@ -193,15 +196,18 @@ public class JdbcPreparedStatement extends JdbcStatement implements
                             boolean scrollable = resultSetType != ResultSet.TYPE_FORWARD_ONLY;
                             boolean updatable = resultSetConcurrency == ResultSet.CONCUR_UPDATABLE;
                             ResultInterface result = command.executeQuery(maxRows, scrollable);
-                            resultSet = new JdbcResultSet(conn, this, result,
+                            lazy = result.isLazy();
+                            resultSet = new JdbcResultSet(conn, this, command, result,
                                     id, closedByResultSet, scrollable,
-                                    updatable);
+                                    updatable, cachedColumnLabelMap);
                         } else {
                             returnsResultSet = false;
                             updateCount = command.executeUpdate();
                         }
                     } finally {
-                        setExecutingStatement(null);
+                        if (!lazy) {
+                            setExecutingStatement(null);
+                        }
                     }
                 }
                 return returnsResultSet;

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -102,14 +102,16 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             synchronized (session) {
                 checkClosed();
                 closeOldResultSet();
-                ResultInterface result = null;
+                ResultInterface result;
+                boolean lazy = false;
                 boolean scrollable = resultSetType != ResultSet.TYPE_FORWARD_ONLY;
                 boolean updatable = resultSetConcurrency == ResultSet.CONCUR_UPDATABLE;
                 try {
                     setExecutingStatement(command);
                     result = command.executeQuery(maxRows, scrollable);
+                    lazy = result.isLazy();
                 } finally {
-                    if (result == null || !result.isLazy()) {
+                    if (!lazy) {
                         setExecutingStatement(null);
                     }
                 }

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -12,6 +12,7 @@ import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.ArrayList;
 import org.h2.api.ErrorCode;
+import org.h2.command.Command;
 import org.h2.command.CommandInterface;
 import org.h2.engine.SessionInterface;
 import org.h2.engine.SysProperties;
@@ -38,7 +39,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
     private int lastExecutedCommandType;
     private ArrayList<String> batchCommands;
     private boolean escapeProcessing = true;
-    private boolean cancelled;
+    private volatile boolean cancelled;
 
     JdbcStatement(JdbcConnection conn, int id, int resultSetType,
             int resultSetConcurrency, boolean closeWithResultSet) {
@@ -71,17 +72,21 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
                 closeOldResultSet();
                 sql = JdbcConnection.translateSQL(sql, escapeProcessing);
                 CommandInterface command = conn.prepareCommand(sql, fetchSize);
-                ResultInterface result;
+                ResultInterface result = null;
                 boolean scrollable = resultSetType != ResultSet.TYPE_FORWARD_ONLY;
                 boolean updatable = resultSetConcurrency == ResultSet.CONCUR_UPDATABLE;
                 setExecutingStatement(command);
                 try {
                     result = command.executeQuery(maxRows, scrollable);
                 } finally {
-                    setExecutingStatement(null);
+                    if (result == null || !result.isLazy()) {
+                        setExecutingStatement(null);
+                    }
                 }
-                command.close();
-                resultSet = new JdbcResultSet(conn, this, result, id,
+                if (!result.isLazy()) {
+                    command.close();
+                }
+                resultSet = new JdbcResultSet(conn, this, command, result, id,
                         closedByResultSet, scrollable, updatable);
             }
             return resultSet;
@@ -168,6 +173,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
             closeOldResultSet();
             sql = JdbcConnection.translateSQL(sql, escapeProcessing);
             CommandInterface command = conn.prepareCommand(sql, fetchSize);
+            boolean lazy = false;
             boolean returnsResultSet;
             synchronized (session) {
                 setExecutingStatement(command);
@@ -177,17 +183,22 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
                         boolean scrollable = resultSetType != ResultSet.TYPE_FORWARD_ONLY;
                         boolean updatable = resultSetConcurrency == ResultSet.CONCUR_UPDATABLE;
                         ResultInterface result = command.executeQuery(maxRows, scrollable);
-                        resultSet = new JdbcResultSet(conn, this, result, id,
+                        lazy = result.isLazy();
+                        resultSet = new JdbcResultSet(conn, this, command, result, id,
                                 closedByResultSet, scrollable, updatable);
                     } else {
                         returnsResultSet = false;
                         updateCount = command.executeUpdate();
                     }
                 } finally {
-                    setExecutingStatement(null);
+                    if (!lazy) {
+                        setExecutingStatement(null);
+                    }
                 }
             }
-            command.close();
+            if (!lazy) {
+                command.close();
+            }
             return returnsResultSet;
         } finally {
             afterWriting();
@@ -549,7 +560,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
      *
      * @return true if yes
      */
-    public boolean wasCancelled() {
+    public boolean isCancelled() {
         return cancelled;
     }
 
@@ -1029,6 +1040,14 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
             lastExecutedCommandType = c.getCommandType();
         }
         executingCommand = c;
+    }
+
+    void onLazyResultSetClose(CommandInterface command, boolean closeCommand) {
+        setExecutingStatement(null);
+        command.stop();
+        if (closeCommand) {
+            command.close();
+        }
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -72,18 +72,20 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
                 closeOldResultSet();
                 sql = JdbcConnection.translateSQL(sql, escapeProcessing);
                 CommandInterface command = conn.prepareCommand(sql, fetchSize);
-                ResultInterface result = null;
+                ResultInterface result;
+                boolean lazy = false;
                 boolean scrollable = resultSetType != ResultSet.TYPE_FORWARD_ONLY;
                 boolean updatable = resultSetConcurrency == ResultSet.CONCUR_UPDATABLE;
                 setExecutingStatement(command);
                 try {
                     result = command.executeQuery(maxRows, scrollable);
+                    lazy = result.isLazy();
                 } finally {
-                    if (result == null || !result.isLazy()) {
+                    if (!lazy) {
                         setExecutingStatement(null);
                     }
                 }
-                if (!result.isLazy()) {
+                if (!lazy) {
                     command.close();
                 }
                 resultSet = new JdbcResultSet(conn, this, command, result, id,

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -7,7 +7,7 @@ SELECT [ TOP term ] [ DISTINCT | ALL ] selectExpression [,...]
 FROM tableExpression [,...] [ WHERE expression ]
 [ GROUP BY expression [,...] ] [ HAVING expression ]
 [ { UNION [ ALL ] | MINUS | EXCEPT | INTERSECT } select ] [ ORDER BY order [,...] ]
-[ [ LIMIT expression ] [ OFFSET expression ] [ SAMPLE_SIZE rowCountInt ] ]
+[ { LIMIT expression [ OFFSET expression ] [ SAMPLE_SIZE rowCountInt ] } | { [ OFFSET expression { ROW | ROWS } ] [ { FETCH { FIRST | NEXT } expression { ROW | ROWS } ONLY } ] } ]
 [ FOR UPDATE ]
 ","
 Selects data from a table or multiple tables."

--- a/h2/src/main/org/h2/result/LazyResult.java
+++ b/h2/src/main/org/h2/result/LazyResult.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2004-2014 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.result;
+
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.message.DbException;
+import org.h2.value.Value;
+
+/**
+ * Lazy execution support for queries.
+ * 
+ * @author Sergi Vladykin
+ */
+public abstract class LazyResult implements ResultInterface {
+
+    private Expression[] expressions;
+    private int rowId = -1;
+    private Value[] currentRow;
+    private Value[] nextRow;
+    private boolean closed;
+    private boolean afterLast;
+    private int limit;
+
+    public LazyResult(Expression[] expressions) {
+        this.expressions = expressions;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    @Override
+    public boolean isLazy() {
+        return true;
+    }
+
+    @Override
+    public void reset() {
+        if (closed) {
+            throw DbException.throwInternalError();
+        }
+        rowId = -1;
+        afterLast = false;
+        currentRow = null;
+        nextRow = null;
+    }
+
+    @Override
+    public Value[] currentRow() {
+        return currentRow;
+    }
+
+    @Override
+    public boolean next() {
+        if (hasNext()) {
+            rowId++;
+            currentRow = nextRow;
+            nextRow = null;
+            return true;
+        }
+        if (!afterLast) {
+            rowId++;
+            currentRow = null;
+            afterLast = true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (closed || afterLast) {
+            return false;
+        }
+        if (nextRow == null && (limit <= 0 || rowId + 1 < limit)) {
+            nextRow = fetchNextRow();
+        }
+        return nextRow != null;
+    }
+
+    /**
+     * Fetch next row or null if none available.
+     * 
+     * @return next row or null
+     */
+    protected abstract Value[] fetchNextRow();
+
+    @Override
+    public boolean isAfterLast() {
+        return afterLast;
+    }
+
+    @Override
+    public int getRowId() {
+        return rowId;
+    }
+
+    @Override
+    public int getRowCount() {
+        throw DbException.getUnsupportedException("Row count is unknown for lazy result.");
+    }
+
+    @Override
+    public boolean needToClose() {
+        return true;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    @Override
+    public String getAlias(int i) {
+        return expressions[i].getAlias();
+    }
+
+    @Override
+    public String getSchemaName(int i) {
+        return expressions[i].getSchemaName();
+    }
+
+    @Override
+    public String getTableName(int i) {
+        return expressions[i].getTableName();
+    }
+
+    @Override
+    public String getColumnName(int i) {
+        return expressions[i].getColumnName();
+    }
+
+    @Override
+    public int getColumnType(int i) {
+        return expressions[i].getType();
+    }
+
+    @Override
+    public long getColumnPrecision(int i) {
+        return expressions[i].getPrecision();
+    }
+
+    @Override
+    public int getColumnScale(int i) {
+        return expressions[i].getScale();
+    }
+
+    @Override
+    public int getDisplaySize(int i) {
+        return expressions[i].getDisplaySize();
+    }
+
+    @Override
+    public boolean isAutoIncrement(int i) {
+        return expressions[i].isAutoIncrement();
+    }
+
+    @Override
+    public int getNullable(int i) {
+        return expressions[i].getNullable();
+    }
+
+    @Override
+    public void setFetchSize(int fetchSize) {
+        // ignore
+    }
+
+    @Override
+    public int getFetchSize() {
+        // We always fetch rows one by one.
+        return 1;
+    }
+
+    @Override
+    public ResultInterface createShallowCopy(Session targetSession) {
+        // Copying is impossible with lazy result.
+        return null;
+    }
+
+    @Override
+    public boolean containsDistinct(Value[] values) {
+        // We have to make sure that we do not allow lazy
+        // evaluation when this call is needed:
+        // WHERE x IN (SELECT ...).
+        throw DbException.throwInternalError();
+    }
+}

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -77,6 +77,11 @@ public class LocalResult implements ResultInterface, ResultTarget {
         this.expressions = expressions;
     }
 
+    @Override
+    public boolean isLazy() {
+        return false;
+    }
+
     public void setMaxMemoryRows(int maxValue) {
         this.maxMemoryRows = maxValue;
     }
@@ -117,6 +122,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
      * @param targetSession the session of the copy
      * @return the copy if possible, or null if copying is not possible
      */
+    @Override
     public LocalResult createShallowCopy(Session targetSession) {
         if (external == null && (rows == null || rows.size() < rowCount)) {
             return null;
@@ -199,6 +205,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
      * @param values the row
      * @return true if the row exists
      */
+    @Override
     public boolean containsDistinct(Value[] values) {
         if (external != null) {
             return external.contains(values);
@@ -217,6 +224,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
     @Override
     public void reset() {
         rowId = -1;
+        currentRow = null;
         if (external != null) {
             external.reset();
             if (diskOffset > 0) {
@@ -252,6 +260,11 @@ public class LocalResult implements ResultInterface, ResultTarget {
     @Override
     public int getRowId() {
         return rowId;
+    }
+
+    @Override
+    public boolean isAfterLast() {
+        return rowId >= rowCount;
     }
 
     private void cloneLobs(Value[] values) {
@@ -373,6 +386,11 @@ public class LocalResult implements ResultInterface, ResultTarget {
     @Override
     public int getRowCount() {
         return rowCount;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return !closed && rowId < rowCount - 1;
     }
 
     /**
@@ -508,6 +526,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
      *
      * @return true if it is
      */
+    @Override
     public boolean isClosed() {
         return closed;
     }

--- a/h2/src/main/org/h2/result/ResultInterface.java
+++ b/h2/src/main/org/h2/result/ResultInterface.java
@@ -5,6 +5,7 @@
  */
 package org.h2.result;
 
+import org.h2.engine.Session;
 import org.h2.value.Value;
 
 /**
@@ -42,6 +43,13 @@ public interface ResultInterface extends AutoCloseable {
     int getRowId();
 
     /**
+     * Check if the current position is after last row.
+     *
+     * @return true if after last
+     */
+    boolean isAfterLast();
+
+    /**
      * Get the number of visible columns.
      * More columns may exist internally for sorting or grouping.
      *
@@ -55,6 +63,13 @@ public interface ResultInterface extends AutoCloseable {
      * @return the number of rows
      */
     int getRowCount();
+
+    /**
+     * Check if this result has more rows to fetch.
+     *
+     * @return true if it has
+     */
+    boolean hasNext();
 
     /**
      * Check if this result set should be closed, for example because it is
@@ -164,4 +179,34 @@ public interface ResultInterface extends AutoCloseable {
      */
     int getFetchSize();
 
+    /**
+     * Check if this a lazy execution result.
+     *
+     * @return true if it is a lazy result
+     */
+    boolean isLazy();
+
+    /**
+     * Check if this result set is closed.
+     *
+     * @return true if it is
+     */
+    boolean isClosed();
+
+    /**
+     * Create a shallow copy of the result set. The data and a temporary table
+     * (if there is any) is not copied.
+     *
+     * @param targetSession the session of the copy
+     * @return the copy if possible, or null if copying is not possible
+     */
+    ResultInterface createShallowCopy(Session targetSession);
+
+    /**
+     * Check if this result set contains the given row.
+     *
+     * @param values the row
+     * @return true if the row exists
+     */
+    boolean containsDistinct(Value[] values);
 }

--- a/h2/src/main/org/h2/result/ResultRemote.java
+++ b/h2/src/main/org/h2/result/ResultRemote.java
@@ -7,6 +7,7 @@ package org.h2.result;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import org.h2.engine.Session;
 import org.h2.engine.SessionRemote;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
@@ -48,6 +49,11 @@ public class ResultRemote implements ResultInterface {
         result = New.arrayList();
         this.fetchSize = fetchSize;
         fetchRows(false);
+    }
+
+    @Override
+    public boolean isLazy() {
+        return false;
     }
 
     @Override
@@ -146,6 +152,11 @@ public class ResultRemote implements ResultInterface {
     }
 
     @Override
+    public boolean isAfterLast() {
+        return rowId >= rowCount;
+    }
+
+    @Override
     public int getVisibleColumnCount() {
         return columns.length;
     }
@@ -153,6 +164,11 @@ public class ResultRemote implements ResultInterface {
     @Override
     public int getRowCount() {
         return rowCount;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return rowId < rowCount - 1;
     }
 
     private void sendClose() {
@@ -254,4 +270,20 @@ public class ResultRemote implements ResultInterface {
         return true;
     }
 
+    @Override
+    public ResultInterface createShallowCopy(Session targetSession) {
+        // The operation is not supported on remote result.
+        return null;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return result == null;
+    }
+
+    @Override
+    public boolean containsDistinct(Value[] values) {
+        // We should never do this on remote result.
+        throw DbException.throwInternalError();
+    }
 }

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -376,7 +376,7 @@ public class PgServerThread implements Runnable {
                     sendCommandComplete(prep, prep.getUpdateCount());
                 }
             } catch (Exception e) {
-                if (prep.wasCancelled()) {
+                if (prep.isCancelled()) {
                     sendCancelQueryResponse();
                 } else {
                     sendErrorResponse(e);
@@ -423,7 +423,7 @@ public class PgServerThread implements Runnable {
                         sendCommandComplete(stat, stat.getUpdateCount());
                     }
                 } catch (SQLException e) {
-                    if (stat != null && stat.wasCancelled()) {
+                    if (stat != null && stat.isCancelled()) {
                         sendCancelQueryResponse();
                     } else {
                         sendErrorResponse(e);

--- a/h2/src/main/org/h2/table/JoinBatch.java
+++ b/h2/src/main/org/h2/table/JoinBatch.java
@@ -21,7 +21,7 @@ import org.h2.index.IndexLookupBatch;
 import org.h2.index.ViewCursor;
 import org.h2.index.ViewIndex;
 import org.h2.message.DbException;
-import org.h2.result.LocalResult;
+import org.h2.result.ResultInterface;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.util.DoneFuture;
@@ -738,6 +738,7 @@ public final class JoinBatch {
 
     /**
      * Simple singleton list.
+     * @param <E> Element type.
      */
     static final class SingletonList<E> extends AbstractList<E> {
         private E element;
@@ -763,6 +764,7 @@ public final class JoinBatch {
 
     /**
      * Base class for SELECT and SELECT UNION view index lookup batches.
+     * @param <R> Runner type.
      */
     private abstract static class ViewIndexLookupBatchBase<R extends QueryRunnerBase>
             implements IndexLookupBatch {
@@ -850,14 +852,15 @@ public final class JoinBatch {
     }
 
     /**
-     * Lazy query runner base.
+     * Lazy query runner base for subqueries and views.
      */
     private abstract static class QueryRunnerBase extends LazyFuture<Cursor> {
         protected final ViewIndex viewIndex;
         protected SearchRow first;
         protected SearchRow last;
+        private boolean isLazyResult;
 
-        public QueryRunnerBase(ViewIndex viewIndex) {
+        QueryRunnerBase(ViewIndex viewIndex) {
             this.viewIndex = viewIndex;
         }
 
@@ -867,6 +870,9 @@ public final class JoinBatch {
 
         @Override
         public final boolean reset() {
+            if (isLazyResult) {
+                resetViewTopFutureCursorAfterQuery();
+            }
             if (super.reset()) {
                 return true;
             }
@@ -875,11 +881,14 @@ public final class JoinBatch {
             return false;
         }
 
-        protected final ViewCursor newCursor(LocalResult localResult) {
+        protected final ViewCursor newCursor(ResultInterface localResult) {
+            isLazyResult = localResult.isLazy();
             ViewCursor cursor = new ViewCursor(viewIndex, localResult, first, last);
             clear();
             return cursor;
         }
+
+        protected abstract void resetViewTopFutureCursorAfterQuery();
     }
 
     /**
@@ -924,12 +933,12 @@ public final class JoinBatch {
     }
 
     /**
-     * Query runner.
+     * Query runner for SELECT.
      */
     private final class QueryRunner extends QueryRunnerBase {
         Future<Cursor> topFutureCursor;
 
-        public QueryRunner(ViewIndex viewIndex) {
+        QueryRunner(ViewIndex viewIndex) {
             super(viewIndex);
         }
 
@@ -948,13 +957,20 @@ public final class JoinBatch {
             }
             viewIndex.setupQueryParameters(viewIndex.getSession(), first, last, null);
             JoinBatch.this.viewTopFutureCursor = topFutureCursor;
-            LocalResult localResult;
+            ResultInterface localResult = null;
             try {
                 localResult = viewIndex.getQuery().query(0);
             } finally {
-                JoinBatch.this.viewTopFutureCursor = null;
+                if (localResult == null || !localResult.isLazy()) {
+                    resetViewTopFutureCursorAfterQuery();
+                }
             }
             return newCursor(localResult);
+        }
+
+        @Override
+        protected void resetViewTopFutureCursorAfterQuery() {
+            JoinBatch.this.viewTopFutureCursor = null;
         }
     }
 
@@ -1056,7 +1072,7 @@ public final class JoinBatch {
         private ViewIndexLookupBatchUnion batchUnion;
 
         @SuppressWarnings("unchecked")
-        public QueryRunnerUnion(ViewIndexLookupBatchUnion batchUnion) {
+        QueryRunnerUnion(ViewIndexLookupBatchUnion batchUnion) {
             super(batchUnion.viewIndex);
             this.batchUnion = batchUnion;
             topFutureCursors = new Future[batchUnion.filters.size()];
@@ -1078,15 +1094,26 @@ public final class JoinBatch {
                 assert topFutureCursors[i] != null;
                 joinBatches.get(i).viewTopFutureCursor = topFutureCursors[i];
             }
-            LocalResult localResult;
+            ResultInterface localResult = null;
             try {
                 localResult = viewIndex.getQuery().query(0);
             } finally {
-                for (int i = 0, size = joinBatches.size(); i < size; i++) {
-                    joinBatches.get(i).viewTopFutureCursor = null;
+                if (localResult == null || !localResult.isLazy()) {
+                    resetViewTopFutureCursorAfterQuery();
                 }
             }
             return newCursor(localResult);
+        }
+
+        @Override
+        protected void resetViewTopFutureCursorAfterQuery() {
+            ArrayList<JoinBatch> joinBatches = batchUnion.joinBatches;
+            if (joinBatches == null) {
+                return;
+            }
+            for (int i = 0, size = joinBatches.size(); i < size; i++) {
+                joinBatches.get(i).viewTopFutureCursor = null;
+            }
         }
     }
 }

--- a/h2/src/main/org/h2/table/JoinBatch.java
+++ b/h2/src/main/org/h2/table/JoinBatch.java
@@ -957,11 +957,13 @@ public final class JoinBatch {
             }
             viewIndex.setupQueryParameters(viewIndex.getSession(), first, last, null);
             JoinBatch.this.viewTopFutureCursor = topFutureCursor;
-            ResultInterface localResult = null;
+            ResultInterface localResult;
+            boolean lazy = false;
             try {
                 localResult = viewIndex.getQuery().query(0);
+                lazy = localResult.isLazy();
             } finally {
-                if (localResult == null || !localResult.isLazy()) {
+                if (!lazy) {
                     resetViewTopFutureCursorAfterQuery();
                 }
             }
@@ -1094,11 +1096,13 @@ public final class JoinBatch {
                 assert topFutureCursors[i] != null;
                 joinBatches.get(i).viewTopFutureCursor = topFutureCursors[i];
             }
-            ResultInterface localResult = null;
+            ResultInterface localResult;
+            boolean lazy = false;
             try {
                 localResult = viewIndex.getQuery().query(0);
+                lazy = localResult.isLazy();
             } finally {
-                if (localResult == null || !localResult.isLazy()) {
+                if (!lazy) {
                     resetViewTopFutureCursorAfterQuery();
                 }
             }

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -26,7 +26,7 @@ import org.h2.index.Index;
 import org.h2.index.IndexType;
 import org.h2.index.ViewIndex;
 import org.h2.message.DbException;
-import org.h2.result.LocalResult;
+import org.h2.result.ResultInterface;
 import org.h2.result.Row;
 import org.h2.result.SortOrder;
 import org.h2.schema.Schema;
@@ -55,7 +55,7 @@ public class TableView extends Table {
     private long maxDataModificationId;
     private User owner;
     private Query topQuery;
-    private LocalResult recursiveResult;
+    private ResultInterface recursiveResult;
     private boolean tableExpression;
 
     public TableView(Schema schema, int id, String name, String querySQL,
@@ -591,14 +591,14 @@ public class TableView extends Table {
         return viewQuery.isEverything(ExpressionVisitor.DETERMINISTIC_VISITOR);
     }
 
-    public void setRecursiveResult(LocalResult value) {
+    public void setRecursiveResult(ResultInterface value) {
         if (recursiveResult != null) {
             recursiveResult.close();
         }
         this.recursiveResult = value;
     }
 
-    public LocalResult getRecursiveResult() {
+    public ResultInterface getRecursiveResult() {
         return recursiveResult;
     }
 
@@ -630,7 +630,7 @@ public class TableView extends Table {
         private final int[] masks;
         private final TableView view;
 
-        public CacheKey(int[] masks, TableView view) {
+        CacheKey(int[] masks, TableView view) {
             this.masks = masks;
             this.view = view;
         }

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -316,6 +316,11 @@ java org.h2.test.TestAll timer
     public boolean multiThreaded;
 
     /**
+     * If lazy queries should be used.
+     */
+    public boolean lazy;
+
+    /**
      * The cipher to use (null for unencrypted).
      */
     public String cipher;
@@ -602,6 +607,13 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         multiThreaded = true;
         test();
         testUnit();
+
+        // lazy
+        lazy = true;
+        memory = true;
+        multiThreaded = true;
+        test();
+        lazy = false;
 
         // but sometimes race conditions need bigger windows
         memory = false;
@@ -1063,6 +1075,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
     public String toString() {
         StringBuilder buff = new StringBuilder();
         appendIf(buff, fast, "fast");
+        appendIf(buff, lazy, "lazy");
         appendIf(buff, mvStore, "mvStore");
         appendIf(buff, big, "big");
         appendIf(buff, networked, "net");

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -22,6 +22,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -317,6 +318,9 @@ public abstract class TestBase {
         }
         if (config.multiThreaded) {
             url = addOption(url, "MULTI_THREADED", "TRUE");
+        }
+        if (config.lazy) {
+            url = addOption(url, "LAZY_QUERY_EXECUTION", "1");
         }
         if (config.cacheType != null && admin) {
             url = addOption(url, "CACHE_TYPE", config.cacheType);
@@ -1056,10 +1060,27 @@ public abstract class TestBase {
     protected void assertThrows(int expectedErrorCode, Statement stat,
             String sql) {
         try {
-            stat.execute(sql);
+            execute(stat, sql);
             fail("Expected error: " + expectedErrorCode);
         } catch (SQLException ex) {
             assertEquals(expectedErrorCode, ex.getErrorCode());
+        }
+    }
+
+    protected void execute(PreparedStatement stat) throws SQLException {
+        execute(stat, null);
+    }
+
+    protected void execute(Statement stat, String sql) throws SQLException {
+        boolean query = sql == null ? ((PreparedStatement) stat).execute() :
+            stat.execute(sql);
+
+        if (query && config.lazy) {
+            try (ResultSet rs = stat.getResultSet()) {
+                while (rs.next()) {
+                    // just loop
+                }
+            }
         }
     }
 
@@ -1497,8 +1518,9 @@ public abstract class TestBase {
                     AssertionError ae = new AssertionError(
                             "Expected an SQLException or DbException with error code "
                                     + expectedErrorCode
-                                    + ", but got a " + t.getClass().getName() + " exception "
-                                    + " with error code " + errorCode);
+                                    + ", but got a " + (t == null ? "null" :
+                                            t.getClass().getName() + " exception "
+                                    + " with error code " + errorCode));
                     ae.initCause(t);
                     throw ae;
                 }

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -163,6 +163,9 @@ public class TestLob extends TestBase {
     }
 
     private void testRemovedAfterTimeout() throws Exception {
+        if (config.lazy) {
+            return;
+        }
         deleteDb("lob");
         final String url = getURL("lob;lob_timeout=50", true);
         Connection conn = getConnection(url);
@@ -199,6 +202,9 @@ public class TestLob extends TestBase {
     }
 
     private void testConcurrentRemoveRead() throws Exception {
+        if (config.lazy) {
+            return;
+        }
         deleteDb("lob");
         final String url = getURL("lob", true);
         Connection conn = getConnection(url);

--- a/h2/src/test/org/h2/test/db/TestOptimizations.java
+++ b/h2/src/test/org/h2/test/db/TestOptimizations.java
@@ -220,6 +220,9 @@ public class TestOptimizations extends TestBase {
     }
 
     private void testQueryCacheConcurrentUse() throws Exception {
+        if (config.lazy) {
+            return;
+        }
         final Connection conn = getConnection("optimizations");
         Statement stat = conn.createStatement();
         stat.execute("create table test(id int primary key, data clob)");

--- a/h2/src/test/org/h2/test/db/TestOutOfMemory.java
+++ b/h2/src/test/org/h2/test/db/TestOutOfMemory.java
@@ -37,9 +37,16 @@ public class TestOutOfMemory extends TestBase {
 
     @Override
     public void test() throws SQLException {
-        testMVStoreUsingInMemoryFileSystem();
-        testDatabaseUsingInMemoryFileSystem();
-        testUpdateWhenNearlyOutOfMemory();
+        try {
+            System.gc();
+            testMVStoreUsingInMemoryFileSystem();
+            System.gc();
+            testDatabaseUsingInMemoryFileSystem();
+            System.gc();
+            testUpdateWhenNearlyOutOfMemory();
+        } finally {
+            System.gc();
+        }
     }
 
     private void testMVStoreUsingInMemoryFileSystem() {

--- a/h2/src/test/org/h2/test/db/TestQueryCache.java
+++ b/h2/src/test/org/h2/test/db/TestQueryCache.java
@@ -52,10 +52,11 @@ public class TestQueryCache extends TestBase {
             // stat.execute("drop table x");
             time = System.nanoTime();
             prep = conn.prepareStatement("select count(*) from test t1, test t2");
-            prep.executeQuery();
+            execute(prep);
             rs = stat.executeQuery("select count(*) from test t1, test t2");
             rs.next();
             int c = rs.getInt(1);
+            rs.close();
             assertEquals(1000000, c);
             time = System.nanoTime() - time;
             if (first == 0) {

--- a/h2/src/test/org/h2/test/db/TestRecursiveQueries.java
+++ b/h2/src/test/org/h2/test/db/TestRecursiveQueries.java
@@ -103,7 +103,7 @@ public class TestRecursiveQueries extends TestBase {
         prep2.setInt(1, 10);
         prep2.setInt(2, 2);
         prep2.setInt(3, 14);
-        prep2.execute();
+        assertTrue(prep2.executeQuery().next());
         rs = prep.executeQuery();
         assertTrue(rs.next());
         assertEquals(10, rs.getInt(1));
@@ -116,7 +116,7 @@ public class TestRecursiveQueries extends TestBase {
         prep2.setInt(1, 100);
         prep2.setInt(2, 3);
         prep2.setInt(3, 103);
-        prep2.execute();
+        assertTrue(prep2.executeQuery().next());
         rs = prep.executeQuery();
         assertTrue(rs.next());
         assertEquals(100, rs.getInt(1));

--- a/h2/src/test/org/h2/test/db/TestScript.java
+++ b/h2/src/test/org/h2/test/db/TestScript.java
@@ -284,12 +284,6 @@ public class TestScript extends TestBase {
         ResultSetMetaData meta = rs.getMetaData();
         int len = meta.getColumnCount();
         int[] max = new int[len];
-        String[] head = new String[len];
-        for (int i = 0; i < len; i++) {
-            String label = formatString(meta.getColumnLabel(i + 1));
-            max[i] = label.length();
-            head[i] = label;
-        }
         result.clear();
         while (rs.next()) {
             String[] row = new String[len];
@@ -301,6 +295,14 @@ public class TestScript extends TestBase {
                 row[i] = data;
             }
             result.add(row);
+        }
+        String[] head = new String[len];
+        for (int i = 0; i < len; i++) {
+            String label = formatString(meta.getColumnLabel(i + 1));
+            if (max[i] < label.length()) {
+                max[i] = label.length();
+            }
+            head[i] = label;
         }
         rs.close();
         writeResult(sql, format(head, max), null);

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -1200,7 +1200,7 @@ public class TestTableEngines extends TestBase {
             }
         };
 
-        public TreeSetTable(CreateTableData data) {
+        TreeSetTable(CreateTableData data) {
             super(data);
         }
 
@@ -1602,7 +1602,7 @@ public class TestTableEngines extends TestBase {
         Iterator<SearchRow> it;
         private Row current;
 
-        public IteratorCursor(Iterator<SearchRow> it) {
+        IteratorCursor(Iterator<SearchRow> it) {
             this.it = it;
         }
 
@@ -1644,12 +1644,12 @@ public class TestTableEngines extends TestBase {
         private int[] cols;
         private boolean descending;
 
-        public RowComparator(int... cols) {
+        RowComparator(int... cols) {
             this.descending = false;
             this.cols = cols;
         }
 
-        public RowComparator(boolean descending, int... cols) {
+        RowComparator(boolean descending, int... cols) {
             this.descending = descending;
             this.cols = cols;
         }

--- a/h2/src/test/org/h2/test/db/TestTempTables.java
+++ b/h2/src/test/org/h2/test/db/TestTempTables.java
@@ -90,6 +90,9 @@ public class TestTempTables extends TestBase {
     }
 
     private void testTempFileResultSet() throws SQLException {
+        if (config.lazy) {
+            return;
+        }
         deleteDb("tempTables");
         Connection conn = getConnection("tempTables;MAX_MEMORY_ROWS=10");
         ResultSet rs1, rs2;
@@ -100,10 +103,10 @@ public class TestTempTables extends TestBase {
         rs1 = stat1.executeQuery("select * from system_range(1, 20)");
         rs2 = stat2.executeQuery("select * from system_range(1, 20)");
         for (int i = 0; i < 20; i++) {
-            rs1.next();
-            rs2.next();
-            rs1.getInt(1);
-            rs2.getInt(1);
+            assertTrue(rs1.next());
+            assertTrue(rs2.next());
+            assertEquals(i + 1, rs1.getInt(1));
+            assertEquals(i + 1, rs2.getInt(1));
         }
         rs2.close();
         // verify the temp table is not deleted yet

--- a/h2/src/test/org/h2/test/jdbc/TestCancel.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCancel.java
@@ -189,9 +189,8 @@ public class TestCancel extends TestBase {
             cancel.start();
             try {
                 Thread.yield();
-                assertThrows(ErrorCode.STATEMENT_WAS_CANCELED, query).
-                        executeQuery("SELECT VISIT(ID), (SELECT SUM(X) " +
-                                "FROM SYSTEM_RANGE(1, 100000) WHERE X<>ID) FROM TEST ORDER BY ID");
+                assertThrows(ErrorCode.STATEMENT_WAS_CANCELED, query, "SELECT VISIT(ID), (SELECT SUM(X) " +
+                        "FROM SYSTEM_RANGE(1, 100000) WHERE X<>ID) FROM TEST ORDER BY ID");
             } finally {
                 cancel.stopNow();
                 cancel.join();

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1256,7 +1256,7 @@ public class TestMetaData extends TestBase {
         stat.execute("SET QUERY_STATISTICS TRUE");
         int count = 100;
         for (int i = 0; i < count; i++) {
-            stat.execute("select * from test limit 10");
+            execute(stat, "select * from test limit 10");
         }
         // The "order by" makes the result set more stable on windows, where the
         // timer resolution is not that great
@@ -1266,7 +1266,7 @@ public class TestMetaData extends TestBase {
         assertTrue(rs.next());
         assertEquals("select * from test limit 10", rs.getString("SQL_STATEMENT"));
         assertEquals(count, rs.getInt("EXECUTION_COUNT"));
-        assertEquals(10 * count, rs.getInt("CUMULATIVE_ROW_COUNT"));
+        assertEquals(config.lazy ? 0 : 10 * count, rs.getInt("CUMULATIVE_ROW_COUNT"));
         rs.close();
         conn.close();
         deleteDb("metaData");

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -372,11 +372,11 @@ public class TestPreparedStatement extends TestBase {
             prepareStatement("SELECT * FROM (SELECT ? FROM DUAL)");
         PreparedStatement prep = conn.prepareStatement("SELECT -?");
         prep.setInt(1, 1);
-        prep.execute();
+        execute(prep);
         prep = conn.prepareStatement("SELECT ?-?");
         prep.setInt(1, 1);
         prep.setInt(2, 2);
-        prep.execute();
+        execute(prep);
     }
 
     private void testCancelReuse(Connection conn) throws Exception {
@@ -390,7 +390,7 @@ public class TestPreparedStatement extends TestBase {
         Task t = new Task() {
             @Override
             public void call() throws SQLException {
-                prep.execute();
+                TestPreparedStatement.this.execute(prep);
             }
         };
         t.execute();

--- a/h2/src/test/org/h2/test/jdbc/TestUpdatableResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestUpdatableResultSet.java
@@ -266,8 +266,13 @@ public class TestUpdatableResultSet extends TestBase {
         assertTrue(rs.absolute(3));
         assertEquals(3, rs.getRow());
 
-        assertTrue(rs.absolute(-1));
-        assertEquals(3, rs.getRow());
+        if (!config.lazy) {
+            assertTrue(rs.absolute(-1));
+            assertEquals(3, rs.getRow());
+
+            assertTrue(rs.absolute(-2));
+            assertEquals(2, rs.getRow());
+        }
 
         assertFalse(rs.absolute(4));
         assertTrue(rs.isAfterLast());

--- a/h2/src/test/org/h2/test/synth/TestHaltApp.java
+++ b/h2/src/test/org/h2/test/synth/TestHaltApp.java
@@ -38,9 +38,9 @@ public class TestHaltApp extends TestHalt {
         }
     }
 
-    private void execute(Statement stat, String sql) throws SQLException {
+    protected void execute(Statement stat, String sql) throws SQLException {
         traceOperation("execute: " + sql);
-        stat.execute(sql);
+        super.execute(stat, sql);
     }
 
     /**

--- a/h2/src/tools/org/h2/android/H2Cursor.java
+++ b/h2/src/tools/org/h2/android/H2Cursor.java
@@ -56,7 +56,7 @@ public class H2Cursor extends AbstractWindowedCursor {
 
     @Override
     public int getCount() {
-        return result.getRowCount();
+        return result.isLazy() ? -1 : result.getRowCount();
     }
 
     /**


### PR DESCRIPTION
Allows to lazily traverse large data sets without generating the whole result set into a separate place. 

Currently works only in embedded mode (network protocol relies on knowing a result set size) and has restrictions for having multiple active result sets from a single connection as well as for concurrent usage of the same connection between threads.

Please review.