### PR TITLE
added Javascript support for Triggers' source

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -735,7 +735,7 @@ The class must be available in the classpath of the database engine
 
 The sourceCodeString must define a single method with no parameters that returns ""org.h2.api.Trigger"".
 See CREATE ALIAS for requirements regarding the compilation.
-Alternatively, it can be a javascript (see javax.script.ScriptEngineManager) that returns ""org.h2.api.Trigger"". In that case the source must begin by ""//javascript"".
+Alternatively, it can be a javascript (see javax.script.ScriptEngineManager) that returns ""org.h2.api.Trigger"". In that case the source must begin with ""//javascript"".
 
 BEFORE triggers are called after data conversion is made, default values are set,
 null and length constraint checks have been made;

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -735,7 +735,9 @@ The class must be available in the classpath of the database engine
 
 The sourceCodeString must define a single method with no parameters that returns ""org.h2.api.Trigger"".
 See CREATE ALIAS for requirements regarding the compilation.
-Alternatively, it can be a javascript (see javax.script.ScriptEngineManager) that returns ""org.h2.api.Trigger"". In that case the source must begin with ""//javascript"".
+Alternatively, javax.script.ScriptEngineManager can be used to create an instance of ""org.h2.api.Trigger"".
+Currently javascript (included in every JRE) and ruby (with JRuby) are supported.
+In that case the source must begin respectively with ""//javascript"" or ""#ruby"".
 
 BEFORE triggers are called after data conversion is made, default values are set,
 null and length constraint checks have been made;
@@ -774,7 +776,8 @@ This command commits an open transaction in this connection.
 ","
 CREATE TRIGGER TRIG_INS BEFORE INSERT ON TEST FOR EACH ROW CALL ""MyTrigger"";
 CREATE TRIGGER TRIG_SRC BEFORE INSERT ON TEST AS $$org.h2.api.Trigger create() { return new MyTrigger(""constructorParam""); } $$;
-CREATE TRIGGER TRIG_SCRIPT BEFORE INSERT ON TEST AS $$//javascript\nreturn new Packages.MyTrigger(""constructorParam""); $$;
+CREATE TRIGGER TRIG_JS BEFORE INSERT ON TEST AS $$//javascript\nreturn new Packages.MyTrigger(""constructorParam""); $$;
+CREATE TRIGGER TRIG_RUBY BEFORE INSERT ON TEST AS $$#ruby\nJava::MyPackage::MyTrigger.new(""constructorParam"") $$;
 "
 "Commands (DDL)","CREATE USER","
 CREATE USER [ IF NOT EXISTS ] newUserName

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -735,6 +735,7 @@ The class must be available in the classpath of the database engine
 
 The sourceCodeString must define a single method with no parameters that returns ""org.h2.api.Trigger"".
 See CREATE ALIAS for requirements regarding the compilation.
+Alternatively, it can be a javascript (see javax.script.ScriptEngineManager) that returns ""org.h2.api.Trigger"". In that case the source must begin by ""//javascript"".
 
 BEFORE triggers are called after data conversion is made, default values are set,
 null and length constraint checks have been made;
@@ -773,6 +774,7 @@ This command commits an open transaction in this connection.
 ","
 CREATE TRIGGER TRIG_INS BEFORE INSERT ON TEST FOR EACH ROW CALL ""MyTrigger"";
 CREATE TRIGGER TRIG_SRC BEFORE INSERT ON TEST AS $$org.h2.api.Trigger create() { return new MyTrigger(""constructorParam""); } $$;
+CREATE TRIGGER TRIG_SCRIPT BEFORE INSERT ON TEST AS $$//javascript\nreturn new Packages.MyTrigger(""constructorParam""); $$;
 "
 "Commands (DDL)","CREATE USER","
 CREATE USER [ IF NOT EXISTS ] newUserName

--- a/h2/src/main/org/h2/schema/TriggerObject.java
+++ b/h2/src/main/org/h2/schema/TriggerObject.java
@@ -5,7 +5,6 @@
  */
 package org.h2.schema;
 
-import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -94,11 +93,7 @@ public class TriggerObject extends SchemaObjectBase {
             String fullClassName = Constants.USER_PACKAGE + ".trigger." + getName();
             compiler.setSource(fullClassName, triggerSource);
             try {
-                Method m = compiler.getMethod(fullClassName);
-                if (m.getParameterTypes().length > 0) {
-                    throw new IllegalStateException("No parameters are allowed for a trigger");
-                }
-                return (Trigger) m.invoke(null);
+                return (Trigger) compiler.invoke(fullClassName);
             } catch (DbException e) {
                 throw e;
             } catch (Exception e) {

--- a/h2/src/main/org/h2/util/SourceCompiler.java
+++ b/h2/src/main/org/h2/util/SourceCompiler.java
@@ -186,9 +186,13 @@ public class SourceCompiler {
         return source.startsWith("//javascript");
     }
 
+    private static boolean isRubySource(String source) {
+        return source.startsWith("#ruby");
+    }
+
     // whether the passed source should be compiled using javax.script.ScriptEngineManager
     private static boolean isJavaxScriptSource(String source) {
-        return isJavascriptSource(source);
+        return isJavascriptSource(source) || isRubySource(source);
     }
 
     public CompiledScript getCompiledScript(String packageAndClassName) throws ScriptException {
@@ -198,6 +202,8 @@ public class SourceCompiler {
             final String lang;
             if (isJavascriptSource(source))
                 lang = "javascript";
+            else if (isRubySource(source))
+                lang = "ruby";
             else
                 throw new IllegalStateException("Unkown language for " + source);
 

--- a/h2/src/main/org/h2/util/SourceCompiler.java
+++ b/h2/src/main/org/h2/util/SourceCompiler.java
@@ -205,7 +205,7 @@ public class SourceCompiler {
             else if (isRubySource(source))
                 lang = "ruby";
             else
-                throw new IllegalStateException("Unkown language for " + source);
+                throw new IllegalStateException("Unknown language for " + source);
 
             final Compilable jsEngine = (Compilable) new ScriptEngineManager().getEngineByName(lang);
             compiledScript = jsEngine.compile(source);

--- a/h2/src/main/org/h2/util/SourceCompiler.java
+++ b/h2/src/main/org/h2/util/SourceCompiler.java
@@ -74,6 +74,9 @@ public class SourceCompiler {
      */
     final HashMap<String, Class<?>> compiled = New.hashMap();
 
+    /**
+     * The class name to compiled scripts map.
+     */
     final Map<String, CompiledScript> compiledScripts = New.hashMap();
 
     /**

--- a/h2/src/main/org/h2/util/SourceCompiler.java
+++ b/h2/src/main/org/h2/util/SourceCompiler.java
@@ -26,12 +26,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.script.Bindings;
 import javax.script.Compilable;
 import javax.script.CompiledScript;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
-import javax.script.SimpleBindings;
 import javax.tools.FileObject;
 import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
@@ -238,24 +236,6 @@ public class SourceCompiler {
             }
         }
         return null;
-    }
-
-    public Object invoke(String className, final Object... args) throws Exception {
-        String source = sources.get(className);
-        if (isJavaxScriptSource(source)) {
-            final Bindings bindings = new SimpleBindings();
-            int i = 0;
-            for (final Object arg : args) {
-                bindings.put("arg" + i, arg);
-                i++;
-            }
-            return this.getCompiledScript(className).eval(bindings);
-        } else {
-            final Method m = this.getMethod(className);
-            if (m.getParameterTypes().length != args.length)
-                throw new IllegalStateException("Wrong number of parameters, " + args.length + " were pased but " + m.getParameterTypes().length + " were needed");
-            return m.invoke(null, args);
-        }
     }
 
     /**

--- a/h2/src/main/org/h2/util/SourceCompiler.java
+++ b/h2/src/main/org/h2/util/SourceCompiler.java
@@ -190,8 +190,13 @@ public class SourceCompiler {
         return source.startsWith("#ruby");
     }
 
-    // whether the passed source should be compiled using javax.script.ScriptEngineManager
-    private static boolean isJavaxScriptSource(String source) {
+    /**
+     * Whether the passed source can be compiled using {@link javax.script.ScriptEngineManager}.
+     * 
+     * @param source the source to test.
+     * @return <code>true</code> if {@link #getCompiledScript(String)} can be called.
+     */
+    public static boolean isJavaxScriptSource(String source) {
         return isJavascriptSource(source) || isRubySource(source);
     }
 


### PR DESCRIPTION
Triggers written as source code require the JDK to compile Java or groovy.jar for Groovy. This patch adds support for javascript using javax.script.ScriptEngineManager. This only needs the JRE, not the JDK and no additional jars which allows easier deployments on end users' systems.
I've looked into adding support for function aliases, but it's much more work as the current code rely on static methods with typed arguments.