### PR TITLE
Add support of java.time.Instant V2

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3826,6 +3826,8 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
         } else if (LocalDateTimeUtils.isLocalDateTime(type)) {
             return type.cast(LocalDateTimeUtils.valueToLocalDateTime(
                             (ValueTimestamp) value));
+        } else if (LocalDateTimeUtils.isInstant(type)) {
+            return type.cast(LocalDateTimeUtils.valueToInstant(value));
         } else if (LocalDateTimeUtils.isOffsetDateTime(type) &&
                 value instanceof ValueTimestampTimeZone) {
             return type.cast(LocalDateTimeUtils.valueToOffsetDateTime(

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -1122,6 +1122,8 @@ public class DataType {
             return LocalDateTimeUtils.localTimeToTimeValue(x);
         } else if (LocalDateTimeUtils.isLocalDateTime(x.getClass())) {
             return LocalDateTimeUtils.localDateTimeToValue(x);
+        } else if (LocalDateTimeUtils.isInstant(x.getClass())) {
+            return LocalDateTimeUtils.instantToValue(x);
         } else if (LocalDateTimeUtils.isOffsetDateTime(x.getClass())) {
             return LocalDateTimeUtils.offsetDateTimeToValue(x);
         } else if (x instanceof TimestampWithTimeZone) {


### PR DESCRIPTION
Simple approach without touching conversions between internal data types.

Only TIMESTAMP and compatible values are supported.