### PR TITLE
Better getObject error message

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3831,7 +3831,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             return type.cast(LocalDateTimeUtils.valueToOffsetDateTime(
                             (ValueTimestampTimeZone) value));
         } else {
-            throw unsupported(type.getClass().getName());
+            throw unsupported(type.getName());
         }
     }
 


### PR DESCRIPTION
When an unsupported type is passed to getObject(int|String, Class) the
error message always says that "java.lang.Class" is unsupported instead
of the actual type.