### PR TITLE
Fix problem with websphere liberty connection pool resetting client info

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -30,9 +30,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.regex.Pattern;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.engine.ConnectionInfo;
@@ -1737,6 +1739,12 @@ public class JdbcConnection extends TraceObject
                         + ");");
             }
             checkClosed();
+            
+            // no change to property: Ignore call. This early exit fixes a problem with websphere liberty
+            // resetting the client info of a pooled connection to its initial values.
+            if (Objects.equals(value, getClientInfo(name))) {
+            	return;
+            }
 
             if (isInternalProperty(name)) {
                 throw new SQLClientInfoException(

--- a/h2/src/test/org/h2/test/jdbc/TestConnection.java
+++ b/h2/src/test/org/h2/test/jdbc/TestConnection.java
@@ -5,14 +5,15 @@
  */
 package org.h2.test.jdbc;
 
+import org.h2.api.ErrorCode;
+import org.h2.test.TestBase;
 import java.sql.Connection;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.h2.api.ErrorCode;
-import org.h2.test.TestBase;
+
 
 /**
  * Tests the client info
@@ -63,7 +64,7 @@ public class TestConnection extends TestBase {
       
       String numServersPropertyName = "numServers";
       
-			String numServers = conn.getClientInfo(numServersPropertyName);
+      String numServers = conn.getClientInfo(numServersPropertyName);
       
       conn.setClientInfo(numServersPropertyName, numServers);
       

--- a/h2/src/test/org/h2/test/jdbc/TestConnection.java
+++ b/h2/src/test/org/h2/test/jdbc/TestConnection.java
@@ -5,13 +5,14 @@
  */
 package org.h2.test.jdbc;
 
-import org.h2.api.ErrorCode;
-import org.h2.test.TestBase;
 import java.sql.Connection;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+
+import org.h2.api.ErrorCode;
+import org.h2.test.TestBase;
 
 /**
  * Tests the client info
@@ -35,6 +36,7 @@ public class TestConnection extends TestBase {
         testSetSupportedClientInfoProperties();
         testSetUnsupportedClientInfoProperties();
         testSetInternalProperty();
+        testSetInternalPropertyToInitialValue();
         testSetGetSchema();
     }
 
@@ -47,6 +49,29 @@ public class TestConnection extends TestBase {
         assertThrows(SQLClientInfoException.class, conn).setClientInfo("server23", "SomeValue");
         conn.close();
     }
+    
+    /**
+     * Test that no exception is thrown if the client info of a connection managed in a connection pool is reset
+     * to its initial values.
+     * 
+     * This is needed when using h2 in websphere liberty.
+     */
+    private void testSetInternalPropertyToInitialValue() throws SQLException {
+      // Use MySQL-mode since this allows all property names
+      // (apart from h2 internal names).
+      Connection conn = getConnection("clientInfoMySQL;MODE=MySQL");
+      
+      String numServersPropertyName = "numServers";
+      
+			String numServers = conn.getClientInfo(numServersPropertyName);
+      
+      conn.setClientInfo(numServersPropertyName, numServers);
+      
+      assertEquals(conn.getClientInfo(numServersPropertyName), numServers);
+
+      conn.close();
+  }
+
 
     private void testSetUnsupportedClientInfoProperties() throws SQLException {
         Connection conn = getConnection("clientInfo");


### PR DESCRIPTION
The liberty application server resets client info properties to their initial values when a connection is returned to the connection pool. H2 currently does not allow setting internal properties. This causes the following exception:

java.sql.SQLClientInfoException: Property name 'server0 is used internally by H2.
	at org.h2.jdbc.JdbcConnection.setClientInfo(JdbcConnection.java:1728)
	at org.h2.jdbc.JdbcConnection.setClientInfo(JdbcConnection.java:1783)
	at com.ibm.ws.rsadapter.impl.DatabaseHelper.resetClientInformation(DatabaseHelper.java:716)
 	at com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl.cleanupStates(WSRdbManagedConnectionImpl.java:2754)
 	at com.ibm.ws.rsadapter.impl.WSRdbManagedConnectionImpl.cleanup(WSRdbManagedConnectionImpl.java:2684)
 	at com.ibm.ejs.j2c.MCWrapper.cleanup(MCWrapper.java:1510)
 	at com.ibm.ejs.j2c.FreePool.returnToFreePoolDelegated(FreePool.java:278)
 	at com.ibm.ejs.j2c.FreePool.returnToFreePool(FreePool.java:265)
 	at com.ibm.ejs.j2c.PoolManager.release(PoolManager.java:965)
 	at com.ibm.ejs.j2c.MCWrapper.releaseToPoolManager(MCWrapper.java:2090)
 	at com.ibm.ejs.j2c.XATransactionWrapper.afterCompletion(XATransactionWrapper.java:259)
 	at com.ibm.tx.jta.impl.RegisteredSyncs.coreDistributeAfter(RegisteredSyncs.java:359)
 	at com.ibm.tx.jta.impl.RegisteredSyncs.distributeAfter(RegisteredSyncs.java:334)
 	at com.ibm.tx.jta.embeddable.impl.EmbeddableTransactionImpl.distributeAfter(EmbeddableTransactionImpl.java:346)
 	at com.ibm.tx.jta.impl.TransactionImpl.postCompletion(TransactionImpl.java:2807)
 	at com.ibm.tx.jta.impl.TransactionImpl.postCompletion(TransactionImpl.java:2727)
 	at com.ibm.tx.jta.impl.TransactionImpl.commitXAResources(TransactionImpl.java:1774)
 	at com.ibm.tx.jta.impl.TransactionImpl.stage1CommitProcessing(TransactionImpl.java:1065)
 	at com.ibm.tx.jta.impl.TransactionImpl.processCommit(TransactionImpl.java:1032)
 	at com.ibm.tx.jta.impl.TransactionImpl.commit(TransactionImpl.java:975)
 	at com.ibm.tx.jta.impl.TranManagerImpl.commit(TranManagerImpl.java:237)
 	at com.ibm.tx.jta.impl.TranManagerSet.commit(TranManagerSet.java:191)
 	at com.ibm.ejs.csi.TranStrategy.commit(TranStrategy.java:865)
 	at com.ibm.ejs.csi.TranStrategy.postInvoke(TranStrategy.java:187)
 	at com.ibm.ejs.csi.TransactionControlImpl.postInvoke(TransactionControlImpl.java:482)

This patch changes the existing behavior to not throw an exception if the property is not changed, but only set to the existing value.