### PR TITLE
SecureRandom is already synchronized

### DIFF
--- a/h2/src/main/org/h2/util/MathUtils.java
+++ b/h2/src/main/org/h2/util/MathUtils.java
@@ -260,10 +260,7 @@ public class MathUtils {
      * @return the random long value
      */
     public static long secureRandomLong() {
-        SecureRandom sr = getSecureRandom();
-        synchronized (sr) {
-            return sr.nextLong();
-        }
+        return getSecureRandom().nextLong();
     }
 
     /**
@@ -286,10 +283,7 @@ public class MathUtils {
             len = 1;
         }
         byte[] buff = new byte[len];
-        SecureRandom sr = getSecureRandom();
-        synchronized (sr) {
-            sr.nextBytes(buff);
-        }
+        getSecureRandom().nextBytes(buff);
         return buff;
     }
 
@@ -312,10 +306,7 @@ public class MathUtils {
      * @return the random long value
      */
     public static int secureRandomInt(int lowerThan) {
-        SecureRandom sr = getSecureRandom();
-        synchronized (sr) {
-            return sr.nextInt(lowerThan);
-        }
+        return getSecureRandom().nextInt(lowerThan);
     }
 
 }


### PR DESCRIPTION
Implementation of SecureRandom.nextBytes() is synchronized on Java 7, Java 8 and Android. In Java 9+ this method is not declared as synchronized, but it performs underlying call to SecureRandomSpi.engineNextBytes() in synchronized block if needed.

Methods nextLong() and nextInt() call protected method next(int) that is overriden in SecureRandom to use nextBytes() as a source.

So any external synchronization for this methods is redundant and should be avoided.