### PR TITLE
Added Oracle compatibility of the NOT NULL syntax.

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.api.JavaObjectSerializer;
@@ -26,6 +27,7 @@ import org.h2.command.CommandInterface;
 import org.h2.command.ddl.CreateTableData;
 import org.h2.command.dml.SetTypes;
 import org.h2.constraint.Constraint;
+import org.h2.engine.Mode.DbTypeEnum;
 import org.h2.index.Cursor;
 import org.h2.index.Index;
 import org.h2.index.IndexType;
@@ -2376,6 +2378,16 @@ public class Database implements DataHandler {
         return mode;
     }
 
+    public boolean isDbTypeOneOf(DbTypeEnum... dbTypes) {
+        DbTypeEnum currentDbType = mode.getDbTypeEnum();
+        for (DbTypeEnum dbType : dbTypes) {
+            if (currentDbType == dbType) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     public boolean isMultiThreaded() {
         return multiThreaded;
     }

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -23,7 +23,25 @@ public class Mode {
      */
     static final String REGULAR = "REGULAR";
 
-    private static final HashMap<String, Mode> MODES = New.hashMap();
+    public static enum DbTypeEnum {
+        REGULAR, UNKNOWN, DB2 , Derby, HSQLDB, Ignite, MSSQLServer, MySQL, Oracle, PostgreSQL;
+    
+        public static DbTypeEnum parse(String modeAsStr) {
+            DbTypeEnum result = DbTypeEnum.UNKNOWN;
+            if (modeAsStr != null) {
+                modeAsStr = StringUtils.toUpperEnglish(modeAsStr.trim());
+                for (DbTypeEnum m: DbTypeEnum.values()) {
+                   if (m.name().toUpperCase().equals(modeAsStr)) {
+                       result = m;
+                       break;
+                   }
+                }
+            }
+            return result;
+        }    
+    }
+    
+    private static final HashMap<DbTypeEnum, Mode> MODES = New.hashMap();
 
     // Modes are also documented in the features section
 
@@ -178,14 +196,14 @@ public class Mode {
      */
     public Set<String> disallowedTypes = Collections.emptySet();
 
-    private final String name;
+    private final DbTypeEnum dbTypeEnum;
 
     static {
-        Mode mode = new Mode(REGULAR);
+        Mode mode = new Mode(DbTypeEnum.REGULAR);
         mode.nullConcatIsNull = true;
         add(mode);
 
-        mode = new Mode("DB2");
+        mode = new Mode(DbTypeEnum.DB2);
         mode.aliasColumnName = true;
         mode.supportOffsetFetch = true;
         mode.sysDummy1 = true;
@@ -200,7 +218,7 @@ public class Mode {
         mode.allowDB2TimestampFormat = true;
         add(mode);
 
-        mode = new Mode("Derby");
+        mode = new Mode(DbTypeEnum.Derby);
         mode.aliasColumnName = true;
         mode.uniqueIndexSingleNull = true;
         mode.supportOffsetFetch = true;
@@ -210,7 +228,7 @@ public class Mode {
         mode.supportedClientInfoPropertiesRegEx = null;
         add(mode);
 
-        mode = new Mode("HSQLDB");
+        mode = new Mode(DbTypeEnum.HSQLDB);
         mode.aliasColumnName = true;
         mode.convertOnlyToSmallerScale = true;
         mode.nullConcatIsNull = true;
@@ -223,7 +241,7 @@ public class Mode {
         mode.supportedClientInfoPropertiesRegEx = null;
         add(mode);
 
-        mode = new Mode("MSSQLServer");
+        mode = new Mode(DbTypeEnum.MSSQLServer);
         mode.aliasColumnName = true;
         mode.squareBracketQuotedNames = true;
         mode.uniqueIndexSingleNull = true;
@@ -235,7 +253,7 @@ public class Mode {
         mode.supportedClientInfoPropertiesRegEx = null;
         add(mode);
 
-        mode = new Mode("MySQL");
+        mode = new Mode(DbTypeEnum.MySQL);
         mode.convertInsertNullToZero = true;
         mode.indexDefinitionInCreateTable = true;
         mode.lowerCaseIdentifiers = true;
@@ -249,7 +267,7 @@ public class Mode {
         mode.prohibitEmptyInPredicate = true;
         add(mode);
 
-        mode = new Mode("Oracle");
+        mode = new Mode(DbTypeEnum.Oracle);
         mode.aliasColumnName = true;
         mode.convertOnlyToSmallerScale = true;
         mode.uniqueIndexSingleNullExceptAllColumnsAreNull = true;
@@ -262,7 +280,7 @@ public class Mode {
         mode.prohibitEmptyInPredicate = true;
         add(mode);
 
-        mode = new Mode("PostgreSQL");
+        mode = new Mode(DbTypeEnum.PostgreSQL);
         mode.aliasColumnName = true;
         mode.nullConcatIsNull = true;
         mode.supportOffsetFetch = true;
@@ -285,19 +303,19 @@ public class Mode {
         mode.disallowedTypes = disallowedTypes;
         add(mode);
 
-        mode = new Mode("Ignite");
+        mode = new Mode(DbTypeEnum.Ignite);
         mode.nullConcatIsNull = true;
         mode.allowAffinityKey = true;
         mode.indexDefinitionInCreateTable = true;
         add(mode);
     }
 
-    private Mode(String name) {
-        this.name = name;
+    private Mode(DbTypeEnum dbTypeEnum) {
+        this.dbTypeEnum = dbTypeEnum;
     }
 
     private static void add(Mode mode) {
-        MODES.put(StringUtils.toUpperEnglish(mode.name), mode);
+        MODES.put(mode.dbTypeEnum, mode);
     }
 
     /**
@@ -307,15 +325,24 @@ public class Mode {
      * @return the mode object
      */
     public static Mode getInstance(String name) {
-        return MODES.get(StringUtils.toUpperEnglish(name));
+        DbTypeEnum dbTypeEnum = DbTypeEnum.parse(name);
+        return MODES.get(dbTypeEnum);
+    }
+    
+    public static Mode getInstance(DbTypeEnum dbTypeEnum) {
+        return  MODES.get(dbTypeEnum);
     }
 
     public static Mode getMySQL() {
-        return getInstance("MySQL");
+        return getInstance(DbTypeEnum.MySQL);
+    }
+    
+    public DbTypeEnum getDbTypeEnum() {
+        return dbTypeEnum;
     }
 
     public String getName() {
-        return name;
+        return dbTypeEnum.name();
     }
 
 }

--- a/h2/src/test/org/h2/test/db/TestAlter.java
+++ b/h2/src/test/org/h2/test/db/TestAlter.java
@@ -304,7 +304,28 @@ public class TestAlter extends TestBase {
         // This failed in v1.4.196 
         stat.execute("create table T (C int not null)");
         stat.execute("alter table T modify C null"); // Silently corrupted column C
-        stat.execute("insert into T values(null)"); // <- ERROR: NULL not allowed
+        stat.execute("insert into T values(null)"); // <- Fixed in v1.4.196 - NULL is allowed
+        stat.execute("drop table T");
+        // Some other variation (oracle syntax)
+        stat.execute("create table T (C int not null)");
+        stat.execute("insert into T values(1)");
+        stat.execute("alter table T modify C not null"); 
+        stat.execute("insert into T values(1)");
+        stat.execute("alter table T modify C not null enable");
+        stat.execute("insert into T values(1)");
+        stat.execute("alter table T modify C not null enable validate");
+        stat.execute("insert into T values(1)");
+        stat.execute("drop table T");
+        // can set NULL
+        stat.execute("create table T (C int null)");
+        stat.execute("insert into T values(null)");
+        stat.execute("alter table T modify C null enable");
+        stat.execute("alter table T modify C null enable validate");
+        stat.execute("insert into T values(null)");
+        stat.execute("alter table T modify C not null disable");            // can set NULL even with 'not null syntax' (oracle)
+        stat.execute("insert into T values(null)");
+        stat.execute("alter table T modify C not null enable novalidate");  // can set NULL even with 'not null syntax' (oracle)
+        stat.execute("insert into T values(null)");
         stat.execute("drop table T");
     }
 }

--- a/h2/src/test/org/h2/test/db/TestAlter.java
+++ b/h2/src/test/org/h2/test/db/TestAlter.java
@@ -306,26 +306,5 @@ public class TestAlter extends TestBase {
         stat.execute("alter table T modify C null"); // Silently corrupted column C
         stat.execute("insert into T values(null)"); // <- Fixed in v1.4.196 - NULL is allowed
         stat.execute("drop table T");
-        // Some other variation (oracle syntax)
-        stat.execute("create table T (C int not null)");
-        stat.execute("insert into T values(1)");
-        stat.execute("alter table T modify C not null"); 
-        stat.execute("insert into T values(1)");
-        stat.execute("alter table T modify C not null enable");
-        stat.execute("insert into T values(1)");
-        stat.execute("alter table T modify C not null enable validate");
-        stat.execute("insert into T values(1)");
-        stat.execute("drop table T");
-        // can set NULL
-        stat.execute("create table T (C int null)");
-        stat.execute("insert into T values(null)");
-        stat.execute("alter table T modify C null enable");
-        stat.execute("alter table T modify C null enable validate");
-        stat.execute("insert into T values(null)");
-        stat.execute("alter table T modify C not null disable");            // can set NULL even with 'not null syntax' (oracle)
-        stat.execute("insert into T values(null)");
-        stat.execute("alter table T modify C not null enable novalidate");  // can set NULL even with 'not null syntax' (oracle)
-        stat.execute("insert into T values(null)");
-        stat.execute("drop table T");
     }
 }

--- a/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
@@ -34,6 +34,7 @@ public class TestCompatibilityOracle extends TestBase {
 
     @Override
     public void test() throws Exception {
+    	testNotNullSyntax();
         testTreatEmptyStringsAsNull();
         testDecimalScale();
         testPoundSymbolInColumnName();
@@ -41,6 +42,28 @@ public class TestCompatibilityOracle extends TestBase {
         testForbidEmptyInClause();
     }
 
+    private void testNotNullSyntax() throws SQLException {
+        deleteDb("oracle");
+        Connection conn = getConnection("oracle;MODE=Oracle");
+        Statement stat = conn.createStatement();
+        // Some other variation (oracle syntax)
+        stat.execute("create table T (C int not null enable)");
+        stat.execute("insert into T values(1)");
+        stat.execute("drop table T");
+        stat.execute("create table T (C int not null enable validate)");
+        stat.execute("insert into T values(1)");
+        stat.execute("drop table T");
+        // can set NULL
+        stat.execute("create table T (C int not null disable)");           // can set NULL even with 'not null syntax' (oracle)
+        stat.execute("insert into T values(null)");
+        stat.execute("drop table T");
+        stat.execute("create table T (C int not null enable novalidate)");  // can set NULL even with 'not null syntax' (oracle)
+        stat.execute("insert into T values(null)");
+        stat.execute("drop table T");
+        conn.close();
+    }
+
+    
     private void testTreatEmptyStringsAsNull() throws SQLException {
         deleteDb("oracle");
         Connection conn = getConnection("oracle;MODE=Oracle");

--- a/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
@@ -60,6 +60,29 @@ public class TestCompatibilityOracle extends TestBase {
         stat.execute("create table T (C int not null enable novalidate)");  // can set NULL even with 'not null syntax' (oracle)
         stat.execute("insert into T values(null)");
         stat.execute("drop table T");
+        
+        // Some other variation with oracle syntax
+        stat.execute("create table T (C int not null)");
+        stat.execute("insert into T values(1)");
+        stat.execute("alter table T modify C not null"); 
+        stat.execute("insert into T values(1)");
+        stat.execute("alter table T modify C not null enable");
+        stat.execute("insert into T values(1)");
+        stat.execute("alter table T modify C not null enable validate");
+        stat.execute("insert into T values(1)");
+        stat.execute("drop table T");
+        // can set NULL
+        stat.execute("create table T (C int null)");
+        stat.execute("insert into T values(null)");
+        stat.execute("alter table T modify C null enable");
+        stat.execute("alter table T modify C null enable validate");
+        stat.execute("insert into T values(null)");
+        stat.execute("alter table T modify C not null disable");            // can set NULL even with 'not null syntax' (oracle)
+        stat.execute("insert into T values(null)");
+        stat.execute("alter table T modify C not null enable novalidate");  // can set NULL even with 'not null syntax' (oracle)
+        stat.execute("insert into T values(null)");
+        stat.execute("drop table T");
+
         conn.close();
     }
 


### PR DESCRIPTION
Oracles NOT NULL syntax can have optional ENABLE VALIDATE added e.g  
  create table T (C int NOT NULL ENABLE VALIDATE)
Some SQL-generators produce such SQL and H2 can now parse it with this
change.