### PR TITLE
Fix handling of UUID in Datatype.readValue()

### DIFF
--- a/h2/src/main/org/h2/expression/TableFunction.java
+++ b/h2/src/main/org/h2/expression/TableFunction.java
@@ -136,6 +136,10 @@ public class TableFunction extends Function {
         simple.setAutoClose(false);
         for (int i = 0; i < columnCount; i++) {
             String name = rs.getColumnName(i);
+            /*
+             * TODO Some types, such as Value.BYTES and Value.UUID are mapped to the same
+             * SQL type and we can lose real type here.
+             */
             int sqlType = DataType.convertTypeToSQLType(rs.getColumnType(i));
             int precision = MathUtils.convertLongToInt(rs.getColumnPrecision(i));
             int scale = rs.getColumnScale(i);

--- a/h2/src/main/org/h2/tools/SimpleResultSet.java
+++ b/h2/src/main/org/h2/tools/SimpleResultSet.java
@@ -36,8 +36,8 @@ import org.h2.message.DbException;
 import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.New;
+import org.h2.util.Utils;
 import org.h2.value.DataType;
-import org.h2.value.ValueUuid;
 
 /**
  * This class is a simple result set and meta data implementation.
@@ -534,8 +534,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
             return (byte[]) o;
         }
         if (o instanceof UUID) {
-            final UUID u = (UUID) o;
-            return ValueUuid.get(u.getMostSignificantBits(), u.getLeastSignificantBits()).getBytes();
+            return Utils.uuidToBytes((UUID) o);
         }
         return JdbcUtils.serialize(o, null);
     }

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -90,6 +91,28 @@ public class Utils {
     public static long readLong(byte[] buff, int pos) {
         return (((long) readInt(buff, pos)) << 32) +
                 (readInt(buff, pos + 4) & 0xffffffffL);
+    }
+
+    /**
+     * @param uuid UUID value
+     * @return byte array representation
+     */
+    public static byte[] uuidToBytes(UUID uuid) {
+        return uuidToBytes(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+    }
+
+    /**
+     * @param msb most significant part of UUID
+     * @param lsb least significant part of UUID
+     * @return byte array representation
+     */
+    public static byte[] uuidToBytes(long msb, long lsb) {
+        byte[] buff = new byte[16];
+        for (int i = 0; i < 8; i++) {
+            buff[i] = (byte) ((msb >> (8 * (7 - i))) & 255);
+            buff[8 + i] = (byte) ((lsb >> (8 * (7 - i))) & 255);
+        }
+        return buff;
     }
 
     /**

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -522,8 +522,7 @@ public class DataType {
                 if (o instanceof byte[]) {
                     v = ValueBytes.getNoCopy((byte[]) o);
                 } else if (o != null) {
-                    UUID u = (UUID) o;
-                    v = ValueUuid.get(u.getMostSignificantBits(), u.getLeastSignificantBits());
+                    v = ValueUuid.get((UUID) o);
                 } else
                     v = ValueNull.INSTANCE;
                 break;
@@ -531,8 +530,7 @@ public class DataType {
             case Value.UUID: {
                 Object o = rs.getObject(columnIndex);
                 if (o instanceof UUID) {
-                    UUID u = (UUID) o;
-                    v = ValueUuid.get(u.getMostSignificantBits(), u.getLeastSignificantBits());
+                    v = ValueUuid.get((UUID) o);
                 } else if (o != null)
                     v = ValueUuid.get((byte[]) o);
                 else
@@ -1114,8 +1112,7 @@ public class DataType {
             }
             return ValueResultSet.getCopy((ResultSet) x, Integer.MAX_VALUE);
         } else if (x instanceof UUID) {
-            UUID u = (UUID) x;
-            return ValueUuid.get(u.getMostSignificantBits(), u.getLeastSignificantBits());
+            return ValueUuid.get((UUID) x);
         } else if (x instanceof Object[]) {
             // (a.getClass().isArray());
             // (a.getClass().getComponentType().isPrimitive());

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -514,9 +514,18 @@ public class DataType {
                 return ValueNull.INSTANCE;
             }
             case Value.BYTES: {
-                byte[] buff = rs.getBytes(columnIndex);
-                v = buff == null ? (Value) ValueNull.INSTANCE :
-                    ValueBytes.getNoCopy(buff);
+                /*
+                 * Both BINARY and UUID may be mapped to Value.BYTES. getObject() returns byte[]
+                 * for SQL BINARY, UUID for SQL UUID and null for SQL NULL.
+                 */
+                Object o = rs.getObject(columnIndex);
+                if (o instanceof byte[]) {
+                    v = ValueBytes.getNoCopy((byte[]) o);
+                } else if (o != null) {
+                    UUID u = (UUID) o;
+                    v = ValueUuid.get(u.getMostSignificantBits(), u.getLeastSignificantBits());
+                } else
+                    v = ValueNull.INSTANCE;
                 break;
             }
             case Value.UUID: {

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -529,9 +529,14 @@ public class DataType {
                 break;
             }
             case Value.UUID: {
-                byte[] buff = rs.getBytes(columnIndex);
-                v = buff == null ? (Value) ValueNull.INSTANCE :
-                    ValueUuid.get(buff);
+                Object o = rs.getObject(columnIndex);
+                if (o instanceof UUID) {
+                    UUID u = (UUID) o;
+                    v = ValueUuid.get(u.getMostSignificantBits(), u.getLeastSignificantBits());
+                } else if (o != null)
+                    v = ValueUuid.get((byte[]) o);
+                else
+                    v = ValueNull.INSTANCE;
                 break;
             }
             case Value.BOOLEAN: {

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -944,9 +944,7 @@ public abstract class Value {
                     Object object = JdbcUtils.deserialize(getBytesNoCopy(),
                             getDataHandler());
                     if (object instanceof java.util.UUID) {
-                        java.util.UUID uuid = (java.util.UUID) object;
-                        return ValueUuid.get(uuid.getMostSignificantBits(),
-                                uuid.getLeastSignificantBits());
+                        return ValueUuid.get((java.util.UUID) object);
                     }
                     throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, getString());
                 case TIMESTAMP_TZ:

--- a/h2/src/main/org/h2/value/ValueUuid.java
+++ b/h2/src/main/org/h2/value/ValueUuid.java
@@ -85,6 +85,16 @@ public class ValueUuid extends Value {
     }
 
     /**
+     * Get or create a UUID for the given Java UUID.
+     *
+     * @param uuid Java UUID
+     * @return the UUID
+     */
+    public static ValueUuid get(UUID uuid) {
+        return get(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+    }
+
+    /**
      * Get or create a UUID for the given text representation.
      *
      * @param s the text representation of the UUID
@@ -176,12 +186,7 @@ public class ValueUuid extends Value {
 
     @Override
     public byte[] getBytes() {
-        byte[] buff = new byte[16];
-        for (int i = 0; i < 8; i++) {
-            buff[i] = (byte) ((high >> (8 * (7 - i))) & 255);
-            buff[8 + i] = (byte) ((low >> (8 * (7 - i))) & 255);
-        }
-        return buff;
+        return Utils.uuidToBytes(high, low);
     }
 
     @Override

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -22,6 +22,7 @@ import org.h2.message.DbException;
 import org.h2.test.TestBase;
 import org.h2.test.utils.AssertThrows;
 import org.h2.tools.SimpleResultSet;
+import org.h2.util.Utils;
 import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
@@ -130,9 +131,7 @@ public class TestValue extends TestBase {
             prep.setObject(1, new Object[] { uuid });
             rs = prep.executeQuery();
             rs.next();
-            assertTrue(Arrays.equals(
-                    ValueUuid.get(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()).getBytes(),
-                    (byte[]) rs.getObject(1)));
+            assertTrue(Arrays.equals(Utils.uuidToBytes(uuid), (byte[]) rs.getObject(1)));
             // Check that type is not changed
             prep = conn.prepareStatement("SELECT * FROM TABLE(X UUID=?)");
             prep.setObject(1, new Object[] { uuid });


### PR DESCRIPTION
This pull request is a follow-up to PR #712. It fixes handling of UUID in Datatype.readValue().

With this change `SELECT * FROM TABLE(X UUID=?)` really returns UUIDs in `ResultSet`.

Changes from #712 are still relevant. This pull request contains the tests for #712 and for its own changes.