### PR TITLE
eliminate memory estimations for "mem:" case

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -72,7 +72,6 @@ public class MVMap<K, V> extends AbstractMap<K, V>
     protected MVMap(DataType keyType, DataType valueType) {
         this.keyType = keyType;
         this.valueType = valueType;
-        this.root = Page.createEmpty(this,  -1);
     }
 
     /**
@@ -106,6 +105,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         this.id = DataUtils.readHexInt(config, "id", 0);
         this.createVersion = DataUtils.readHexLong(config, "createVersion", 0);
         this.writeVersion = store.getCurrentVersion();
+        this.root = Page.createEmpty(this,  -1);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -298,9 +298,15 @@ public final class MVStore {
             fileStore = new FileStore();
         }
         o = config.get("pageSplitSize");
-        pageSplitSize = o != null         ? (Integer) o :
-                        fileStore == null ? 48 :
-                                            16 * 1024;
+        int pgSplitSize;
+        if (o != null) {
+            pgSplitSize = (Integer) o;
+        } else if(fileStore != null) {
+            pgSplitSize = 16 * 1024;
+        } else {
+            pgSplitSize = 48; // number of keys per page in that case
+        }
+        pageSplitSize = pgSplitSize;
         o = config.get("backgroundExceptionHandler");
         this.backgroundExceptionHandler = (UncaughtExceptionHandler) o;
         meta = new MVMap<String, String>(StringDataType.INSTANCE,

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -36,6 +36,7 @@ public class Page {
      * An empty object array.
      */
     public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
+    private static final int IN_MEMORY = Integer.MIN_VALUE;
 
     private final MVMap<?, ?> map;
     private long version;
@@ -125,13 +126,15 @@ public class Page {
         p.values = values;
         p.children = children;
         p.totalCount = totalCount;
-        if (memory == 0) {
+        MVStore store = map.store;
+        if(store.getFileStore() == null) {
+            p.memory = IN_MEMORY;
+        } else if (memory == 0) {
             p.recalculateMemory();
         } else {
             p.addMemory(memory);
         }
-        MVStore store = map.store;
-        if (store != null) {
+        if(store.getFileStore() != null) {
             store.registerUnsavedPage(p.memory);
         }
         return p;
@@ -146,18 +149,8 @@ public class Page {
      * @return the page
      */
     public static Page create(MVMap<?, ?> map, long version, Page source) {
-        Page p = new Page(map, version);
-        // the position is 0
-        p.keys = source.keys;
-        p.values = source.values;
-        p.children = source.children;
-        p.totalCount = source.totalCount;
-        p.memory = source.memory;
-        MVStore store = map.store;
-        if (store != null) {
-            store.registerUnsavedPage(p.memory);
-        }
-        return p;
+        return create(map, version, source.keys, source.values, source.children,
+                source.totalCount, source.memory);
     }
 
     /**
@@ -302,7 +295,7 @@ public class Page {
         Page newPage = create(map, version,
                 keys, values,
                 children, totalCount,
-                getMemory());
+                memory);
         // mark the old as deleted
         removePage();
         newPage.cachedCompare = cachedCompare;
@@ -388,9 +381,11 @@ public class Page {
         Page newPage = create(map, version,
                 bKeys, bValues,
                 null,
-                bKeys.length, 0);
-        recalculateMemory();
-        newPage.recalculateMemory();
+                b, 0);
+        if(isPersistent()) {
+            recalculateMemory();
+            newPage.recalculateMemory();
+        }
         return newPage;
     }
 
@@ -422,8 +417,10 @@ public class Page {
                 bKeys, null,
                 bChildren,
                 t, 0);
-        recalculateMemory();
-        newPage.recalculateMemory();
+        if(isPersistent()) {
+            recalculateMemory();
+            newPage.recalculateMemory();
+        }
         return newPage;
     }
 
@@ -498,13 +495,15 @@ public class Page {
         // this is slightly slower:
         // keys = Arrays.copyOf(keys, keys.length);
         keys = keys.clone();
-        Object old = keys[index];
-        DataType keyType = map.getKeyType();
-        int mem = keyType.getMemory(key);
-        if (old != null) {
-            mem -= keyType.getMemory(old);
+        if(isPersistent()) {
+            Object old = keys[index];
+            DataType keyType = map.getKeyType();
+            int mem = keyType.getMemory(key);
+            if (old != null) {
+                mem -= keyType.getMemory(old);
+            }
+            addMemory(mem);
         }
-        addMemory(mem);
         keys[index] = key;
     }
 
@@ -521,8 +520,10 @@ public class Page {
         // values = Arrays.copyOf(values, values.length);
         values = values.clone();
         DataType valueType = map.getValueType();
-        addMemory(valueType.getMemory(value) -
-                valueType.getMemory(old));
+        if(isPersistent()) {
+            addMemory(valueType.getMemory(value) -
+                    valueType.getMemory(old));
+        }
         values[index] = value;
         return old;
     }
@@ -569,8 +570,10 @@ public class Page {
         keys[index] = key;
         values[index] = value;
         totalCount++;
-        addMemory(map.getKeyType().getMemory(key) +
-                map.getValueType().getMemory(value));
+        if(isPersistent()) {
+            addMemory(map.getKeyType().getMemory(key) +
+                    map.getValueType().getMemory(value));
+        }
     }
 
     /**
@@ -595,8 +598,10 @@ public class Page {
         children = newChildren;
 
         totalCount += childPage.totalCount;
-        addMemory(map.getKeyType().getMemory(key) +
-                DataUtils.PAGE_MEMORY_CHILD);
+        if(isPersistent()) {
+            addMemory(map.getKeyType().getMemory(key) +
+                    DataUtils.PAGE_MEMORY_CHILD);
+        }
     }
 
     /**
@@ -607,22 +612,28 @@ public class Page {
     public void remove(int index) {
         int keyLength = keys.length;
         int keyIndex = index >= keyLength ? index - 1 : index;
-        Object old = keys[keyIndex];
-        addMemory(-map.getKeyType().getMemory(old));
+        if(isPersistent()) {
+            Object old = keys[keyIndex];
+            addMemory(-map.getKeyType().getMemory(old));
+        }
         Object[] newKeys = new Object[keyLength - 1];
         DataUtils.copyExcept(keys, newKeys, keyLength, keyIndex);
         keys = newKeys;
 
         if (values != null) {
-            old = values[index];
-            addMemory(-map.getValueType().getMemory(old));
+            if(isPersistent()) {
+                Object old = values[index];
+                addMemory(-map.getValueType().getMemory(old));
+            }
             Object[] newValues = new Object[keyLength - 1];
             DataUtils.copyExcept(values, newValues, keyLength, index);
             values = newValues;
             totalCount--;
         }
         if (children != null) {
-            addMemory(-DataUtils.PAGE_MEMORY_CHILD);
+            if(isPersistent()) {
+                addMemory(-DataUtils.PAGE_MEMORY_CHILD);
+            }
             long countOffset = children[index].count;
 
             int childCount = children.length;
@@ -887,37 +898,50 @@ public class Page {
         return pos != 0 ? (int) (pos | (pos >>> 32)) : super.hashCode();
     }
 
+    private boolean isPersistent() {
+        return memory != IN_MEMORY;
+    }
+
     public int getMemory() {
-        if (MVStore.ASSERT) {
-            int mem = memory;
-            recalculateMemory();
-            if (mem != memory) {
-                throw DataUtils.newIllegalStateException(
-                        DataUtils.ERROR_INTERNAL, "Memory calculation error");
+        if (isPersistent()) {
+            if (MVStore.ASSERT) {
+                int mem = memory;
+                recalculateMemory();
+                if (mem != memory) {
+                    throw DataUtils.newIllegalStateException(
+                            DataUtils.ERROR_INTERNAL, "Memory calculation error");
+                }
             }
+            return memory;
         }
-        return memory;
+        return getKeyCount();
     }
 
     private void addMemory(int mem) {
+        if(!isPersistent()) {
+            throw DataUtils.newIllegalStateException(
+                    DataUtils.ERROR_INTERNAL, "Memory calculation error2");
+        }
         memory += mem;
     }
 
     private void recalculateMemory() {
-        int mem = DataUtils.PAGE_MEMORY;
-        DataType keyType = map.getKeyType();
-        for (int i = 0; i < keys.length; i++) {
-            mem += keyType.getMemory(keys[i]);
-        }
-        if (this.isLeaf()) {
-            DataType valueType = map.getValueType();
+        if(isPersistent()) {
+            int mem = DataUtils.PAGE_MEMORY;
+            DataType keyType = map.getKeyType();
             for (int i = 0; i < keys.length; i++) {
-                mem += valueType.getMemory(values[i]);
+                mem += keyType.getMemory(keys[i]);
             }
-        } else {
-            mem += this.getRawChildPageCount() * DataUtils.PAGE_MEMORY_CHILD;
+            if (this.isLeaf()) {
+                DataType valueType = map.getValueType();
+                for (int i = 0; i < keys.length; i++) {
+                    mem += valueType.getMemory(values[i]);
+                }
+            } else {
+                mem += this.getRawChildPageCount() * DataUtils.PAGE_MEMORY_CHILD;
+            }
+            addMemory(mem - memory);
         }
-        addMemory(mem - memory);
     }
 
     void setVersion(long version) {
@@ -928,11 +952,13 @@ public class Page {
      * Remove the page.
      */
     public void removePage() {
-        long p = pos;
-        if (p == 0) {
-            removedInMemory = true;
+        if(isPersistent()) {
+            long p = pos;
+            if (p == 0) {
+                removedInMemory = true;
+            }
+            map.removePage(p, memory);
         }
-        map.removePage(p, memory);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -53,7 +53,7 @@ public class Page {
     private int cachedCompare;
 
     /**
-     * The estimated memory used.
+     * The estimated memory used in persistent case, IN_MEMORY marker value otherwise.
      */
     private int memory;
 

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1416,7 +1416,9 @@ public class TestMVStore extends TestBase {
             assertEquals(i + 1, m.size());
         }
         assertEquals(1000, m.size());
-        assertEquals(131896, s.getUnsavedMemory());
+        // previously (131896) we fail to account for initial root page for every map
+        // there are two of them here (meta and "data"), hence lack of 256 bytes
+        assertEquals(132152, s.getUnsavedMemory());
         s.commit();
         assertEquals(2, s.getFileStore().getWriteCount());
         s.close();


### PR DESCRIPTION
Provides 25-30% performance increase running TestPerformance.java for in-memory case.