### PR TITLE
Support TIMESTAMP_WITH_TIMEZONE 2014 JDBC type

### DIFF
--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -902,6 +902,8 @@ public class DataType {
             return Value.TIME;
         case Types.TIMESTAMP:
             return Value.TIMESTAMP;
+        case 2014: // Types.TIMESTAMP_WITH_TIMEZONE
+            return Value.TIMESTAMP_TZ;
         case Types.BLOB:
             return Value.BLOB;
         case Types.CLOB:

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -682,6 +682,15 @@ public class TestPreparedStatement extends TestBase {
         rs.next();
         Object offsetDateTime2 = rs.getObject(1, LocalDateTimeUtils.getOffsetDateTimeClass());
         assertEquals(offsetDateTime, offsetDateTime2);
+        assertFalse(rs.next());
+        rs.close();
+
+        prep.setObject(1, offsetDateTime, 2014); // Types.TIMESTAMP_WITH_TIMEZONE
+        rs = prep.executeQuery();
+        rs.next();
+        offsetDateTime2 = rs.getObject(1, LocalDateTimeUtils.getOffsetDateTimeClass());
+        assertEquals(offsetDateTime, offsetDateTime2);
+        assertFalse(rs.next());
         rs.close();
     }
 


### PR DESCRIPTION
While we currently support TIMESTAMP WITH TIME ZONE and OffsetDateTime
the corresponding JDBC type TIMESTAMP_WITH_TIMEZONE(2014) is not
supported when calling PreparedStatement.setObject(int, Object, int).