### PR TITLE
Fix for issue #725: FilePathMem.tryLock() fails since Java 9

### DIFF
--- a/h2/src/main/org/h2/store/fs/FakeFileChannel.java
+++ b/h2/src/main/org/h2/store/fs/FakeFileChannel.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2004-2014 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.store.fs;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Fake file channel to use by in-memory and ZIP file systems.
+ */
+public class FakeFileChannel extends FileChannel {
+    @Override
+    protected void implCloseChannel() throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public FileLock lock(long position, long size, boolean shared) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public long position() throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public FileChannel position(long newPosition) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public int read(ByteBuffer dst, long position) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public long size() throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public FileChannel truncate(long size) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public int write(ByteBuffer src, long position) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int len) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public void force(boolean metaData) throws IOException {
+        throw new IOException();
+    }
+}

--- a/h2/src/main/org/h2/store/fs/FilePathMem.java
+++ b/h2/src/main/org/h2/store/fs/FilePathMem.java
@@ -392,8 +392,7 @@ class FileMem extends FileBase {
             }
         }
 
-        // cast to FileChannel to avoid JDK 1.7 ambiguity
-        FileLock lock = new FileLock((FileChannel) null, position, size, shared) {
+        FileLock lock = new FileLock(new FakeFileChannel(), position, size, shared) {
 
             @Override
             public boolean isValid() {

--- a/h2/src/main/org/h2/store/fs/FilePathNioMem.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNioMem.java
@@ -386,8 +386,7 @@ class FileNioMem extends FileBase {
             }
         }
 
-        // cast to FileChannel to avoid JDK 1.7 ambiguity
-        FileLock lock = new FileLock((FileChannel) null, position, size, shared) {
+        FileLock lock = new FileLock(new FakeFileChannel(), position, size, shared) {
 
             @Override
             public boolean isValid() {

--- a/h2/src/main/org/h2/store/fs/FilePathZip.java
+++ b/h2/src/main/org/h2/store/fs/FilePathZip.java
@@ -354,8 +354,7 @@ class FileZip extends FileBase {
     public synchronized FileLock tryLock(long position, long size,
             boolean shared) throws IOException {
         if (shared) {
-            // cast to FileChannel to avoid JDK 1.7 ambiguity
-            return new FileLock((FileChannel) null, position, size, shared) {
+            return new FileLock(new FakeFileChannel(), position, size, shared) {
 
                 @Override
                 public boolean isValid() {

--- a/h2/src/tools/org/h2/dev/fs/FilePathZip2.java
+++ b/h2/src/tools/org/h2/dev/fs/FilePathZip2.java
@@ -17,6 +17,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.h2.engine.Constants;
 import org.h2.message.DbException;
+import org.h2.store.fs.FakeFileChannel;
 import org.h2.store.fs.FileBase;
 import org.h2.store.fs.FileChannelInputStream;
 import org.h2.store.fs.FilePath;
@@ -426,9 +427,7 @@ class FileZip2 extends FileBase {
     public synchronized FileLock tryLock(long position, long size,
             boolean shared) throws IOException {
         if (shared) {
-
-            // cast to FileChannel to avoid JDK 1.7 ambiguity
-            return new FileLock((FileChannel) null, position, size, shared) {
+            return new FileLock(new FakeFileChannel(), position, size, shared) {
 
                 @Override
                 public boolean isValid() {


### PR DESCRIPTION
Workaround suggested in #725 seems to work on Java 9 and on Java 8 too.