### PR TITLE
Allocate less amount of garbage

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1154,10 +1154,10 @@ public class Parser {
             TableFilter sourceTableFilter = readSimpleTableFilterWithAliasExcludes(0, excludeIdentifiers);
             command.setSourceTableFilter(sourceTableFilter);
 
-            StringBuilder buff = new StringBuilder(
-                    "SELECT * FROM "+sourceTableFilter.getTable().getName());
+            StringBuilder buff = new StringBuilder("SELECT * FROM ")
+                    .append(sourceTableFilter.getTable().getName());
             if (sourceTableFilter.getTableAlias() != null) {
-                buff.append(" AS "+sourceTableFilter.getTableAlias());
+                buff.append(" AS ").append(sourceTableFilter.getTableAlias());
             }
             Prepared preparedQuery = prepare(session, buff.toString(), null/*paramValues*/);
             command.setQuery((Select) preparedQuery);
@@ -1208,7 +1208,7 @@ public class Parser {
                     " AS " + command.getTargetTableFilter().getTableAlias());
         }
         targetMatchQuerySQL
-                .append(" WHERE " + command.getOnCondition().getSQL());
+                .append(" WHERE ").append(command.getOnCondition().getSQL());
         command.setTargetMatchQuery(
                 (Select) parse(targetMatchQuerySQL.toString()));
 

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -423,10 +423,10 @@ public class ScriptCommand extends ScriptBase {
                     int id;
                     if (v.getType() == Value.CLOB) {
                         id = writeLobStream(v);
-                        buff.append("SYSTEM_COMBINE_CLOB(" + id + ")");
+                        buff.append("SYSTEM_COMBINE_CLOB(").append(id).append(')');
                     } else if (v.getType() == Value.BLOB) {
                         id = writeLobStream(v);
-                        buff.append("SYSTEM_COMBINE_BLOB(" + id + ")");
+                        buff.append("SYSTEM_COMBINE_BLOB(").append(id).append(')');
                     } else {
                         buff.append(v.getSQL());
                     }
@@ -471,8 +471,8 @@ public class ScriptCommand extends ScriptBase {
             try (InputStream input = v.getInputStream()) {
                 for (int i = 0;; i++) {
                     StringBuilder buff = new StringBuilder(lobBlockSize * 2);
-                    buff.append("INSERT INTO SYSTEM_LOB_STREAM VALUES(" + id +
-                            ", " + i + ", NULL, '");
+                    buff.append("INSERT INTO SYSTEM_LOB_STREAM VALUES(").append(id)
+                            .append(", ").append(i).append(", NULL, '");
                     int len = IOUtils.readFully(input, bytes, lobBlockSize);
                     if (len <= 0) {
                         break;
@@ -490,7 +490,8 @@ public class ScriptCommand extends ScriptBase {
             try (Reader reader = v.getReader()) {
                 for (int i = 0;; i++) {
                     StringBuilder buff = new StringBuilder(lobBlockSize * 2);
-                    buff.append("INSERT INTO SYSTEM_LOB_STREAM VALUES(" + id + ", " + i + ", ");
+                    buff.append("INSERT INTO SYSTEM_LOB_STREAM VALUES(").append(id).append(", ").append(i)
+                            .append(", ");
                     int len = IOUtils.readFully(reader, chars, lobBlockSize);
                     if (len == 0) {
                         break;

--- a/h2/src/main/org/h2/command/dml/SetTypes.java
+++ b/h2/src/main/org/h2/command/dml/SetTypes.java
@@ -6,7 +6,6 @@
 package org.h2.command.dml;
 
 import java.util.ArrayList;
-import org.h2.util.New;
 
 /**
  * The list of setting for a SET statement.
@@ -247,20 +246,22 @@ public class SetTypes {
      * The type of SET BUILTIN_ALIAS_OVERRIDE statement.
      */
     public static final int BUILTIN_ALIAS_OVERRIDE = 47;
+
     /**
      * The type of a SET COLUMN_NAME_RULES statement.
      */
     public static final int COLUMN_NAME_RULES = 48;
 
+    private static final int COUNT = COLUMN_NAME_RULES + 1;
 
-    private static final ArrayList<String> TYPES = New.arrayList();
+    private static final ArrayList<String> TYPES;
 
     private SetTypes() {
         // utility class
     }
 
     static {
-        ArrayList<String> list = TYPES;
+        ArrayList<String> list = new ArrayList<>(COUNT);
         list.add(null);
         list.add(IGNORECASE, "IGNORECASE");
         list.add(MAX_LOG_SIZE, "MAX_LOG_SIZE");
@@ -310,7 +311,7 @@ public class SetTypes {
         list.add(LAZY_QUERY_EXECUTION, "LAZY_QUERY_EXECUTION");
         list.add(BUILTIN_ALIAS_OVERRIDE, "BUILTIN_ALIAS_OVERRIDE");
         list.add(COLUMN_NAME_RULES, "COLUMN_NAME_RULES");
-
+        TYPES = list;
     }
 
     /**
@@ -320,12 +321,7 @@ public class SetTypes {
      * @return the number
      */
     public static int getType(String name) {
-        for (int i = 0; i < getTypes().size(); i++) {
-            if (name.equals(getTypes().get(i))) {
-                return i;
-            }
-        }
-        return -1;
+        return TYPES.indexOf(name);
     }
 
     public static ArrayList<String> getTypes() {
@@ -339,7 +335,7 @@ public class SetTypes {
      * @return the name
      */
     public static String getTypeName(int type) {
-        return getTypes().get(type);
+        return TYPES.get(type);
     }
 
 }

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -28,7 +28,7 @@ import org.h2.util.Utils;
  * Encapsulates the connection settings, including user name and password.
  */
 public class ConnectionInfo implements Cloneable {
-    private static final HashSet<String> KNOWN_SETTINGS = New.hashSet();
+    private static final HashSet<String> KNOWN_SETTINGS;
 
     private Properties prop = new Properties();
     private String originalURL;
@@ -93,18 +93,19 @@ public class ConnectionInfo implements Cloneable {
 
     static {
         ArrayList<String> list = SetTypes.getTypes();
-        HashSet<String> set = KNOWN_SETTINGS;
-        set.addAll(list);
         String[] connectionTime = { "ACCESS_MODE_DATA", "AUTOCOMMIT", "CIPHER",
                 "CREATE", "CACHE_TYPE", "FILE_LOCK", "IGNORE_UNKNOWN_SETTINGS",
                 "IFEXISTS", "INIT", "PASSWORD", "RECOVER", "RECOVER_TEST",
                 "USER", "AUTO_SERVER", "AUTO_SERVER_PORT", "NO_UPGRADE",
                 "AUTO_RECONNECT", "OPEN_NEW", "PAGE_SIZE", "PASSWORD_HASH", "JMX" };
+        HashSet<String> set = new HashSet<>(list.size() + connectionTime.length);
+        set.addAll(list);
         for (String key : connectionTime) {
             if (!set.add(key) && SysProperties.CHECK) {
                 DbException.throwInternalError(key);
             }
         }
+        KNOWN_SETTINGS = set;
     }
 
     private static boolean isKnownSetting(String s) {

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -101,10 +101,9 @@ public class ConnectionInfo implements Cloneable {
                 "USER", "AUTO_SERVER", "AUTO_SERVER_PORT", "NO_UPGRADE",
                 "AUTO_RECONNECT", "OPEN_NEW", "PAGE_SIZE", "PASSWORD_HASH", "JMX" };
         for (String key : connectionTime) {
-            if (SysProperties.CHECK && set.contains(key)) {
+            if (!set.add(key) && SysProperties.CHECK) {
                 DbException.throwInternalError(key);
             }
-            set.add(key);
         }
     }
 

--- a/h2/src/main/org/h2/expression/Aggregate.java
+++ b/h2/src/main/org/h2/expression/Aggregate.java
@@ -22,7 +22,6 @@ import org.h2.table.Column;
 import org.h2.table.ColumnResolver;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
-import org.h2.util.New;
 import org.h2.util.StatementBuilder;
 import org.h2.util.StringUtils;
 import org.h2.value.DataType;
@@ -125,7 +124,7 @@ public class Aggregate extends Expression {
      */
     static final int HISTOGRAM = 16;
 
-    private static final HashMap<String, Integer> AGGREGATES = New.hashMap();
+    private static final HashMap<String, Integer> AGGREGATES = new HashMap<>(24);
 
     private final int type;
     private final Select select;
@@ -156,6 +155,9 @@ public class Aggregate extends Expression {
     }
 
     static {
+        /*
+         * Update initial size of AGGREGATES after editing the following list.
+         */
         addAggregate("COUNT", COUNT);
         addAggregate("SUM", SUM);
         addAggregate("MIN", MIN);

--- a/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
+++ b/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
@@ -197,9 +197,9 @@ public class FreeSpaceBitSet {
                     on = 0;
                 }
             }
-            buff.append("\n");
-            buff.append(" on " + onCount + " off " + offCount);
-            buff.append(" " + 100 * onCount / (onCount+offCount) + "% used ");
+            buff.append('\n')
+                    .append(" on ").append(onCount).append(" off ").append(offCount)
+                    .append(' ').append(100 * onCount / (onCount+offCount)).append("% used ");
         }
         buff.append('[');
         for (int i = 0;;) {

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -259,18 +259,18 @@ public class Page {
     public String toString() {
         StringBuilder buff = new StringBuilder();
         buff.append("id: ").append(System.identityHashCode(this)).append('\n');
-        buff.append("version: ").append(Long.toHexString(version)).append("\n");
-        buff.append("pos: ").append(Long.toHexString(pos)).append("\n");
+        buff.append("version: ").append(Long.toHexString(version)).append('\n');
+        buff.append("pos: ").append(Long.toHexString(pos)).append('\n');
         if (pos != 0) {
             int chunkId = DataUtils.getPageChunkId(pos);
-            buff.append("chunk: ").append(Long.toHexString(chunkId)).append("\n");
+            buff.append("chunk: ").append(Long.toHexString(chunkId)).append('\n');
         }
         for (int i = 0; i <= keys.length; i++) {
             if (i > 0) {
                 buff.append(" ");
             }
             if (children != null) {
-                buff.append("[" + Long.toHexString(children[i].pos) + "] ");
+                buff.append('[').append(Long.toHexString(children[i].pos)).append("] ");
             }
             if (i < keys.length) {
                 buff.append(keys[i]);

--- a/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.UUID;
 import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.WriteBuffer;
-import org.h2.util.New;
 
 /**
  * A data type implementation for the most common data types, including
@@ -94,8 +93,7 @@ public class ObjectDataType implements DataType {
             Float.class, Double.class, BigDecimal.class, String.class,
             UUID.class, Date.class };
 
-    private static final HashMap<Class<?>, Integer> COMMON_CLASSES_MAP = New
-            .hashMap();
+    private static final HashMap<Class<?>, Integer> COMMON_CLASSES_MAP = new HashMap<>(COMMON_CLASSES.length);
 
     private AutoDetectDataType last = new StringType(this);
 

--- a/h2/src/main/org/h2/result/RowImpl.java
+++ b/h2/src/main/org/h2/result/RowImpl.java
@@ -134,7 +134,7 @@ public class RowImpl implements Row {
         StatementBuilder buff = new StatementBuilder("( /* key:");
         buff.append(getKey());
         if (version != 0) {
-            buff.append(" v:" + version);
+            buff.append(" v:").append(version);
         }
         if (isDeleted()) {
             buff.append(" deleted");

--- a/h2/src/main/org/h2/result/SimpleRow.java
+++ b/h2/src/main/org/h2/result/SimpleRow.java
@@ -64,7 +64,7 @@ public class SimpleRow implements SearchRow {
         StatementBuilder buff = new StatementBuilder("( /* key:");
         buff.append(getKey());
         if (version != 0) {
-            buff.append(" v:" + version);
+            buff.append(" v:").append(version);
         }
         buff.append(" */ ");
         for (Value v : data) {

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -490,14 +490,16 @@ public class WebApp {
             columnsBuffer.append(column.getName());
             String col = escapeIdentifier(column.getName());
             String level = mainSchema ? ", 1, 1" : ", 2, 2";
-            buff.append("setNode(" + treeIndex + level + ", 'column', '" +
-                    PageParser.escapeJavaScript(column.getName()) +
-                    "', 'javascript:ins(\\'" + col + "\\')');\n");
+            buff.append("setNode(").append(treeIndex).append(level)
+                    .append(", 'column', '")
+                    .append(PageParser.escapeJavaScript(column.getName()))
+                    .append("', 'javascript:ins(\\'").append(col).append("\\')');\n");
             treeIndex++;
             if (mainSchema && showColumnTypes) {
-                buff.append("setNode(" + treeIndex + ", 2, 2, 'type', '" +
-                        PageParser.escapeJavaScript(column.getDataType()) +
-                        "', null);\n");
+                buff.append("setNode(").append(treeIndex)
+                        .append(", 2, 2, 'type', '")
+                        .append(PageParser.escapeJavaScript(column.getDataType()))
+                        .append("', null);\n");
                 treeIndex++;
             }
         }
@@ -574,21 +576,22 @@ public class WebApp {
             String level = mainSchema ? ", 1, 1" : ", 2, 1";
             String levelIndex = mainSchema ? ", 2, 1" : ", 3, 1";
             String levelColumnType = mainSchema ? ", 3, 2" : ", 4, 2";
-            buff.append("setNode(" + treeIndex + level +
-                    ", 'index_az', '${text.tree.indexes}', null);\n");
+            buff.append("setNode(").append(treeIndex).append(level)
+                    .append(", 'index_az', '${text.tree.indexes}', null);\n");
             treeIndex++;
             for (IndexInfo info : indexMap.values()) {
-                buff.append("setNode(" + treeIndex + levelIndex +
-                        ", 'index', '" +
-                        PageParser.escapeJavaScript(info.name) + "', null);\n");
+                buff.append("setNode(").append(treeIndex).append(levelIndex)
+                        .append(", 'index', '")
+                        .append(PageParser.escapeJavaScript(info.name))
+                        .append("', null);\n");
                 treeIndex++;
-                buff.append("setNode(" + treeIndex + levelColumnType +
-                        ", 'type', '" + info.type + "', null);\n");
+                buff.append("setNode(").append(treeIndex).append(levelColumnType)
+                        .append(", 'type', '").append(info.type).append("', null);\n");
                 treeIndex++;
-                buff.append("setNode(" + treeIndex + levelColumnType +
-                        ", 'type', '" +
-                        PageParser.escapeJavaScript(info.columns) +
-                        "', null);\n");
+                buff.append("setNode(").append(treeIndex).append(levelColumnType)
+                        .append(", 'type', '")
+                        .append(PageParser.escapeJavaScript(info.columns))
+                        .append("', null);\n");
                 treeIndex++;
             }
         }
@@ -622,9 +625,10 @@ public class WebApp {
                 tab = schema.quotedName + "." + tab;
             }
             tab = escapeIdentifier(tab);
-            buff.append("setNode(" + treeIndex + indentation + " 'table', '" +
-                    PageParser.escapeJavaScript(table.getName()) +
-                    "', 'javascript:ins(\\'" + tab + "\\',true)');\n");
+            buff.append("setNode(").append(treeIndex).append(indentation)
+                    .append(" 'table', '")
+                    .append(PageParser.escapeJavaScript(table.getName()))
+                    .append("', 'javascript:ins(\\'").append(tab).append("\\',true)');\n");
             treeIndex++;
             if (mainSchema || showColumns) {
                 StringBuilder columnsBuffer = new StringBuilder();
@@ -634,10 +638,10 @@ public class WebApp {
                     treeIndex = addIndexes(mainSchema, meta, table.getName(),
                             schema.name, buff, treeIndex);
                 }
-                buff.append("addTable('" +
-                        PageParser.escapeJavaScript(table.getName()) + "', '" +
-                        PageParser.escapeJavaScript(columnsBuffer.toString()) +
-                        "', " + tableId + ");\n");
+                buff.append("addTable('")
+                        .append(PageParser.escapeJavaScript(table.getName())).append("', '")
+                        .append(PageParser.escapeJavaScript(columnsBuffer.toString())).append("', ")
+                        .append(tableId).append(");\n");
             }
         }
         tables = schema.getTables();
@@ -651,9 +655,10 @@ public class WebApp {
                 tab = view.getSchema().quotedName + "." + tab;
             }
             tab = escapeIdentifier(tab);
-            buff.append("setNode(" + treeIndex + indentation + " 'view', '" +
-                    PageParser.escapeJavaScript(view.getName()) +
-                    "', 'javascript:ins(\\'" + tab + "\\',true)');\n");
+            buff.append("setNode(").append(treeIndex).append(indentation)
+                    .append(" 'view', '")
+                    .append(PageParser.escapeJavaScript(view.getName()))
+                    .append("', 'javascript:ins(\\'").append(tab).append("\\',true)');\n");
             treeIndex++;
             if (mainSchema) {
                 StringBuilder columnsBuffer = new StringBuilder();
@@ -667,19 +672,20 @@ public class WebApp {
                         ResultSet rs = prep.executeQuery();
                         if (rs.next()) {
                             String sql = rs.getString("SQL");
-                            buff.append("setNode(" + treeIndex + indentNode +
-                                    " 'type', '" +
-                                    PageParser.escapeJavaScript(sql) +
-                                    "', null);\n");
+                            buff.append("setNode(").append(treeIndex)
+                                    .append(indentNode)
+                                    .append(" 'type', '")
+                                    .append(PageParser.escapeJavaScript(sql))
+                                    .append("', null);\n");
                             treeIndex++;
                         }
                         rs.close();
                     }
                 }
-                buff.append("addTable('" +
-                        PageParser.escapeJavaScript(view.getName()) + "', '" +
-                        PageParser.escapeJavaScript(columnsBuffer.toString()) +
-                        "', " + tableId + ");\n");
+                buff.append("addTable('")
+                        .append(PageParser.escapeJavaScript(view.getName())).append("', '")
+                        .append(PageParser.escapeJavaScript(columnsBuffer.toString())).append("', ")
+                        .append(tableId).append(");\n");
             }
         }
         return treeIndex;
@@ -695,9 +701,10 @@ public class WebApp {
             session.loadBnf();
             isH2 = contents.isH2();
 
-            StringBuilder buff = new StringBuilder();
-            buff.append("setNode(0, 0, 0, 'database', '" + PageParser.escapeJavaScript(url)
-                    + "', null);\n");
+            StringBuilder buff = new StringBuilder()
+                    .append("setNode(0, 0, 0, 'database', '")
+                    .append(PageParser.escapeJavaScript(url))
+                    .append("', null);\n");
             int treeIndex = 1;
 
             DbSchema defaultSchema = contents.getDefaultSchema();
@@ -707,9 +714,9 @@ public class WebApp {
                 if (schema == defaultSchema || schema == null) {
                     continue;
                 }
-                buff.append("setNode(" + treeIndex + ", 0, 1, 'folder', '" +
-                        PageParser.escapeJavaScript(schema.name) +
-                        "', null);\n");
+                buff.append("setNode(").append(treeIndex).append(", 0, 1, 'folder', '")
+                        .append(PageParser.escapeJavaScript(schema.name))
+                        .append("', null);\n");
                 treeIndex++;
                 treeIndex = addTablesAndViews(schema, false, buff, treeIndex);
             }
@@ -719,29 +726,28 @@ public class WebApp {
                             "INFORMATION_SCHEMA.SEQUENCES ORDER BY SEQUENCE_NAME");
                     for (int i = 0; rs.next(); i++) {
                         if (i == 0) {
-                            buff.append("setNode(" + treeIndex +
-                                    ", 0, 1, 'sequences', '${text.tree.sequences}', null);\n");
+                            buff.append("setNode(").append(treeIndex)
+                                    .append(", 0, 1, 'sequences', '${text.tree.sequences}', null);\n");
                             treeIndex++;
                         }
                         String name = rs.getString("SEQUENCE_NAME");
                         String current = rs.getString("CURRENT_VALUE");
                         String increment = rs.getString("INCREMENT");
-                        buff.append("setNode(" + treeIndex +
-                                ", 1, 1, 'sequence', '" +
-                                PageParser.escapeJavaScript(name) +
-                                "', null);\n");
+                        buff.append("setNode(").append(treeIndex)
+                                .append(", 1, 1, 'sequence', '")
+                                .append(PageParser.escapeJavaScript(name))
+                                .append("', null);\n");
                         treeIndex++;
-                        buff.append("setNode(" + treeIndex +
-                                ", 2, 2, 'type', '${text.tree.current}: " +
-                                PageParser.escapeJavaScript(current) +
-                                "', null);\n");
+                        buff.append("setNode(").append(treeIndex)
+                                .append(", 2, 2, 'type', '${text.tree.current}: ")
+                                .append(PageParser.escapeJavaScript(current))
+                                .append("', null);\n");
                         treeIndex++;
                         if (!"1".equals(increment)) {
-                            buff.append("setNode(" +
-                                    treeIndex +
-                                    ", 2, 2, 'type', '${text.tree.increment}: " +
-                                    PageParser.escapeJavaScript(increment) +
-                                    "', null);\n");
+                            buff.append("setNode(").append(treeIndex)
+                                    .append(", 2, 2, 'type', '${text.tree.increment}: ")
+                                    .append(PageParser.escapeJavaScript(increment))
+                                    .append("', null);\n");
                             treeIndex++;
                         }
                     }
@@ -750,20 +756,20 @@ public class WebApp {
                             "INFORMATION_SCHEMA.USERS ORDER BY NAME");
                     for (int i = 0; rs.next(); i++) {
                         if (i == 0) {
-                            buff.append("setNode(" + treeIndex +
-                                    ", 0, 1, 'users', '${text.tree.users}', null);\n");
+                            buff.append("setNode(").append(treeIndex)
+                                    .append(", 0, 1, 'users', '${text.tree.users}', null);\n");
                             treeIndex++;
                         }
                         String name = rs.getString("NAME");
                         String admin = rs.getString("ADMIN");
-                        buff.append("setNode(" + treeIndex +
-                                ", 1, 1, 'user', '" +
-                                PageParser.escapeJavaScript(name) +
-                                "', null);\n");
+                        buff.append("setNode(").append(treeIndex)
+                                .append(", 1, 1, 'user', '")
+                                .append(PageParser.escapeJavaScript(name))
+                                .append("', null);\n");
                         treeIndex++;
                         if (admin.equalsIgnoreCase("TRUE")) {
-                            buff.append("setNode(" + treeIndex +
-                                    ", 2, 2, 'type', '${text.tree.admin}', null);\n");
+                            buff.append("setNode(").append(treeIndex)
+                                    .append(", 2, 2, 'type', '${text.tree.admin}', null);\n");
                             treeIndex++;
                         }
                     }
@@ -773,9 +779,11 @@ public class WebApp {
             DatabaseMetaData meta = session.getMetaData();
             String version = meta.getDatabaseProductName() + " " +
                     meta.getDatabaseProductVersion();
-            buff.append("setNode(" + treeIndex + ", 0, 0, 'info', '" +
-                    PageParser.escapeJavaScript(version) + "', null);\n");
-            buff.append("refreshQueryTables();");
+            buff.append("setNode(").append(treeIndex)
+                    .append(", 0, 0, 'info', '")
+                    .append(PageParser.escapeJavaScript(version))
+                    .append("', null);\n")
+                    .append("refreshQueryTables();");
             session.put("tree", buff.toString());
         } catch (Exception e) {
             session.put("tree", "");
@@ -1357,21 +1365,22 @@ public class WebApp {
                     int level = Integer.parseInt(s);
                     conn.setTransactionIsolation(level);
                 }
-                buff.append("Transaction Isolation: " +
-                        conn.getTransactionIsolation() + "<br />");
-                buff.append(Connection.TRANSACTION_READ_UNCOMMITTED +
-                        ": read_uncommitted<br />");
-                buff.append(Connection.TRANSACTION_READ_COMMITTED +
-                        ": read_committed<br />");
-                buff.append(Connection.TRANSACTION_REPEATABLE_READ +
-                        ": repeatable_read<br />");
-                buff.append(Connection.TRANSACTION_SERIALIZABLE +
-                        ": serializable");
+                buff.append("Transaction Isolation: ")
+                        .append(conn.getTransactionIsolation())
+                        .append("<br />");
+                buff.append(Connection.TRANSACTION_READ_UNCOMMITTED)
+                        .append(": read_uncommitted<br />");
+                buff.append(Connection.TRANSACTION_READ_COMMITTED)
+                        .append(": read_committed<br />");
+                buff.append(Connection.TRANSACTION_REPEATABLE_READ)
+                        .append(": repeatable_read<br />");
+                buff.append(Connection.TRANSACTION_SERIALIZABLE)
+                        .append(": serializable");
             }
             if (sql.startsWith("@")) {
                 rs = getMetaResultSet(conn, sql);
                 if (rs == null) {
-                    buff.append("?: " + sql);
+                    buff.append("?: ").append(sql);
                     return buff.toString();
                 }
             } else {
@@ -1385,7 +1394,8 @@ public class WebApp {
                     rs = stat.getGeneratedKeys();
                 } else {
                     if (!isResultSet) {
-                        buff.append("${text.result.updateCount}: " + stat.getUpdateCount());
+                        buff.append("${text.result.updateCount}: ")
+                                .append(stat.getUpdateCount());
                         time = System.currentTimeMillis() - time;
                         buff.append("<br />(").append(time).append(" ms)");
                         stat.close();

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -387,7 +387,7 @@ public class TableLink extends Table {
         if (readOnly) {
             buff.append(" READONLY");
         }
-        buff.append(" /*" + JdbcSQLException.HIDE_SQL + "*/");
+        buff.append(" /*").append(JdbcSQLException.HIDE_SQL).append("*/");
         return buff.toString();
     }
 

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -1477,7 +1477,7 @@ public class Recover extends Tool implements DataHandler {
 
     private void writeRow(PrintWriter writer, Data s, Value[] data) {
         StringBuilder sb = new StringBuilder();
-        sb.append("INSERT INTO " + storageName + " VALUES(");
+        sb.append("INSERT INTO ").append(storageName).append(" VALUES(");
         for (valueId = 0; valueId < recordLength; valueId++) {
             try {
                 Value v = s.readValue();

--- a/h2/src/main/org/h2/util/AbbaLockingDetector.java
+++ b/h2/src/main/org/h2/util/AbbaLockingDetector.java
@@ -184,15 +184,15 @@ public class AbbaLockingDetector implements Runnable {
      * stack frames)
      */
     private static String getStackTraceForThread(ThreadInfo info) {
-        StringBuilder sb = new StringBuilder("\"" +
-                info.getThreadName() + "\"" + " Id=" +
-                info.getThreadId() + " " + info.getThreadState());
+        StringBuilder sb = new StringBuilder().append('"')
+                .append(info.getThreadName()).append("\"" + " Id=")
+                .append(info.getThreadId()).append(' ').append(info.getThreadState());
         if (info.getLockName() != null) {
-            sb.append(" on " + info.getLockName());
+            sb.append(" on ").append(info.getLockName());
         }
         if (info.getLockOwnerName() != null) {
-            sb.append(" owned by \"" + info.getLockOwnerName() +
-                    "\" Id=" + info.getLockOwnerId());
+            sb.append(" owned by \"").append(info.getLockOwnerName())
+                    .append("\" Id=").append(info.getLockOwnerId());
         }
         if (info.isSuspended()) {
             sb.append(" (suspended)");
@@ -229,22 +229,25 @@ public class AbbaLockingDetector implements Runnable {
 
     private static void dumpStackTraceElement(ThreadInfo info,
             StringBuilder sb, int i, StackTraceElement e) {
-        sb.append('\t').append("at ").append(e.toString());
-        sb.append('\n');
+        sb.append('\t').append("at ").append(e)
+                .append('\n');
         if (i == 0 && info.getLockInfo() != null) {
             Thread.State ts = info.getThreadState();
             switch (ts) {
             case BLOCKED:
-                sb.append("\t-  blocked on " + info.getLockInfo());
-                sb.append('\n');
+                sb.append("\t-  blocked on ")
+                        .append(info.getLockInfo())
+                        .append('\n');
                 break;
             case WAITING:
-                sb.append("\t-  waiting on " + info.getLockInfo());
-                sb.append('\n');
+                sb.append("\t-  waiting on ")
+                        .append(info.getLockInfo())
+                        .append('\n');
                 break;
             case TIMED_WAITING:
-                sb.append("\t-  waiting on " + info.getLockInfo());
-                sb.append('\n');
+                sb.append("\t-  waiting on ")
+                        .append(info.getLockInfo())
+                        .append('\n');
                 break;
             default:
             }


### PR DESCRIPTION
1. Specify initial size for a few collections which size initially known and large enough to cause reallocations during initialization.

2. Use `ArrayList.indexOf()` instead of own code in `SetTypes`.

3. Do not call `HashSet.contains()` just before `HashSet.add()` with the same argument, use result of `HashSet.add()` instead.

4. Concatenations inside calls to `StringBuilder.append()` which cannot be combined to constant strings  by Java compiler are replaced with subsequent calls to `append()` to reduce size of generated code and reduce amount of temporary objects. Replacements done by IDE with some manual post-editing to wrap lines of code mostly in the way it was.