### PR TITLE
Fix classpath loading issue #697

### DIFF
--- a/h2/src/main/org/h2/store/fs/FilePathDisk.java
+++ b/h2/src/main/org/h2/store/fs/FilePathDisk.java
@@ -299,13 +299,15 @@ public class FilePathDisk extends FilePath {
             // file name with a colon
             if (name.startsWith(CLASSPATH_PREFIX)) {
                 String fileName = name.substring(CLASSPATH_PREFIX.length());
+		// Force absolute resolution in Class.getResourceAsStream
                 if (!fileName.startsWith("/")) {
                     fileName = "/" + fileName;
                 }
                 InputStream in = getClass().getResourceAsStream(fileName);
                 if (in == null) {
+                    // ClassLoader.getResourceAsStream doesn't need leading "/"
                     in = Thread.currentThread().getContextClassLoader().
-                            getResourceAsStream(fileName);
+                            getResourceAsStream(fileName.substring(1));
                 }
                 if (in == null) {
                     throw new FileNotFoundException("resource " + fileName);


### PR DESCRIPTION
See issue #697 for details - when calling `ClassLoader.getResourceAsStream`, we don't need the leading "/" (which makes sense if you think about it, since it will *always* use absolute resolution).