### PR TITLE
Issue#619 CTE have wrong column names when AS newname used with simpl…

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -5032,10 +5032,20 @@ public class Parser {
             querySQL = StringUtils.cache(withQuery.getPlanSQL());
             ArrayList<Expression> withExpressions = withQuery.getExpressions();
             for (int i = 0; i < withExpressions.size(); ++i) {
-                String columnName = cols != null ? cols[i]
-                        : withExpressions.get(i).getColumnName();
+                Expression columnExp = withExpressions.get(i);
+                // use the passed in column name if supplied, otherwise use alias (if used) otherwise use column name
+                // derived from column expression
+                String columnName;
+                if (cols != null){
+                    columnName = cols[i];
+                } else if (columnExp.getAlias()!=null){
+                    columnName = columnExp.getAlias();
+                }
+                else{
+                     columnName =  columnExp.getColumnName();
+                }
                 columnTemplateList.add(new Column(columnName,
-                        withExpressions.get(i).getType()));
+                        columnExp.getType()));
             }
         } finally {
             session.removeLocalTempTable(recursiveTable);

--- a/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
+++ b/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
@@ -466,18 +466,6 @@ public class TestGeneralCommonTableQueries extends TestBase {
 
         assertFalse(rs.next());
 
-        try{
-            prep = conn.prepareStatement("SELECT * FROM t1 UNION ALL SELECT * FROM t2 "+
-                    "UNION ALL SELECT X, 'Q' FROM SYSTEM_RANGE(5,6)");
-            rs = prep.executeQuery();
-            fail("Temp view T1 was accessible after previous WITH statement finished "+
-                    "- but should not have been.");
-        }
-        catch(JdbcSQLException e){
-            // ensure the T1 table has been removed even without auto commit
-            assertContains(e.getMessage(),"Table \"T1\" not found;");
-        }
-
         conn.close();
         deleteDb("commonTableExpressionQueries");
     }


### PR DESCRIPTION
Issue#619 CTE have wrong column names when AS newname used with simple column expression, for example:

WITH AAA AS (
SELECT X AS ID, 'Marcy' AS NAME FROM SYSTEM_RANGE(1,2)
)
SELECT * FROM AAA

Returns columns titled X and NAME - the first of which is clearly aliased to ID (not X).

This fixes that !