### PR TITLE
Issue #499, take two: fix for "Unique index or primary key violation" in TestMvccMultiThrea…

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -327,7 +327,8 @@ public class TransactionStore {
         // TODO could synchronize on blocks (100 at a time or so)
         synchronized (undoLog) {
             t.setStatus(Transaction.STATUS_COMMITTING);
-            for (long logId = 0; logId < maxLogId; logId++) {
+            for (long logId = maxLogId - 1; logId >= 0; logId--) {
+//            for (long logId = 0; logId < maxLogId; logId++) {
                 Long undoKey = getOperationId(t.getId(), logId);
                 Object[] op = undoLog.get(undoKey);
                 if (op == null) {

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -342,24 +342,21 @@ public class TransactionStore {
                 }
                 int mapId = (Integer) op[0];
                 MVMap<Object, VersionedValue> map = openMap(mapId);
-                if (map == null) {
-                    // map was later removed
-                } else {
+                if (map != null) { // might be null if map was removed later
                     Object key = op[1];
                     VersionedValue value = map.get(key);
-                    if (value == null) {
-                        // nothing to do
-                    } else if (value.value == null) {
+                    if (value != null) {
                         int tx = getTransactionId(value.operationId);
                         if (tx == t.transactionId) {
-                            // remove the value
-                            // only if it's transaction id is same as current transaction id
-                            map.remove(key);
+                            // only remove/update value if it's transaction id is same as current transaction id
+                            if (value.value == null) {
+                                    map.remove(key);
+                            } else {
+                                VersionedValue v2 = new VersionedValue();
+                                v2.value = value.value;
+                                map.put(key, v2);
+                            }
                         }
-                    } else {
-                        VersionedValue v2 = new VersionedValue();
-                        v2.value = value.value;
-                        map.put(key, v2);
                     }
                 }
                 undoLog.remove(undoKey);

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
@@ -103,10 +103,7 @@ public class TestMvccMultiThreaded2 extends TestBase {
                         if (now - start > 1000 * 60)
                             done = true;
                     } catch (JdbcSQLException e1) {
-                        // skip DUPLICATE_KEY_1 to just focus on this bug.
-                        if (e1.getErrorCode() != ErrorCode.DUPLICATE_KEY_1) {
-                            throw e1;
-                        }
+                        throw e1;
                     }
                 }
             } catch (SQLException e) {


### PR DESCRIPTION
In recently added TestMvccMultiThreaded2 (#499) by @danguria the following error is suppressed:
ERROR: error org.h2.jdbc.JdbcSQLException: 

`Unique index or primary key violation: "PRIMARY KEY ON PUBLIC.TEST(ENTITY_ID)"; SQL statement: SELECT * FROM test WHERE entity_id = ? FOR UPDATE [23505-195]`

His fix is dealing with removal values from the map during commit, but it also applicable to values update.
Basically, no transaction should commit anything modified outside of it, but it does. Filtering out undoLog entries from other transactions on commit-update as well, will make an error above disappear.

One might ask: how come another transaction was able to modify entry already modified by this transaction? The answer, I think, is related to the fact that although commit is synchronized, it is still not atomic from readers point of view, therefore specific entry might have been already committed, than modified by another transaction, and then needlessly committed again, if there is another entry in undoLog exists within commiting transaction for the same key. To fix this bigger problem will probably take more than one-liner.