### PR TITLE
fix postgres connection issue #695 with redshift driver in classpath

### DIFF
--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -292,7 +292,8 @@ public class JdbcUtils {
             if (java.sql.Driver.class.isAssignableFrom(d)) {
                 try {
                     Driver driverInstance = (Driver) d.newInstance();
-                    return driverInstance.connect(url, prop);
+                    return driverInstance.connect(url, prop); /*fix issue #695 with drivers with the same
+                    jdbc subprotocol in classpath of jdbc drivers (as example redshift and postgresql drivers)*/
                 } catch (Exception e) {
                     throw DbException.toSQLException(e);
                 }

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -11,11 +11,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Properties;
@@ -294,7 +290,12 @@ public class JdbcUtils {
         } else {
             Class<?> d = loadUserClass(driver);
             if (java.sql.Driver.class.isAssignableFrom(d)) {
-                return DriverManager.getConnection(url, prop);
+                try {
+                    Driver driverInstance = (Driver) d.newInstance();
+                    return driverInstance.connect(url, prop);
+                } catch (Exception e) {
+                    throw DbException.toSQLException(e);
+                }
             } else if (javax.naming.Context.class.isAssignableFrom(d)) {
                 // JNDI context
                 try {


### PR DESCRIPTION
When I try to create JDBC connection to postgres in H2 web console it fails because of redshift diver expose old postgresql as supported protocol and register it in DriverManager.

So right way to fix this and similar issue not use DriverManager.getConnection(url, prop); and invoke driver.connect(url, prop) on concrete driver instance

Postgresql jdbc driver expose "postgresql" protocol to DriverManager and redshift jdbc driver expose  "postgresql"(8.x old wire protocol) and "redshift" protocols to DriverManager. But DriverManager.getConnection() return first match (redshift) driver for requested protocol.

Our application use postgresql and redshift connection simultaneously. 
Use two or more different databases/datasources is absolutely regular situation on integration project.