### PR TITLE
Properly reflect SLF4J log levels in TraceSystem.isEnabled(level)

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -25,6 +25,8 @@ Change Log
 </li>
 <li>Issue #426: Support ANALYZE TABLE statement
 </li>
+<li>Issue #438: Fix slow logging via SLF4J (TRACE_LEVEL_FILE=4).
+</li>
 <li>Issue #472: Support CREATE SEQUENCE ... ORDER as a NOOP for Oracle compatibility
 </li>
 </ul>

--- a/h2/src/main/org/h2/message/TraceSystem.java
+++ b/h2/src/main/org/h2/message/TraceSystem.java
@@ -146,6 +146,9 @@ public class TraceSystem implements TraceWriter {
 
     @Override
     public boolean isEnabled(int level) {
+        if (levelMax == ADAPTER) {
+            return writer.isEnabled(level);
+        }
         return level <= this.levelMax;
     }
 

--- a/h2/src/test/org/h2/test/unit/TestTraceSystem.java
+++ b/h2/src/test/org/h2/test/unit/TestTraceSystem.java
@@ -32,13 +32,19 @@ public class TestTraceSystem extends TestBase {
         testAdapter();
     }
 
-    private static void testAdapter() {
+    private void testAdapter() {
         TraceSystem ts = new TraceSystem(null);
         ts.setName("test");
         ts.setLevelFile(TraceSystem.ADAPTER);
         ts.getTrace("test").debug("test");
         ts.getTrace("test").info("test");
         ts.getTrace("test").error(new Exception(), "test");
+
+        // The used SLF4J-nop logger has all log levels disabled,
+        // so this should be reflected in the trace system.
+        assertFalse(ts.isEnabled(TraceSystem.INFO));
+        assertFalse(ts.getTrace("test").isInfoEnabled());
+
         ts.close();
     }
 


### PR DESCRIPTION
SLF4J log levels are not properly reported by the `TraceSystem` class. It can therefore happen that log messages are assembled by H2, only to be discarded by SLF4J afterwards. This can lead to significant slowdowns. Fixes  #438.

----
I wrote the code, it's mine, and I'm contributing it to H2 for distribution multiple-licensed under the MPL 2.0, and the EPL 1.0 (http://h2database.com/html/license.html).