### PR TITLE
Check for unsupported column types in PostgreSQL mode

### DIFF
--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -5,11 +5,13 @@
  */
 package org.h2.engine;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.regex.Pattern;
+
 import org.h2.util.New;
 import org.h2.util.StringUtils;
-
-import java.util.HashMap;
-import java.util.regex.Pattern;
 
 /**
  * The compatibility modes. There is a fixed set of modes (for example
@@ -170,6 +172,13 @@ public class Mode {
      */
     public boolean allowDB2TimestampFormat;
 
+    /**
+     * An optional Set of hidden/disallowed column types.
+     * Certain DBMSs don't support all column types provided by H2, such as 
+     * "NUMBER" when using PostgreSQL mode.
+     */
+    public Set<String> disallowedTypes = Collections.emptySet();
+
     private final String name;
 
     static {
@@ -268,6 +277,12 @@ public class Mode {
                 Pattern.compile("ApplicationName");
         mode.prohibitEmptyInPredicate = true;
         mode.padFixedLengthStrings = true;
+        // Enumerate all H2 types NOT supported by PostgreSQL:
+        Set<String> disallowedTypes = new java.util.HashSet<String>();
+        disallowedTypes.add("NUMBER");
+        disallowedTypes.add("IDENTITY");
+        disallowedTypes.add("TINYINT");
+        mode.disallowedTypes = disallowedTypes;
         add(mode);
 
         mode = new Mode("Ignite");

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -246,6 +246,8 @@ public class TestCompatibility extends TestBase {
         assertResult("ABC", stat, "SELECT SUBSTRING('ABCDEF' FOR 3)");
         assertResult("ABCD", stat, "SELECT SUBSTRING('0ABCDEF' FROM 2 FOR 4)");
 
+        /* --------- Behaviour of CHAR(N) --------- */
+
         /* Test right-padding of CHAR(N) at INSERT */
         stat.execute("CREATE TABLE TEST(CH CHAR(10))");
         stat.execute("INSERT INTO TEST (CH) VALUES ('Hello')");
@@ -273,6 +275,19 @@ public class TestCompatibility extends TestBase {
         stat.execute("INSERT INTO TEST (CH) VALUES ('1   ')");
         assertResult("1 ", stat, "SELECT CH FROM TEST");
         assertResult("1 ", stat, "SELECT CH FROM TEST WHERE CH = '1      '");
+
+        /* --------- Disallowed column types --------- */
+
+        String[] DISALLOWED_TYPES = {"NUMBER", "IDENTITY", "TINYINT"};
+        for (String type : DISALLOWED_TYPES) {
+            stat.execute("DROP TABLE IF EXISTS TEST");
+            try {
+                stat.execute("CREATE TABLE TEST(COL " + type + ")");
+                fail("Expect type " + type + " to not exist in PostgreSQL mode");
+            } catch (org.h2.jdbc.JdbcSQLException e) {
+                /* Expected! */
+            }
+        }
     }
 
     private void testMySQL() throws SQLException {


### PR DESCRIPTION
This adds a check for the types "IDENTITY", "NUMBER" and "TINYINT" in PostgreSQL mode and raises an exception when they are used in that mode.