### PR TITLE
Add entries for Generic cloud and datawarehouse databases.

### DIFF
--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -76,6 +76,20 @@ public class WebServer implements Service {
     private static final String[] GENERIC = {
         "Generic JNDI Data Source|javax.naming.InitialContext|" +
                 "java:comp/env/jdbc/Test|sa",
+        "Generic Teradata|com.teradata.jdbc.TeraDriver|" +
+                "jdbc:teradata://whomooz/|",
+        "Generic Snowflake|com.snowflake.client.jdbc.SnowflakeDriver|" +
+                "jdbc:snowflake://accountName.snowflakecomputing.com|",
+        "Generic Redshift|com.amazon.redshift.jdbc42.Driver|" +
+                "jdbc:redshift://endpoint:5439/database|",
+        "Generic Impala|org.cloudera.impala.jdbc41.Driver|" +
+                "jdbc:impala://clustername:21050/default|",
+        "Generic Hive 2|org.apache.hive.jdbc.HiveDriver|" +
+                "jdbc:hive2://clustername:10000/default|",
+        "Generic Hive|org.apache.hadoop.hive.jdbc.HiveDriver|" +
+                "jdbc:hive://clustername:10000/default|",
+        "Generic Azure SQL|com.microsoft.sqlserver.jdbc.SQLServerDriver|" +
+                "jdbc:sqlserver://name.database.windows.net:1433|",
         "Generic Firebird Server|org.firebirdsql.jdbc.FBDriver|" +
                 "jdbc:firebirdsql:localhost:c:/temp/firebird/test|sysdba",
         "Generic SQLite|org.sqlite.JDBC|" +


### PR DESCRIPTION
This patch adds entries for Generic database entries for cloud
and data warehouse databases. This is solely for convenience
for people using the web server as a convenient frontend for
SQL database.

Conventional RDBMS databases moved into the cloud:

 - Azure SQL (Microsoft, based on SQL Server)
 - Redshift (Amazon, based on PostgreSQL 8)

(Note: Redshift can also use a PostgreSQL driver but the
Redshift driver has significantly better performance.)

Cloud-native databases:

 - Hive 1
 - Hive 2

(Note: hive may be run on a vanilla Hadoop cluster, a Cloudera
cluster, or a Hortonworks cluster. The last two products may
offer custom JDBC drivers.)

(Note: this patch does not address Kerberos authentication
or SSL encryption.)

Data warehouse databases:

 - Impala
 - Snowflake
 - Teradata

Impala is part of the Hadoop ecosystem and provided by Cloudera.
Snowflake and Teradata are both commercial products.