### PR TITLE
typo in merge

### DIFF
--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -169,7 +169,7 @@ public class Merge extends Prepared {
                     if (index != null) {
                         // verify the index columns match the key
                         Column[] indexColumns = index.getColumns();
-                        boolean indexMatchesKeys = false;
+                        boolean indexMatchesKeys = true;
                         if (indexColumns.length <= keys.length) {
                             for (int i = 0; i < indexColumns.length; i++) {
                                 if (indexColumns[i] != keys[i]) {


### PR DESCRIPTION
Looks like a definite typo to me, or was it intentional?

On an unrelated note, I would like to take this opportunity to ask committers a few general questions.

**Source text right margin**: Is it appropriate to keep it at 80 in a third millennium?
Does anyone still use those punch cards, or even know / remember what it was? 8-)
IMHO, extending it to 120 will help readability, and if someone still have that old CRT monitor, I am sure he can find an antique dealer, who would be happy to swap it for a modest flat screen. 8-)

**Java 7 syntax**: Is it OK to use abbreviated "<>" generics syntax on this project?

**Full text search**: Is there any interest to support it in multi-threaded mode or is better to keep that single-init-connection hack to trade scalability for some performance gains? 
