### PR TITLE
Issue#573 Remove temp views for CTEs after WITH statement executed

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4904,7 +4904,7 @@ public class Parser {
         // clean up temp views starting with last to first (in case of dependencies)
         Collections.reverse(viewsCreated);
 
-        for (TableView view : viewsCreated){
+        for (final TableView view : viewsCreated){
             if(view==null){
                 continue;
             }

--- a/h2/src/main/org/h2/command/Prepared.java
+++ b/h2/src/main/org/h2/command/Prepared.java
@@ -6,6 +6,8 @@
 package org.h2.command;
 
 import java.util.ArrayList;
+import java.util.List;
+
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Database;
@@ -55,6 +57,7 @@ public abstract class Prepared {
     private int objectId;
     private int currentRowNumber;
     private int rowScanCount;
+    private List<Runnable> cleanupCallbacks;
 
     /**
      * Create a new object.
@@ -173,6 +176,9 @@ public abstract class Prepared {
      */
     public void setCommand(Command command) {
         this.command = command;
+        if(command!=null && cleanupCallbacks!=null){
+            command.setCleanupCallbacks(cleanupCallbacks);
+        }
     }
 
     /**
@@ -433,5 +439,14 @@ public abstract class Prepared {
     public boolean isCacheable() {
         return false;
     }
+
+    public List<Runnable> getCleanupCallbacks() {
+        return cleanupCallbacks;
+    }
+
+    public void setCleanupCallbacks(List<Runnable> cleanupCallbacks) {
+        this.cleanupCallbacks = cleanupCallbacks;
+    }
+
 
 }

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -381,6 +381,12 @@ SET BINARY_COLLATION
 ","
 Sets the collation used for comparing BINARY columns, the default is SIGNED
 for version 1."
+"Commands (Other)","SET BUILTIN_ALIAS_OVERRIDE","
+SET BUILTIN_ALIAS_OVERRIDE
+{ TRUE | FALSE } ] }
+","
+Allows the overriding of the builtin system date/time functions
+for unit testing purposes."
 "Commands (Other)","SET COLLATION","
 SET [ DATABASE ] COLLATION
 { OFF | collationName [ STRENGTH { PRIMARY | SECONDARY | TERTIARY | IDENTICAL } ] }

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -381,12 +381,6 @@ SET BINARY_COLLATION
 ","
 Sets the collation used for comparing BINARY columns, the default is SIGNED
 for version 1."
-"Commands (Other)","SET BUILTIN_ALIAS_OVERRIDE","
-SET BUILTIN_ALIAS_OVERRIDE
-{ TRUE | FALSE } ] }
-","
-Allows the overriding of the builtin system date/time functions
-for unit testing purposes."
 "Commands (Other)","SET COLLATION","
 SET [ DATABASE ] COLLATION
 { OFF | collationName [ STRENGTH { PRIMARY | SECONDARY | TERTIARY | IDENTICAL } ] }


### PR DESCRIPTION
Currently CTE session temp views are left behind after WITH statement execution (however they are not committed at end of transaction though, but could be user-visible as part of a longer transaction run). This change cleans them up after WITH execution via Prepared class new feature - cleanupCallbacks.

"I wrote the code, it's mine, and I'm contributing it to H2 for distribution multiple-licensed under the MPL 2.0, and the EPL 1.0 (http://h2database.com/html/license.html)."