### PR TITLE
Improve the look of error messages in web console

### DIFF
--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -917,7 +917,7 @@ public class WebApp {
                     PageParser.escapeHtml(profClose) +
                     "</span>";
             } else {
-                success = "${text.login.testSuccessful}";
+                success = "<div class=\"success\">${text.login.testSuccessful}</div>";
             }
             session.put("error", success);
             // session.put("error", "${text.login.testSuccessful}");

--- a/h2/src/main/org/h2/server/web/res/stylesheet.css
+++ b/h2/src/main/org/h2/server/web/res/stylesheet.css
@@ -191,18 +191,18 @@ td.empty {
 }
 
 .error {
-    color: #882222;
+    color: #771111;
 }
 
 div.error {
-    background-color: #ffdddd;
-    border-color: #eecccc;
+    background-color: #eecccc;
+    border-color: #ddbbbb;
 }
 
 div.success {
-    color: #337733;
-    background-color: #ddffdd;
-    border-color: #cceecc;
+    color: #226622;
+    background-color: #cceecc;
+    border-color: #bbddbb;
 }
 
 div.error, div.success {

--- a/h2/src/main/org/h2/server/web/res/stylesheet.css
+++ b/h2/src/main/org/h2/server/web/res/stylesheet.css
@@ -191,11 +191,25 @@ td.empty {
 }
 
 .error {
-    color: #ff0000;
+    color: #882222;
 }
 
-p.error {
-    color: #ff0000;
+div.error {
+    background-color: #ffdddd;
+    border-color: #eecccc;
+}
+
+div.success {
+    color: #337733;
+    background-color: #ddffdd;
+    border-color: #cceecc;
+}
+
+div.error, div.success {
+    border-radius: 4px;
+    padding: 10px;
+    border-width: 1px;
+    border-style: solid;
 }
 
 input.button {


### PR DESCRIPTION
Possible fix for issue #688.

Before and after:
![error_messages-darker](https://user-images.githubusercontent.com/23182944/34912836-3f010e94-f926-11e7-864e-c2659e5cbf53.jpg)

Previous version (with bright colors):
![error_messages](https://user-images.githubusercontent.com/23182944/34912201-cbb7b934-f915-11e7-849e-5d871877897e.jpg)
