### PR TITLE
lastkey calulation on primary index reopening

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -72,7 +72,7 @@ public class MVPrimaryIndex extends BaseIndex {
         if (!table.isPersistData()) {
             dataMap.map.setVolatile(true);
         }
-        Value k = dataMap.lastKey();
+        Value k = dataMap.map.lastKey();    // include uncommitted keys as well
         lastKey.set(k == null ? 0 : k.getLong());
     }
 


### PR DESCRIPTION
Calculation of the last key for MVPrimaryIndex (last used rowid) should consider
uncommitted keys as well. This might be the case when index re-opens after previous
abrupt database closure.