### PR TITLE
Fix issue #740

### DIFF
--- a/h2/src/main/org/h2/tools/Server.java
+++ b/h2/src/main/org/h2/tools/Server.java
@@ -706,8 +706,27 @@ public class Server extends Tool implements Runnable, ShutdownHandler {
      * @param conn the database connection (the database must be open)
      */
     public static void startWebServer(Connection conn) throws SQLException {
+        startWebServer(conn, false);
+    }
+
+    /**
+     * Start a web server and a browser that uses the given connection. The
+     * current transaction is preserved. This is specially useful to manually
+     * inspect the database when debugging. This method return as soon as the
+     * user has disconnected.
+     *
+     * @param conn the database connection (the database must be open)
+     * @param ignoreProperties if {@code true} properties from
+     *         {@code .h2.server.properties} will be ignored
+     */
+    public static void startWebServer(Connection conn, boolean ignoreProperties) throws SQLException {
         WebServer webServer = new WebServer();
-        Server web = new Server(webServer, new String[] { "-webPort", "0" });
+        String[] args;
+        if (ignoreProperties)
+            args = new String[] { "-webPort", "0", "-properties", "null"};
+        else
+            args = new String[] { "-webPort", "0" };
+        Server web = new Server(webServer, args);
         web.start();
         Server server = new Server();
         server.web = web;

--- a/h2/src/test/org/h2/test/server/TestWeb.java
+++ b/h2/src/test/org/h2/test/server/TestWeb.java
@@ -557,7 +557,7 @@ public class TestWeb extends TestBase {
             Task t = new Task() {
                 @Override
                 public void call() throws Exception {
-                    Server.startWebServer(conn);
+                    Server.startWebServer(conn, true);
                 }
             };
             t.execute();

--- a/h2/src/test/org/h2/test/server/TestWeb.java
+++ b/h2/src/test/org/h2/test/server/TestWeb.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
 import java.security.Principal;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -572,7 +573,7 @@ public class TestWeb extends TestBase {
             url = client.getBaseUrl(url);
             try {
                 client.get(url, "logout.do");
-            } catch (Exception e) {
+            } catch (ConnectException e) {
                 // the server stops on logout
             }
             t.get();


### PR DESCRIPTION
Server.startWebServer() now optionally ignores .h2.server.properties.

Catch block in TestWeb is also adjusted so now we get a stack trace in case of unexpected exception.

This pull request, however, does not resolve possible deadlock in case of failure. It resolves only original issue with `webSSL=true` in configuration.