### PR TITLE
MVStore can't read enums with values greater than 16

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -464,6 +464,7 @@ public class ValueDataType implements DataType {
             return ValueBoolean.get(false);
         case INT_NEG:
             return ValueInt.get(-readVarInt(buff));
+        case Value.ENUM:
         case Value.INT:
             return ValueInt.get(readVarInt(buff));
         case LONG_NEG:


### PR DESCRIPTION
Good day.

MVStore fails to read enum values greater than 16. The smallest case to reproduce:
```
CREATE TABLE ENUMTEST ( 
  e ENUM('0x00', '0x01', '0x02', '0x03', '0x04', '0x05', '0x06', '0x07', '0x08', '0x09', '0x0A', '0x0B', '0x0C', '0x0D', '0x0E', '0x0F', '0x10'),
);


INSERT INTO ENUMTEST VALUES ('0x10');
```

When I try to create a new connection to db after running these SQLs  I get next error:
```
File corrupted while reading record: "type: 25". Possible solution: use the recovery tool; SQL statement:
CREATE CACHED TABLE PUBLIC.ENUMTEST(
    E ENUM('0x00','0x01','0x02','0x03','0x04','0x05','0x06','0x07','0x08','0x09','0x0A','0x0B','0x0C','0x0D','0x0E','0x0F','0x10')
) [90030-196] 90030/90030
``` 

As far as I understand this commit https://github.com/h2database/h2database/commit/eb39694549d77a69029f714ec491486b56b0fdde#diff-58e7066f27f34ec51d8ae7f079cca34f added separate case for writeValue() but forgot case for readValue(). Pull request just adds the case statement. This is enough to fix the issue described above.