### PR TITLE
Implement MetaData.getColumns() for synonyms.

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -224,6 +224,7 @@ public class Parser {
     private ArrayList<String> expectedList;
     private boolean rightsChecked;
     private boolean recompileAlways;
+    private boolean literalsChecked;
     private ArrayList<Parameter> indexedParameterList;
     private int orderInFrom;
     private ArrayList<Parameter> suppliedParameterList;
@@ -3507,7 +3508,7 @@ public class Parser {
     }
 
     private void checkLiterals(boolean text) {
-        if (!session.getAllowLiterals()) {
+        if (!literalsChecked && !session.getAllowLiterals()) {
             int allowed = database.getAllowLiterals();
             if (allowed == Constants.ALLOW_LITERALS_NONE ||
                     (text && allowed != Constants.ALLOW_LITERALS_ALL)) {
@@ -4980,11 +4981,11 @@ public class Parser {
         // then we just compile it again.
         TableView view = new TableView(schema, id, tempViewName, querySQL,
                 parameters, columnTemplateList.toArray(new Column[0]), session,
-                true/* recursive */);
+                true/* recursive */, false);
         if (!view.isRecursiveQueryDetected()) {
             view = new TableView(schema, id, tempViewName, querySQL, parameters,
                     columnTemplateList.toArray(new Column[0]), session,
-                    false/* recursive */);
+                    false/* recursive */, false);
         }
         view.setTableExpression(true);
         view.setTemporary(true);
@@ -6432,6 +6433,10 @@ public class Parser {
             return StringUtils.quoteIdentifier(s);
         }
         return s;
+    }
+
+    public void setLiteralsChecked(boolean literalsChecked) {
+        this.literalsChecked = literalsChecked;
     }
 
     public void setRightsChecked(boolean rightsChecked) {

--- a/h2/src/main/org/h2/command/ddl/CreateView.java
+++ b/h2/src/main/org/h2/command/ddl/CreateView.java
@@ -116,9 +116,9 @@ public class CreateView extends SchemaCommand {
                         }
                     }
                     view = new TableView(getSchema(), id, viewName, querySQL, null,
-                            columnTemplates, sysSession, false);
+                            columnTemplates, sysSession, false, false);
                 } else {
-                    view.replace(querySQL, sysSession, false, force);
+                    view.replace(querySQL, sysSession, false, force, false);
                     view.setModified();
                 }
             } finally {

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -527,7 +527,20 @@ public class Session extends SessionWithState {
      * @return the prepared statement
      */
     public Prepared prepare(String sql) {
-        return prepare(sql, false);
+        return prepare(sql, false, false);
+    }
+
+    /**
+     * Parse and prepare the given SQL statement. This method also checks the
+     * rights.
+     *
+     * @param sql the SQL statement
+     * @param literalsChecked true if the sql string has already been checked for literals (only used if
+     *                        ALLOW_LITERALS NONE is set).
+     * @return the prepared statement
+     */
+    public Prepared prepare(String sql, boolean literalsChecked) {
+        return prepare(sql, false, literalsChecked);
     }
 
     /**
@@ -535,11 +548,14 @@ public class Session extends SessionWithState {
      *
      * @param sql the SQL statement
      * @param rightsChecked true if the rights have already been checked
+     * @param literalsChecked true if the sql string has already been checked for literals (only used if
+     *                        ALLOW_LITERALS NONE is set).
      * @return the prepared statement
      */
-    public Prepared prepare(String sql, boolean rightsChecked) {
+    public Prepared prepare(String sql, boolean rightsChecked, boolean literalsChecked) {
         Parser parser = new Parser(this);
         parser.setRightsChecked(rightsChecked);
+        parser.setLiteralsChecked(literalsChecked);
         return parser.prepare(sql);
     }
 

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -531,19 +531,6 @@ public class Session extends SessionWithState {
     }
 
     /**
-     * Parse and prepare the given SQL statement. This method also checks the
-     * rights.
-     *
-     * @param sql the SQL statement
-     * @param literalsChecked true if the sql string has already been checked for literals (only used if
-     *                        ALLOW_LITERALS NONE is set).
-     * @return the prepared statement
-     */
-    public Prepared prepare(String sql, boolean literalsChecked) {
-        return prepare(sql, false, literalsChecked);
-    }
-
-    /**
      * Parse and prepare the given SQL statement.
      *
      * @param sql the SQL statement

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -173,7 +173,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
         Prepared p;
         session.pushSubQueryInfo(masks, filters, filter, sortOrder);
         try {
-            p = session.prepare(sql, true, false);
+            p = session.prepare(sql, true, true);
         } finally {
             session.popSubQueryInfo();
         }

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -173,7 +173,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
         Prepared p;
         session.pushSubQueryInfo(masks, filters, filter, sortOrder);
         try {
-            p = session.prepare(sql, true);
+            p = session.prepare(sql, true, false);
         } finally {
             session.popSubQueryInfo();
         }

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -546,6 +546,7 @@ public class MetaTable extends Table {
                         "SYNONYM_SCHEMA",
                         "SYNONYM_NAME",
                         "SYNONYM_FOR",
+                        "SYNONYM_FOR_SCHEMA",
                         "TYPE_NAME",
                         "STATUS",
                         "REMARKS",
@@ -1889,6 +1890,8 @@ public class MetaTable extends Table {
                             identifier(synonym.getName()),
                             // SYNONYM_FOR
                             synonym.getSynonymForName(),
+                            // SYNONYM_FOR_SCHEMA
+                            synonym.getSynonymForSchema().getName(),
                             // TYPE NAME
                             "SYNONYM",
                             // STATUS

--- a/h2/src/main/org/h2/table/TableSynonym.java
+++ b/h2/src/main/org/h2/table/TableSynonym.java
@@ -9,6 +9,7 @@ import org.h2.command.ddl.CreateSynonymData;
 import org.h2.engine.Session;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
+import org.h2.schema.Schema;
 import org.h2.schema.SchemaObjectBase;
 
 /**
@@ -71,6 +72,10 @@ public class TableSynonym extends SchemaObjectBase {
 
     public String getSynonymForName() {
         return data.synonymFor;
+    }
+
+    public Schema getSynonymForSchema() {
+        return data.synonymForSchema;
     }
 
     public boolean isInvalid() {

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -61,9 +61,9 @@ public class TableView extends Table {
 
     public TableView(Schema schema, int id, String name, String querySQL,
             ArrayList<Parameter> params, Column[] columnTemplates, Session session,
-            boolean recursive) {
+            boolean recursive, boolean literalsChecked) {
         super(schema, id, name, false, true);
-        init(querySQL, params, columnTemplates, session, recursive);
+        init(querySQL, params, columnTemplates, session, recursive, literalsChecked);
     }
 
     /**
@@ -76,34 +76,34 @@ public class TableView extends Table {
      * @param force if errors should be ignored
      */
     public void replace(String querySQL,  Session session,
-            boolean recursive, boolean force) {
+            boolean recursive, boolean force, boolean literalsChecked) {
         String oldQuerySQL = this.querySQL;
         Column[] oldColumnTemplates = this.columnTemplates;
         boolean oldRecursive = this.recursive;
-        init(querySQL, null, columnTemplates, session, recursive);
+        init(querySQL, null, columnTemplates, session, recursive, literalsChecked);
         DbException e = recompile(session, force, true);
         if (e != null) {
-            init(oldQuerySQL, null, oldColumnTemplates, session, oldRecursive);
+            init(oldQuerySQL, null, oldColumnTemplates, session, oldRecursive, literalsChecked);
             recompile(session, true, false);
             throw e;
         }
     }
 
     private synchronized void init(String querySQL, ArrayList<Parameter> params,
-            Column[] columnTemplates, Session session, boolean recursive) {
+            Column[] columnTemplates, Session session, boolean recursive, boolean literalsChecked) {
         this.querySQL = querySQL;
         this.columnTemplates = columnTemplates;
         this.recursive = recursive;
         this.isRecursiveQueryDetected = false;
         index = new ViewIndex(this, querySQL, params, recursive);
-        initColumnsAndTables(session);
+        initColumnsAndTables(session, literalsChecked);
     }
 
-    private static Query compileViewQuery(Session session, String sql) {
+    private static Query compileViewQuery(Session session, String sql, boolean literalsChecked) {
         Prepared p;
         session.setParsingView(true);
         try {
-            p = session.prepare(sql);
+            p = session.prepare(sql, literalsChecked);
         } finally {
             session.setParsingView(false);
         }
@@ -125,7 +125,7 @@ public class TableView extends Table {
     public synchronized DbException recompile(Session session, boolean force,
             boolean clearIndexCache) {
         try {
-            compileViewQuery(session, querySQL);
+            compileViewQuery(session, querySQL, false);
         } catch (DbException e) {
             if (!force) {
                 return e;
@@ -135,7 +135,7 @@ public class TableView extends Table {
         if (views != null) {
             views = New.arrayList(views);
         }
-        initColumnsAndTables(session);
+        initColumnsAndTables(session, false);
         if (views != null) {
             for (TableView v : views) {
                 DbException e = v.recompile(session, force, false);
@@ -150,11 +150,11 @@ public class TableView extends Table {
         return force ? null : createException;
     }
 
-    private void initColumnsAndTables(Session session) {
+    private void initColumnsAndTables(Session session, boolean literalsChecked) {
         Column[] cols;
         removeViewFromTables();
         try {
-            Query query = compileViewQuery(session, querySQL);
+            Query query = compileViewQuery(session, querySQL, literalsChecked);
             this.querySQL = query.getPlanSQL();
             tables = New.arrayList(query.getTables());
             ArrayList<Expression> expressions = query.getExpressions();
@@ -539,7 +539,7 @@ public class TableView extends Table {
         String querySQL = query.getPlanSQL();
         TableView v = new TableView(mainSchema, 0, name,
                 querySQL, query.getParameters(), null, session,
-                false);
+                false, true /* literals have already been checked when parsing original query */);
         if (v.createException != null) {
             throw v.createException;
         }

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -103,7 +103,7 @@ public class TableView extends Table {
         Prepared p;
         session.setParsingView(true);
         try {
-            p = session.prepare(sql, literalsChecked);
+            p = session.prepare(sql, false, literalsChecked);
         } finally {
             session.setParsingView(false);
         }

--- a/h2/src/test/org/h2/test/db/TestSynonymForTable.java
+++ b/h2/src/test/org/h2/test/db/TestSynonymForTable.java
@@ -171,6 +171,12 @@ public class TestSynonymForTable extends TestBase {
         assertEquals(tables.getString("TABLE_TYPE"), "SYNONYM");
         assertFalse(tables.next());
 
+        ResultSet columns = conn.getMetaData().getColumns(null, Constants.SCHEMA_MAIN, "TESTSYNONYM", null);
+        assertTrue(columns.next());
+        assertEquals(columns.getString("TABLE_NAME"), "TESTSYNONYM");
+        assertEquals(columns.getString("COLUMN_NAME"), "ID");
+        assertFalse(columns.next());
+
         ResultSet synonyms = conn.createStatement().executeQuery("SELECT * FROM INFORMATION_SCHEMA.SYNONYMS");
         assertTrue(synonyms.next());
         assertEquals("SYNONYM", synonyms.getString("SYNONYM_CATALOG"));


### PR DESCRIPTION
Currently the columns of a synonym cannot be queried using the JDBC MetaData API.
This pull request fixes this problem.

Unfortunately it also runs into problems with the "SET ALLOW_LITERALS NONE" setting. For the query all kinds of interesting optimizations are created, that range from a join "ON 1=1" to an "ORDER BY 2, 3, 17" or an inlining of the ZERO() function. All these cases lead to a failure in the "no literals" check. Some of those could be fixed, other not so easy.

I guess the best way would be to only activate the literals check when parsing the original query and disable while parsing variations generated by the optimizer. This should still make sure no SQL injections can happen (I guess this is, what the flag is for?). Is this a viable approach?