### PR TITLE
Use AtomicIntegerArray and StandardCharsets

### DIFF
--- a/h2/src/main/org/h2/command/dml/RunScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/RunScriptCommand.java
@@ -9,9 +9,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import org.h2.command.CommandInterface;
 import org.h2.command.Prepared;
-import org.h2.engine.Constants;
 import org.h2.engine.Session;
 import org.h2.message.DbException;
 import org.h2.result.ResultInterface;
@@ -30,7 +31,7 @@ public class RunScriptCommand extends ScriptBase {
      */
     private static final char UTF8_BOM = '\uFEFF';
 
-    private Charset charset = Constants.UTF8;
+    private Charset charset = StandardCharsets.UTF_8;
 
     public RunScriptCommand(Session session) {
         super(session);

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -67,7 +68,7 @@ import org.h2.value.ValueString;
  */
 public class ScriptCommand extends ScriptBase {
 
-    private Charset charset = Constants.UTF8;
+    private Charset charset = StandardCharsets.UTF_8;
     private Set<String> schemaNames;
     private Collection<Table> tables;
     private boolean passwords;

--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -5,7 +5,6 @@
  */
 package org.h2.engine;
 
-import java.nio.charset.Charset;
 import java.sql.ResultSet;
 
 /**
@@ -493,11 +492,6 @@ public class Constants {
      * The package name of user defined classes.
      */
     public static final String USER_PACKAGE = "org.h2.dynamic";
-
-    /**
-     * Name of the character encoding format.
-     */
-    public static final Charset UTF8 = Charset.forName("UTF-8");
 
     /**
      * The maximum time in milliseconds to keep the cost of a view.

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -809,11 +810,11 @@ public class Function extends Expression implements FunctionCall {
             break;
         case STRINGTOUTF8:
             result = ValueBytes.getNoCopy(v0.getString().
-                    getBytes(Constants.UTF8));
+                    getBytes(StandardCharsets.UTF_8));
             break;
         case UTF8TOSTRING:
             result = ValueString.get(new String(v0.getBytesNoCopy(),
-                    Constants.UTF8),
+                    StandardCharsets.UTF_8),
                     database.getMode().treatEmptyStringsAsNull);
             break;
         case XMLCOMMENT:

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.text.MessageFormat;
@@ -17,7 +18,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.h2.api.ErrorCode;
-import org.h2.engine.Constants;
 import org.h2.jdbc.JdbcSQLException;
 import org.h2.util.SortedProperties;
 import org.h2.util.StringUtils;
@@ -51,7 +51,7 @@ public class DbException extends RuntimeException {
                 // (otherwise certain applications don't work)
                 if (translations != null) {
                     Properties p = SortedProperties.fromLines(
-                            new String(translations, Constants.UTF8));
+                            new String(translations, StandardCharsets.UTF_8));
                     for (Entry<Object, Object> e : p.entrySet()) {
                         String key = (String) e.getKey();
                         String translation = (String) e.getValue();

--- a/h2/src/main/org/h2/message/TraceObject.java
+++ b/h2/src/main/org/h2/message/TraceObject.java
@@ -8,7 +8,8 @@ package org.h2.message;
 import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
 import org.h2.util.StringUtils;
 
 /**
@@ -92,10 +93,10 @@ public class TraceObject {
     protected static final int ARRAY = 16;
 
     private static final int LAST = ARRAY + 1;
-    private static final AtomicInteger[] ID = new AtomicInteger[LAST];
+    private static final AtomicIntegerArray ID = new AtomicIntegerArray(LAST);
     static {
         for (int i=0; i<LAST; i++) {
-            ID[i] = new AtomicInteger(-1);
+            ID.set(i, -1);
         }
     }
     private static final String[] PREFIX = { "call", "conn", "dbMeta", "prep",
@@ -144,7 +145,7 @@ public class TraceObject {
      * @return the new trace object id
      */
     protected static int getNextId(int type) {
-        return ID[type].incrementAndGet();
+        return ID.incrementAndGet(type);
     }
 
     /**

--- a/h2/src/main/org/h2/message/TraceObject.java
+++ b/h2/src/main/org/h2/message/TraceObject.java
@@ -94,11 +94,7 @@ public class TraceObject {
 
     private static final int LAST = ARRAY + 1;
     private static final AtomicIntegerArray ID = new AtomicIntegerArray(LAST);
-    static {
-        for (int i=0; i<LAST; i++) {
-            ID.set(i, -1);
-        }
-    }
+
     private static final String[] PREFIX = { "call", "conn", "dbMeta", "prep",
             "rs", "rsMeta", "sp", "ex", "stat", "blob", "clob", "pMeta", "ds",
             "xads", "xares", "xid", "ar" };
@@ -145,7 +141,7 @@ public class TraceObject {
      * @return the new trace object id
      */
     protected static int getNextId(int type) {
-        return ID.incrementAndGet(type);
+        return ID.getAndIncrement(type);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -6,6 +6,7 @@
 package org.h2.mvstore;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 /**
@@ -127,7 +128,7 @@ public class Chunk {
                 if (data[i] == '\n') {
                     // set the position to the start of the first page
                     buff.position(pos + i + 1);
-                    String s = new String(data, 0, i, DataUtils.LATIN).trim();
+                    String s = new String(data, 0, i, StandardCharsets.ISO_8859_1).trim();
                     return fromString(s);
                 }
             }
@@ -150,7 +151,7 @@ public class Chunk {
      */
     void writeChunkHeader(WriteBuffer buff, int minLength) {
         long pos = buff.position();
-        buff.put(asString().getBytes(DataUtils.LATIN));
+        buff.put(asString().getBytes(StandardCharsets.ISO_8859_1));
         while (buff.position() - pos < minLength - 1) {
             buff.put((byte) ' ');
         }
@@ -257,14 +258,14 @@ public class Chunk {
         DataUtils.appendMap(buff, "chunk", id);
         DataUtils.appendMap(buff, "block", block);
         DataUtils.appendMap(buff, "version", version);
-        byte[] bytes = buff.toString().getBytes(DataUtils.LATIN);
+        byte[] bytes = buff.toString().getBytes(StandardCharsets.ISO_8859_1);
         int checksum = DataUtils.getFletcher32(bytes, bytes.length);
         DataUtils.appendMap(buff, "fletcher", checksum);
         while (buff.length() < Chunk.FOOTER_LENGTH - 1) {
             buff.append(' ');
         }
         buff.append("\n");
-        return buff.toString().getBytes(DataUtils.LATIN);
+        return buff.toString().getBytes(StandardCharsets.ISO_8859_1);
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.charset.Charset;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -153,16 +152,6 @@ public final class DataUtils {
      * The marker size of a very large page.
      */
     public static final int PAGE_LARGE = 2 * 1024 * 1024;
-
-    /**
-     * The UTF-8 character encoding format.
-     */
-    public static final Charset UTF8 = Charset.forName("UTF-8");
-
-    /**
-     * The ISO Latin character encoding format.
-     */
-    public static final Charset LATIN = Charset.forName("ISO-8859-1");
 
     /**
      * An 0-size byte array.

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -7,6 +7,7 @@ package org.h2.mvstore;
 
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -575,7 +576,7 @@ public final class MVStore {
             // the following can fail for various reasons
             try {
                 String s = new String(buff, 0, BLOCK_SIZE,
-                        DataUtils.LATIN).trim();
+                        StandardCharsets.ISO_8859_1).trim();
                 HashMap<String, String> m = DataUtils.parseMap(s);
                 int blockSize = DataUtils.readHexInt(
                         m, "blockSize", BLOCK_SIZE);
@@ -588,7 +589,7 @@ public final class MVStore {
                 int check = DataUtils.readHexInt(m, "fletcher", 0);
                 m.remove("fletcher");
                 s = s.substring(0, s.lastIndexOf("fletcher") - 1);
-                byte[] bytes = s.getBytes(DataUtils.LATIN);
+                byte[] bytes = s.getBytes(StandardCharsets.ISO_8859_1);
                 int checksum = DataUtils.getFletcher32(bytes,
                         bytes.length);
                 if (check != checksum) {
@@ -803,12 +804,12 @@ public final class MVStore {
                     end - Chunk.FOOTER_LENGTH, Chunk.FOOTER_LENGTH);
             byte[] buff = new byte[Chunk.FOOTER_LENGTH];
             lastBlock.get(buff);
-            String s = new String(buff, DataUtils.LATIN).trim();
+            String s = new String(buff, StandardCharsets.ISO_8859_1).trim();
             HashMap<String, String> m = DataUtils.parseMap(s);
             int check = DataUtils.readHexInt(m, "fletcher", 0);
             m.remove("fletcher");
             s = s.substring(0, s.lastIndexOf("fletcher") - 1);
-            byte[] bytes = s.getBytes(DataUtils.LATIN);
+            byte[] bytes = s.getBytes(StandardCharsets.ISO_8859_1);
             int checksum = DataUtils.getFletcher32(bytes, bytes.length);
             if (check == checksum) {
                 int chunk = DataUtils.readHexInt(m, "chunk", 0);
@@ -831,11 +832,11 @@ public final class MVStore {
             storeHeader.put("version", lastChunk.version);
         }
         DataUtils.appendMap(buff, storeHeader);
-        byte[] bytes = buff.toString().getBytes(DataUtils.LATIN);
+        byte[] bytes = buff.toString().getBytes(StandardCharsets.ISO_8859_1);
         int checksum = DataUtils.getFletcher32(bytes, bytes.length);
         DataUtils.appendMap(buff, "fletcher", checksum);
         buff.append("\n");
-        bytes = buff.toString().getBytes(DataUtils.LATIN);
+        bytes = buff.toString().getBytes(StandardCharsets.ISO_8859_1);
         ByteBuffer header = ByteBuffer.allocate(2 * BLOCK_SIZE);
         header.put(bytes);
         header.position(BLOCK_SIZE);

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -11,6 +11,7 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -124,7 +125,7 @@ public class MVStoreTool {
                 block.rewind();
                 int headerType = block.get();
                 if (headerType == 'H') {
-                    String header = new String(block.array(), DataUtils.LATIN).trim();
+                    String header = new String(block.array(), StandardCharsets.ISO_8859_1).trim();
                     pw.printf("%0" + len + "x fileHeader %s%n",
                             pos, header);
                     pos += blockSize;
@@ -293,7 +294,7 @@ public class MVStoreTool {
                             "+%0" + len + "x chunkFooter %s%n",
                             footerPos,
                             new String(chunk.array(), chunk.position(),
-                                    Chunk.FOOTER_LENGTH, DataUtils.LATIN).trim());
+                                    Chunk.FOOTER_LENGTH, StandardCharsets.ISO_8859_1).trim());
                 } catch (IllegalArgumentException e) {
                     // too far
                     pw.printf("ERROR illegal footer position %d%n", footerPos);

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -13,6 +13,7 @@ import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ParameterMetaData;
@@ -399,7 +400,7 @@ public class WebApp {
             try {
                 tool.runTool(argList);
                 out.flush();
-                String o = new String(outBuff.toByteArray(), Constants.UTF8);
+                String o = new String(outBuff.toByteArray(), StandardCharsets.UTF_8);
                 String result = PageParser.escapeHtml(o);
                 session.put("toolResult", result);
             } catch (Exception e) {
@@ -993,7 +994,7 @@ public class WebApp {
             }
             final Connection conn = session.getConnection();
             if (SysProperties.CONSOLE_STREAM && server.getAllowChunked()) {
-                String page = new String(server.getFile("result.jsp"), Constants.UTF8);
+                String page = new String(server.getFile("result.jsp"), StandardCharsets.UTF_8);
                 int idx = page.indexOf("${result}");
                 // the first element of the list is the header, the last the
                 // footer

--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
@@ -453,7 +454,7 @@ public class WebServer implements Service {
             trace("translation: "+language);
             byte[] trans = getFile("_text_"+language+".prop");
             trace("  "+new String(trans));
-            text = SortedProperties.fromLines(new String(trans, Constants.UTF8));
+            text = SortedProperties.fromLines(new String(trans, StandardCharsets.UTF_8));
             // remove starting # (if not translated yet)
             for (Entry<Object, Object> entry : text.entrySet()) {
                 String value = (String) entry.getValue();

--- a/h2/src/main/org/h2/server/web/WebServlet.java
+++ b/h2/src/main/org/h2/server/web/WebServlet.java
@@ -8,6 +8,7 @@ package org.h2.server.web;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Properties;
@@ -18,7 +19,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.h2.engine.Constants;
 import org.h2.util.New;
 
 /**
@@ -134,12 +134,12 @@ public class WebServlet extends HttpServlet {
         byte[] bytes = server.getFile(file);
         if (bytes == null) {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND);
-            bytes = ("File not found: " + file).getBytes(Constants.UTF8);
+            bytes = ("File not found: " + file).getBytes(StandardCharsets.UTF_8);
         } else {
             if (session != null && file.endsWith(".jsp")) {
-                String page = new String(bytes, Constants.UTF8);
+                String page = new String(bytes, StandardCharsets.UTF_8);
                 page = PageParser.parse(page, session.map);
-                bytes = page.getBytes(Constants.UTF8);
+                bytes = page.getBytes(StandardCharsets.UTF_8);
             }
             resp.setContentType(mimeType);
             if (!cache) {

--- a/h2/src/main/org/h2/server/web/WebThread.java
+++ b/h2/src/main/org/h2/server/web/WebThread.java
@@ -12,11 +12,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.StringTokenizer;
-import org.h2.engine.Constants;
+
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.mvstore.DataUtils;
@@ -145,11 +146,11 @@ class WebThread extends WebApp implements Runnable {
                 bytes = server.getFile(file);
                 if (bytes == null) {
                     message = "HTTP/1.1 404 Not Found\r\n";
-                    bytes = ("File not found: " + file).getBytes(Constants.UTF8);
+                    bytes = ("File not found: " + file).getBytes(StandardCharsets.UTF_8);
                     message += "Content-Length: " + bytes.length + "\r\n";
                 } else {
                     if (session != null && file.endsWith(".jsp")) {
-                        String page = new String(bytes, Constants.UTF8);
+                        String page = new String(bytes, StandardCharsets.UTF_8);
                         if (SysProperties.CONSOLE_STREAM) {
                             Iterator<String> it = (Iterator<String>) session.map.remove("chunks");
                             if (it != null) {
@@ -163,7 +164,7 @@ class WebThread extends WebApp implements Runnable {
                                 while (it.hasNext()) {
                                     String s = it.next();
                                     s = PageParser.parse(s, session.map);
-                                    bytes = s.getBytes(Constants.UTF8);
+                                    bytes = s.getBytes(StandardCharsets.UTF_8);
                                     if (bytes.length == 0) {
                                         continue;
                                     }
@@ -179,7 +180,7 @@ class WebThread extends WebApp implements Runnable {
                             }
                         }
                         page = PageParser.parse(page, session.map);
-                        bytes = page.getBytes(Constants.UTF8);
+                        bytes = page.getBytes(StandardCharsets.UTF_8);
                     }
                     message = "HTTP/1.1 200 OK\r\n";
                     message += "Content-Type: " + mimeType + "\r\n";

--- a/h2/src/main/org/h2/store/CountingReaderInputStream.java
+++ b/h2/src/main/org/h2/store/CountingReaderInputStream.java
@@ -12,6 +12,8 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+
 import org.h2.engine.Constants;
 
 /**
@@ -25,7 +27,7 @@ public class CountingReaderInputStream extends InputStream {
     private final CharBuffer charBuffer =
             CharBuffer.allocate(Constants.IO_BUFFER_SIZE);
 
-    private final CharsetEncoder encoder = Constants.UTF8.newEncoder().
+    private final CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder().
             onMalformedInput(CodingErrorAction.REPLACE).
             onUnmappableCharacter(CodingErrorAction.REPLACE);
 

--- a/h2/src/main/org/h2/store/FileStore.java
+++ b/h2/src/main/org/h2/store/FileStore.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
@@ -139,7 +140,7 @@ public class FileStore {
      * @return the random salt or the magic
      */
     protected byte[] generateSalt() {
-        return HEADER.getBytes(Constants.UTF8);
+        return HEADER.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
@@ -175,7 +176,7 @@ public class FileStore {
     public void init() {
         int len = Constants.FILE_BLOCK_SIZE;
         byte[] salt;
-        byte[] magic = HEADER.getBytes(Constants.UTF8);
+        byte[] magic = HEADER.getBytes(StandardCharsets.UTF_8);
         if (length() < HEADER_LENGTH) {
             // write unencrypted
             checkedWriting = false;

--- a/h2/src/main/org/h2/store/LobStorageMap.java
+++ b/h2/src/main/org/h2/store/LobStorageMap.java
@@ -8,11 +8,11 @@ package org.h2.store;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map.Entry;
 import org.h2.api.ErrorCode;
-import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.message.DbException;
 import org.h2.mvstore.MVMap;
@@ -182,7 +182,7 @@ public class LobStorageMap implements LobStorageInterface {
                             "len > blobLength, " + len + " > " + maxLength);
                 }
                 byte[] utf8 = new String(small, 0, len)
-                        .getBytes(Constants.UTF8);
+                        .getBytes(StandardCharsets.UTF_8);
                 if (utf8.length > database.getMaxLengthInplaceLob()) {
                     throw new IllegalStateException(
                             "len > maxinplace, " + utf8.length + " > "

--- a/h2/src/main/org/h2/store/fs/FilePathEncrypt.java
+++ b/h2/src/main/org/h2/store/fs/FilePathEncrypt.java
@@ -12,9 +12,9 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import org.h2.engine.Constants;
 import org.h2.mvstore.DataUtils;
 import org.h2.security.AES;
 import org.h2.security.BlockCipher;
@@ -39,7 +39,7 @@ public class FilePathEncrypt extends FilePathWrapper {
     public FileChannel open(String mode) throws IOException {
         String[] parsed = parse(name);
         FileChannel file = FileUtils.open(parsed[1], mode);
-        byte[] passwordBytes = parsed[0].getBytes(Constants.UTF8);
+        byte[] passwordBytes = parsed[0].getBytes(StandardCharsets.UTF_8);
         return new FileEncrypt(name, passwordBytes, file);
     }
 

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -201,7 +202,7 @@ public class Recover extends Tool implements DataHandler {
      */
     public static Reader readClob(String fileName) throws IOException {
         return new BufferedReader(new InputStreamReader(readBlob(fileName),
-                Constants.UTF8));
+                StandardCharsets.UTF_8));
     }
 
     /**
@@ -297,7 +298,7 @@ public class Recover extends Tool implements DataHandler {
     public static Reader readClobMap(Connection conn, long lobId, long precision)
             throws Exception {
         InputStream in = readBlobMap(conn, lobId, precision);
-        return new BufferedReader(new InputStreamReader(in, Constants.UTF8));
+        return new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
     }
 
     private void trace(String message) {

--- a/h2/src/main/org/h2/tools/RunScript.java
+++ b/h2/src/main/org/h2/tools/RunScript.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -323,7 +324,7 @@ public class RunScript extends Tool {
             org.h2.Driver.load();
             Connection conn = DriverManager.getConnection(url, user, password);
             if (charset == null) {
-                charset = Constants.UTF8;
+                charset = StandardCharsets.UTF_8;
             }
             try {
                 process(conn, fileName, continueOnError, charset);

--- a/h2/src/main/org/h2/util/IOUtils.java
+++ b/h2/src/main/org/h2/util/IOUtils.java
@@ -19,6 +19,8 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
@@ -393,7 +395,7 @@ public class IOUtils {
      */
     public static Reader getBufferedReader(InputStream in) {
         return in == null ? null : new BufferedReader(
-                new InputStreamReader(in, Constants.UTF8));
+                new InputStreamReader(in, StandardCharsets.UTF_8));
     }
 
     /**
@@ -408,7 +410,7 @@ public class IOUtils {
     public static Reader getReader(InputStream in) {
         // InputStreamReader may read some more bytes
         return in == null ? null : new BufferedReader(
-                new InputStreamReader(in, Constants.UTF8));
+                new InputStreamReader(in, StandardCharsets.UTF_8));
     }
 
     /**
@@ -420,7 +422,7 @@ public class IOUtils {
      */
     public static Writer getBufferedWriter(OutputStream out) {
         return out == null ? null : new BufferedWriter(
-                new OutputStreamWriter(out, Constants.UTF8));
+                new OutputStreamWriter(out, StandardCharsets.UTF_8));
     }
 
     /**
@@ -464,7 +466,7 @@ public class IOUtils {
         if (s == null) {
             return null;
         }
-        return new ByteArrayInputStream(s.getBytes(Constants.UTF8));
+        return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/h2/src/main/org/h2/util/SourceCompiler.java
+++ b/h2/src/main/org/h2/util/SourceCompiler.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,7 +42,6 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
 import org.h2.api.ErrorCode;
-import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
@@ -368,7 +368,7 @@ public class SourceCompiler {
             copyInThread(p.getInputStream(), buff);
             copyInThread(p.getErrorStream(), buff);
             p.waitFor();
-            String output = new String(buff.toByteArray(), Constants.UTF8);
+            String output = new String(buff.toByteArray(), StandardCharsets.UTF_8);
             handleSyntaxError(output);
             return p.exitValue();
         } catch (Exception e) {
@@ -400,7 +400,7 @@ public class SourceCompiler {
                     "-d", COMPILE_DIR,
                     "-encoding", "UTF-8",
                     javaFile.getAbsolutePath() });
-            String output = new String(buff.toByteArray(), Constants.UTF8);
+            String output = new String(buff.toByteArray(), StandardCharsets.UTF_8);
             handleSyntaxError(output);
         } catch (Exception e) {
             throw DbException.convert(e);

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -7,12 +7,12 @@ package org.h2.util;
 
 import java.lang.ref.SoftReference;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
-import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 
@@ -454,7 +454,7 @@ public class StringUtils {
                 buff[j++] = (byte) ch;
             }
         }
-        String s = new String(buff, 0, j, Constants.UTF8);
+        String s = new String(buff, 0, j, StandardCharsets.UTF_8);
         return s;
     }
 

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -25,7 +26,6 @@ import java.util.HashMap;
 import java.util.UUID;
 import org.h2.api.ErrorCode;
 import org.h2.api.TimestampWithTimeZone;
-import org.h2.engine.Constants;
 import org.h2.engine.SessionInterface;
 import org.h2.engine.SysProperties;
 import org.h2.jdbc.JdbcArray;
@@ -619,7 +619,7 @@ public class DataType {
                 if (session == null) {
                     String s = rs.getString(columnIndex);
                     v = s == null ? ValueNull.INSTANCE :
-                        ValueLobDb.createSmallLob(Value.CLOB, s.getBytes(Constants.UTF8));
+                        ValueLobDb.createSmallLob(Value.CLOB, s.getBytes(StandardCharsets.UTF_8));
                 } else {
                     Reader in = rs.getCharacterStream(columnIndex);
                     if (in == null) {

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -14,6 +14,7 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -662,7 +663,7 @@ public class Transfer {
                     throw DbException.get(
                             ErrorCode.CONNECTION_BROKEN_1, "magic=" + magic);
                 }
-                byte[] small = new String(buff).getBytes(Constants.UTF8);
+                byte[] small = new String(buff).getBytes(StandardCharsets.UTF_8);
                 return ValueLobDb.createSmallLob(Value.CLOB, small, length);
             }
             Value v = session.getDataHandler().getLobStorage().

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -11,6 +11,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.lang.ref.SoftReference;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -19,7 +20,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import org.h2.api.ErrorCode;
-import org.h2.engine.Constants;
 import org.h2.engine.Mode;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
@@ -1028,7 +1028,7 @@ public abstract class Value {
                 return ValueFloat.get(Float.parseFloat(s.trim()));
             case CLOB:
                 return ValueLobDb.createSmallLob(
-                        CLOB, s.getBytes(Constants.UTF8));
+                        CLOB, s.getBytes(StandardCharsets.UTF_8));
             case BLOB:
                 return ValueLobDb.createSmallLob(
                         BLOB, StringUtils.convertHexToBytes(s.trim()));

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import org.h2.engine.Constants;
@@ -169,7 +170,7 @@ public class ValueLob extends Value {
         try {
             if (handler == null) {
                 String s = IOUtils.readStringAndClose(in, (int) length);
-                return createSmallLob(Value.CLOB, s.getBytes(Constants.UTF8));
+                return createSmallLob(Value.CLOB, s.getBytes(StandardCharsets.UTF_8));
             }
             boolean compress = handler.getLobCompressionAlgorithm(Value.CLOB) != null;
             long remaining = Long.MAX_VALUE;
@@ -187,7 +188,7 @@ public class ValueLob extends Value {
                 len = IOUtils.readFully(in, buff, len);
             }
             if (len <= handler.getMaxLengthInplaceLob()) {
-                byte[] small = new String(buff, 0, len).getBytes(Constants.UTF8);
+                byte[] small = new String(buff, 0, len).getBytes(StandardCharsets.UTF_8);
                 return ValueLob.createSmallLob(Value.CLOB, small);
             }
             ValueLob lob = new ValueLob(Value.CLOB, null);
@@ -227,7 +228,7 @@ public class ValueLob extends Value {
             boolean compress = h.getLobCompressionAlgorithm(Value.CLOB) != null;
             while (true) {
                 precision += len;
-                byte[] b = new String(buff, 0, len).getBytes(Constants.UTF8);
+                byte[] b = new String(buff, 0, len).getBytes(StandardCharsets.UTF_8);
                 out.write(b, 0, b.length);
                 remaining -= len;
                 if (remaining <= 0) {
@@ -549,7 +550,7 @@ public class ValueLob extends Value {
         try {
             if (type == Value.CLOB) {
                 if (small != null) {
-                    return new String(small, Constants.UTF8);
+                    return new String(small, StandardCharsets.UTF_8);
                 }
                 return IOUtils.readStringAndClose(getReader(), len);
             }

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import org.h2.engine.Constants;
@@ -286,7 +287,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
         try {
             if (type == Value.CLOB) {
                 if (small != null) {
-                    return new String(small, Constants.UTF8);
+                    return new String(small, StandardCharsets.UTF_8);
                 }
                 return IOUtils.readStringAndClose(getReader(), len);
             }
@@ -537,7 +538,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
                 len = IOUtils.readFully(reader, buff, len);
             }
             if (len <= handler.getMaxLengthInplaceLob()) {
-                byte[] small = new String(buff, 0, len).getBytes(Constants.UTF8);
+                byte[] small = new String(buff, 0, len).getBytes(StandardCharsets.UTF_8);
                 return ValueLobDb.createSmallLob(Value.CLOB, small, len);
             }
             reader.reset();
@@ -620,7 +621,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
                 try {
                     int p = MathUtils.convertLongToInt(precision);
                     String s = IOUtils.readStringAndClose(getReader(), p);
-                    byte[] data = s.getBytes(Constants.UTF8);
+                    byte[] data = s.getBytes(StandardCharsets.UTF_8);
                     lob = ValueLobDb.createSmallLob(type, data, s.length());
                 } catch (IOException e) {
                     throw DbException.convertIOException(e, null);
@@ -654,7 +655,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
     public static Value createSmallLob(int type, byte[] small) {
         int precision;
         if (type == Value.CLOB) {
-            precision = new String(small, Constants.UTF8).length();
+            precision = new String(small, StandardCharsets.UTF_8).length();
         } else {
             precision = small.length;
         }

--- a/h2/src/test/org/h2/test/unit/TestCharsetCollator.java
+++ b/h2/src/test/org/h2/test/unit/TestCharsetCollator.java
@@ -6,6 +6,7 @@
 package org.h2.test.unit;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.text.Collator;
 import org.h2.test.TestBase;
@@ -17,7 +18,7 @@ import org.h2.value.CompareMode;
  */
 public class TestCharsetCollator extends TestBase {
     private CharsetCollator cp500Collator = new CharsetCollator(Charset.forName("cp500"));
-    private CharsetCollator utf8Collator = new CharsetCollator(Charset.forName("UTF-8"));
+    private CharsetCollator utf8Collator = new CharsetCollator(StandardCharsets.UTF_8);
 
     /**
      * Run just this test.
@@ -50,7 +51,7 @@ public class TestCharsetCollator extends TestBase {
     private void testCreationFromCompareMode() {
         Collator utf8Col = CompareMode.getCollator("CHARSET_UTF-8");
         assertTrue(utf8Col instanceof CharsetCollator);
-        assertEquals(((CharsetCollator) utf8Col).getCharset(), Charset.forName("UTF-8"));
+        assertEquals(((CharsetCollator) utf8Col).getCharset(), StandardCharsets.UTF_8);
     }
 
     private void testBasicComparison() {

--- a/h2/src/tools/org/h2/dev/ftp/FtpClient.java
+++ b/h2/src/tools/org/h2/dev/ftp/FtpClient.java
@@ -17,8 +17,8 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
-import org.h2.engine.Constants;
 import org.h2.util.IOUtils;
 import org.h2.util.NetUtils;
 import org.h2.util.StatementBuilder;
@@ -57,7 +57,7 @@ public class FtpClient {
         InputStream in = socket.getInputStream();
         OutputStream out = socket.getOutputStream();
         reader = new BufferedReader(new InputStreamReader(in));
-        writer = new PrintWriter(new OutputStreamWriter(out, Constants.UTF8));
+        writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         readCode(220);
     }
 

--- a/h2/src/tools/org/h2/dev/ftp/server/FtpControl.java
+++ b/h2/src/tools/org/h2/dev/ftp/server/FtpControl.java
@@ -13,7 +13,8 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import org.h2.engine.Constants;
+import java.nio.charset.StandardCharsets;
+
 import org.h2.store.fs.FileUtils;
 import org.h2.util.StringUtils;
 
@@ -47,7 +48,7 @@ public class FtpControl extends Thread {
     public void run() {
         try {
             output = new PrintWriter(new OutputStreamWriter(
-                    control.getOutputStream(), Constants.UTF8));
+                    control.getOutputStream(), StandardCharsets.UTF_8));
             if (stop) {
                 reply(421, "Too many users");
             } else {

--- a/h2/src/tools/org/h2/dev/hash/MinimalPerfectHash.java
+++ b/h2/src/tools/org/h2/dev/hash/MinimalPerfectHash.java
@@ -7,7 +7,7 @@ package org.h2.dev.hash;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Set;
@@ -677,8 +677,6 @@ public class MinimalPerfectHash<K> {
      */
     public static class StringHash implements UniversalHash<String> {
 
-        private static final Charset UTF8 = Charset.forName("UTF-8");
-
         @Override
         public int hashCode(String o, int index, int seed) {
             if (index == 0) {
@@ -723,7 +721,7 @@ public class MinimalPerfectHash<K> {
          * @return the hash value
          */
         public static int getSipHash24(String o, long k0, long k1) {
-            byte[] b = o.getBytes(UTF8);
+            byte[] b = o.getBytes(StandardCharsets.UTF_8);
             return getSipHash24(b, 0, b.length, k0, k1);
         }
 

--- a/h2/src/tools/org/h2/dev/util/Migrate.java
+++ b/h2/src/tools/org/h2/dev/util/Migrate.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
@@ -95,7 +96,7 @@ public class Migrate {
                 "-password", password
         });
         file.renameTo(new File(file.getAbsoluteFile() + ".backup"));
-        RunScript.execute(url, user, password, TEMP_SCRIPT, Constants.UTF8, true);
+        RunScript.execute(url, user, password, TEMP_SCRIPT, StandardCharsets.UTF_8, true);
         new File(TEMP_SCRIPT).delete();
     }
 

--- a/h2/src/tools/org/h2/dev/util/ReaderInputStream.java
+++ b/h2/src/tools/org/h2/dev/util/ReaderInputStream.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.h2.engine.Constants;
 
@@ -33,7 +34,7 @@ public class ReaderInputStream extends InputStream {
         chars = new char[Constants.IO_BUFFER_SIZE];
         this.reader = reader;
         out = new ByteArrayOutputStream(Constants.IO_BUFFER_SIZE);
-        writer = new BufferedWriter(new OutputStreamWriter(out, Constants.UTF8));
+        writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
     }
 
     private void fillBuffer() throws IOException {


### PR DESCRIPTION
1. Replace `AtomicInteger[]` with `AtomicIntegerArray`.

2. Use `StandardCharsets` instead of own constants declared in different places. Available since Android API 19 that is no more an issue because H2 code is not compatible with older versions in many other places.
