### PR TITLE
SIGNAL function

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4013,6 +4013,14 @@ This function may be expensive since it has to load every page in the table.
 CALL DISK_SPACE_USED('my_table');
 "
 
+"Functions (System)","SIGNAL","
+SIGNAL(sqlState, message)
+","
+Throw an SQLException with the passed SQLState and reason.
+","
+CALL SIGNAL('23505', 'Duplicate user ID: ' || user_id);
+"
+
 "Functions (System)","FILE_READ","
 FILE_READ(fileNameString [,encodingString])
 ","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4014,7 +4014,7 @@ CALL DISK_SPACE_USED('my_table');
 "
 
 "Functions (System)","SIGNAL","
-SIGNAL(sqlState, message)
+SIGNAL(sqlStateString, messageString)
 ","
 Throw an SQLException with the passed SQLState and reason.
 ","

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.Command;
 import org.h2.command.Parser;
@@ -109,7 +110,9 @@ public class Function extends Expression implements FunctionCall {
     public static final int DATABASE = 150, USER = 151, CURRENT_USER = 152,
             IDENTITY = 153, SCOPE_IDENTITY = 154, AUTOCOMMIT = 155,
             READONLY = 156, DATABASE_PATH = 157, LOCK_TIMEOUT = 158,
-            DISK_SPACE_USED = 159;
+            DISK_SPACE_USED = 159, SIGNAL = 160;
+
+    private static final Pattern SIGNAL_PATTERN = Pattern.compile("[0-9A-Z]{5}");
 
     public static final int IFNULL = 200, CASEWHEN = 201, CONVERT = 202,
             CAST = 203, COALESCE = 204, NULLIF = 205, CASE = 206,
@@ -480,6 +483,7 @@ public class Function extends Expression implements FunctionCall {
                 VAR_ARGS, Value.NULL);
         addFunctionNotDeterministic("DISK_SPACE_USED", DISK_SPACE_USED,
                 1, Value.LONG);
+        addFunctionWithNull("SIGNAL", SIGNAL, 2, Value.NULL);
         addFunction("H2VERSION", H2VERSION, 0, Value.STRING);
 
         // TableFunction
@@ -1705,6 +1709,13 @@ public class Function extends Expression implements FunctionCall {
             result = session.getVariable(args[0].getSchemaName() + "." +
                     args[0].getTableName() + "." + args[0].getColumnName());
             break;
+        case SIGNAL: {
+            String sqlState = v0.getString();
+            if (sqlState.startsWith("00") || !SIGNAL_PATTERN.matcher(sqlState).matches())
+                throw DbException.getInvalidValueException("SQLSTATE", sqlState);
+            String msgText = v1.getString();
+            throw DbException.fromUser(sqlState, msgText);
+        }
         default:
             throw DbException.throwInternalError("type=" + info.type);
         }

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -187,7 +187,8 @@ public class DbException extends RuntimeException {
      * @return the exception
      */
     public static DbException fromUser(String sqlstate, String message) {
-        return new DbException(getJdbcSQLException(sqlstate, message));
+        // do not translate as sqlstate is arbitrary : avoid "message not found"
+        return new DbException(new JdbcSQLException(message, null, sqlstate, 0, null, null));
     }
 
     /**
@@ -354,11 +355,6 @@ public class DbException extends RuntimeException {
         String sqlstate = ErrorCode.getState(errorCode);
         String message = translate(sqlstate, params);
         return new JdbcSQLException(message, null, sqlstate, errorCode, cause, null);
-    }
-
-    private static JdbcSQLException getJdbcSQLException(String sqlstate, String message) {
-        // do not translate as sqlstate is arbitrary : avoid "message not found"
-        return new JdbcSQLException(message, null, sqlstate, 0, null, null);
     }
 
     /**

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -180,6 +180,17 @@ public class DbException extends RuntimeException {
     }
 
     /**
+     * Create a database exception for an arbitrary SQLState.
+     *
+     * @param sqlstate the state to use
+     * @param message the message to use
+     * @return the exception
+     */
+    public static DbException fromUser(String sqlstate, String message) {
+        return new DbException(getJdbcSQLException(sqlstate, message));
+    }
+
+    /**
      * Create a syntax error exception.
      *
      * @param sql the SQL statement
@@ -343,6 +354,11 @@ public class DbException extends RuntimeException {
         String sqlstate = ErrorCode.getState(errorCode);
         String message = translate(sqlstate, params);
         return new JdbcSQLException(message, null, sqlstate, errorCode, cause, null);
+    }
+
+    private static JdbcSQLException getJdbcSQLException(String sqlstate, String message) {
+        // do not translate as sqlstate is arbitrary : avoid "message not found"
+        return new JdbcSQLException(message, null, sqlstate, 0, null, null);
     }
 
     /**


### PR DESCRIPTION
This adds a SIGNAL function similar to what's found in other systems. Useful in triggers for example to reject a modification. Up until now, I abused CSVREAD('my error message') and hoped no files with that name existed.

[postgresql](https://www.postgresql.org/docs/current/static/plpgsql-errors-and-messages.html)
[MySQL](https://dev.mysql.com/doc/refman/5.5/en/signal.html)
[DB2](https://www.ibm.com/support/knowledgecenter/en/SSEPEK_11.0.0/sqlref/src/tpc/db2z_signalstatement4externalsqlpl.html)