### PR TITLE
Issue 636: Avoid using String.substring() excessively in H2's internals

### DIFF
--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -6,7 +6,6 @@
 package org.h2.mvstore;
 
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 
 /**
  * A chunk of data, containing one or multiple pages.
@@ -34,6 +33,8 @@ public class Chunk {
      */
     static final int FOOTER_LENGTH = 128;
 
+
+    
     /**
      * The chunk id.
      */
@@ -179,22 +180,7 @@ public class Chunk {
      * @return the block
      */
     public static Chunk fromString(String s) {
-        HashMap<String, String> map = DataUtils.parseMap(s);
-        int id = DataUtils.readHexInt(map, "chunk", 0);
-        Chunk c = new Chunk(id);
-        c.block = DataUtils.readHexLong(map, "block", 0);
-        c.len = DataUtils.readHexInt(map, "len", 0);
-        c.pageCount = DataUtils.readHexInt(map, "pages", 0);
-        c.pageCountLive = DataUtils.readHexInt(map, "livePages", c.pageCount);
-        c.mapId = DataUtils.readHexInt(map, "map", 0);
-        c.maxLen = DataUtils.readHexLong(map, "max", 0);
-        c.maxLenLive = DataUtils.readHexLong(map, "liveMax", c.maxLen);
-        c.metaRootPos = DataUtils.readHexLong(map, "root", 0);
-        c.time = DataUtils.readHexLong(map, "time", 0);
-        c.unused = DataUtils.readHexLong(map, "unused", 0);
-        c.version = DataUtils.readHexLong(map, "version", id);
-        c.next = DataUtils.readHexLong(map, "next", 0);
-        return c;
+        return ChunkParser.parse(s);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/ChunkParser.java
+++ b/h2/src/main/org/h2/mvstore/ChunkParser.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2004-2017 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+
+package org.h2.mvstore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Namespace for methods used to parse a Chunk encoded as a String.
+ * A time efficient design intended to minimize the number of String objects
+ * created during parsing and minimize the number of String comparisons.
+ */
+public class ChunkParser {
+	public enum Field {
+		// TODO Using Java 8 replace this field -> key mapping code with method references.
+
+		// Serialized Chunk fields
+		// Each enum value contains the serialized key name, the value type, and
+		// a default value or a different field value to use as the default.
+		// Any new values here need code added to the setField() method below.
+		ID 				("chunk", Integer.class, 0), // ID requires a default value
+		BLOCK 			("block", Long.class, 0),
+		LEN 			("len", Integer.class, 0),
+		PAGE_COUNT 		("pages", Integer.class, 0),
+		PAGE_COUNT_LIVE ("livePages", Integer.class, PAGE_COUNT),
+		MAP_ID 			("map", Integer.class, 0),
+		MAX_LEN 		("max", Long.class, 0),
+		MAX_LEN_LIVE	("liveMax", Long.class, MAX_LEN),
+		META_ROOT_POS	("root", Long.class, 0),
+		TIME			("time", Long.class, 0),
+		UNUSED			("unused", Long.class, 0),
+		VERSION			("version", Long.class, ID),
+		NEXT			("next", Long.class, 0);
+
+		private final String key;
+    	private final Number defaultValue;
+    	private final Field keyForDefaultValue;
+    	private final Class<? extends Number> valueType;
+
+		private Field(String key, Class<? extends Number> valueType, Number defaultValue) {
+			this(key, valueType, defaultValue, null);
+		}
+		
+		private Field(String key, Class<? extends Number> valueType, Field keyForDefaultValue) {
+			this(key, valueType, null, keyForDefaultValue);
+		}
+		
+		private Field(String key, Class<? extends Number> valueType, Number defaultValue, Field keyForDefaultValue) {
+			this.key = key;
+			this.valueType = valueType;
+			this.defaultValue = defaultValue;
+			this.keyForDefaultValue = keyForDefaultValue;
+		}
+
+		public Number getDefaultValue() {
+			if (defaultValue == null) {
+				return keyForDefaultValue.getDefaultValue();
+			}
+			
+			return defaultValue;
+		}
+		
+		/**
+		 * Get a Field from a key name contained in a string.
+		 * @param source The string containing the key name
+		 * @param startPos Start position of the key name
+		 * @param len Length of the key name
+		 * @return The Field corresponding to the key name or null for no match.
+		 */
+		public static Field getField(String source, int startPos, int len) {
+			// Other validation checks are done by regionMatches() below
+			if (source == null || len < 1) {
+				return null;
+			}
+			
+			for (Field f: Field.values()) {
+				if (f.key.regionMatches(0, source, startPos, len)) {
+					return f;
+				}
+			}
+			
+			return null;
+		}
+    }
+	
+
+	// Maximum length of a long represented as a hex string in a serialized Chunk
+	private static final int STRING_LEN_MAX_VALUE = Long.BYTES * 2;
+
+	// Prevent instance creation
+	private ChunkParser() {}
+    
+	/**
+	 * Create a Chunk from its string representation.
+	 * Set default values where needed.
+	 * @param source A serialized Chunk
+	 * @return The deserialized Chunk
+	 */
+    public static Chunk parse(String source) {
+    	if (source == null || source.isEmpty()) {
+    		assert (Field.ID.defaultValue != null) : "ID Field enum value has no default set";
+    		return new Chunk(Field.ID.defaultValue.intValue());
+    	}
+    	
+    	// Deserialize to a map
+    	Map<Field, Number> mapChunkValues = parseMap(source);
+
+        // Set Chunk field values
+    	Number idVal = mapChunkValues.get(Field.ID);
+    	if (idVal == null) {
+    		idVal = getDefault(Field.ID, mapChunkValues);
+    	}
+        Chunk c = new Chunk(idVal.intValue());
+        for (Field f: Field.values()) {
+        	if (f != Field.ID) {
+        		Number value = mapChunkValues.get(f);
+    			setField(c, f, value != null ? value : getDefault(f, mapChunkValues));
+        	}
+        }
+        
+        return c;
+    }
+    
+    // Deserialize a Chunk to a map
+    private static Map<Field, Number> parseMap(String source) {
+    	final Map<Field, Number> mapChunkValues = new HashMap<>();
+    	final char[] value = new char[STRING_LEN_MAX_VALUE];
+
+        for (int i = 0, size = source.length(); i < size;) {
+            int startKey = i;
+            i = source.indexOf(':', i);
+            if (i < 0) {
+                throw DataUtils.newIllegalStateException(
+                        DataUtils.ERROR_FILE_CORRUPT, "Not a map: {0}", source);
+            }
+            
+            int valuePos = 0;
+            Field field = Field.getField(source, startKey, i - startKey);
+            i++;
+            while (i < size) {
+                char c = source.charAt(i++);
+                if (c == ',') {
+                    break;
+                } else if (c == '\"') {
+                    while (i < size) {
+                        c = source.charAt(i++);
+                        if (c == '\\') {
+                            if (i == size) {
+                                throw DataUtils.newIllegalStateException(
+                                        DataUtils.ERROR_FILE_CORRUPT,
+                                        "Not a map: {0}", source);
+                            }
+                            c = source.charAt(i++);
+                        } else if (c == '\"') {
+                            break;
+                        }
+
+                        // We're ignoring unrecognized keys
+                        if (field != null) {
+		                    value[valuePos++] = c;
+		                    
+		                    if (valuePos == STRING_LEN_MAX_VALUE) {
+		                        throw DataUtils.newIllegalStateException(
+		                                DataUtils.ERROR_FILE_CORRUPT,
+		                                "Value for key {0} is too long in {1}", field.key, source);
+		                    }
+                        }
+                    }
+                } else if (field != null) { // We're ignoring unrecognized keys
+                	value[valuePos++] = c;
+                    
+                    if (valuePos == STRING_LEN_MAX_VALUE) {
+                        throw DataUtils.newIllegalStateException(
+                                DataUtils.ERROR_FILE_CORRUPT,
+                                "Value for key {0} is too long in {1}", field.key, source);
+                    }
+                }
+            }
+
+            if (field != null) {
+	            // Parse the hex string into a Number
+	            
+	            // TODO With Java 8 use DataUtils.parse* method references
+	            // instead of the 'valueType'.
+	            if (Long.class.isAssignableFrom(field.valueType)) {
+	            	mapChunkValues.put(field, new Long(DataUtils.parseHexLong(value, valuePos)));
+	            } else if (Integer.class.isAssignableFrom(field.valueType)) {
+	            	mapChunkValues.put(field, new Integer(DataUtils.parseHexInt(value, valuePos)));
+	            } else {
+	            	throw DataUtils.newIllegalStateException(
+	                        DataUtils.ERROR_INTERNAL,
+	                        "Unknown value type: {0}", field.valueType.getName());
+	            }
+            }
+        }
+        
+        return mapChunkValues;
+    }
+	
+    // Set the specified Chunk field
+	private static Chunk setField(Chunk chunk, Field field, Number value) {
+		switch (field) {
+		case BLOCK:
+			chunk.block = value.longValue();
+			break;
+		case LEN:
+			chunk.len = value.intValue();
+			break;
+		case MAP_ID:
+			chunk.mapId = value.intValue();
+			break;
+		case MAX_LEN:
+			chunk.maxLen = value.longValue();
+			break;
+		case MAX_LEN_LIVE:
+			chunk.maxLenLive = value.longValue();
+			break;
+		case META_ROOT_POS:
+			chunk.metaRootPos = value.longValue();
+			break;
+		case NEXT:
+			chunk.next = value.longValue();
+			break;
+		case PAGE_COUNT:
+			chunk.pageCount = value.intValue();
+			break;
+		case PAGE_COUNT_LIVE:
+			chunk.pageCountLive = value.intValue();
+			break;
+		case TIME:
+			chunk.time = value.longValue();
+			break;
+		case UNUSED:
+			chunk.unused = value.longValue();
+			break;
+		case VERSION:
+			chunk.version = value.longValue();
+			break;
+		default:
+			break;
+		
+		}
+		
+		return chunk;
+	}
+	
+	// Get the default value for a Chunk field.
+	// This should only be called after deserialization so that all serialized fields are set.
+	private static Number getDefault(Field f, Map<Field, Number> mapChunkValues) {
+		if (f.defaultValue != null) {
+			return f.defaultValue;
+		} else if (f.keyForDefaultValue != null) {
+			Number n = mapChunkValues.get(f.keyForDefaultValue);
+			if (n != null) {
+				return n;
+			} else {
+				return getDefault(f.keyForDefaultValue, mapChunkValues);
+			}
+		} else {
+        	throw DataUtils.newIllegalStateException(
+                    DataUtils.ERROR_FILE_CORRUPT,
+                    "No value set or default value found for {0}", f.key);
+    	}
+	}
+
+}

--- a/h2/src/main/org/h2/mvstore/ChunkParser.java
+++ b/h2/src/main/org/h2/mvstore/ChunkParser.java
@@ -78,7 +78,7 @@ public class ChunkParser {
 			}
 			
 			for (Field f: Field.values()) {
-				if (f.key.regionMatches(0, source, startPos, len)) {
+				if (f.key.length() == len && f.key.regionMatches(0, source, startPos, len)) {
 					return f;
 				}
 			}
@@ -89,7 +89,7 @@ public class ChunkParser {
 	
 
 	// Maximum length of a long represented as a hex string in a serialized Chunk
-	private static final int STRING_LEN_MAX_VALUE = Long.BYTES * 2;
+	private static final int STRING_LEN_MAX_VALUE = 2 * Long.SIZE / Byte.SIZE; // TODO Java 8 Use: Long.BYTES * 2;
 
 	// Prevent instance creation
 	private ChunkParser() {}

--- a/h2/src/test/org/h2/test/store/TestChunkParser.java
+++ b/h2/src/test/org/h2/test/store/TestChunkParser.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2004-2017 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.test.store;
+
+import org.h2.mvstore.Chunk;
+import org.h2.mvstore.ChunkParser;
+import org.h2.mvstore.DataUtils;
+import org.h2.test.TestBase;
+
+/**
+ * Tests the MVStore.
+ */
+public class TestChunkParser extends TestBase {
+    /**
+     * Run just this test.
+     *
+     * @param a ignored
+     */
+    public static void main(String... a) throws Exception {
+        TestBase test = TestBase.createCaller().init();
+        test.config.traceTest = true;
+        test.config.big = true;
+        test.test();
+    }
+
+    @Override
+    public void test() throws Exception {
+    	testFieldExists();
+    	testGetField();
+    	testParse();
+    	testParseDefaults();
+    	testParseAllowedBadFormat();
+    	testParseBadFormat();
+    	testWrongCaseKeys();
+    }
+
+    private void testFieldExists() {
+    	ChunkParser.Field f = ChunkParser.Field.valueOf("BLOCK");
+    	assertTrue(f.equals(ChunkParser.Field.BLOCK));
+    }
+    
+    private void testGetField() {
+    	assertEquals(ChunkParser.Field.ID, ChunkParser.Field.getField("chunk", 0, 5));
+    	assertEquals(ChunkParser.Field.PAGE_COUNT_LIVE, ChunkParser.Field.getField("livePages", 0, 9));
+    	assertEquals(ChunkParser.Field.NEXT, ChunkParser.Field.getField("next", 0, 4));
+
+    	assertNull(ChunkParser.Field.getField("NoSuchField", 0, 11));
+    	assertNull(ChunkParser.Field.getField("map", 0, 100));
+    	assertNull(ChunkParser.Field.getField("map", 1000, 3));
+    	assertNull(ChunkParser.Field.getField("map", -1, 3));
+    	assertNull(ChunkParser.Field.getField("map", 0, 0));
+    	assertNull(ChunkParser.Field.getField("map", 0, -1));
+    	assertNull(ChunkParser.Field.getField("maps", 0, 4));
+    	assertNull(ChunkParser.Field.getField("xmap", 0, 4));
+    	assertNull(ChunkParser.Field.getField("xmap", 1, 2));
+    	
+    	assertEquals(ChunkParser.Field.MAP_ID, ChunkParser.Field.getField("maps", 0, 3));
+    	assertEquals(ChunkParser.Field.MAP_ID, ChunkParser.Field.getField("xmap", 1, 3));
+    	assertEquals(ChunkParser.Field.MAP_ID, ChunkParser.Field.getField("xmaps", 1, 3));
+    	assertEquals(ChunkParser.Field.MAP_ID, ChunkParser.Field.getField(
+    			"A big long string with the word map in it at position 32", 32, 3));
+    }
+    
+    private void testParseAllowedBadFormat() {
+    	String source = "chunk:\"\\12";
+    	checkChunk(ChunkParser.parse(source), 0x12);
+    	
+    	source = "chunk:12\"";
+    	checkChunk(ChunkParser.parse(source), 0x12);
+    	
+    	source = "chunk:\"\"";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "chunk:\"\"12\"";
+    	checkChunk(ChunkParser.parse(source), 0x12);
+    	
+    	source = "chunk:\"\",";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "chunk:";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "chunk:,";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "chunk:,nosuchkey:";
+    	checkChunk(ChunkParser.parse(source));
+
+    	source = "nosuchkey:,chunk:";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "nosuchkey:";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "nosuchkey:,";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "::";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "chunk:,chunk:ab,chunk:1234";
+    	checkChunk(ChunkParser.parse(source), 0x1234);
+    }
+
+    private void testParse() {
+    	String source = "chunk:\"12\\34\"";
+    	checkChunk(ChunkParser.parse(source), 0x1234);
+    	
+    	source = "chunk:\"\"1234\"\",";
+    	checkChunk(ChunkParser.parse(source), 0x1234);
+
+    	source = "";
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = null;
+    	checkChunk(ChunkParser.parse(source));
+    	
+    	source = "pages:" + Integer.toHexString(Integer.MAX_VALUE);
+    	checkChunk(ChunkParser.parse(source),
+    			null,
+    			null,
+    			null,
+    			Integer.MAX_VALUE,
+    			Integer.MAX_VALUE,
+    			null,
+    			null,
+    			null,
+    			null,
+    			null,
+    			null,
+    			null,
+    			null
+    			);
+
+    	source = "block:abcd," +
+    			"nosuchkey:no such data for this key," +
+    			"id:q," +
+    			"block:1234," +
+    			"badkey:," +
+    			"chunk:f00d," +
+    			"map:0A," +
+    			"version:beef";
+    	checkChunk(ChunkParser.parse(source),
+    			0xf00d,
+    			0x1234L,
+    			null,
+    			null,
+    			null,
+    			0xa,
+    			null,
+    			null,
+    			null,
+    			null,
+    			null,
+    			0xbeefL,
+    			null
+    			);
+    	
+    	source = "next:12," +
+    			"version:23," +
+    			"unused:34," +
+    			"time:45," +
+    			"root:56," +
+    			"liveMax:67," +
+    			"max:78," +
+    			"map:89," +
+    			"livePages:9A," +
+    			"pages:ab," +
+    			"len:Bc," +
+    			"block:cD," +
+    			"chunk:DE";
+    	checkChunk(ChunkParser.parse(source),
+    			0xde, 0xcdL, 0xbc, 0xab, 0x9a, 0x89, 0x78L, 0x67L, 0x56L, 0x45L, 0x34L, 0x23L, 0x12L);
+    	
+    	source = "nosuchkey: blah blah blah ," + source + ",another no such key: blah";
+    	checkChunk(ChunkParser.parse(source),
+    			0xde, 0xcdL, 0xbc, 0xab, 0x9a, 0x89, 0x78L, 0x67L, 0x56L, 0x45L, 0x34L, 0x23L, 0x12L);
+
+    	source = "next:1,next:2,next:3,map:4,next:5";
+    	checkChunk(ChunkParser.parse(source),
+    			null,
+    			null,
+    			null,
+    			null,
+    			null,
+    			0x4,
+    			null,
+    			null,
+    			null,
+    			null,
+    			null,
+    			null,
+    			0x5L
+    			);
+    }
+
+    private void testParseDefaults() {
+    	String source = "chunk:1234,pages:abcd,max:8888";
+    	checkChunk(ChunkParser.parse(source),
+    			0x1234,
+    			null,
+    			null,
+    			0xabcd,
+    			0xabcd,
+    			null,
+    			0x8888L,
+    			0x8888L,
+    			null,
+    			null,
+    			null,
+    			0x1234L,
+    			null
+    			);
+
+    	source = "version:1234,livePages:abcd,liveMax:8888";
+    	checkChunk(ChunkParser.parse(source),
+    			null,
+    			null,
+    			null,
+    			null,
+    			0xabcd,
+    			null,
+    			null,
+    			0x8888L,
+    			null,
+    			null,
+    			null,
+    			0x1234L,
+    			null
+    			);
+    }
+    
+    private void testParseBadFormat() {
+    	String[] source = {
+    			"chunk:\\",
+    			"chunk:12\\",
+    			"chunk:\\12",
+    			"chunk:\"\"12\\34\"\",",
+    			"chunk",
+    			"chunk:\"\\,",
+    			"chunk:\"12\\,",
+    			"chunk:\",",
+    			"chunk:xyz",
+    			"chunk: 123",
+    			"chunk:123456789",
+    			"block:FFFFFFFFFFFFFFFF",
+    			"block:12345678901234567",
+    	};
+
+    	for (String s: source) {
+	        try {
+	        	ChunkParser.parse(s);
+	            fail();
+	        } catch (IllegalStateException e) {
+	            assertEquals(DataUtils.ERROR_FILE_CORRUPT,
+	                    DataUtils.getErrorCode(e.getMessage()));
+	        }
+    	}
+    }
+    
+    private void testWrongCaseKeys() {
+    	String source = "Block:12,leN:12,livepages:12,ROOT:12";
+    	checkChunk(ChunkParser.parse(source));
+    }
+    
+    private void checkChunk(Chunk c) {
+    	checkChunk(c, null, null, null, null, null, null, null, null, null, null, null, null, null);
+    }
+    
+    private void checkChunk(Chunk c, int id) {
+    	checkChunk(c, id, null, null, null, null, null, null, null, null, null, null, new Long(id), null);
+    }
+
+    // Pass null to check for default value
+    private void checkChunk(Chunk c,
+    		Integer id,
+    		Long block,
+    		Integer len,
+    		Integer pageCount,
+    		Integer pageCountLive,
+    		Integer mapId,
+    		Long maxLen,
+    		Long maxLenLive,
+    		Long metaRootPos,
+    		Long time,
+    		Long unused,
+    		Long version,
+    		Long next) {
+    	assertEquals(ChunkParser.Field.ID, id, c.id);
+    	assertEquals(ChunkParser.Field.BLOCK, block, c.block);
+    	assertEquals(ChunkParser.Field.LEN, len, c.len);
+    	assertEquals(ChunkParser.Field.PAGE_COUNT, pageCount, c.pageCount);
+    	assertEquals(ChunkParser.Field.PAGE_COUNT_LIVE, pageCountLive, c.pageCountLive);
+    	assertEquals(ChunkParser.Field.MAP_ID, mapId, c.mapId);
+    	assertEquals(ChunkParser.Field.MAX_LEN, maxLen, c.maxLen);
+    	assertEquals(ChunkParser.Field.MAX_LEN_LIVE, maxLenLive, c.maxLenLive);
+    	assertEquals(ChunkParser.Field.META_ROOT_POS, metaRootPos, c.metaRootPos);
+    	assertEquals(ChunkParser.Field.TIME, time, c.time);
+    	assertEquals(ChunkParser.Field.UNUSED, unused, c.unused);
+    	assertEquals(ChunkParser.Field.VERSION, version, c.version);
+    	assertEquals(ChunkParser.Field.NEXT, next, c.next);
+    }
+    
+    private void assertEquals(ChunkParser.Field f, Number compareTo, Number test) {
+    	if (compareTo == null) {
+    		compareTo = f.getDefaultValue();
+    	}
+    	
+    	assertEquals(compareTo.longValue(), test.longValue());
+    }
+}

--- a/h2/src/test/org/h2/test/store/TestDataUtils.java
+++ b/h2/src/test/org/h2/test/store/TestDataUtils.java
@@ -248,14 +248,18 @@ public class TestDataUtils extends TestBase {
         for (long i = -1; i != 0; i >>>= 1) {
             String x = Long.toHexString(i);
             assertEquals(i, DataUtils.parseHexLong(x));
+            assertEquals(i, DataUtils.parseHexLong(x.toCharArray(), x.length()));
             x = Long.toHexString(-i);
             assertEquals(-i, DataUtils.parseHexLong(x));
+            assertEquals(-i, DataUtils.parseHexLong(x.toCharArray(), x.length()));
             int j = (int) i;
             x = Integer.toHexString(j);
             assertEquals(j, DataUtils.parseHexInt(x));
+            assertEquals(j, DataUtils.parseHexInt(x.toCharArray(), x.length()));
             j = (int) -i;
             x = Integer.toHexString(j);
             assertEquals(j, DataUtils.parseHexInt(x));
+            assertEquals(j, DataUtils.parseHexInt(x.toCharArray(), x.length()));
         }
     }
 


### PR DESCRIPTION
New Chunk deserialization methods avoiding multiple String copies and comparisons