### PR TITLE
Fix #744: TestFile failure on Java 9 and Java 10

### DIFF
--- a/h2/src/main/org/h2/store/fs/FilePathDisk.java
+++ b/h2/src/main/org/h2/store/fs/FilePathDisk.java
@@ -436,9 +436,11 @@ class FileDisk extends FileBase {
         if (readOnly) {
             throw new NonWritableChannelException();
         }
-        if (newLength < file.length()) {
-            file.setLength(newLength);
-        }
+        /*
+         * RandomAccessFile.setLength() does not always work here since Java 9 for
+         * unknown reason so use FileChannel.truncate().
+         */
+        file.getChannel().truncate(newLength);
         return this;
     }
 


### PR DESCRIPTION
FileChannel.truncate() works on Java 8, 9, and early access builds of 10. Did not test Java 7, but Travis will do it.