### PR TITLE
issue#637: Oracle REPLACE(X,Y,NULL)

### DIFF
--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -314,6 +314,10 @@ public class Mode {
         return getInstance("MySQL");
     }
 
+    public static Mode getOracle() {
+        return getInstance("Oracle");
+    }
+
     public String getName() {
         return name;
     }

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -279,7 +279,7 @@ public class Function extends Expression implements FunctionCall {
         addFunction("OCTET_LENGTH", OCTET_LENGTH, 1, Value.LONG);
         addFunction("RAWTOHEX", RAWTOHEX, 1, Value.STRING);
         addFunction("REPEAT", REPEAT, 2, Value.STRING);
-        addFunction("REPLACE", REPLACE, VAR_ARGS, Value.STRING);
+        addFunction("REPLACE", REPLACE, VAR_ARGS, Value.STRING, false, true,true);
         addFunction("RIGHT", RIGHT, 2, Value.STRING);
         addFunction("RTRIM", RTRIM, VAR_ARGS, Value.STRING);
         addFunction("SOUNDEX", SOUNDEX, 1, Value.STRING);
@@ -1342,11 +1342,19 @@ public class Function extends Expression implements FunctionCall {
             break;
         }
         case REPLACE: {
-            String s0 = v0.getString();
-            String s1 = v1.getString();
-            String s2 = (v2 == null) ? "" : v2.getString();
-            result = ValueString.get(replace(s0, s1, s2),
-                    database.getMode().treatEmptyStringsAsNull);
+            if (v0 == ValueNull.INSTANCE || v1 == ValueNull.INSTANCE
+                    || v2 == ValueNull.INSTANCE && database.getMode() != Mode.getOracle()) {
+                result = ValueNull.INSTANCE;
+            } else {
+                String s0 = v0.getString();
+                String s1 = v1.getString();
+                String s2 = (v2 == null) ? "" : v2.getString();
+                if (s2 == null) {
+                    s2 = "";
+                }
+                result = ValueString.get(replace(s0, s1, s2),
+                        database.getMode().treatEmptyStringsAsNull);
+            }
             break;
         }
         case RIGHT:

--- a/h2/src/test/org/h2/test/scripts/functions/string/replace.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/replace.sql
@@ -15,3 +15,12 @@ select replace('abchihihi', 'i', 'o') abcehohoho, replace('that is tom', 'i') ab
 > ---------- ----------
 > abchohoho  that s tom
 > rows: 1
+
+set mode oracle;
+> ok
+
+select replace('white space', ' ', '') x, replace('white space', ' ', null) y from dual;
+> X          Y
+> ---------- ----------
+> whitespace whitespace
+> rows: 1


### PR DESCRIPTION
Fix for #637. Not sure if comparison with Mode.getOracle() is ok, or treatEmptyStringsAsNull should be used, or yet another flag created. BTW I would make Mode enum, much more elegant.