### PR TITLE
Fix for "Change not-null / null -constraint to existing column" (MySql/ORACLE - SQL style)

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Fix bug in MySQL/ORACLE-syntax silently corrupting the modified column in cases of setting the 'NULL'- or 'NOT NULL'-constraint. E.g. alter table T modify C NULL;
+</li>
 <li>Issue #570: MySQL compatibility for ALTER TABLE .. DROP INDEX
 </li>
 <li>Issue #537: Include the COLUMN name in message "Numeric value out of range"

--- a/h2/src/docsrc/html/history.html
+++ b/h2/src/docsrc/html/history.html
@@ -166,6 +166,7 @@ To become a donor, use PayPal (at the very bottom of the main web page).
 </li><li>Cristan Meijer, Netherlands
 </li><li>Adam McMahon, USA
 </li><li>F&aacute;bio Gomes Lisboa Gomes, Brasil
+</li><li><a href="http://tao.works">Sam Blume, Switzerland</a>
 </li></ul>
 
 <!-- [close] { --></div></td></tr></table><!-- } --><!-- analytics --></body></html>

--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -344,7 +344,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Allow to scan index backwards starting with a value (to better support ORDER BY DESC).
 </li><li>Java Service Wrapper: try http://yajsw.sourceforge.net/
 </li><li>Batch parameter for INSERT, UPDATE, and DELETE, and commit after each batch. See also MySQL DELETE.
-</li><li>MySQL compatibility: support ALTER TABLE .. MODIFY COLUMN.
 </li><li>Use a lazy and auto-close input stream (open resource when reading, close on eof).
 </li><li>Connection pool: 'reset session' command (delete temp tables, rollback, auto-commit true).
 </li><li>Improve SQL documentation, see http://www.w3schools.com/sql/

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -5869,7 +5869,23 @@ public class Parser {
             // MySQL compatibility
             readIf("COLUMN");
             String columnName = readColumnIdentifier();
-            return parseAlterTableAlterColumnType(schema, tableName, columnName, ifTableExists);
+            if ((isToken("NOT") || isToken("NULL"))) {
+            	AlterTableAlterColumn command = new AlterTableAlterColumn(
+            			session, schema);
+            	command.setTableName(tableName);
+            	command.setIfTableExists(ifTableExists);
+            	Column column = columnIfTableExists(schema, tableName, columnName, ifTableExists);
+            	command.setOldColumn(column);
+                if (readIf("NOT")) {
+                    command.setType(CommandInterface.ALTER_TABLE_ALTER_COLUMN_NOT_NULL);
+                } else {
+                	read("NULL");
+                    command.setType(CommandInterface.ALTER_TABLE_ALTER_COLUMN_NULL);
+                }
+                return command;
+            } else {
+                return parseAlterTableAlterColumnType(schema, tableName, columnName, ifTableExists);
+            }
         } else if (readIf("ALTER")) {
             readIf("COLUMN");
             String columnName = readColumnIdentifier();

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -1305,10 +1305,6 @@ public class TestFunctions extends TestBase implements AggregateFunction {
     }
 
     private void testToDate() throws ParseException {
-        if (Locale.getDefault() != Locale.ENGLISH) {
-            return;
-        }
-
         final int month = Calendar.getInstance().get(Calendar.MONTH);
 
         Date date = null;
@@ -1418,23 +1414,25 @@ public class TestFunctions extends TestBase implements AggregateFunction {
         date = new SimpleDateFormat("yyyy-MM-dd").parse("2013-01-29");
         assertEquals(date, ToDateParser.toDate("113029", "J"));
 
-        date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+        if (Locale.getDefault() == Locale.ENGLISH) {
+          date = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
                 .parse("9999-12-31T23:59:59");
-        assertEquals(date, ToDateParser.toDate("31-DEC-9999 23:59:59",
+          assertEquals(date, ToDateParser.toDate("31-DEC-9999 23:59:59",
                 "DD-MON-YYYY HH24:MI:SS"));
-        assertEquals(date, ToDateParser.toDate("31-DEC-9999 23:59:59",
+          assertEquals(date, ToDateParser.toDate("31-DEC-9999 23:59:59",
                 "DD-MON-RRRR HH24:MI:SS"));
 
-        SimpleDateFormat ymd = new SimpleDateFormat("yyyy-MM-dd");
-        assertEquals(ymd.parse("0001-03-01"), ToDateParser.toDate("1-MAR-0001", "DD-MON-RRRR"));
-        assertEquals(ymd.parse("9999-03-01"), ToDateParser.toDate("1-MAR-9999", "DD-MON-RRRR"));
-        assertEquals(ymd.parse("2000-03-01"), ToDateParser.toDate("1-MAR-000", "DD-MON-RRRR"));
-        assertEquals(ymd.parse("1999-03-01"), ToDateParser.toDate("1-MAR-099", "DD-MON-RRRR"));
-        assertEquals(ymd.parse("0100-03-01"), ToDateParser.toDate("1-MAR-100", "DD-MON-RRRR"));
-        assertEquals(ymd.parse("2000-03-01"), ToDateParser.toDate("1-MAR-00", "DD-MON-RRRR"));
-        assertEquals(ymd.parse("2049-03-01"), ToDateParser.toDate("1-MAR-49", "DD-MON-RRRR"));
-        assertEquals(ymd.parse("1950-03-01"), ToDateParser.toDate("1-MAR-50", "DD-MON-RRRR"));
-        assertEquals(ymd.parse("1999-03-01"), ToDateParser.toDate("1-MAR-99", "DD-MON-RRRR"));
+          SimpleDateFormat ymd = new SimpleDateFormat("yyyy-MM-dd");
+          assertEquals(ymd.parse("0001-03-01"), ToDateParser.toDate("1-MAR-0001", "DD-MON-RRRR"));
+          assertEquals(ymd.parse("9999-03-01"), ToDateParser.toDate("1-MAR-9999", "DD-MON-RRRR"));
+          assertEquals(ymd.parse("2000-03-01"), ToDateParser.toDate("1-MAR-000", "DD-MON-RRRR"));
+          assertEquals(ymd.parse("1999-03-01"), ToDateParser.toDate("1-MAR-099", "DD-MON-RRRR"));
+          assertEquals(ymd.parse("0100-03-01"), ToDateParser.toDate("1-MAR-100", "DD-MON-RRRR"));
+          assertEquals(ymd.parse("2000-03-01"), ToDateParser.toDate("1-MAR-00", "DD-MON-RRRR"));
+          assertEquals(ymd.parse("2049-03-01"), ToDateParser.toDate("1-MAR-49", "DD-MON-RRRR"));
+          assertEquals(ymd.parse("1950-03-01"), ToDateParser.toDate("1-MAR-50", "DD-MON-RRRR"));
+          assertEquals(ymd.parse("1999-03-01"), ToDateParser.toDate("1-MAR-99", "DD-MON-RRRR"));
+        }
     }
 
     private static void setMonth(Date date, int month) {
@@ -1732,13 +1730,26 @@ public class TestFunctions extends TestBase implements AggregateFunction {
                 "SELECT TO_CHAR(12345, '$999') FROM DUAL");
         assertResult("######", stat,
                 "SELECT TO_CHAR(12345, '$9999') FROM DUAL");
-        assertResult("    " + cs + "12345", stat,
-                "SELECT TO_CHAR(12345, '$99999999') FROM DUAL");
-        assertResult("     " + cs + "12,345.35", stat,
-                "SELECT TO_CHAR(12345.345, '$99,999,999.99') FROM DUAL");
         String expected = String.format("%,d", 12345);
-        assertResult("     " + cs + expected, stat,
+        if (Locale.getDefault() == Locale.ENGLISH) {
+          assertResult(String.format("%5s12345", cs), stat,
+                    "SELECT TO_CHAR(12345, '$99999999') FROM DUAL");
+          assertResult(String.format("%6s12,345.35", cs), stat,
+                    "SELECT TO_CHAR(12345.345, '$99,999,999.99') FROM DUAL");
+          assertResult(String.format("%5s%s", cs, expected), stat,
                 "SELECT TO_CHAR(12345.345, '$99g999g999') FROM DUAL");
+          assertResult("          " + cs + "123.45", stat,
+                  "SELECT TO_CHAR(123.45, 'L999.99') FROM DUAL");
+          assertResult("         -" + cs + "123.45", stat,
+                  "SELECT TO_CHAR(-123.45, 'L999.99') FROM DUAL");
+          assertResult(cs + "123.45", stat,
+                  "SELECT TO_CHAR(123.45, 'FML999.99') FROM DUAL");
+          assertResult("          " + cs + "123.45", stat,
+                  "SELECT TO_CHAR(123.45, 'U999.99') FROM DUAL");
+          assertResult("          " + cs + "123.45", stat,
+                  "SELECT TO_CHAR(123.45, 'u999.99') FROM DUAL");
+
+        }
         assertResult("     12,345.35", stat,
                 "SELECT TO_CHAR(12345.345, '99,999,999.99') FROM DUAL");
         assertResult("12,345.35", stat,
@@ -1827,16 +1838,6 @@ public class TestFunctions extends TestBase implements AggregateFunction {
                 "SELECT TO_CHAR(123.45, 'C999g999') FROM DUAL");
         assertResult(cc + "123.45", stat,
                 "SELECT TO_CHAR(123.45, 'FMC999,999.99') FROM DUAL");
-        assertResult("          " + cs + "123.45", stat,
-                "SELECT TO_CHAR(123.45, 'L999.99') FROM DUAL");
-        assertResult("         -" + cs + "123.45", stat,
-                "SELECT TO_CHAR(-123.45, 'L999.99') FROM DUAL");
-        assertResult(cs + "123.45", stat,
-                "SELECT TO_CHAR(123.45, 'FML999.99') FROM DUAL");
-        assertResult("          " + cs + "123.45", stat,
-                "SELECT TO_CHAR(123.45, 'U999.99') FROM DUAL");
-        assertResult("          " + cs + "123.45", stat,
-                "SELECT TO_CHAR(123.45, 'u999.99') FROM DUAL");
         expected = String.format("%.2f", 0.33f).substring(1);
         assertResult("   " + expected, stat,
                 "SELECT TO_CHAR(0.326, '99D99') FROM DUAL");


### PR DESCRIPTION
Command failed silently corrupting the changed column.
Before the change (added after v1.4.196) following was observed:
 alter table T modify C int null; -- Worked as expected
 alter table T modify C null;     -- Silently corrupted column C