### PR TITLE
Issue 580: NPE on store reopen

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -162,7 +162,7 @@ public class MVTableEngine implements TableEngine {
                 }
                 this.transactionStore = new TransactionStore(
                         store,
-                        new ValueDataType(null, db, null));
+                        new ValueDataType(db.getCompareMode(), db, null));
                 transactionStore.init();
             } catch (IllegalStateException e) {
                 throw convertIllegalStateException(e);

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -101,7 +101,7 @@ public class ValueDataType implements DataType {
             int bl = bx.length;
             int len = Math.min(al, bl);
             for (int i = 0; i < len; i++) {
-                int sortType = sortTypes[i];
+                int sortType = sortTypes == null ? SortOrder.ASCENDING : sortTypes[i];
                 int comp = compareValues(ax[i], bx[i], sortType);
                 if (comp != 0) {
                     return comp;


### PR DESCRIPTION
This is immediate fix for issue #580. Issue is very much reproducible indeed,
although store is not really corrupt in this case, but rather uncommited tx
are present, and on database opening it causes NPE. Root cause is the fact
that during this process some maps (temp tables) are opened in a generic way, 
disregarding their real key/value types.
Possible proper fix, I think, either remove those beforehand or even better
store type info with the map. Such fix would be be much more involved, of course.