### PR TITLE
Rollback and delayed meta save.

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1067,7 +1067,6 @@ public class MVStore {
         int currentUnsavedPageCount = unsavedMemory;
         long storeVersion = currentStoreVersion;
         long version = ++currentVersion;
-        setWriteVersion(version);
         lastCommitTime = time;
         retainChunk = null;
 

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -138,8 +138,8 @@ public class TestMVStore extends TestBase {
         store.rollback();
         assertTrue(store.hasMap("test"));
         map = store.openMap("test");
-        // TODO the data should get back alive
-        assertNull(map.get("1"));
+        // the data will get back alive
+        assertEquals("Hello", map.get("1"));
         store.close();
     }
 


### PR DESCRIPTION
Fix for issue #531. MVStore.storeNowTry() fails to save any updated map's new root position with the **current** version of the meta map, therefore saved meta map lags by one version. That may manifest itself if store is later rolled back.