### PR TITLE
More cleanups in LocalDateTimeUtils and other minor changes

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6830,34 +6830,22 @@ public class Parser {
      * @return the quoted identifier
      */
     public static String quoteIdentifier(String s) {
-        if (s == null || s.length() == 0) {
+        if (s == null) {
             return "\"\"";
         }
-        char c = s.charAt(0);
-        // lowercase a-z is quoted as well
-        if ((!Character.isLetter(c) && c != '_') || Character.isLowerCase(c)) {
-            return StringUtils.quoteIdentifier(s);
-        }
-        for (int i = 1, length = s.length(); i < length; i++) {
-            c = s.charAt(i);
-            if ((!Character.isLetterOrDigit(c) && c != '_') ||
-                    Character.isLowerCase(c)) {
-                return StringUtils.quoteIdentifier(s);
-            }
-        }
-        if (isKeyword(s, true)) {
-            return StringUtils.quoteIdentifier(s);
-        }
-        return s;
+        if (isSimpleIdentifier(s))
+            return s;
+        return StringUtils.quoteIdentifier(s);
     }
 
     /**
      * @param s
      *            identifier to check
      * @return is specified identifier may be used without quotes
+     * @throws NullPointerException if s is {@code null}
      */
     public static boolean isSimpleIdentifier(String s) {
-        if (s == null || s.length() == 0) {
+        if (s.length() == 0) {
             return false;
         }
         char c = s.charAt(0);

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -79,7 +79,7 @@ public class Mode {
      * [OFFSET .. ROW|ROWS] [FETCH FIRST .. ROW|ROWS ONLY]
      * as an alternative for LIMIT .. OFFSET.
      */
-    public boolean supportOffsetFetch = Constants.VERSION_MINOR >= 4 ? true : false;
+    public boolean supportOffsetFetch = Constants.VERSION_MINOR >= 4;
 
     /**
      * The system columns 'CTID' and 'OID' are supported.

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -344,7 +344,7 @@ public class SysProperties {
      */
     public static final boolean OLD_STYLE_OUTER_JOIN =
             Utils.getProperty("h2.oldStyleOuterJoin",
-                    Constants.VERSION_MINOR >= 4 ? false : true);
+                    Constants.VERSION_MINOR < 4);
 
     /**
      * System property <code>h2.pgClientEncoding</code> (default: UTF-8).<br />
@@ -401,7 +401,7 @@ public class SysProperties {
      */
     public static final boolean SORT_BINARY_UNSIGNED =
             Utils.getProperty("h2.sortBinaryUnsigned",
-                    Constants.VERSION_MINOR >= 4 ? true : false);
+                    Constants.VERSION_MINOR >= 4);
 
     /**
      * System property <code>h2.sortNullsHigh</code> (default: false).<br />
@@ -455,7 +455,7 @@ public class SysProperties {
      */
     public static final boolean IMPLICIT_RELATIVE_PATH =
             Utils.getProperty("h2.implicitRelativePath",
-                    Constants.VERSION_MINOR >= 4 ? false : true);
+                    Constants.VERSION_MINOR < 4);
 
     /**
      * System property <code>h2.urlMap</code> (default: null).<br />

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3824,8 +3824,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
         } else if (LocalDateTimeUtils.isLocalTime(type)) {
             return type.cast(LocalDateTimeUtils.valueToLocalTime(value));
         } else if (LocalDateTimeUtils.isLocalDateTime(type)) {
-            return type.cast(LocalDateTimeUtils.valueToLocalDateTime(
-                            (ValueTimestamp) value));
+            return type.cast(LocalDateTimeUtils.valueToLocalDateTime(value));
         } else if (LocalDateTimeUtils.isInstant(type)) {
             return type.cast(LocalDateTimeUtils.valueToInstant(value));
         } else if (LocalDateTimeUtils.isOffsetDateTime(type) &&

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3829,8 +3829,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             return type.cast(LocalDateTimeUtils.valueToInstant(value));
         } else if (LocalDateTimeUtils.isOffsetDateTime(type) &&
                 value instanceof ValueTimestampTimeZone) {
-            return type.cast(LocalDateTimeUtils.valueToOffsetDateTime(
-                            (ValueTimestampTimeZone) value));
+            return type.cast(LocalDateTimeUtils.valueToOffsetDateTime(value));
         } else {
             throw unsupported(type.getName());
         }

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -1332,9 +1332,6 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
      */
     @Override
     public boolean isSimpleIdentifier(String identifier) throws SQLException {
-        if (identifier == null)
-            // To conform with JDBC specification
-            throw new NullPointerException();
         return Parser.isSimpleIdentifier(identifier);
     }
 

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -1099,7 +1099,7 @@ public class WebApp {
         if (isBuiltIn(sql, "@best_row_identifier")) {
             String[] p = split(sql);
             int scale = p[4] == null ? 0 : Integer.parseInt(p[4]);
-            boolean nullable = p[5] == null ? false : Boolean.parseBoolean(p[5]);
+            boolean nullable = Boolean.parseBoolean(p[5]);
             return meta.getBestRowIdentifier(p[1], p[2], p[3], scale, nullable);
         } else if (isBuiltIn(sql, "@catalogs")) {
             return meta.getCatalogs();
@@ -1120,8 +1120,8 @@ public class WebApp {
             return meta.getImportedKeys(p[1], p[2], p[3]);
         } else if (isBuiltIn(sql, "@index_info")) {
             String[] p = split(sql);
-            boolean unique = p[4] == null ? false : Boolean.parseBoolean(p[4]);
-            boolean approx = p[5] == null ? false : Boolean.parseBoolean(p[5]);
+            boolean unique = Boolean.parseBoolean(p[4]);
+            boolean approx = Boolean.parseBoolean(p[5]);
             return meta.getIndexInfo(p[1], p[2], p[3], unique, approx);
         } else if (isBuiltIn(sql, "@primary_keys")) {
             String[] p = split(sql);

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -422,9 +422,7 @@ public class LocalDateTimeUtils {
         long dateValue = valueTimestamp.getDateValue();
         long timeNanos = valueTimestamp.getTimeNanos();
         try {
-            Object localDate = localDateFromDateValue(dateValue);
-            Object localDateTime = LOCAL_DATE_AT_START_OF_DAY.invoke(localDate);
-            return LOCAL_DATE_TIME_PLUS_NANOS.invoke(localDateTime, timeNanos);
+            return localDateTimeFromDateNanos(dateValue, timeNanos);
         } catch (IllegalAccessException e) {
             throw DbException.convert(e);
         } catch (InvocationTargetException e) {

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -459,8 +459,9 @@ public class LocalDateTimeUtils {
      * @param value the value to convert
      * @return the OffsetDateTime
      */
-    public static Object valueToOffsetDateTime(ValueTimestampTimeZone value) {
-        return timestampWithTimeZoneToOffsetDateTime((TimestampWithTimeZone) value.getObject());
+    public static Object valueToOffsetDateTime(Value value) {
+        ValueTimestampTimeZone valueTimestampTimeZone = (ValueTimestampTimeZone) value.convertTo(Value.TIMESTAMP_TZ);
+        return timestampWithTimeZoneToOffsetDateTime((TimestampWithTimeZone) valueTimestampTimeZone.getObject());
     }
 
     private static Object timestampWithTimeZoneToOffsetDateTime(

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -418,9 +418,10 @@ public class LocalDateTimeUtils {
      * @param value the value to convert
      * @return the LocalDateTime
      */
-    public static Object valueToLocalDateTime(ValueTimestamp value) {
-        long dateValue = value.getDateValue();
-        long timeNanos = value.getTimeNanos();
+    public static Object valueToLocalDateTime(Value value) {
+        ValueTimestamp valueTimestamp = (ValueTimestamp) value.convertTo(Value.TIMESTAMP);
+        long dateValue = valueTimestamp.getDateValue();
+        long timeNanos = valueTimestamp.getTimeNanos();
         try {
             Object localDate = localDateFromDateValue(dateValue);
             Object localDateTime = LOCAL_DATE_AT_START_OF_DAY.invoke(localDate);

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -13,7 +13,6 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import org.h2.api.TimestampWithTimeZone;
 import org.h2.message.DbException;
 import org.h2.value.Value;
 import org.h2.value.ValueDate;
@@ -461,13 +460,12 @@ public class LocalDateTimeUtils {
      */
     public static Object valueToOffsetDateTime(Value value) {
         ValueTimestampTimeZone valueTimestampTimeZone = (ValueTimestampTimeZone) value.convertTo(Value.TIMESTAMP_TZ);
-        TimestampWithTimeZone timestampWithTimeZone = (TimestampWithTimeZone) valueTimestampTimeZone.getObject();
-        long dateValue = timestampWithTimeZone.getYMD();
-        long timeNanos = timestampWithTimeZone.getNanosSinceMidnight();
+        long dateValue = valueTimestampTimeZone.getDateValue();
+        long timeNanos = valueTimestampTimeZone.getTimeNanos();
         try {
             Object localDateTime = localDateTimeFromDateNanos(dateValue, timeNanos);
 
-            short timeZoneOffsetMins = timestampWithTimeZone.getTimeZoneOffsetMins();
+            short timeZoneOffsetMins = valueTimestampTimeZone.getTimeZoneOffsetMins();
             int offsetSeconds = (int) TimeUnit.MINUTES.toSeconds(timeZoneOffsetMins);
 
             Object offset = ZONE_OFFSET_OF_TOTAL_SECONDS.invoke(null, offsetSeconds);

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -461,12 +461,7 @@ public class LocalDateTimeUtils {
      */
     public static Object valueToOffsetDateTime(Value value) {
         ValueTimestampTimeZone valueTimestampTimeZone = (ValueTimestampTimeZone) value.convertTo(Value.TIMESTAMP_TZ);
-        return timestampWithTimeZoneToOffsetDateTime((TimestampWithTimeZone) valueTimestampTimeZone.getObject());
-    }
-
-    private static Object timestampWithTimeZoneToOffsetDateTime(
-            TimestampWithTimeZone timestampWithTimeZone) {
-
+        TimestampWithTimeZone timestampWithTimeZone = (TimestampWithTimeZone) valueTimestampTimeZone.getObject();
         long dateValue = timestampWithTimeZone.getYMD();
         long timeNanos = timestampWithTimeZone.getNanosSinceMidnight();
         try {

--- a/h2/src/main/org/h2/util/ToChar.java
+++ b/h2/src/main/org/h2/util/ToChar.java
@@ -31,6 +31,12 @@ public class ToChar {
      */
     private static final long JULIAN_EPOCH;
 
+    private static final int[] ROMAN_VALUES = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9,
+            5, 4, 1 };
+
+    private static final String[] ROMAN_NUMERALS = { "M", "CM", "D", "CD", "C", "XC",
+            "L", "XL", "X", "IX", "V", "IV", "I" };
+
     static {
         GregorianCalendar epoch = new GregorianCalendar(Locale.ENGLISH);
         epoch.setGregorianChange(new Date(Long.MAX_VALUE));
@@ -410,14 +416,10 @@ public class ToChar {
     }
 
     private static String toRomanNumeral(int number) {
-        int[] values = new int[] { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9,
-                5, 4, 1 };
-        String[] numerals = new String[] { "M", "CM", "D", "CD", "C", "XC",
-                "L", "XL", "X", "IX", "V", "IV", "I" };
         StringBuilder result = new StringBuilder();
-        for (int i = 0; i < values.length; i++) {
-            int value = values[i];
-            String numeral = numerals[i];
+        for (int i = 0; i < ROMAN_VALUES.length; i++) {
+            int value = ROMAN_VALUES[i];
+            String numeral = ROMAN_NUMERALS[i];
             while (number >= value) {
                 result.append(numeral);
                 number -= value;


### PR DESCRIPTION
### LocalDateTimeUtils

1. Match behaviour of `getObject(..., LocalDateTime.class)` with `getTimestamp()`. Reading of timestamp invokes `Value.convertTo(Value.TIMESTAMP)` and so `valueToLocalDateTime()` should do the same for consistency.

2. Do not bother with `TimestampWithTimeZone` in `valueToOffsetDateTime()`, read the same three values directly from `ValueTimestampTimeZone` instead.

3. Reuse `localDateTimeFromDateNanos()` in `valueToLocalDateTime()` to reduce code duplication.

### Parser

Use recently added `isSimpleIdentifier()` in `quoteIdentifier()`, code duplication was a bad decision.

### ToChar

`toRomanNumeral()` initializes constant arrays on each invokation. Move it to private static fields.