### PR TITLE
Cleanup CreateCluster tool

### DIFF
--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -124,16 +124,16 @@ public class CreateCluster extends Tool {
 
     private static void performTransfer(Statement statSource, String urlTarget,
             String user, String password, String serverList) throws SQLException {
+
+        // Delete the target database first.
+        try (Connection connTarget = DriverManager.getConnection(
+                     urlTarget + ";CLUSTER=''", user, password);
+             Statement statTarget = connTarget.createStatement())
+        {
+            statTarget.execute("DROP ALL OBJECTS DELETE FILES");
+        }
+
         try (PipedReader pipeReader = new PipedReader()) {
-
-            // Delete the target database first.
-            try (Connection connTarget = DriverManager.getConnection(
-                         urlTarget + ";CLUSTER=''", user, password);
-                 Statement statTarget = connTarget.createStatement())
-            {
-                statTarget.execute("DROP ALL OBJECTS DELETE FILES");
-            }
-
             Future<?> threadFuture = startWriter(pipeReader, statSource);
 
             // Read data from pipe reader, restore on target.

--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -166,6 +166,7 @@ public class CreateCluster extends Tool {
                         urlTarget + ";CLUSTER=''", user, password);
                 statTarget = connTarget.createStatement();
                 statTarget.execute("DROP ALL OBJECTS DELETE FILES");
+                statTarget.close();
                 connTarget.close();
 
 

--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -191,9 +191,7 @@ public class CreateCluster extends Tool {
                     while (rs.next()) {
                         pipeWriter.write(rs.getString(1) + "\n");
                     }
-                } catch (SQLException ex) {
-                    throw new IllegalStateException("Producing script from the source DB is failing.", ex);
-                } catch (IOException ex) {
+                } catch (SQLException | IOException ex) {
                     throw new IllegalStateException("Producing script from the source DB is failing.", ex);
                 } finally {
                     IOUtils.closeSilently(pipeWriter);

--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -143,20 +143,19 @@ public class CreateCluster extends Tool {
             {
                 RunScript.execute(connTarget, pipeReader);
 
+                // Check if the writer encountered any exception
+                try {
+                    threadFuture.get();
+                } catch (ExecutionException ex) {
+                    throw new SQLException(ex.getCause());
+                } catch (InterruptedException ex) {
+                    throw new SQLException(ex);
+                }
+
                 // set the cluster to the serverList on both databases
                 statSource.executeUpdate("SET CLUSTER '" + serverList + "'");
                 statTarget.executeUpdate("SET CLUSTER '" + serverList + "'");
             }
-
-            // Check if the writer encountered any exception
-            try {
-                threadFuture.get();
-            } catch (ExecutionException ex) {
-                throw new SQLException(ex.getCause());
-            } catch (InterruptedException ex) {
-                throw new SQLException(ex);
-            }
-
         } catch (IOException ex) {
             throw new SQLException(ex);
         }

--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -102,30 +102,6 @@ public class CreateCluster extends Tool {
             String user, String password, String serverList) throws SQLException {
         org.h2.Driver.load();
 
-        // verify that the database doesn't exist,
-        // or if it exists (an old cluster instance), it is deleted
-        boolean exists = true;
-        try (Connection connTarget = DriverManager.getConnection(urlTarget +
-                     ";IFEXISTS=TRUE;CLUSTER=" + Constants.CLUSTERING_ENABLED,
-                     user, password);
-             Statement stat = connTarget.createStatement())
-        {
-            stat.execute("DROP ALL OBJECTS DELETE FILES");
-            exists = false;
-        } catch (SQLException e) {
-            if (e.getErrorCode() == ErrorCode.DATABASE_NOT_FOUND_1) {
-                // database does not exists yet - ok
-                exists = false;
-            } else {
-                throw e;
-            }
-        }
-        if (exists) {
-            throw new SQLException(
-                    "Target database must not yet exist. Please delete it first: " +
-                    urlTarget);
-        }
-
         try (Connection connSource = DriverManager.getConnection(
                      // use cluster='' so connecting is possible
                      // even if the cluster is enabled

--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -161,7 +161,7 @@ public class CreateCluster extends Tool {
                 }
 
                 new Thread(
-                    new Runnable(){
+                    new Runnable() {
                         @Override
                         public void run() {
                             try {
@@ -169,9 +169,9 @@ public class CreateCluster extends Tool {
                                     pipeWriter.write(rs.getString(1) + "\n");
                                 }
                             } catch (SQLException ex) {
-                                throw new IllegalStateException("Producing script from the source DB is failing.",ex);
+                                throw new IllegalStateException("Producing script from the source DB is failing.", ex);
                             } catch (IOException ex) {
-                                throw new IllegalStateException("Producing script from the source DB is failing.",ex);
+                                throw new IllegalStateException("Producing script from the source DB is failing.", ex);
                             } finally {
                                 IOUtils.closeSilently(pipeWriter);
                             }
@@ -184,7 +184,7 @@ public class CreateCluster extends Tool {
                              urlTarget, user, password);
                      Statement statTarget = connTarget.createStatement())
                 {
-                    RunScript.execute(connTarget,pipeReader);
+                    RunScript.execute(connTarget, pipeReader);
 
                     // set the cluster to the serverList on both databases
                     statSource.executeUpdate("SET CLUSTER '" + serverList + "'");

--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -21,7 +21,7 @@ import java.util.concurrent.Future;
 import org.h2.util.Tool;
 
 /**
- * Creates a cluster from a standalone database.
+ * Creates a cluster from a stand-alone database.
  * <br />
  * Copies a database to another location if required.
  * @h2.resource

--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -104,33 +104,33 @@ public class CreateCluster extends Tool {
         Statement statSource = null;
         PipedReader pipeReader = null;
 
-        try {
-            org.h2.Driver.load();
+        org.h2.Driver.load();
 
-            // verify that the database doesn't exist,
-            // or if it exists (an old cluster instance), it is deleted
-            boolean exists = true;
-            try (Connection connTarget = DriverManager.getConnection(urlTarget +
-                         ";IFEXISTS=TRUE;CLUSTER=" + Constants.CLUSTERING_ENABLED,
-                         user, password);
-                 Statement stat = connTarget.createStatement())
-            {
-                stat.execute("DROP ALL OBJECTS DELETE FILES");
+        // verify that the database doesn't exist,
+        // or if it exists (an old cluster instance), it is deleted
+        boolean exists = true;
+        try (Connection connTarget = DriverManager.getConnection(urlTarget +
+                     ";IFEXISTS=TRUE;CLUSTER=" + Constants.CLUSTERING_ENABLED,
+                     user, password);
+             Statement stat = connTarget.createStatement())
+        {
+            stat.execute("DROP ALL OBJECTS DELETE FILES");
+            exists = false;
+        } catch (SQLException e) {
+            if (e.getErrorCode() == ErrorCode.DATABASE_NOT_FOUND_1) {
+                // database does not exists yet - ok
                 exists = false;
-            } catch (SQLException e) {
-                if (e.getErrorCode() == ErrorCode.DATABASE_NOT_FOUND_1) {
-                    // database does not exists yet - ok
-                    exists = false;
-                } else {
-                    throw e;
-                }
+            } else {
+                throw e;
             }
-            if (exists) {
-                throw new SQLException(
-                        "Target database must not yet exist. Please delete it first: " +
-                        urlTarget);
-            }
+        }
+        if (exists) {
+            throw new SQLException(
+                    "Target database must not yet exist. Please delete it first: " +
+                    urlTarget);
+        }
 
+        try {
             // use cluster='' so connecting is possible
             // even if the cluster is enabled
             connSource = DriverManager.getConnection(urlSource +


### PR DESCRIPTION
At first I set out to just fix a leaked resource warning, but then I ended up reworking large parts of the CreateCluster tool to make it more readable.

- The ~110 line process() was split into three methods with 20-35 lines each.
- Max nesting depth is from seven(!) down to four.
- Made use of try-with statements to get the boilerplate close()ing down.
- Deleted some code blocks that apparently did nothing useful.
- Implemented a way to actually get exceptions that are thrown in the second thread (which might never be relevant if the piped reader throws exceptions first)
- Stopped closeSilently()ing because that's a) most of the time a bad idea and b) try-with statements made properly handling those exceptions the shorter option.
- Fixed the resource leak that I was looking for initially.

All comments and suggestions are welcome. Please review carefully as I have absolutely no subject knowledge and these changes are UNTESTED. Most of it was just moving code around and my IDE doesn't complain about build errors, but still...