### PR TITLE
Issue #694: Support for Oracle style parenthesised column modification:

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6143,6 +6143,7 @@ public class Parser {
         } else if (readIf("MODIFY")) {
             // MySQL compatibility
             readIf("COLUMN"); // optional
+            boolean hasOpeningBracket = readIf("("); // Oracle specifies (but will not require) an opening parenthesis
             String columnName = readColumnIdentifier();
             AlterTableAlterColumn command = null;
             NullConstraintType nullConstraint = parseNotNullConstraint();
@@ -6166,6 +6167,9 @@ public class Parser {
             default:
                 throw DbException.get(ErrorCode.UNKNOWN_MODE_1,
                         "Internal Error - unhandled case: " + nullConstraint.name());
+            }
+            if(hasOpeningBracket) {
+                read(")");
             }
             return command;
         } else if (readIf("ALTER")) {

--- a/h2/src/test/org/h2/test/db/TestAlter.java
+++ b/h2/src/test/org/h2/test/db/TestAlter.java
@@ -52,6 +52,7 @@ public class TestAlter extends TestBase {
         testAlterTableAddMultipleColumnsAfter();
         testAlterTableModifyColumn();
         testAlterTableModifyColumnSetNull();
+        testAlterTableModifyColumnNotNullOracle();
         conn.close();
         deleteDb(getTestName());
     }
@@ -316,5 +317,17 @@ public class TestAlter extends TestBase {
         stat.execute("alter table T modify C null"); // Silently corrupted column C
         stat.execute("insert into T values(null)"); // <- Fixed in v1.4.196 - NULL is allowed
         stat.execute("drop table T");
+    }
+
+    private void testAlterTableModifyColumnNotNullOracle() throws SQLException {
+        stat.execute("create table foo (bar varchar(255))");
+        stat.execute("alter table foo modify (bar varchar(255) not null)");
+        try {
+            stat.execute("insert into foo values(null)");
+            fail("Null should not be allowed after modification.");
+        }
+        catch(SQLException e) {
+            // This is what we expect, fails to insert null.
+        }
     }
 }


### PR DESCRIPTION
ALTER TABLE foo MODIFY (bar VARCHAR2(255) NOT NULL)