### PR TITLE
Optimize StringUtils.trim() and remove StringUtils.equals()

### DIFF
--- a/h2/src/main/org/h2/bnf/Sentence.java
+++ b/h2/src/main/org/h2/bnf/Sentence.java
@@ -7,6 +7,7 @@ package org.h2.bnf;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.bnf.context.DbSchema;
@@ -186,7 +187,7 @@ public class Sentence {
      * @param query the query string
      */
     public void setQuery(String query) {
-        if (!StringUtils.equals(this.query, query)) {
+        if (!Objects.equals(this.query, query)) {
             this.query = query;
             this.queryUpper = StringUtils.toUpperEnglish(query);
         }

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -579,7 +580,7 @@ public class Database implements DataHandler {
      * @return true if the cipher algorithm and the password match
      */
     boolean validateFilePasswordHash(String testCipher, byte[] testHash) {
-        if (!StringUtils.equals(testCipher, this.cipher)) {
+        if (!Objects.equals(testCipher, this.cipher)) {
             return false;
         }
         return Utils.compareSecure(testHash, filePasswordHash);

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -6,6 +6,8 @@
 package org.h2.engine;
 
 import java.util.HashMap;
+import java.util.Objects;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.command.Parser;
@@ -15,7 +17,6 @@ import org.h2.message.Trace;
 import org.h2.store.FileLock;
 import org.h2.util.MathUtils;
 import org.h2.util.New;
-import org.h2.util.StringUtils;
 import org.h2.util.ThreadDeadlockDetector;
 import org.h2.util.Utils;
 
@@ -245,7 +246,7 @@ public class Engine implements SessionFactory {
         String clusterDb = database.getCluster();
         if (!Constants.CLUSTERING_DISABLED.equals(clusterDb)) {
             if (!Constants.CLUSTERING_ENABLED.equals(clusterSession)) {
-                if (!StringUtils.equals(clusterSession, clusterDb)) {
+                if (!Objects.equals(clusterSession, clusterDb)) {
                     if (clusterDb.equals(Constants.CLUSTERING_DISABLED)) {
                         throw DbException.get(
                                 ErrorCode.CLUSTER_ERROR_DATABASE_RUNS_ALONE);

--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -14,6 +14,8 @@ import java.io.StringWriter;
 import java.net.Socket;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Objects;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.Command;
 import org.h2.engine.ConnectionInfo;
@@ -33,7 +35,6 @@ import org.h2.store.LobStorageInterface;
 import org.h2.util.IOUtils;
 import org.h2.util.SmallLRUCache;
 import org.h2.util.SmallMap;
-import org.h2.util.StringUtils;
 import org.h2.value.Transfer;
 import org.h2.value.Value;
 import org.h2.value.ValueLobDb;
@@ -540,7 +541,7 @@ public class TcpServerThread implements Runnable {
      * @param statementId the statement to cancel
      */
     void cancelStatement(String targetSessionId, int statementId) {
-        if (StringUtils.equals(targetSessionId, this.sessionId)) {
+        if (Objects.equals(targetSessionId, this.sessionId)) {
             Command cmd = (Command) cache.getObject(statementId, false);
             cmd.cancel();
         }

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -15,6 +15,8 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.Prepared;
 import org.h2.engine.Session;
@@ -137,8 +139,8 @@ public class TableLink extends Table {
             if (schema == null) {
                 schema = thisSchema;
             }
-            if (!StringUtils.equals(catalog, thisCatalog) ||
-                    !StringUtils.equals(schema, thisSchema)) {
+            if (!Objects.equals(catalog, thisCatalog) ||
+                    !Objects.equals(schema, thisSchema)) {
                 // if the table exists in multiple schemas or tables,
                 // use the alternative solution
                 columnMap.clear();

--- a/h2/src/main/org/h2/table/TableLinkConnection.java
+++ b/h2/src/main/org/h2/table/TableLinkConnection.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.Objects;
 import org.h2.message.DbException;
 import org.h2.util.JdbcUtils;
-import org.h2.util.StringUtils;
 
 /**
  * A connection for a linked table. The same connection may be used for multiple
@@ -105,10 +104,10 @@ public class TableLinkConnection {
     public boolean equals(Object o) {
         if (o instanceof TableLinkConnection) {
             TableLinkConnection other = (TableLinkConnection) o;
-            return StringUtils.equals(driver, other.driver)
-                    && StringUtils.equals(url, other.url)
-                    && StringUtils.equals(user, other.user)
-                    && StringUtils.equals(password, other.password);
+            return Objects.equals(driver, other.driver)
+                    && Objects.equals(url, other.url)
+                    && Objects.equals(user, other.user)
+                    && Objects.equals(password, other.password);
         }
         return false;
     }

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -77,20 +77,6 @@ public class StringUtils {
     }
 
     /**
-     * Check if two strings are equal. Here, null is equal to null.
-     *
-     * @param a the first value
-     * @param b the second value
-     * @return true if both are null or both are equal
-     */
-    public static boolean equals(String a, String b) {
-        if (a == null) {
-            return b == null;
-        }
-        return a.equals(b);
-    }
-
-    /**
      * Convert a string to uppercase using the English locale.
      *
      * @param s the test to convert

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -845,23 +845,20 @@ public class StringUtils {
      */
     public static String trim(String s, boolean leading, boolean trailing,
             String sp) {
-        char space = (sp == null || sp.length() < 1) ? ' ' : sp.charAt(0);
+        char space = sp == null || sp.isEmpty() ? ' ' : sp.charAt(0);
+        int begin = 0, end = s.length();
         if (leading) {
-            int len = s.length(), i = 0;
-            while (i < len && s.charAt(i) == space) {
-                i++;
+            while (begin < end && s.charAt(begin) == space) {
+                begin++;
             }
-            s = (i == 0) ? s : s.substring(i);
         }
         if (trailing) {
-            int endIndex = s.length() - 1;
-            int i = endIndex;
-            while (i >= 0 && s.charAt(i) == space) {
-                i--;
+            while (end > begin && s.charAt(end - 1) == space) {
+                end--;
             }
-            s = i == endIndex ? s : s.substring(0, i + 1);
         }
-        return s;
+        // substring() returns self if start == 0 && end == length()
+        return s.substring(begin, end);
     }
 
     /**

--- a/h2/src/main/org/h2/value/CompareMode.java
+++ b/h2/src/main/org/h2/value/CompareMode.java
@@ -8,6 +8,7 @@ package org.h2.value;
 import java.nio.charset.Charset;
 import java.text.Collator;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.h2.engine.SysProperties;
 import org.h2.util.StringUtils;
@@ -111,7 +112,7 @@ public class CompareMode {
     public static CompareMode getInstance(String name, int strength, boolean binaryUnsigned) {
         CompareMode last = lastUsed;
         if (last != null) {
-            if (StringUtils.equals(last.name, name) &&
+            if (Objects.equals(last.name, name) &&
                     last.strength == strength &&
                     last.binaryUnsigned == binaryUnsigned) {
                 return last;

--- a/h2/src/test/org/h2/test/unit/TestStringUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestStringUtils.java
@@ -39,6 +39,7 @@ public class TestStringUtils extends TestBase {
         testURL();
         testPad();
         testReplaceAll();
+        testTrim();
     }
 
     private void testHex() {
@@ -225,5 +226,29 @@ public class TestStringUtils extends TestBase {
         assertEquals("abcabcabc",
                 StringUtils.replaceAll("abcabcabc", "aBc", ""));
     }
+
+    private void testTrim() {
+        assertEquals("a a",
+                StringUtils.trim("a a", true, true, null));
+        assertEquals("  a a  ",
+                StringUtils.trim("  a a  ", false, false, null));
+        assertEquals("  a a",
+                StringUtils.trim("  a a  ", false, true, null));
+        assertEquals("a a  ",
+                StringUtils.trim("  a a  ", true, false, null));
+        assertEquals("a a",
+                StringUtils.trim("  a a  ", true, true, null));
+        assertEquals("a a",
+                StringUtils.trim("  a a  ", true, true, ""));
+        assertEquals("zzbbzz",
+                StringUtils.trim("zzbbzz", false, false, "z"));
+        assertEquals("zzbb",
+                StringUtils.trim("zzbbzz", false, true, "z"));
+        assertEquals("bbzz",
+                StringUtils.trim("zzbbzz", true, false, "z"));
+        assertEquals("bb",
+                StringUtils.trim("zzbbzz", true, true, "z"));
+    }
+
 
 }


### PR DESCRIPTION
1. Since we support only Java 7 and Android API 19 (really 21) it's better to use `Objects.equals()` instead of own method. Code in `Objects.equals()` are better, but there are no measurable difference in perfomance, just cleanup.

2. Rewrite `StringUtils.trim()` so it use only one `substring()` call. `substring()` allocates a new `String` in case of truncation in all supported versions of JDK, it's better to call in only once. I also wrote a test for this method.