### PR TITLE
TimestampWithTimeZone can not be bound

### DIFF
--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -1121,6 +1121,8 @@ public class DataType {
             return LocalDateTimeUtils.localDateTimeToValue(x);
         } else if (LocalDateTimeUtils.isOffsetDateTime(x.getClass())) {
             return LocalDateTimeUtils.offsetDateTimeToValue(x);
+        } else if (x instanceof TimestampWithTimeZone) {
+            return ValueTimestampTimeZone.get((TimestampWithTimeZone) x);
         } else {
             if (JdbcUtils.customDataTypesHandler != null) {
                 return JdbcUtils.customDataTypesHandler.getValue(type, x,


### PR DESCRIPTION
Clients that are still on Java 7 and can not use OffsetDateTime need a
way to bind TimestampWithTimeZone. Unfortunately TimestampWithTimeZone
can currently not be used as a bind parameter
The obvious way to bind TimestampWithTimeZone would be to use
PreparedStatement.setObject(int, Object). This does not work because
DataTye#convertTo currently does not check for TimestampWithTimeZone.

This commit fixes this by adding a check and conversion in
DataTye#convertTo and also adding a unit test.