### PR TITLE
Disallow BLOB type in PostgreSQL mode

### DIFF
--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -282,6 +282,7 @@ public class Mode {
         disallowedTypes.add("NUMBER");
         disallowedTypes.add("IDENTITY");
         disallowedTypes.add("TINYINT");
+        disallowedTypes.add("BLOB");
         mode.disallowedTypes = disallowedTypes;
         add(mode);
 

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -278,7 +278,7 @@ public class TestCompatibility extends TestBase {
 
         /* --------- Disallowed column types --------- */
 
-        String[] DISALLOWED_TYPES = {"NUMBER", "IDENTITY", "TINYINT"};
+        String[] DISALLOWED_TYPES = {"NUMBER", "IDENTITY", "TINYINT", "BLOB"};
         for (String type : DISALLOWED_TYPES) {
             stat.execute("DROP TABLE IF EXISTS TEST");
             try {


### PR DESCRIPTION
We just faced another issue when locally developing on H2 and deploying to PostgreSQL.
The BLOB type does not exist in PostgreSQL. They call it "bytea" there.
So, disallow BLOB type when in PostreSQL mode.
This is an addition to PR #558.