### PR TITLE
Fix for issue #644: Year changing from negative -509 to a positive 510

### DIFF
--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -634,6 +634,13 @@ public class TestPreparedStatement extends TestBase {
         Object localDate2 = rs.getObject(1, LocalDateTimeUtils.getLocalDateClass());
         assertEquals(localDate, localDate2);
         rs.close();
+        localDate = LocalDateTimeUtils.parseLocalDate("-0509-01-01");
+        prep.setObject(1, localDate);
+        rs = prep.executeQuery();
+        rs.next();
+        localDate2 = rs.getObject(1, LocalDateTimeUtils.getLocalDateClass());
+        assertEquals(localDate, localDate2);
+        rs.close();
     }
 
     private void testTime8(Connection conn) throws SQLException {


### PR DESCRIPTION
Usage of java.sql.Date in conversions from ValueDate to LocalDate and vice versa is not efficient and such unusual dates are not handled properly.

LocalDateTimeUtils.localDateFromDateValue() and LocalDateTimeUtils.dateValueFromLocalDate() was arleady here for LocalDateTime and OffsetDateTime so I reuse them for LocalDate too.