### PR TITLE
Implement enquoteIdentifier() and isSimpleIdentifier() from JDBC 4.3

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6851,6 +6851,30 @@ public class Parser {
         return s;
     }
 
+    /**
+     * @param s
+     *            identifier to check
+     * @return is specified identifier may be used without quotes
+     */
+    public static boolean isSimpleIdentifier(String s) {
+        if (s == null || s.length() == 0) {
+            return false;
+        }
+        char c = s.charAt(0);
+        // lowercase a-z is quoted as well
+        if ((!Character.isLetter(c) && c != '_') || Character.isLowerCase(c)) {
+            return false;
+        }
+        for (int i = 1, length = s.length(); i < length; i++) {
+            c = s.charAt(i);
+            if ((!Character.isLetterOrDigit(c) && c != '_') ||
+                    Character.isLowerCase(c)) {
+                return false;
+            }
+        }
+        return !isKeyword(s, true);
+    }
+
     public void setLiteralsChecked(boolean literalsChecked) {
         this.literalsChecked = literalsChecked;
     }

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -11,14 +11,17 @@ import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.ArrayList;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
+import org.h2.command.Parser;
 import org.h2.engine.SessionInterface;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.message.TraceObject;
 import org.h2.result.ResultInterface;
 import org.h2.util.New;
+import org.h2.util.StringUtils;
 
 /**
  * Represents a statement.
@@ -1293,6 +1296,33 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
         if (isDebugEnabled()) {
             debugCode("setPoolable("+poolable+");");
         }
+    }
+
+    /**
+     * @param identifier
+     *            identifier to quote if required
+     * @param alwaysQuote
+     *            if {@code true} identifier will be quoted unconditionally
+     * @return specified identifier quoted if required or explicitly requested
+     */
+    @Override
+    public String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException {
+        if (alwaysQuote)
+            return StringUtils.quoteIdentifier(identifier);
+        return Parser.quoteIdentifier(identifier);
+    }
+
+    /**
+     * @param identifier
+     *            identifier to check
+     * @return is specified identifier may be used without quotes
+     */
+    @Override
+    public boolean isSimpleIdentifier(String identifier) throws SQLException {
+        if (identifier == null)
+            // To conform with JDBC specification
+            throw new NullPointerException();
+        return Parser.isSimpleIdentifier(identifier);
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcStatementBackwardsCompat.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatementBackwardsCompat.java
@@ -32,4 +32,10 @@ public interface JdbcStatementBackwardsCompat {
     long executeLargeUpdate(String sql, int columnIndexes[]) throws SQLException;
 
     long executeLargeUpdate(String sql, String columnNames[]) throws SQLException;
+
+    // JDBC 4.3 (incomplete)
+
+    String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException;
+
+    boolean isSimpleIdentifier(String identifier) throws SQLException;
 }

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -330,6 +330,17 @@ public class TestStatement extends TestBase {
         assertTrue(stat.getWarnings() == null);
         assertTrue(conn == stat.getConnection());
 
+        assertEquals("SOME_ID", statBC.enquoteIdentifier("SOME_ID", false));
+        assertEquals("\"SOME ID\"", statBC.enquoteIdentifier("SOME ID", false));
+        assertEquals("\"SOME_ID\"", statBC.enquoteIdentifier("SOME_ID", true));
+        assertEquals("\"FROM\"", statBC.enquoteIdentifier("FROM", false));
+        assertEquals("\"Test\"", statBC.enquoteIdentifier("Test", false));
+
+        assertTrue(statBC.isSimpleIdentifier("SOME_ID"));
+        assertFalse(statBC.isSimpleIdentifier("SOME ID"));
+        assertFalse(statBC.isSimpleIdentifier("FROM"));
+        assertFalse(statBC.isSimpleIdentifier("Test"));
+
         stat.close();
     }
 


### PR DESCRIPTION
There are 4 new methods in Statement introduced in JDBC 4.3. Default implementations of two of them are compatible with H2 and can be used as is. This pull requests adds custom implementations for enquoteIdentifier() and isSimpleIdentifier() which default implementations are not compatible.