### PR TITLE
issue#493 Query with distinct/limit/offset subquery returns unexpected rows

### DIFF
--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -410,10 +410,12 @@ public class LocalResult implements ResultInterface, ResultTarget {
             if (rows.size() > limit) {
                 rows = New.arrayList(rows.subList(0, limit));
                 rowCount = limit;
+                distinctRows = null;
             }
         } else {
             if (limit < rowCount) {
                 rowCount = limit;
+                distinctRows = null;
             }
         }
     }
@@ -513,6 +515,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
                 rowCount -= offset;
             }
         }
+        distinctRows = null;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/testScript.sql
+++ b/h2/src/test/org/h2/test/testScript.sql
@@ -10308,6 +10308,9 @@ create table test(id int, name varchar);
 insert into test values(5, 'b'), (5, 'b'), (20, 'a');
 > update count: 3
 
+drop table test;
+> ok
+
 select 0 from ((
     select 0 as f from dual u1 where null in (?, ?, ?, ?, ?)
 ) union all (
@@ -10738,4 +10741,23 @@ drop table card;
 > ok
 
 drop type CARD_SUIT;
+> ok
+
+----- Issue#493 -----
+create table test (year int, action varchar(10));
+> ok
+
+insert into test values (2015, 'order'), (2016, 'order'), (2014, 'order');
+> update count: 3
+
+insert into test values (2014, 'execution'), (2015, 'execution'), (2016, 'execution');
+> update count: 3
+
+select * from test where year in (select distinct year from test order by year desc limit 1 offset 0);
+> YEAR ACTION
+> ---- ---------
+> 2016 order
+> 2016 execution
+
+drop table test;
 > ok


### PR DESCRIPTION
Fix for #493. This specific case is fixed, not 100% sure, if I've covered all the bases