### PR TITLE
Issue #638: Oracle mode: incompatible regexp back-reference syntax

### DIFF
--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -120,6 +120,11 @@ public class Mode {
     public boolean logIsLogBase10;
 
     /**
+     * The function REGEXP_REPLACE() uses \ for back-references.
+     */
+    public boolean regexpReplaceBackslashReferences;
+
+    /**
      * SERIAL and BIGSERIAL columns are not automatically primary keys.
      */
     public boolean serialColumnIsNotPK;
@@ -255,6 +260,7 @@ public class Mode {
         mode.convertOnlyToSmallerScale = true;
         mode.uniqueIndexSingleNullExceptAllColumnsAreNull = true;
         mode.treatEmptyStringsAsNull = true;
+        mode.regexpReplaceBackslashReferences = true;
         mode.supportPoundSymbolForColumnNames = true;
         // Oracle accepts keys of the form <namespace>.*. See
         // https://docs.oracle.com/database/121/JJDBC/jdbcvers.htm#JJDBC29006

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1430,6 +1430,10 @@ public class Function extends Expression implements FunctionCall {
                                     sb.append('$');
                                     continue;
                                 }
+                                if (c == '\\') {
+                                    sb.append('\\');
+                                    i++;
+                                }
                             }
                         }
                         sb.append(c);

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1414,6 +1414,29 @@ public class Function extends Expression implements FunctionCall {
         case REGEXP_REPLACE: {
             String regexp = v1.getString();
             String replacement = v2.getString();
+            if (database.getMode().regexpReplaceBackslashReferences) {
+                if ((replacement.indexOf('\\') >= 0) || (replacement.indexOf('$') >= 0)) {
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < replacement.length(); i++) {
+                        char c = replacement.charAt(i);
+                        switch (c) {
+                        case '$':
+                            sb.append('\\');
+                            break;
+                        case '\\':
+                            if (i + 1 < replacement.length()) {
+                                c = replacement.charAt(i + 1);
+                                if (c >= '0' && c <= '9') {
+                                    sb.append('$');
+                                    continue;
+                                }
+                            }
+                        }
+                        sb.append(c);
+                    }
+                    replacement = sb.toString();
+                }
+            }
             String regexpMode = v3 == null || v3.getString() == null ? "" :
                     v3.getString();
             int flags = makeRegexpFlags(regexpMode);

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1419,22 +1419,11 @@ public class Function extends Expression implements FunctionCall {
                     StringBuilder sb = new StringBuilder();
                     for (int i = 0; i < replacement.length(); i++) {
                         char c = replacement.charAt(i);
-                        switch (c) {
-                        case '$':
+                        if (c == '$') {
                             sb.append('\\');
-                            break;
-                        case '\\':
-                            if (i + 1 < replacement.length()) {
-                                c = replacement.charAt(i + 1);
-                                if (c >= '0' && c <= '9') {
-                                    sb.append('$');
-                                    continue;
-                                }
-                                if (c == '\\') {
-                                    sb.append('\\');
-                                    i++;
-                                }
-                            }
+                        } else if (c == '\\' && ++i < replacement.length()) {
+                            c = replacement.charAt(i);
+                            sb.append(c >= '0' && c <= '9' ? '$' : '\\');
                         }
                         sb.append(c);
                     }

--- a/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
@@ -2,3 +2,18 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+call regexp_replace('x', 'x', '\');
+> exception
+
+CALL REGEXP_REPLACE('abckaboooom', 'o+', 'o');
+> 'abckabom'
+> ----------
+> abckabom
+> rows: 1
+
+select regexp_replace('Sylvain', 'S..', 'TOTO', 'mni') as X;
+> X
+> --------
+> TOTOvain
+> rows: 1

--- a/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
@@ -17,3 +17,31 @@ select regexp_replace('Sylvain', 'S..', 'TOTO', 'mni') as X;
 > --------
 > TOTOvain
 > rows: 1
+
+set mode oracle;
+
+select regexp_replace('first last', '(\w+) (\w+)', '\2 \1') as X from dual;
+> X
+> ----------
+> last first
+> rows: 1
+
+select regexp_replace('first last', '(\w+) (\w+)', '$2 $1') as X from dual;
+> X
+> -----
+> $2 $1
+> rows: 1
+
+set mode regular;
+
+select regexp_replace('first last', '(\w+) (\w+)', '\2 \1') as X from dual;
+> X
+> ---
+> 2 1
+> rows: 1
+
+select regexp_replace('first last', '(\w+) (\w+)', '$2 $1') as X from dual;
+> X
+> ----------
+> last first
+> rows: 1

--- a/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
@@ -26,6 +26,12 @@ select regexp_replace('first last', '(\w+) (\w+)', '\2 \1') as X from dual;
 > last first
 > rows: 1
 
+select regexp_replace('first last', '(\w+) (\w+)', '\\2 \1') as X from dual;
+> X
+> --------
+> \2 first
+> rows: 1
+
 select regexp_replace('first last', '(\w+) (\w+)', '$2 $1') as X from dual;
 > X
 > -----

--- a/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
@@ -32,6 +32,12 @@ select regexp_replace('first last', '(\w+) (\w+)', '\\2 \1') as X from dual;
 > \2 first
 > rows: 1
 
+select regexp_replace('first last', '(\w+) (\w+)', '\$2 \1') as X from dual;
+> X
+> --------
+> $2 first
+> rows: 1
+
 select regexp_replace('first last', '(\w+) (\w+)', '$2 $1') as X from dual;
 > X
 > -----

--- a/h2/src/test/org/h2/test/scripts/functions/string/regexp-like.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/regexp-like.sql
@@ -2,3 +2,17 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+call select 1 from dual where regexp_like('x', 'x', '\');
+> exception
+
+select x from dual where REGEXP_LIKE('A', '[a-z]', 'i');
+> X
+> -
+> 1
+> rows: 1
+
+select x from dual where REGEXP_LIKE('A', '[a-z]', 'c');
+> X
+> -
+> rows: 0

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -164,12 +164,6 @@ select 1 from test group by x;
 drop table test;
 > ok
 
-call regexp_replace('x', 'x', '\');
-> exception
-
-call select 1 from dual where regexp_like('x', 'x', '\');
-> exception
-
 select * from dual where x = x + 1 or x in(2, 0);
 > X
 > -
@@ -2108,29 +2102,6 @@ drop table test;
 
 set autocommit true;
 > ok
-
-CALL REGEXP_REPLACE('abckaboooom', 'o+', 'o');
-> 'abckabom'
-> ----------
-> abckabom
-> rows: 1
-
-select x from dual where REGEXP_LIKE('A', '[a-z]', 'i');
-> X
-> -
-> 1
-> rows: 1
-
-select x from dual where REGEXP_LIKE('A', '[a-z]', 'c');
-> X
-> -
-> rows: 0
-
-select regexp_replace('Sylvain', 'S..', 'TOTO', 'mni') as X;
-> X
-> --------
-> TOTOvain
-> rows: 1
 
 SELECT 'Hello' ~ 'He.*' T1, 'HELLO' ~ 'He.*' F2, CAST('HELLO' AS VARCHAR_IGNORECASE) ~ 'He.*' T3;
 > T1   F2    T3


### PR DESCRIPTION
This pull request adds custom handling of replacement string in REGEXP_REPLACE() in Oracle mode.