### PR TITLE
Fix for Issue #543

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2211,6 +2211,7 @@ public class Parser {
                 r = new CompareLike(database, r, b, esc, false);
             } else if (readIf("REGEXP")) {
                 Expression b = readConcat();
+                recompileAlways = true;
                 r = new CompareLike(database, r, b, null, true);
             } else if (readIf("IS")) {
                 if (readIf("NOT")) {

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -40,15 +40,15 @@ public class TestStatement extends TestBase {
     public void test() throws Exception {
         deleteDb("statement");
         conn = getConnection("statement");
-        testUnwrap();
-        testUnsupportedOperations();
-        testTraceError();
-        testSavepoint();
-        testConnectionRollback();
-        testStatement();
+//        testUnwrap();
+//        testUnsupportedOperations();
+//        testTraceError();
+//        testSavepoint();
+//        testConnectionRollback();
+//        testStatement();
         testPreparedStatement();
-        testIdentityMerge();
-        testIdentity();
+//        testIdentityMerge();
+//        testIdentity();
         conn.close();
         deleteDb("statement");
     }
@@ -414,9 +414,9 @@ public class TestStatement extends TestBase {
         assertTrue(rs.next());
         assertEquals("World", rs.getString("name"));
         assertFalse(rs.next());  
-        //Change the table difinition
+        //Changes the table structure
         stat.execute("create index t_id on test(name)");
-        //Test the prepared statement again
+        //Test the prepared statement again to check if the internal cache attributes were reset
         ps.setString(1, "Hello");
         rs = ps.executeQuery();
         assertTrue(rs.next());

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -40,15 +40,15 @@ public class TestStatement extends TestBase {
     public void test() throws Exception {
         deleteDb("statement");
         conn = getConnection("statement");
-//        testUnwrap();
-//        testUnsupportedOperations();
-//        testTraceError();
-//        testSavepoint();
-//        testConnectionRollback();
-//        testStatement();
+        testUnwrap();
+        testUnsupportedOperations();
+        testTraceError();
+        testSavepoint();
+        testConnectionRollback();
+        testStatement();
         testPreparedStatement();
-//        testIdentityMerge();
-//        testIdentity();
+        testIdentityMerge();
+        testIdentity();
         conn.close();
         deleteDb("statement");
     }

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -6,6 +6,7 @@
 package org.h2.test.jdbc;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Savepoint;
@@ -45,6 +46,7 @@ public class TestStatement extends TestBase {
         testSavepoint();
         testConnectionRollback();
         testStatement();
+        testPreparedStatement();
         testIdentityMerge();
         testIdentity();
         conn.close();
@@ -394,6 +396,38 @@ public class TestStatement extends TestBase {
 
         stat.execute("DROP TABLE TEST");
         stat.execute("DROP TABLE TEST2");
+    }
+    
+    private void testPreparedStatement() throws SQLException{
+        Statement stat = conn.createStatement();
+        stat.execute("create table test(id int primary key, name varchar(255))");
+        stat.execute("insert into test values(1, 'Hello')");
+        stat.execute("insert into test values(2, 'World')");
+        PreparedStatement ps = conn.prepareStatement("select name from test where id in (select id from test where name REGEXP ?)");
+        ps.setString(1, "Hello");
+        ResultSet rs = ps.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("Hello", rs.getString("name"));
+        assertFalse(rs.next());  
+        ps.setString(1, "World");
+        rs = ps.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("World", rs.getString("name"));
+        assertFalse(rs.next());  
+        //Change the table difinition
+        stat.execute("create index t_id on test(name)");
+        //Test the prepared statement again
+        ps.setString(1, "Hello");
+        rs = ps.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("Hello", rs.getString("name"));
+        assertFalse(rs.next());  
+        ps.setString(1, "World");
+        rs = ps.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("World", rs.getString("name"));
+        assertFalse(rs.next());  
+        stat.execute("drop table test");        
     }
 
 }


### PR DESCRIPTION
Hi,

The parser set the property recompileAlways to true in case of a LIKE cause. According to the documentation of the attribute prepareAlways in Prepared class, this is necessary because the query plan depends on the parameter value before each execution. Although the REGEXP and LIKE clauses have different approachs, I think they have the same behavior in this context.