### PR TITLE
Bugfix for #682: Queries with 'like' expressions may filter rows incorrectly...

### DIFF
--- a/h2/src/main/org/h2/expression/CompareLike.java
+++ b/h2/src/main/org/h2/expression/CompareLike.java
@@ -422,6 +422,11 @@ public class CompareLike extends Condition {
         }
         patternString = new String(patternChars, 0, patternLength);
 
+        // Clear optimizations
+        shortcutToStartsWith = false;
+        shortcutToEndsWith = false;
+        shortcutToContains = false;
+
         // optimizes the common case of LIKE 'foo%'
         if (compareMode.getName().equals(CompareMode.OFF) && patternLength > 1) {
             int maxMatch = 0;

--- a/h2/src/test/org/h2/test/db/TestCases.java
+++ b/h2/src/test/org/h2/test/db/TestCases.java
@@ -58,6 +58,7 @@ public class TestCases extends TestBase {
         testSortedSelect();
         testMaxMemoryRows();
         testDeleteTop();
+        testLikeExpressions();
         testUnicode();
         testOuterJoin();
         testCommentOnColumnWithSchemaEqualDatabase();
@@ -1841,4 +1842,15 @@ public class TestCases extends TestBase {
         conn.close();
     }
 
+    /** Tests fix for bug #682: Queries with 'like' expressions may filter rows incorrectly */
+    private void testLikeExpressions() throws SQLException {
+        Connection conn = getConnection("cases");
+        Statement stat = conn.createStatement();
+        ResultSet rs = stat.executeQuery("select * from (select 'fo%' a union all select '%oo') where 'foo' like a");
+        assertTrue(rs.next());
+        assertEquals("fo%", rs.getString(1));
+        assertTrue(rs.next());
+        assertEquals("%oo", rs.getString(1));
+        conn.close();
+    }
 }


### PR DESCRIPTION
Pattern initialisation did not properly clear previous optimisation fields.