### PR TITLE
issue#611 getMetaData().getColumnClassName() fails

### DIFF
--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -23,6 +23,7 @@ import org.h2.table.TableFilter;
 import org.h2.value.Value;
 import org.h2.value.ValueBoolean;
 import org.h2.value.ValueEnum;
+import org.h2.value.ValueNull;
 
 /**
  * A expression that represents a column of a table or view.
@@ -188,7 +189,7 @@ public class ExpressionColumn extends Expression {
             columnResolver.getValue(column);
             throw DbException.get(ErrorCode.MUST_GROUP_BY_COLUMN_1, getSQL());
         }
-        if (column.getEnumerators() != null) {
+        if (column.getEnumerators() != null && value != ValueNull.INSTANCE) {
             return ValueEnum.get(column.getEnumerators(), value.getInt());
         }
         return value;

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -383,7 +383,7 @@ public class Column {
                         getCreateSQL(), s + " (" + value.getPrecision() + ")");
             }
         }
-        if (isEnumerated()) {
+        if (isEnumerated() && value != ValueNull.INSTANCE) {
             if (!ValueEnum.isValid(enumerators, value)) {
                 String s = value.getTraceSQL();
                 if (s.length() > 127) {

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -727,6 +727,7 @@ public class DataType {
             // "java.lang.Short";
             return Short.class.getName();
         case Value.INT:
+        case Value.ENUM:
             // "java.lang.Integer";
             return Integer.class.getName();
         case Value.LONG:

--- a/h2/src/test/org/h2/test/scripts/datatypes-enum.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes-enum.sql
@@ -7,8 +7,8 @@
 create table card (rank int, suit enum('hearts', 'clubs', 'spades'));
 > ok
 
-insert into card (rank, suit) values (0, 'clubs'), (3, 'hearts');
-> update count: 2
+insert into card (rank, suit) values (0, 'clubs'), (3, 'hearts'), (4, NULL);
+> update count: 3
 
 alter table card alter column suit enum('hearts', 'clubs', 'spades', 'diamonds');
 > ok
@@ -18,10 +18,12 @@ select * from card;
 > ---- ------
 > 0    clubs
 > 3    hearts
+> 4    null
 
 select * from card order by suit;
 > RANK SUIT
 > ---- ------
+> 4    null
 > 3    hearts
 > 0    clubs
 
@@ -31,6 +33,7 @@ insert into card (rank, suit) values (8, 'diamonds'), (10, 'clubs'), (7, 'hearts
 select suit, count(rank) from card group by suit order by suit, count(rank);
 > SUIT     COUNT(RANK)
 > -------- -----------
+> null     1
 > hearts   2
 > clubs    2
 > diamonds 1


### PR DESCRIPTION
I can cofirm that while issue exists in 1.4.196, it seems to be fixed in master.
Another minor one I've discovered while testing is fixed here:
getMetaData().getColumnClassName() fails due to a lack of case for ENUM.
Also fixed issue with null value inserted/retrieved from enum column, reported on Google user group by Никита Карпухин