### PR TITLE
Add support of java.time.Instant

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3829,6 +3829,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
         } else if (LocalDateTimeUtils.isOffsetDateTime(type)) {
             return type.cast(LocalDateTimeUtils.valueToOffsetDateTime(
                             (ValueTimestampTimeZone) value.convertTo(Value.TIMESTAMP_TZ)));
+        } else if (LocalDateTimeUtils.isInstant(type)) {
+            return type.cast(LocalDateTimeUtils.valueToInstant(
+                            (ValueTimestampTimeZone) value.convertTo(Value.TIMESTAMP_TZ)));
         } else {
             throw unsupported(type.getName());
         }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3825,11 +3825,10 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             return type.cast(LocalDateTimeUtils.valueToLocalTime(value));
         } else if (LocalDateTimeUtils.isLocalDateTime(type)) {
             return type.cast(LocalDateTimeUtils.valueToLocalDateTime(
-                            (ValueTimestamp) value));
-        } else if (LocalDateTimeUtils.isOffsetDateTime(type) &&
-                value instanceof ValueTimestampTimeZone) {
+                            (ValueTimestamp) value.convertTo(Value.TIMESTAMP)));
+        } else if (LocalDateTimeUtils.isOffsetDateTime(type)) {
             return type.cast(LocalDateTimeUtils.valueToOffsetDateTime(
-                            (ValueTimestampTimeZone) value));
+                            (ValueTimestampTimeZone) value.convertTo(Value.TIMESTAMP_TZ)));
         } else {
             throw unsupported(type.getName());
         }

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -1124,6 +1124,8 @@ public class DataType {
             return LocalDateTimeUtils.localDateTimeToValue(x);
         } else if (LocalDateTimeUtils.isOffsetDateTime(x.getClass())) {
             return LocalDateTimeUtils.offsetDateTimeToValue(x);
+        } else if (LocalDateTimeUtils.isInstant(x.getClass())) {
+            return LocalDateTimeUtils.instantToValue(x);
         } else if (x instanceof TimestampWithTimeZone) {
             return ValueTimestampTimeZone.get((TimestampWithTimeZone) x);
         } else {

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -347,7 +347,7 @@ public class ValueTimestamp extends Value {
         ValueTimestamp t = (ValueTimestamp) v.convertTo(Value.TIMESTAMP);
         long d1 = DateTimeUtils.absoluteDayFromDateValue(dateValue);
         long d2 = DateTimeUtils.absoluteDayFromDateValue(t.dateValue);
-        return DateTimeUtils.normalizeTimestamp(d1 + d2, timeNanos + t.timeNanos);
+        return DateTimeUtils.normalizeTimestamp(d1 + d2, timeNanos + t.timeNanos, false);
     }
 
     @Override
@@ -355,7 +355,7 @@ public class ValueTimestamp extends Value {
         ValueTimestamp t = (ValueTimestamp) v.convertTo(Value.TIMESTAMP);
         long d1 = DateTimeUtils.absoluteDayFromDateValue(dateValue);
         long d2 = DateTimeUtils.absoluteDayFromDateValue(t.dateValue);
-        return DateTimeUtils.normalizeTimestamp(d1 - d2, timeNanos - t.timeNanos);
+        return DateTimeUtils.normalizeTimestamp(d1 - d2, timeNanos - t.timeNanos, false);
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -8,7 +8,6 @@ package org.h2.value;
 import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.util.TimeZone;
 import org.h2.api.ErrorCode;
 import org.h2.api.TimestampWithTimeZone;
@@ -201,11 +200,6 @@ public class ValueTimestampTimeZone extends Value {
      */
     public short getTimeZoneOffsetMins() {
         return timeZoneOffsetMins;
-    }
-
-    @Override
-    public Timestamp getTimestamp() {
-        throw new UnsupportedOperationException("unimplemented");
     }
 
     @Override

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -77,6 +77,7 @@ public class TestPreparedStatement extends TestBase {
         testTime8(conn);
         testDateTime8(conn);
         testOffsetDateTime8(conn);
+        testInstant8(conn);
         testArray(conn);
         testUUIDGeneratedKeys(conn);
         testSetObject(conn);
@@ -713,6 +714,34 @@ public class TestPreparedStatement extends TestBase {
         rs.next();
         offsetDateTime2 = rs.getObject(1, LocalDateTimeUtils.getOffsetDateTimeClass());
         assertEquals(instant, offsetToInstant.invoke(offsetDateTime2));
+        assertFalse(rs.next());
+        rs.close();
+    }
+
+    private void testInstant8(Connection conn) throws Exception {
+        if (!LocalDateTimeUtils.isJava8DateApiPresent()) {
+            return;
+        }
+        Method timestampToInstant = Timestamp.class.getMethod("toInstant"),
+                now = LocalDateTimeUtils.getInstantClass().getMethod("now");
+
+        PreparedStatement prep = conn.prepareStatement("SELECT ?");
+        Object instant1 = now.invoke(null);
+        prep.setObject(1, instant1);
+        ResultSet rs = prep.executeQuery();
+        rs.next();
+        Object instant2 = rs.getObject(1, LocalDateTimeUtils.getInstantClass());
+        assertEquals(instant1, instant2);
+        Timestamp ts = rs.getTimestamp(1);
+        assertEquals(instant1, timestampToInstant.invoke(ts));
+        assertFalse(rs.next());
+        rs.close();
+
+        prep.setTimestamp(1, ts);
+        rs = prep.executeQuery();
+        rs.next();
+        instant2 = rs.getObject(1, LocalDateTimeUtils.getInstantClass());
+        assertEquals(instant1, instant2);
         assertFalse(rs.next());
         rs.close();
     }


### PR DESCRIPTION
1. Fix conversion from ValueTimestampTimeZone to ValueTimestamp. Handle timezone offset and convert timestamp to local timezone.

2. Implement conversion from ValueTimestamp to ValueTimestampTimeZone.

3. Add support of java.time.Instant on Java 8. I decided to map it to ValueTimestampTimeZone with 0 offset. If TIMESTAMP_UTC will be reimplemented, we can map it to it.

Instant can also be used to set and read TIMESTAMP values.