### PR TITLE
Fix for issue #311

### DIFF
--- a/h2/src/main/org/h2/bnf/Bnf.java
+++ b/h2/src/main/org/h2/bnf/Bnf.java
@@ -283,7 +283,7 @@ public class Bnf {
             }
             list.add(s);
         }
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
     /**

--- a/h2/src/main/org/h2/bnf/context/DbContents.java
+++ b/h2/src/main/org/h2/bnf/context/DbContents.java
@@ -234,9 +234,7 @@ public class DbContents {
             schemaList.add(schema);
         }
         rs.close();
-        String[] list = new String[schemaList.size()];
-        schemaList.toArray(list);
-        return list;
+        return schemaList.toArray(new String[0]);
     }
 
     private String getDefaultSchemaName(DatabaseMetaData meta) {

--- a/h2/src/main/org/h2/bnf/context/DbSchema.java
+++ b/h2/src/main/org/h2/bnf/context/DbSchema.java
@@ -117,8 +117,7 @@ public class DbSchema {
             list.add(table);
         }
         rs.close();
-        tables = new DbTableOrView[list.size()];
-        list.toArray(tables);
+        tables = list.toArray(new DbTableOrView[0]);
         if (tables.length < SysProperties.CONSOLE_MAX_TABLES_LIST_COLUMNS) {
             for (DbTableOrView tab : tables) {
                 try {
@@ -146,8 +145,7 @@ public class DbSchema {
             list.add(new DbProcedure(this, rs));
         }
         rs.close();
-        procedures = new DbProcedure[list.size()];
-        list.toArray(procedures);
+        procedures = list.toArray(new DbProcedure[0]);
         if (procedures.length < SysProperties.CONSOLE_MAX_PROCEDURES_LIST_COLUMNS) {
             for (DbProcedure procedure : procedures) {
                 procedure.readParameters(meta);

--- a/h2/src/main/org/h2/bnf/context/DbTableOrView.java
+++ b/h2/src/main/org/h2/bnf/context/DbTableOrView.java
@@ -98,8 +98,7 @@ public class DbTableOrView {
             list.add(column);
         }
         rs.close();
-        columns = new DbColumn[list.size()];
-        list.toArray(columns);
+        columns = list.toArray(new DbColumn[0]);
     }
 
 }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -913,7 +913,7 @@ public class Parser {
             }
         } while (readIf(","));
         read(")");
-        return columns.toArray(new IndexColumn[columns.size()]);
+        return columns.toArray(new IndexColumn[0]);
     }
 
     private String[] parseColumnList() {
@@ -922,7 +922,7 @@ public class Parser {
             String columnName = readColumnIdentifier();
             columns.add(columnName);
         } while (readIfMore());
-        return columns.toArray(new String[columns.size()]);
+        return columns.toArray(new String[0]);
     }
 
     private Column[] parseColumnList(Table table) {
@@ -938,7 +938,7 @@ public class Parser {
                 columns.add(column);
             } while (readIfMore());
         }
-        return columns.toArray(new Column[columns.size()]);
+        return columns.toArray(new Column[0]);
     }
 
     private Column parseColumn(Table table) {
@@ -1117,7 +1117,7 @@ public class Parser {
                         }
                     } while (readIfMore());
                 }
-                command.addRow(values.toArray(new Expression[values.size()]));
+                command.addRow(values.toArray(new Expression[0]));
             } while (readIf(","));
         } else {
             command.setQuery(parseSelect());
@@ -1283,7 +1283,7 @@ public class Parser {
                         }
                     } while (readIfMore());
                 }
-                command.addRow(values.toArray(new Expression[values.size()]));
+                command.addRow(values.toArray(new Expression[0]));
                 // the following condition will allow (..),; and (..);
             } while (readIf(",") && readIf("("));
         } else if (readIf("SET")) {
@@ -1303,8 +1303,8 @@ public class Parser {
                 }
                 values.add(expression);
             } while (readIf(","));
-            command.setColumns(columnList.toArray(new Column[columnList.size()]));
-            command.addRow(values.toArray(new Expression[values.size()]));
+            command.setColumns(columnList.toArray(new Column[0]));
+            command.addRow(values.toArray(new Expression[0]));
         } else {
             command.setQuery(parseSelect());
         }
@@ -1342,7 +1342,7 @@ public class Parser {
                         }
                     } while (readIfMore());
                 }
-                command.addRow(values.toArray(new Expression[values.size()]));
+                command.addRow(values.toArray(new Expression[0]));
             } while (readIf(","));
         } else {
             command.setQuery(parseSelect());
@@ -2712,8 +2712,7 @@ public class Parser {
             }
             argList.add(readExpression());
         }
-        args = new Expression[numArgs];
-        argList.toArray(args);
+        args = argList.toArray(new Expression[0]);
         JavaFunction func = new JavaFunction(functionAlias, args);
         return func;
     }
@@ -2724,8 +2723,7 @@ public class Parser {
             params.add(readExpression());
         } while (readIf(","));
         read(")");
-        Expression[] list = new Expression[params.size()];
-        params.toArray(list);
+        Expression[] list = params.toArray(new Expression[0]);
         JavaAggregate agg = new JavaAggregate(aggregate, list, currentSelect);
         currentSelect.setGroupQuery();
         return agg;
@@ -3227,9 +3225,7 @@ public class Parser {
                             break;
                         }
                     }
-                    Expression[] array = new Expression[list.size()];
-                    list.toArray(array);
-                    r = new ExpressionList(array);
+                    r = new ExpressionList(list.toArray(new Expression[0]));
                 } else {
                     read(")");
                 }
@@ -4533,7 +4529,7 @@ public class Parser {
                 }
                 read(")");
                 original += ')';
-                enumerators = enumeratorList.toArray(new String[enumeratorList.size()]);
+                enumerators = enumeratorList.toArray(new String[0]);
             }
             try {
                 ValueEnum.check(enumerators);
@@ -5756,9 +5752,7 @@ public class Parser {
             while (readIf(",")) {
                 list.add(readAliasIdentifier());
             }
-            String[] schemaNames = new String[list.size()];
-            list.toArray(schemaNames);
-            command.setStringArray(schemaNames);
+            command.setStringArray(list.toArray(new String[0]));
             return command;
         } else if (readIf("JAVA_OBJECT_SERIALIZER")) {
             readIfEqualOrTo();

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -387,7 +387,7 @@ public class Select extends Query {
             }
             sortColumns.add(exprCol.getColumn());
         }
-        Column[] sortCols = sortColumns.toArray(new Column[sortColumns.size()]);
+        Column[] sortCols = sortColumns.toArray(new Column[0]);
         if (sortCols.length == 0) {
             // sort just on constants - can use scan index
             return topTableFilter.getTable().getScanIndex(session);
@@ -930,8 +930,7 @@ public class Select extends Query {
                 isGroupSortedQuery = true;
             }
         }
-        expressionArray = new Expression[expressions.size()];
-        expressions.toArray(expressionArray);
+        expressionArray = expressions.toArray(new Expression[0]);
         isPrepared = true;
     }
 
@@ -947,7 +946,7 @@ public class Select extends Query {
             list.add(f);
             f = f.getJoin();
         } while (f != null);
-        TableFilter[] fs = list.toArray(new TableFilter[list.size()]);
+        TableFilter[] fs = list.toArray(new TableFilter[0]);
         // prepare join batch
         JoinBatch jb = null;
         for (int i = fs.length - 1; i >= 0; i--) {
@@ -982,8 +981,7 @@ public class Select extends Query {
     }
 
     private double preparePlan(boolean parse) {
-        TableFilter[] topArray = topFilters.toArray(
-                new TableFilter[topFilters.size()]);
+        TableFilter[] topArray = topFilters.toArray(new TableFilter[0]);
         for (TableFilter t : topArray) {
             t.setFullCondition(condition);
         }
@@ -1058,8 +1056,7 @@ public class Select extends Query {
         // can not use the field sqlStatement because the parameter
         // indexes may be incorrect: ? may be in fact ?2 for a subquery
         // but indexes may be set manually as well
-        Expression[] exprList = expressions.toArray(
-                new Expression[expressions.size()]);
+        Expression[] exprList = expressions.toArray(new Expression[0]);
         StatementBuilder buff = new StatementBuilder();
         for (TableFilter f : topFilters) {
             Table t = f.getTable();

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -348,8 +348,7 @@ public class SelectUnion extends Query {
             sort = prepareOrder(orderList, expressions.size());
             orderList = null;
         }
-        expressionArray = new Expression[expressions.size()];
-        expressions.toArray(expressionArray);
+        expressionArray = expressions.toArray(new Expression[0]);
     }
 
     @Override
@@ -435,7 +434,7 @@ public class SelectUnion extends Query {
             DbException.throwInternalError("type=" + unionType);
         }
         buff.append('(').append(right.getPlanSQL()).append(')');
-        Expression[] exprList = expressions.toArray(new Expression[expressions.size()]);
+        Expression[] exprList = expressions.toArray(new Expression[0]);
         if (sort != null) {
             buff.append("\nORDER BY ").append(sort.getSQL(exprList, exprList.length));
         }

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -225,8 +225,7 @@ public class ConnectionInfo implements Cloneable {
     }
 
     private void readProperties(Properties info) {
-        Object[] list = new Object[info.size()];
-        info.keySet().toArray(list);
+        Object[] list = info.keySet().toArray();
         DbSettings s = null;
         for (Object k : list) {
             String key = StringUtils.toUpperEnglish(k.toString());

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1677,9 +1677,7 @@ public class Database implements DataHandler {
         if (includingSystemSession && lob != null) {
             list.add(lob);
         }
-        Session[] array = new Session[list.size()];
-        list.toArray(array);
-        return array;
+        return list.toArray(new Session[0]);
     }
 
     /**

--- a/h2/src/main/org/h2/engine/FunctionAlias.java
+++ b/h2/src/main/org/h2/engine/FunctionAlias.java
@@ -168,8 +168,7 @@ public class FunctionAlias extends SchemaObjectBase {
                     ErrorCode.PUBLIC_STATIC_JAVA_METHOD_NOT_FOUND_1,
                     methodName + " (" + className + ")");
         }
-        javaMethods = new JavaMethod[list.size()];
-        list.toArray(javaMethods);
+        javaMethods = list.toArray(new JavaMethod[0]);
         // Sort elements. Methods with a variable number of arguments must be at
         // the end. Reason: there could be one method without parameters and one
         // with a variable number. The one without parameters needs to be used

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1440,9 +1440,7 @@ public class Session extends SessionWithState {
                 break;
             }
         }
-        Table[] list = new Table[copy.size()];
-        copy.toArray(list);
-        return list;
+        return copy.toArray(new Table[0]);
     }
 
     /**

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -2308,10 +2308,8 @@ public class Function extends Expression implements FunctionCall {
      */
     public void doneWithParameters() {
         if (info.parameterCount == VAR_ARGS) {
-            int len = varArgs.size();
-            checkParameterCount(len);
-            args = new Expression[len];
-            varArgs.toArray(args);
+            checkParameterCount(varArgs.size());
+            args = varArgs.toArray(new Expression[0]);
             varArgs = null;
         } else {
             int len = args.length;

--- a/h2/src/main/org/h2/expression/TableFunction.java
+++ b/h2/src/main/org/h2/expression/TableFunction.java
@@ -73,8 +73,7 @@ public class TableFunction extends Function {
     }
 
     public void setColumns(ArrayList<Column> columns) {
-        this.columnList = new Column[columns.size()];
-        columns.toArray(columnList);
+        this.columnList = columns.toArray(new Column[0]);
     }
 
     private ValueResultSet getTable(Session session, Expression[] argList,

--- a/h2/src/main/org/h2/fulltext/FullText.java
+++ b/h2/src/main/org/h2/fulltext/FullText.java
@@ -469,10 +469,8 @@ public class FullText {
         Parser p = new Parser(session);
         Expression expr = p.parseExpression(key);
         addColumnData(columns, data, expr);
-        Object[] col = new Object[columns.size()];
-        columns.toArray(col);
-        Object[] dat = new Object[columns.size()];
-        data.toArray(dat);
+        Object[] col = columns.toArray();
+        Object[] dat = data.toArray();
         Object[][] columnData = { col, dat };
         return columnData;
     }

--- a/h2/src/main/org/h2/fulltext/FullText.java
+++ b/h2/src/main/org/h2/fulltext/FullText.java
@@ -905,8 +905,7 @@ public class FullText {
             index = new IndexInfo();
             index.schema = schemaName;
             index.table = tableName;
-            index.columns = new String[columnList.size()];
-            columnList.toArray(index.columns);
+            index.columns = columnList.toArray(new String[0]);
             rs = meta.getColumns(null,
                     StringUtils.escapeMetaDataPattern(schemaName),
                     StringUtils.escapeMetaDataPattern(tableName),

--- a/h2/src/main/org/h2/fulltext/FullTextLucene.java
+++ b/h2/src/main/org/h2/fulltext/FullTextLucene.java
@@ -497,8 +497,7 @@ public class FullTextLucene extends FullText {
                 columnList.add(rs.getString("COLUMN_NAME"));
             }
             columnTypes = new int[columnList.size()];
-            columns = new String[columnList.size()];
-            columnList.toArray(columns);
+            columns = columnList.toArray(new String[0]);
             rs = meta.getColumns(null,
                     StringUtils.escapeMetaDataPattern(schemaName),
                     StringUtils.escapeMetaDataPattern(tableName),

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -359,8 +359,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
                 i++;
             }
         }
-        columns = new Column[columnList.size()];
-        columnList.toArray(columns);
+        columns = columnList.toArray(new Column[0]);
 
         // reconstruct the index columns from the masks
         this.indexColumns = new IndexColumn[indexColumnCount];

--- a/h2/src/main/org/h2/jdbcx/JdbcXAConnection.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcXAConnection.java
@@ -201,8 +201,7 @@ public class JdbcXAConnection extends TraceObject implements XAConnection,
                 list.add(xid);
             }
             rs.close();
-            Xid[] result = new Xid[list.size()];
-            list.toArray(result);
+            Xid[] result = list.toArray(new Xid[0]);
             if (list.size() > 0) {
                 prepared = true;
             }

--- a/h2/src/main/org/h2/result/SortOrder.java
+++ b/h2/src/main/org/h2/result/SortOrder.java
@@ -209,7 +209,7 @@ public class SortOrder implements Comparator<Value[]> {
             rows.set(0, Collections.min(rows, this));
             return;
         }
-        Value[][] arr = rows.toArray(new Value[rowsSize][]);
+        Value[][] arr = rows.toArray(new Value[0][]);
         Utils.sortTopN(arr, offset, limit, this);
         for (int i = 0, end = Math.min(offset + limit, rowsSize); i < end; i++) {
             rows.set(i, arr[i]);

--- a/h2/src/main/org/h2/server/web/WebServlet.java
+++ b/h2/src/main/org/h2/server/web/WebServlet.java
@@ -46,8 +46,7 @@ public class WebServlet extends HttpServlet {
                 list.add(value);
             }
         }
-        String[] args = new String[list.size()];
-        list.toArray(args);
+        String[] args = list.toArray(new String[0]);
         server = new WebServer();
         server.setAllowChunked(false);
         server.init(args);

--- a/h2/src/main/org/h2/store/fs/FilePathSplit.java
+++ b/h2/src/main/org/h2/store/fs/FilePathSplit.java
@@ -131,8 +131,7 @@ public class FilePathSplit extends FilePathWrapper {
                 break;
             }
         }
-        FileChannel[] array = new FileChannel[list.size()];
-        list.toArray(array);
+        FileChannel[] array = list.toArray(new FileChannel[0]);
         long maxLength = array[0].size();
         long length = maxLength;
         if (array.length == 1) {

--- a/h2/src/main/org/h2/table/Plan.java
+++ b/h2/src/main/org/h2/table/Plan.java
@@ -54,10 +54,8 @@ public class Plan {
                 }
             });
         }
-        allConditions = new Expression[allCond.size()];
-        allCond.toArray(allConditions);
-        allFilters = new TableFilter[all.size()];
-        all.toArray(allFilters);
+        allConditions = allCond.toArray(new Expression[0]);
+        allFilters = all.toArray(new TableFilter[0]);
     }
 
     /**

--- a/h2/src/main/org/h2/table/TableBase.java
+++ b/h2/src/main/org/h2/table/TableBase.java
@@ -40,8 +40,7 @@ public abstract class TableBase extends Table {
             this.tableEngineParams = data.tableEngineParams;
         }
         setTemporary(data.temporary);
-        Column[] cols = new Column[data.columns.size()];
-        data.columns.toArray(cols);
+        Column[] cols = data.columns.toArray(new Column[0]);
         setColumns(cols);
     }
 

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -195,8 +195,7 @@ public class TableLink extends Table {
             throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, e,
                     originalTable + "(" + e.toString() + ")");
         }
-        Column[] cols = new Column[columnList.size()];
-        columnList.toArray(cols);
+        Column[] cols = columnList.toArray(new Column[0]);
         setColumns(cols);
         int id = getId();
         linkedIndex = new LinkedIndex(this, id, IndexColumn.wrap(cols),
@@ -344,8 +343,7 @@ public class TableLink extends Table {
                     "recognized columns of {1} total columns.", firstNull, list.size());
             list = list.subList(0, firstNull);
         }
-        Column[] cols = new Column[list.size()];
-        list.toArray(cols);
+        Column[] cols = list.toArray(new Column[0]);
         Index index = new LinkedIndex(this, 0, IndexColumn.wrap(cols), indexType);
         indexes.add(index);
     }

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -198,8 +198,7 @@ public class TableView extends Table {
                 }
                 list.add(col);
             }
-            cols = new Column[list.size()];
-            list.toArray(cols);
+            cols = list.toArray(new Column[0]);
             createException = null;
             viewQuery = query;
         } catch (DbException e) {

--- a/h2/src/main/org/h2/tools/Csv.java
+++ b/h2/src/main/org/h2/tools/Csv.java
@@ -361,8 +361,7 @@ public class Csv implements SimpleRowSource {
                 }
             }
         }
-        columnNames = new String[list.size()];
-        list.toArray(columnNames);
+        columnNames = list.toArray(new String[0]);
     }
 
     private static boolean isSimpleColumnName(String columnName) {

--- a/h2/src/main/org/h2/tools/MultiDimension.java
+++ b/h2/src/main/org/h2/tools/MultiDimension.java
@@ -222,9 +222,7 @@ public class MultiDimension implements Comparator<long[]> {
         ArrayList<long[]> list = New.arrayList();
         addMortonRanges(list, min, max, len, 0);
         combineEntries(list, total);
-        long[][] ranges = new long[list.size()][2];
-        list.toArray(ranges);
-        return ranges;
+        return list.toArray(new long[0][]);
     }
 
     private static int getSize(int[] min, int[] max, int len) {

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -156,8 +156,7 @@ public class JdbcUtils {
                     classNames.add(p);
                 }
             }
-            allowedClassNamePrefixes = new String[prefixes.size()];
-            prefixes.toArray(allowedClassNamePrefixes);
+            allowedClassNamePrefixes = prefixes.toArray(new String[0]);
             allowAllClasses = allowAll;
             allowedClassNames = classNames;
         }

--- a/h2/src/main/org/h2/util/Profiler.java
+++ b/h2/src/main/org/h2/util/Profiler.java
@@ -257,7 +257,7 @@ public class Profiler implements Runnable {
                 stack.add(line);
             }
             if (stack.size() > 0) {
-                String[] s = stack.toArray(new String[stack.size()]);
+                String[] s = stack.toArray(new String[0]);
                 list.add(s);
             }
         }

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -492,9 +492,7 @@ public class StringUtils {
         }
         String e = buff.toString();
         list.add(trim ? e.trim() : e);
-        String[] array = new String[list.size()];
-        list.toArray(array);
-        return array;
+        return list.toArray(new String[0]);
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueArray.java
+++ b/h2/src/main/org/h2/value/ValueArray.java
@@ -212,9 +212,7 @@ public class ValueArray extends Value {
             }
             list.add(v);
         }
-        Value[] array = new Value[list.size()];
-        list.toArray(array);
-        return get(array);
+        return get(list.toArray(new Value[0]));
     }
 
 }

--- a/h2/src/test/org/h2/test/db/TaskProcess.java
+++ b/h2/src/test/org/h2/test/db/TaskProcess.java
@@ -57,8 +57,7 @@ public class TaskProcess {
             if (args != null && args.length > 0) {
                 list.addAll(Arrays.asList(args));
             }
-            String[] procDef = new String[list.size()];
-            list.toArray(procDef);
+            String[] procDef = list.toArray(new String[0]);
             process = Runtime.getRuntime().exec(procDef);
             copyInThread(process.getErrorStream(), System.err);
             reader = new BufferedReader(new InputStreamReader(process.getInputStream()));

--- a/h2/src/test/org/h2/test/synth/sql/Expression.java
+++ b/h2/src/test/org/h2/test/synth/sql/Expression.java
@@ -47,9 +47,7 @@ public class Expression {
             exp.add(sql);
             sql = "";
         }
-        String[] list = new String[exp.size()];
-        exp.toArray(list);
-        return list;
+        return exp.toArray(new String[0]);
     }
 
     /**

--- a/h2/src/test/org/h2/test/trace/Parser.java
+++ b/h2/src/test/org/h2/test/trace/Parser.java
@@ -214,8 +214,7 @@ class Parser {
                         values.add(parseValue().getValue());
                     } while (readIf(","));
                     read("}");
-                    String[] list = new String[values.size()];
-                    values.toArray(list);
+                    String[] list = values.toArray(new String[0]);
                     return new Arg(String[].class, list);
                 } else if (readIf("BigDecimal")) {
                     read("(");

--- a/h2/src/test/org/h2/test/trace/Statement.java
+++ b/h2/src/test/org/h2/test/trace/Statement.java
@@ -162,7 +162,6 @@ class Statement {
     }
 
     public void setArgs(ArrayList<Arg> list) {
-        args = new Arg[list.size()];
-        list.toArray(args);
+        args = list.toArray(new Arg[0]);
     }
 }


### PR DESCRIPTION
This fix consists of two parts.

First part replaces usages of Collection.toArray(new Object[size]) with old plain Collection.toArray() which is generally faster and looks more reasonable in this use cases.

Secord part replaces usages of ArrayList.toArray(new T[size]) with ArrayList.toArray(new T[0]) for better performance. See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ and issue #311 for details and tests with different sizes of collections and on different versions of Java.

There are also few remaining usages of Collection.toArray(T[]) with other different types of collections, such as LinkedList, HashMap.keySet(), and ConcurrentHashMap.keySet(). I prefer not to touch them for now. I didn't test LinkedList, but my JMH tests for key set views of HashMap and ConcurrentHashMap with different sizes shows mixed results.