### PR TITLE
Return properly encoded UUID from SimpleResultSet.getBytes()

### DIFF
--- a/h2/src/main/org/h2/tools/SimpleResultSet.java
+++ b/h2/src/main/org/h2/tools/SimpleResultSet.java
@@ -28,6 +28,8 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Map;
+import java.util.UUID;
+
 import org.h2.api.ErrorCode;
 import org.h2.jdbc.JdbcResultSetBackwardsCompat;
 import org.h2.message.DbException;
@@ -35,6 +37,7 @@ import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.New;
 import org.h2.value.DataType;
+import org.h2.value.ValueUuid;
 
 /**
  * This class is a simple result set and meta data implementation.
@@ -529,6 +532,10 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
         Object o = get(columnIndex);
         if (o == null || o instanceof byte[]) {
             return (byte[]) o;
+        }
+        if (o instanceof UUID) {
+            final UUID u = (UUID) o;
+            return ValueUuid.get(u.getMostSignificantBits(), u.getLeastSignificantBits()).getBytes();
         }
         return JdbcUtils.serialize(o, null);
     }

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -35,6 +35,8 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
+
 import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;
 import org.h2.store.FileLister;
@@ -56,6 +58,7 @@ import org.h2.tools.SimpleResultSet;
 import org.h2.tools.SimpleResultSet.SimpleArray;
 import org.h2.util.JdbcUtils;
 import org.h2.util.Task;
+import org.h2.value.ValueUuid;
 
 /**
  * Tests the database tools.
@@ -457,6 +460,13 @@ public class TestTools extends TestBase {
         assertFalse(rs.isClosed());
         rs.close();
         assertTrue(rs.isClosed());
+        rs = new SimpleResultSet();
+        rs.addColumn("TEST", Types.BINARY, 0, 0);
+        UUID uuid = UUID.randomUUID();
+        rs.addRow(uuid);
+        rs.next();
+        assertEquals(uuid, rs.getObject(1));
+        assertEquals(uuid, ValueUuid.get(rs.getBytes(1)).getObject());
     }
 
     private void testJdbcDriverUtils() {


### PR DESCRIPTION
H2 documentation provides a sample how to avoid statements with variable size IN(). It works for standard SQL data types, but with UUID it always returns an empty result set.

```Java
PreparedStatement prep = conn.prepareStatement(
"SELECT * FROM TABLE(X UUID=?) T INNER JOIN TEST ON T.X=TEST.ID");
prep.setObject(1, new Object[] { someUUID, someUUID2 });
ResultSet rs = prep.executeQuery();
```

This simplified code shows that UUID values serialized as Java objects.
```Java
PreparedStatement prep = conn.prepareStatement(
"SELECT * FROM TABLE(X UUID=?)");
prep.setObject(1, new Object[] { UUID.randomUUID(); });
ResultSet rs = prep.executeQuery();
rs.next();
System.out.println(Arrays.toString((byte[]) rs.getObject(1)));
```
The actual cause is that ValueType.convertTypeToSQLType() returns Types.BINARY for UUID and all other code expects that SimpleResultSet.getBytes() is a proper method to read such values. This patch fixes conversion to byte array in this method.

With this change original select with INNER JOIN returns expected rows, but if we include X column in result it still will be with BINARY type and getObject() method will return byte[] instead of UUID for it. It's not a problem for this specific case, we can include ID from real table instead.