### PR TITLE
Update Manifest with Provide Capability

### DIFF
--- a/h2/src/main/META-INF/MANIFEST.MF
+++ b/h2/src/main/META-INF/MANIFEST.MF
@@ -58,4 +58,5 @@ Export-Package: org.h2;version="${version}",
  org.h2.mvstore.db;version="${version}",
  org.h2.mvstore.type;version="${version}",
  org.h2.mvstore.rtree;version="${version}"
+Provide-Capability: osgi.service;objectClass:List<String>=org.osgi.service.jdbc.DataSourceFactory
 Premain-Class: org.h2.util.Profiler


### PR DESCRIPTION
For the OSGi resolver to work in deployment scenarios the bundle needs a Provide Capability for the service it registers. This PR lets this bundle provide the capability.