### PR TITLE
Fix Travis Builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /.idea/
 .checkstyle
 /temp/
+/h2web/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 /test.out.txt
 .DS_Store
 /.idea/
+*.iml
+*.ipr
+*.iws
 .checkstyle
 /temp/
 /h2web/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 
-before_script: cd h2
-
 script: ./build.sh jar testFast
 
 cache:
@@ -18,6 +16,10 @@ matrix:
         apt:
           packages:
             - oracle-java8-installer
+      before_script: 
+        - "cd h2"
+        - "echo $JAVA_OPTS"
+        - "export JAVA_OPTS=-Xmx512m"
     - jdk: openjdk7 
       dist: trusty
       group: edge
@@ -26,3 +28,5 @@ matrix:
         apt:
           packages:
             - openjdk-7-jdk
+      before_script: 
+        - "cd h2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
-sudo: false
-
 language: java
-
-jdk:
-  - openjdk7
-  - oraclejdk8
 
 before_script: cd h2
 
@@ -14,3 +8,21 @@ cache:
   directories:
     - $HOME/.m2/repository
 
+matrix:
+  include:
+    - jdk: oraclejdk8 
+      dist: trusty
+      group: edge
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
+    - jdk: openjdk7 
+      dist: trusty
+      group: edge
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - openjdk-7-jdk


### PR DESCRIPTION
Fix Travis Builds by:
 - using a Travis build matrix
 - updating to the latest JDKs for each version
 - using more memory for Java 8 (since the tests seem to give OutOfMemory with default settings on Travis) - Java 7 has no problem whatsoever.