### PR TITLE
Update synonym implementation

### DIFF
--- a/h2/src/main/org/h2/command/ddl/CreateSynonym.java
+++ b/h2/src/main/org/h2/command/ddl/CreateSynonym.java
@@ -84,6 +84,7 @@ public class CreateSynonym extends SchemaCommand {
             table.updateData(data);
             table.setComment(comment);
             table.setModified();
+            db.updateMeta(session, table);
         } else {
             data.id = getObjectId();
             table = getSchema().createSynonym(data);
@@ -91,6 +92,7 @@ public class CreateSynonym extends SchemaCommand {
             db.addSchemaObject(session, table);
         }
 
+        table.updateSynonymFor();
         return 0;
     }
 

--- a/h2/src/main/org/h2/table/AbstractTable.java
+++ b/h2/src/main/org/h2/table/AbstractTable.java
@@ -380,6 +380,13 @@ public abstract class AbstractTable extends SchemaObjectBase {
     public abstract void removeView(TableView view);
 
     /**
+     * Remove the given synonym from the list.
+     *
+     * @param synonym the synonym to remove
+     */
+    public abstract void removeSynonym(TableSynonym synonym);
+
+    /**
      * Remove the given constraint from the list.
      *
      * @param constraint the constraint to remove
@@ -406,6 +413,13 @@ public abstract class AbstractTable extends SchemaObjectBase {
      * @param view the view to add
      */
     public abstract void addView(TableView view);
+
+    /**
+     * Add a synonym to this table.
+     *
+     * @param synonym the synonym to add
+     */
+    public abstract void addSynonym(TableSynonym synonym);
 
     /**
      * Add a constraint to the table.

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -72,6 +72,7 @@ public abstract class Table extends AbstractTable {
     private ArrayList<Constraint> constraints;
     private ArrayList<Sequence> sequences;
     private ArrayList<TableView> views;
+    private ArrayList<TableSynonym> synonyms;
     private boolean checkForeignKeyConstraints = true;
     private boolean onCommitDrop, onCommitTruncate;
     private volatile Row nullRow;
@@ -249,6 +250,9 @@ public abstract class Table extends AbstractTable {
         if (views != null) {
             children.addAll(views);
         }
+        if (synonyms != null) {
+            children.addAll(synonyms);
+        }
         ArrayList<Right> rights = database.getAllRights();
         for (Right right : rights) {
             if (right.getGrantedObject() == this) {
@@ -378,6 +382,11 @@ public abstract class Table extends AbstractTable {
             TableView view = views.get(0);
             views.remove(0);
             database.removeSchemaObject(session, view);
+        }
+        while (synonyms != null && synonyms.size() > 0) {
+            TableSynonym synonym = synonyms.get(0);
+            synonyms.remove(0);
+            database.removeSchemaObject(session, synonym);
         }
         while (triggers != null && triggers.size() > 0) {
             TriggerObject trigger = triggers.get(0);
@@ -703,6 +712,16 @@ public abstract class Table extends AbstractTable {
     }
 
     /**
+     * Remove the given view from the list.
+     *
+     * @param synonym the synonym to remove
+     */
+    @Override
+    public void removeSynonym(TableSynonym synonym) {
+        remove(synonyms, synonym);
+    }
+
+    /**
      * Remove the given constraint from the list.
      *
      * @param constraint the constraint to remove
@@ -740,6 +759,16 @@ public abstract class Table extends AbstractTable {
     @Override
     public void addView(TableView view) {
         views = add(views, view);
+    }
+
+    /**
+     * Add a synonym to this table.
+     *
+     * @param synonym the synonym to add
+     */
+    @Override
+    public void addSynonym(TableSynonym synonym) {
+        synonyms = add(synonyms, synonym);
     }
 
     /**

--- a/h2/src/main/org/h2/table/TableSynonym.java
+++ b/h2/src/main/org/h2/table/TableSynonym.java
@@ -29,6 +29,8 @@ public class TableSynonym extends AbstractTable {
 
     private CreateSynonymData data;
 
+    private AbstractTable synonymFor;
+
     public TableSynonym(CreateSynonymData data) {
         initSchemaObjectBase(data.schema, data.id, data.synonymName, Trace.TABLE);
         this.data = data;
@@ -39,7 +41,7 @@ public class TableSynonym extends AbstractTable {
     }
 
     private AbstractTable getSynonymFor() {
-        return data.synonymForSchema.getTableOrView(data.session, data.synonymFor);
+        return synonymFor;
     }
 
     @Override
@@ -55,7 +57,7 @@ public class TableSynonym extends AbstractTable {
 
     @Override
     public int getType() {
-        return getSynonymFor().getType();
+        return TABLE_OR_VIEW;
     }
 
     @Override
@@ -265,6 +267,7 @@ public class TableSynonym extends AbstractTable {
 
     @Override
     public void removeChildrenAndResources(Session session) {
+        synonymFor.removeSynonym(this);
         database.removeMeta(session, getId());
     }
 
@@ -412,6 +415,11 @@ public class TableSynonym extends AbstractTable {
     }
 
     @Override
+    public void removeSynonym(TableSynonym synonym) {
+        throw DbException.getUnsupportedException("SYNONYM");
+    }
+
+    @Override
     public void removeConstraint(Constraint constraint) {
         getSynonymFor().removeConstraint(constraint);
     }
@@ -424,6 +432,11 @@ public class TableSynonym extends AbstractTable {
     @Override
     public void addView(TableView view) {
         getSynonymFor().addView(view);
+    }
+
+    @Override
+    public void addSynonym(TableSynonym synonym) {
+        throw DbException.getUnsupportedException("SYNONYM");
     }
 
     @Override
@@ -471,9 +484,18 @@ public class TableSynonym extends AbstractTable {
         getSynonymFor().fireAfterRow(session, oldRow, newRow, rollback);
     }
 
+    public void updateSynonymFor() {
+        if (synonymFor != null) {
+            synonymFor.removeSynonym(this);
+        }
+        synonymFor = data.synonymForSchema.getTableOrView(data.session, data.synonymFor);
+        synonymFor.addSynonym(this);
+    }
+
     @Override
     public boolean isGlobalTemporary() {
         return getSynonymFor().isGlobalTemporary();
     }
+
 
 }

--- a/h2/src/test/org/h2/test/db/TestSynonymForTable.java
+++ b/h2/src/test/org/h2/test/db/TestSynonymForTable.java
@@ -84,14 +84,12 @@ public class TestSynonymForTable extends TestBase {
         // Backing table does not exist anymore.
         assertThrows(JdbcSQLException.class, stat).execute("SELECT id FROM testsynonym");
 
-        // Meta data should show INVALID
+        // Synonym should be dropped as well
         ResultSet synonyms = conn.createStatement().executeQuery("SELECT * FROM INFORMATION_SCHEMA.SYNONYMS WHERE SYNONYM_NAME='TESTSYNONYM'");
-        assertTrue(synonyms.next());
-        assertEquals("TESTSYNONYM", synonyms.getString("SYNONYM_NAME"));
-        assertEquals("INVALID", synonyms.getString("STATUS"));
+        assertFalse(synonyms.next());
         conn.close();
 
-        // Reopening should work with invalid synonym
+        // Reopening should work with dropped synonym
         Connection conn2 = getConnection("synonym");
         assertThrows(JdbcSQLException.class, stat).execute("SELECT id FROM testsynonym");
         conn2.close();
@@ -112,6 +110,7 @@ public class TestSynonymForTable extends TestBase {
 
         // Without "if exists" the command should fail if the synonym does not exist.
         assertThrows(JdbcSQLException.class, stat).execute("DROP SYNONYM testsynonym");
+        conn.close();
     }
 
     private void testSynonymInDifferentSchema() throws SQLException {
@@ -124,6 +123,7 @@ public class TestSynonymForTable extends TestBase {
         stat.execute("CREATE OR REPLACE SYNONYM testsynonym FOR s1.backingtable");
         stat.execute("INSERT INTO s1.backingtable VALUES(15)");
         assertSynonymContains(conn, 15);
+        conn.close();
     }
 
     private void testCreateOrReplaceExistingTable() throws SQLException {


### PR DESCRIPTION
* Close connections in test
* Call updateMeta in CreateSynonym to make sure changes get persisted
* Drop synonym when the backing is table is dropped to fix ticket #556