### PR TITLE
Use predefined charsets instead of names where possible

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -17,6 +17,8 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.Socket;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
@@ -572,11 +574,11 @@ public class PgServerThread implements Runnable {
         }
     }
 
-    private String getEncoding() {
+    private Charset getEncoding() {
         if ("UNICODE".equals(clientEncoding)) {
-            return "UTF-8";
+            return StandardCharsets.UTF_8;
         }
-        return clientEncoding;
+        return Charset.forName(clientEncoding);
     }
 
     private void setParameter(PreparedStatement prep,

--- a/h2/src/main/org/h2/util/IOUtils.java
+++ b/h2/src/main/org/h2/util/IOUtils.java
@@ -433,12 +433,7 @@ public class IOUtils {
      * @return the reader
      */
     public static Reader getAsciiReader(InputStream in) {
-        try {
-            return in == null ? null : new InputStreamReader(in, "US-ASCII");
-        } catch (Exception e) {
-            // UnsupportedEncodingException
-            throw DbException.convert(e);
-        }
+        return in == null ? null : new InputStreamReader(in, StandardCharsets.US_ASCII);
     }
 
     /**

--- a/h2/src/main/org/h2/util/MathUtils.java
+++ b/h2/src/main/org/h2/util/MathUtils.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -151,7 +152,7 @@ public class MathUtils {
                 // can't use writeUTF, as the string
                 // might be larger than 64 KB
                 out.writeInt(s.length());
-                out.write(s.getBytes("UTF-8"));
+                out.write(s.getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 warn("generateAlternativeSeed", e);
             }

--- a/h2/src/main/org/h2/util/Profiler.java
+++ b/h2/src/main/org/h2/util/Profiler.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.lang.instrument.Instrumentation;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -272,11 +273,11 @@ public class Profiler implements Runnable {
             copyInThread(p.getInputStream(), out);
             copyInThread(p.getErrorStream(), err);
             p.waitFor();
-            String e = new String(err.toByteArray(), "UTF-8");
+            String e = new String(err.toByteArray(), StandardCharsets.UTF_8);
             if (e.length() > 0) {
                 throw new RuntimeException(e);
             }
-            String output = new String(out.toByteArray(), "UTF-8");
+            String output = new String(out.toByteArray(), StandardCharsets.UTF_8);
             return output;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/h2/src/main/org/h2/util/SortedProperties.java
+++ b/h2/src/main/org/h2/util/SortedProperties.java
@@ -15,6 +15,7 @@ import java.io.LineNumberReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map.Entry;
@@ -104,7 +105,7 @@ public class SortedProperties extends Properties {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         store(out, null);
         ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-        InputStreamReader reader = new InputStreamReader(in, "ISO8859-1");
+        InputStreamReader reader = new InputStreamReader(in, StandardCharsets.ISO_8859_1);
         LineNumberReader r = new LineNumberReader(reader);
         Writer w;
         try {

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -111,7 +111,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
                 if (len == 0) {
                     break;
                 }
-                byte[] data = new String(buff, 0, len).getBytes("UTF-8");
+                byte[] data = new String(buff, 0, len).getBytes(StandardCharsets.UTF_8);
                 out.write(data);
                 tmpPrecision += len;
             }

--- a/h2/src/test/org/h2/samples/Newsfeed.java
+++ b/h2/src/test/org/h2/samples/Newsfeed.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -36,7 +37,7 @@ public class Newsfeed {
         Class.forName("org.h2.Driver");
         Connection conn = DriverManager.getConnection("jdbc:h2:mem:", "sa", "");
         InputStream in = Newsfeed.class.getResourceAsStream("newsfeed.sql");
-        ResultSet rs = RunScript.execute(conn, new InputStreamReader(in, "ISO-8859-1"));
+        ResultSet rs = RunScript.execute(conn, new InputStreamReader(in, StandardCharsets.ISO_8859_1));
         in.close();
         while (rs.next()) {
             String file = rs.getString("FILE");
@@ -46,7 +47,7 @@ public class Newsfeed {
             }
             new File(targetDir).mkdirs();
             FileOutputStream out = new FileOutputStream(targetDir + "/" + file);
-            Writer writer = new OutputStreamWriter(out, "UTF-8");
+            Writer writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
             writer.write(content);
             writer.close();
             out.close();

--- a/h2/src/test/org/h2/test/db/TestCsv.java
+++ b/h2/src/test/org/h2/test/db/TestCsv.java
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -242,9 +243,9 @@ public class TestCsv extends TestBase {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         // UTF-8 "BOM" / marker
         out.write(StringUtils.convertHexToBytes("ef" + "bb" + "bf"));
-        out.write("\"ID\", \"NAME\"\n1, Hello".getBytes("UTF-8"));
+        out.write("\"ID\", \"NAME\"\n1, Hello".getBytes(StandardCharsets.UTF_8));
         byte[] buff = out.toByteArray();
-        Reader r = new InputStreamReader(new ByteArrayInputStream(buff), "UTF-8");
+        Reader r = new InputStreamReader(new ByteArrayInputStream(buff), StandardCharsets.UTF_8);
         ResultSet rs = new Csv().read(r, null);
         assertEquals("ID", rs.getMetaData().getColumnLabel(1));
         assertEquals("NAME", rs.getMetaData().getColumnLabel(2));
@@ -306,7 +307,7 @@ public class TestCsv extends TestBase {
 
         OutputStream out = FileUtils.newOutputStream(fileName, false);
         String csvContent = "\"A\",\"B\",\"C\",\"D\"\n\\N,\"\",\"\\N\",";
-        byte[] b = csvContent.getBytes("UTF-8");
+        byte[] b = csvContent.getBytes(StandardCharsets.UTF_8);
         out.write(b, 0, b.length);
         out.close();
         Csv csv = new Csv();

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
@@ -1358,7 +1359,7 @@ public class TestLob extends TestBase {
         PreparedStatement prep;
         prep = conn.prepareStatement("INSERT INTO TEST VALUES(1, ?)");
         String s = new String(getRandomChars(10000, 1));
-        byte[] data = s.getBytes("UTF-8");
+        byte[] data = s.getBytes(StandardCharsets.UTF_8);
         // if we keep the string, debugging with Eclipse is not possible
         // because Eclipse wants to display the large string and fails
         s = "";

--- a/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
@@ -10,6 +10,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.sql.Array;
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -365,15 +366,15 @@ public class TestCallableStatement extends TestBase {
         call.executeUpdate();
         assertEquals("XYZ", call.getString("B"));
         call.setAsciiStream("B",
-                new ByteArrayInputStream("xyz".getBytes("UTF-8")));
+                new ByteArrayInputStream("xyz".getBytes(StandardCharsets.UTF_8)));
         call.executeUpdate();
         assertEquals("XYZ", call.getString("B"));
         call.setAsciiStream("B",
-                new ByteArrayInputStream("xyz-".getBytes("UTF-8")), 3);
+                new ByteArrayInputStream("xyz-".getBytes(StandardCharsets.UTF_8)), 3);
         call.executeUpdate();
         assertEquals("XYZ", call.getString("B"));
         call.setAsciiStream("B",
-                new ByteArrayInputStream("xyz-".getBytes("UTF-8")), 3L);
+                new ByteArrayInputStream("xyz-".getBytes(StandardCharsets.UTF_8)), 3L);
         call.executeUpdate();
         assertEquals("XYZ", call.getString("B"));
 

--- a/h2/src/test/org/h2/test/jdbc/TestLobApi.java
+++ b/h2/src/test/org/h2/test/jdbc/TestLobApi.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
@@ -76,7 +77,7 @@ public class TestLobApi extends TestBase {
         rs.next();
         Clob clob = rs.getClob(2);
         byte[] data = IOUtils.readBytesAndClose(clob.getAsciiStream(), -1);
-        assertEquals("x", new String(data, "UTF-8"));
+        assertEquals("x", new String(data, StandardCharsets.UTF_8));
         assertTrue(clob.toString().endsWith("'x'"));
         clob.free();
         assertTrue(clob.toString().endsWith("null"));

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -13,6 +13,7 @@ import java.io.InputStreamReader;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -257,37 +258,37 @@ public class TestResultSet extends TestBase {
 
         rs.moveToInsertRow();
         rs.updateInt(1, 6);
-        in = new ByteArrayInputStream("Hello".getBytes("UTF-8"));
+        in = new ByteArrayInputStream("Hello".getBytes(StandardCharsets.UTF_8));
         rs.updateAsciiStream(2, in);
         rs.insertRow();
 
         rs.moveToInsertRow();
         rs.updateInt(1, 7);
-        in = new ByteArrayInputStream("Hello".getBytes("UTF-8"));
+        in = new ByteArrayInputStream("Hello".getBytes(StandardCharsets.UTF_8));
         rs.updateAsciiStream("data", in);
         rs.insertRow();
 
         rs.moveToInsertRow();
         rs.updateInt(1, 8);
-        in = new ByteArrayInputStream("Hello-".getBytes("UTF-8"));
+        in = new ByteArrayInputStream("Hello-".getBytes(StandardCharsets.UTF_8));
         rs.updateAsciiStream(2, in, 5);
         rs.insertRow();
 
         rs.moveToInsertRow();
         rs.updateInt(1, 9);
-        in = new ByteArrayInputStream("Hello-".getBytes("UTF-8"));
+        in = new ByteArrayInputStream("Hello-".getBytes(StandardCharsets.UTF_8));
         rs.updateAsciiStream("data", in, 5);
         rs.insertRow();
 
         rs.moveToInsertRow();
         rs.updateInt(1, 10);
-        in = new ByteArrayInputStream("Hello-".getBytes("UTF-8"));
+        in = new ByteArrayInputStream("Hello-".getBytes(StandardCharsets.UTF_8));
         rs.updateAsciiStream(2, in, 5L);
         rs.insertRow();
 
         rs.moveToInsertRow();
         rs.updateInt(1, 11);
-        in = new ByteArrayInputStream("Hello-".getBytes("UTF-8"));
+        in = new ByteArrayInputStream("Hello-".getBytes(StandardCharsets.UTF_8));
         rs.updateAsciiStream("data", in, 5L);
         rs.insertRow();
 
@@ -1615,7 +1616,7 @@ public class TestResultSet extends TestBase {
         rs.next();
         InputStreamReader reader = null;
         try {
-            reader = new InputStreamReader(rs.getAsciiStream(2), "ISO-8859-1");
+            reader = new InputStreamReader(rs.getAsciiStream(2), StandardCharsets.ISO_8859_1);
         } catch (Exception e) {
             assertTrue(false);
         }
@@ -1625,7 +1626,7 @@ public class TestResultSet extends TestBase {
         assertTrue(string != null && string.equals("Hello"));
         rs.next();
         try {
-            reader = new InputStreamReader(rs.getAsciiStream("value"), "ISO-8859-1");
+            reader = new InputStreamReader(rs.getAsciiStream("value"), StandardCharsets.ISO_8859_1);
         } catch (Exception e) {
             assertTrue(false);
         }

--- a/h2/src/test/org/h2/test/server/TestWeb.java
+++ b/h2/src/test/org/h2/test/server/TestWeb.java
@@ -12,6 +12,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -1175,11 +1176,7 @@ public class TestWeb extends TestBase {
 
         @Override
         public String toString() {
-            try {
-                return new String(buff.toByteArray(), "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                return e.toString();
-            }
+            return new String(buff.toByteArray(), StandardCharsets.UTF_8);
         }
 
         @Override

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -8,6 +8,7 @@ package org.h2.test.store;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -970,7 +971,7 @@ public class TestMVStore extends TestBase {
             }
             ByteBuffer buff = ByteBuffer.allocate(4 * 1024);
             fc.read(buff, i);
-            String h = new String(buff.array(), "UTF-8").trim();
+            String h = new String(buff.array(), StandardCharsets.UTF_8).trim();
             int idx = h.indexOf("fletcher:");
             int old = Character.digit(h.charAt(idx + "fletcher:".length()), 16);
             int bad = (old + 1) & 15;

--- a/h2/src/test/org/h2/test/unit/TestSampleApps.java
+++ b/h2/src/test/org/h2/test/unit/TestSampleApps.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
@@ -131,7 +132,7 @@ public class TestSampleApps extends TestBase {
         out.flush();
         System.setOut(oldOut);
         System.setErr(oldErr);
-        String s = new String(buff.toByteArray(), "UTF-8");
+        String s = new String(buff.toByteArray(), StandardCharsets.UTF_8);
         s = StringUtils.replaceAll(s, "\r\n", "\n");
         s = s.trim();
         expected = expected.trim();

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
@@ -860,7 +861,7 @@ public class TestTools extends TestBase {
         byte[] large = new byte[getSize(10 * 1024, 100 * 1024)];
         random.nextBytes(large);
         prep.setBytes(2, large);
-        String largeText = new String(large, "ISO-8859-1");
+        String largeText = new String(large, StandardCharsets.ISO_8859_1);
         prep.setString(3, largeText);
         prep.execute();
 

--- a/h2/src/tools/org/h2/build/BuildBase.java
+++ b/h2/src/tools/org/h2/build/BuildBase.java
@@ -28,6 +28,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -495,7 +496,7 @@ public class BuildBase {
                 buff.write(b);
                 if (b == '\n') {
                     byte[] data = buff.toByteArray();
-                    String line = new String(data, "UTF-8");
+                    String line = new String(data, StandardCharsets.UTF_8);
                     boolean print = true;
                     for (String l : exclude) {
                         if (line.startsWith(l)) {

--- a/h2/src/tools/org/h2/build/code/AbbaDetect.java
+++ b/h2/src/tools/org/h2/build/code/AbbaDetect.java
@@ -8,6 +8,7 @@ package org.h2.build.code;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Enable / disable AB-BA deadlock detector code.
@@ -46,7 +47,7 @@ public class AbbaDetect {
         byte[] data = new byte[(int) file.length()];
         in.readFully(data);
         in.close();
-        String source = new String(data, "UTF-8");
+        String source = new String(data, StandardCharsets.UTF_8);
         String original = source;
 
         source = disable(source);
@@ -63,7 +64,7 @@ public class AbbaDetect {
         }
         File newFile = new File(file + ".new");
         RandomAccessFile out = new RandomAccessFile(newFile, "rw");
-        out.write(source.getBytes("UTF-8"));
+        out.write(source.getBytes(StandardCharsets.UTF_8));
         out.close();
 
         File oldFile = new File(file + ".old");

--- a/h2/src/tools/org/h2/build/doc/FileConverter.java
+++ b/h2/src/tools/org/h2/build/doc/FileConverter.java
@@ -8,6 +8,7 @@ package org.h2.build.doc;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import org.h2.build.indexer.HtmlConverter;
@@ -52,10 +53,10 @@ public class FileConverter {
     private void convert() throws IOException {
         InputStream in = FileUtils.newInputStream(inFile);
         byte[] bytes = IOUtils.readBytesAndClose(in, -1);
-        String s = new String(bytes, "UTF-8");
+        String s = new String(bytes, StandardCharsets.UTF_8);
         String s2 = HtmlConverter.convertHtmlToString(s);
         String s3 = StringUtils.javaDecode(s2);
-        byte[] result = s3.getBytes("UTF-8");
+        byte[] result = s3.getBytes(StandardCharsets.UTF_8);
         OutputStream out = FileUtils.newOutputStream(outFile, false);
         out.write(result);
         out.close();

--- a/h2/src/tools/org/h2/build/doc/UploadBuild.java
+++ b/h2/src/tools/org/h2/build/doc/UploadBuild.java
@@ -13,6 +13,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -54,7 +55,7 @@ public class UploadBuild {
         if (coverage) {
             byte[] data = IOUtils.readBytesAndClose(
                     new FileInputStream("coverage/index.html"), -1);
-            String index = new String(data, "ISO-8859-1");
+            String index = new String(data, StandardCharsets.ISO_8859_1);
             coverageFailed = index.contains("CLASS=\"h\"");
             while (true) {
                 int idx = index.indexOf("<A HREF=\"");
@@ -69,7 +70,7 @@ public class UploadBuild {
             index = StringUtils.replaceAll(index, "[all", "");
             index = StringUtils.replaceAll(index, "classes]", "");
             FileOutputStream out = new FileOutputStream("coverage/overview.html");
-            out.write(index.getBytes("ISO-8859-1"));
+            out.write(index.getBytes(StandardCharsets.ISO_8859_1));
             out.close();
             new File("details").mkdir();
             zip("details/coverage_files.zip", "coverage", true);

--- a/h2/src/tools/org/h2/build/doc/WebSite.java
+++ b/h2/src/tools/org/h2/build/doc/WebSite.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import org.h2.samples.Newsfeed;
@@ -65,7 +66,7 @@ public class WebSite {
             if (f.getName().startsWith("fragments")) {
                 FileInputStream in = new FileInputStream(f);
                 byte[] bytes = IOUtils.readBytesAndClose(in, 0);
-                String page = new String(bytes, "UTF-8");
+                String page = new String(bytes, StandardCharsets.UTF_8);
                 fragments.put(f.getName(), page);
             }
         }
@@ -140,7 +141,7 @@ public class WebSite {
             FileInputStream in = new FileInputStream(source);
             byte[] bytes = IOUtils.readBytesAndClose(in, 0);
             if (name.endsWith(".html")) {
-                String page = new String(bytes, "UTF-8");
+                String page = new String(bytes, StandardCharsets.UTF_8);
                 if (web) {
                     page = StringUtils.replaceAll(page, ANALYTICS_TAG, ANALYTICS_SCRIPT);
                 }
@@ -155,7 +156,7 @@ public class WebSite {
                     page = StringUtils.replaceAll(page, "<pre>", "<pre class=\"notranslate\">");
                     page = StringUtils.replaceAll(page, "<code>", "<code class=\"notranslate\">");
                 }
-                bytes = page.getBytes("UTF-8");
+                bytes = page.getBytes(StandardCharsets.UTF_8);
             }
             FileOutputStream out = new FileOutputStream(target);
             out.write(bytes);

--- a/h2/src/tools/org/h2/build/i18n/PrepareTranslation.java
+++ b/h2/src/tools/org/h2/build/i18n/PrepareTranslation.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -153,7 +154,7 @@ public class PrepareTranslation {
                 target = targetDir + "/" + name + "_" + language + ".html";
             }
             OutputStream out = new FileOutputStream(target);
-            OutputStreamWriter writer = new OutputStreamWriter(out, "UTF-8");
+            OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
             writer.write(html);
             writer.close();
         }
@@ -231,7 +232,7 @@ public class PrepareTranslation {
     private static String extract(String documentName, File f, String target)
             throws Exception {
         String xml = IOUtils.readStringAndClose(new InputStreamReader(
-                new FileInputStream(f), "UTF-8"), -1);
+                new FileInputStream(f), StandardCharsets.UTF_8), -1);
         // the template contains ${} instead of text
         StringBuilder template = new StringBuilder(xml.length());
         int id = 0;
@@ -444,7 +445,7 @@ public class PrepareTranslation {
             throws IOException {
         if (utf8) {
             String s = new String(IOUtils.readBytesAndClose(
-                    new FileInputStream(fileName), -1), "UTF-8");
+                    new FileInputStream(fileName), -1), StandardCharsets.UTF_8);
             return SortedProperties.fromLines(s);
         }
         return SortedProperties.loadProperties(fileName);
@@ -455,7 +456,7 @@ public class PrepareTranslation {
         if (utf8) {
             String s = p.toLines();
             FileOutputStream f = new FileOutputStream(fileName);
-            f.write(s.getBytes("UTF-8"));
+            f.write(s.getBytes(StandardCharsets.UTF_8));
             f.close();
         } else {
             p.store(fileName);

--- a/h2/src/tools/org/h2/build/i18n/PropertiesToUTF8.java
+++ b/h2/src/tools/org/h2/build/i18n/PropertiesToUTF8.java
@@ -13,6 +13,7 @@ import java.io.LineNumberReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Properties;
 import org.h2.build.code.CheckTextFiles;
@@ -55,7 +56,7 @@ public class PropertiesToUTF8 {
         }
         Properties prop = SortedProperties.loadProperties(source);
         FileOutputStream out = new FileOutputStream(target);
-        PrintWriter writer = new PrintWriter(new OutputStreamWriter(out, "UTF-8"));
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         // keys is sorted
         for (Enumeration<Object> en = prop.keys(); en.hasMoreElements();) {
             String key = (String) en.nextElement();
@@ -79,7 +80,7 @@ public class PropertiesToUTF8 {
             return;
         }
         LineNumberReader reader = new LineNumberReader(new InputStreamReader(
-                new FileInputStream(source), "UTF-8"));
+                new FileInputStream(source), StandardCharsets.UTF_8));
         try {
             SortedProperties prop = new SortedProperties();
             StringBuilder buff = new StringBuilder();
@@ -123,7 +124,7 @@ public class PropertiesToUTF8 {
                 continue;
             }
             FileInputStream in = new FileInputStream(f);
-            InputStreamReader r = new InputStreamReader(in, "UTF-8");
+            InputStreamReader r = new InputStreamReader(in, StandardCharsets.UTF_8);
             String s = IOUtils.readStringAndClose(r, -1);
             in.close();
             String name = f.getName();
@@ -142,7 +143,7 @@ public class PropertiesToUTF8 {
                 // s = unescapeHtml(s);
                 utf8 = StringUtils.javaDecode(utf8);
                 FileOutputStream out = new FileOutputStream("_utf8" + f.getName());
-                OutputStreamWriter w = new OutputStreamWriter(out, "UTF-8");
+                OutputStreamWriter w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
                 w.write(utf8);
                 w.close();
                 out.close();

--- a/h2/src/tools/org/h2/build/indexer/Indexer.java
+++ b/h2/src/tools/org/h2/build/indexer/Indexer.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -256,7 +257,7 @@ public class Indexer {
 
     private void readPage(File file) throws Exception {
         byte[] data = IOUtils.readBytesAndClose(new FileInputStream(file), 0);
-        String text = new String(data, "UTF-8");
+        String text = new String(data, StandardCharsets.UTF_8);
         StringTokenizer t = new StringTokenizer(text, "<> \r\n", true);
         boolean inTag = false;
         title = false;

--- a/h2/src/tools/org/h2/dev/util/FileContentHash.java
+++ b/h2/src/tools/org/h2/dev/util/FileContentHash.java
@@ -7,6 +7,7 @@ package org.h2.dev.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -99,8 +100,8 @@ public class FileContentHash {
                     checkCollision(f, length, StringUtils.convertHexToBytes(hash));
                 }
                 propNew.put(entry, hash);
-                mdDir.update(entry.getBytes("UTF-8"));
-                mdDir.update(hash.getBytes("UTF-8"));
+                mdDir.update(entry.getBytes(StandardCharsets.UTF_8));
+                mdDir.update(hash.getBytes(StandardCharsets.UTF_8));
             }
             String oldFile = propOld.toString();
             String newFile = propNew.toString();

--- a/h2/src/tools/org/h2/dev/util/JavaProcessKiller.java
+++ b/h2/src/tools/org/h2/dev/util/JavaProcessKiller.java
@@ -8,6 +8,7 @@ package org.h2.dev.util;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
@@ -91,11 +92,11 @@ public class JavaProcessKiller {
             copyInThread(p.getInputStream(), out);
             copyInThread(p.getErrorStream(), err);
             p.waitFor();
-            String e = new String(err.toByteArray(), "UTF-8");
+            String e = new String(err.toByteArray(), StandardCharsets.UTF_8);
             if (e.length() > 0) {
                 throw new RuntimeException(e);
             }
-            String output = new String(out.toByteArray(), "UTF-8");
+            String output = new String(out.toByteArray(), StandardCharsets.UTF_8);
             return output;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/h2/src/tools/org/h2/dev/util/RemovePasswords.java
+++ b/h2/src/tools/org/h2/dev/util/RemovePasswords.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel.MapMode;
+import java.nio.charset.StandardCharsets;
 
 import org.h2.engine.Constants;
 import org.h2.security.SHA256;
@@ -45,7 +46,7 @@ public class RemovePasswords {
             }
             buff.position(i);
             buff.get(data);
-            String s = new String(data, "UTF-8");
+            String s = new String(data, StandardCharsets.UTF_8);
             if (!s.startsWith("CREATE USER ")) {
                 continue;
             }

--- a/h2/src/tools/org/h2/java/JavaParser.java
+++ b/h2/src/tools/org/h2/java/JavaParser.java
@@ -8,6 +8,7 @@ package org.h2.java;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -166,7 +167,7 @@ public class JavaParser {
             RandomAccessFile file = new RandomAccessFile(fileName, "r");
             byte[] buff = new byte[(int) file.length()];
             file.readFully(buff);
-            source = new String(buff, "UTF-8");
+            source = new String(buff, StandardCharsets.UTF_8);
             file.close();
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
This pull request replaces string names with predefined charsets in many places to avoid lookups of charsets. I also removed catches of UnsupportedEncodingException in such places.

There are a few remaining places where charset names are still in use. Charsets from clients (we can lookup and store them but it requires more work), some public methods, calls to URLEncoder.