### PR TITLE
Oracle doesn't support enum types

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -123,7 +123,7 @@ Change Log
 </li>
 <li>Added support for invisible columns.
 </li>
-<li>Added an ENUM data type, with syntax similar to that of MySQL and Oracle.
+<li>Added an ENUM data type, with syntax similar to that of MySQL.
 </li>
 <li>MVStore: for object data types, the cache size memory estimation
     was sometimes far off in a read-only scenario.


### PR DESCRIPTION
I'm not sure why there is a reference to Oracle in the discussion of https://github.com/h2database/h2database/pull/451. Oracle does not support an enum type (although it can be emulated, as in any database, using a `CHECK` constraint).