### PR TITLE
"Connection is broken: "unexpected status 16777216" [90067-192]" message when using older h2 releases as client

### DIFF
--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -411,7 +411,9 @@ public class TcpServerThread implements Runnable {
         case SessionRemote.SESSION_SET_ID: {
             sessionId = transfer.readString();
             transfer.writeInt(SessionRemote.STATUS_OK);
-            transfer.writeBoolean(session.getAutoCommit());
+            if (clientVersion >= Constants.TCP_PROTOCOL_VERSION_15) {
+                transfer.writeBoolean(session.getAutoCommit());
+            }
             transfer.flush();
             break;
         }

--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -82,18 +82,18 @@ public class TcpServerThread implements Runnable {
                     throw DbException.get(ErrorCode.REMOTE_CONNECTION_NOT_ALLOWED);
                 }
                 int minClientVersion = transfer.readInt();
-                if (minClientVersion < Constants.TCP_PROTOCOL_VERSION_6) {
+                int maxClientVersion = transfer.readInt();
+                if (maxClientVersion < Constants.TCP_PROTOCOL_VERSION_6) {
                     throw DbException.get(ErrorCode.DRIVER_VERSION_ERROR_2,
                             "" + clientVersion, "" + Constants.TCP_PROTOCOL_VERSION_6);
                 } else if (minClientVersion > Constants.TCP_PROTOCOL_VERSION_16) {
                     throw DbException.get(ErrorCode.DRIVER_VERSION_ERROR_2,
                             "" + clientVersion, "" + Constants.TCP_PROTOCOL_VERSION_16);
                 }
-                int maxClientVersion = transfer.readInt();
                 if (maxClientVersion >= Constants.TCP_PROTOCOL_VERSION_16) {
                     clientVersion = Constants.TCP_PROTOCOL_VERSION_16;
                 } else {
-                    clientVersion = minClientVersion;
+                    clientVersion = maxClientVersion;
                 }
                 transfer.setVersion(clientVersion);
                 String db = transfer.readString();


### PR DESCRIPTION
Good day.

I noticed strange error message "Connection is broken: "unexpected status 16777216" [90067-192]" when tried to use latest release as a server and version 1.4.192 as a client.

The source of the error is missed protocol version check in commit be2d01c8dda6083d9c9a053534dd2bf6cbed55a2
There is clientVersion check in SessionRemote: https://github.com/h2database/h2database/commit/be2d01c8dda6083d9c9a053534dd2bf6cbed55a2#diff-adb6ff577387d89e7003cb4f79742d92R130
and check is missing in TcpServerThread: https://github.com/h2database/h2database/commit/be2d01c8dda6083d9c9a053534dd2bf6cbed55a2#diff-e79a62c2a547b4bd80fd58af74bf2c06R404
That creates cases where boolean is written to tcp socket but client never attempts to read separate boolean and it's end up as first byte of the status (16777216 == 0x1000000)
Here is commit with missed check: https://github.com/dubrovskip/h2database/commit/3eee97d701ee616625e6426e4113feb4bd56269f

The second thing that caught my attention is that in my test client and server using 6 as a protocol version, but client supports 6-15 and server supports 6-16.
As far as I understand this code https://github.com/h2database/h2database/blob/0dcc32529c67464b01354387aa6637ed578e3a74/h2/src/main/org/h2/server/TcpServerThread.java#L84-L97 should choose the highest version supported by both client and server, but it's doing it incorrectly resulting in 6 in my case.
Here is proposed fix: https://github.com/dubrovskip/h2database/commit/92176172eda5b87227af76e3665689d717b82c83

I created pull request with mentioned above changes. Is everything alright with it?