### PR TITLE
Assorted minor optimizations

### DIFF
--- a/h2/src/main/org/h2/command/ddl/DropView.java
+++ b/h2/src/main/org/h2/command/ddl/DropView.java
@@ -73,7 +73,7 @@ public class DropView extends SchemaCommand {
             // supported from imported keys - but not for dependent db objects
 
             TableView tableView = (TableView) view;
-            ArrayList<Table> copyOfDependencies = new ArrayList<Table>(tableView.getTables());
+            ArrayList<Table> copyOfDependencies = new ArrayList<>(tableView.getTables());
 
             view.lock(session, true, true);
             session.getDatabase().removeSchemaObject(session, view);

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -92,8 +92,8 @@ public class Database implements DataHandler {
 
     private static int initialPowerOffCount;
 
-    private static final ThreadLocal<Session> META_LOCK_DEBUGGING = new ThreadLocal<Session>();
-    private static final ThreadLocal<Throwable> META_LOCK_DEBUGGING_STACK = new ThreadLocal<Throwable>();
+    private static final ThreadLocal<Session> META_LOCK_DEBUGGING = new ThreadLocal<>();
+    private static final ThreadLocal<Throwable> META_LOCK_DEBUGGING_STACK = new ThreadLocal<>();
 
     /**
      * The default name of the system user. This name is only used as long as

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -123,7 +123,7 @@ public class Session extends SessionWithState {
     private long modificationMetaID = -1;
     private SubQueryInfo subQueryInfo;
     private int parsingView;
-    private Deque<String> viewNameStack = new ArrayDeque<String>();
+    private Deque<String> viewNameStack = new ArrayDeque<>();
     private int preparingQueryExpression;
     private volatile SmallLRUCache<Object, ViewIndex> viewIndexCache;
     private HashMap<Object, ViewIndex> subQueryIndexCache;

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -269,7 +269,7 @@ public class MVTableEngine implements TableEngine {
                     MVMap<?, ?> map = store.openMap(mapName);
                     store.removeMap(map);
                 } else if (mapName.startsWith("table.") || mapName.startsWith("index.")) {
-                    int id = Integer.parseInt(mapName.substring(1 + mapName.indexOf(".")));
+                    int id = Integer.parseInt(mapName.substring(1 + mapName.indexOf('.')));
                     if (!objectIds.get(id)) {
                         ValueDataType keyType = new ValueDataType(null, null, null);
                         ValueDataType valueType = new ValueDataType(null, null, null);

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -314,9 +314,9 @@ public class WebApp {
                         value = space + value;
                     }
                     key = StringUtils.urlEncode(key);
-                    key = StringUtils.replaceAll(key, "+", " ");
+                    key = key.replace('+', ' ');
                     value = StringUtils.urlEncode(value);
-                    value = StringUtils.replaceAll(value, "+", " ");
+                    value = value.replace('+', ' ');
                     list.add(type + "#" + key + "#" + value);
                 }
                 Collections.sort(list);

--- a/h2/src/main/org/h2/server/web/WebThread.java
+++ b/h2/src/main/org/h2/server/web/WebThread.java
@@ -120,7 +120,7 @@ class WebThread extends WebApp implements Runnable {
             trace(head + ": " + file);
             file = getAllowedFile(file);
             attributes = new Properties();
-            int paramIndex = file.indexOf("?");
+            int paramIndex = file.indexOf('?');
             session = null;
             if (paramIndex >= 0) {
                 String attrib = file.substring(paramIndex + 1);

--- a/h2/src/main/org/h2/store/fs/FilePathNioMem.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNioMem.java
@@ -248,8 +248,8 @@ class FilePathNioMemLZF extends FilePathNioMem {
             throw new IllegalArgumentException(path +
                     " doesn't start with " + getScheme());
         }
-        int idx1 = path.indexOf(":");
-        int idx2 = path.lastIndexOf(":");
+        int idx1 = path.indexOf(':');
+        int idx2 = path.lastIndexOf(':');
         final FilePathNioMemLZF p = new FilePathNioMemLZF();
         if (idx1 != -1 && idx1 != idx2) {
             p.compressLaterCachePercent = Float.parseFloat(path.substring(idx1 + 1, idx2));
@@ -260,7 +260,7 @@ class FilePathNioMemLZF extends FilePathNioMem {
 
     @Override
     protected boolean isRoot() {
-        return name.lastIndexOf(":") == name.length() - 1;
+        return name.lastIndexOf(':') == name.length() - 1;
     }
 
     @Override

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -725,7 +725,7 @@ public class TableView extends Table {
 
         List<Column> columnTemplateList;
         String[] querySQLOutput = new String[]{null};
-        ArrayList<String> columnNames = new ArrayList<String>();
+        ArrayList<String> columnNames = new ArrayList<>();
         for (Column columnTemplate: columnTemplates) {
             columnNames.add(columnTemplate.getName());
         }
@@ -811,7 +811,7 @@ public class TableView extends Table {
         // create table data object
         CreateTableData recursiveTableData = new CreateTableData();
         recursiveTableData.id = db.allocateObjectId();
-        recursiveTableData.columns = new ArrayList<Column>(columns);
+        recursiveTableData.columns = new ArrayList<>(columns);
         recursiveTableData.tableName = cteViewName;
         recursiveTableData.temporary = !isPersistent;
         recursiveTableData.persistData = true;

--- a/h2/src/main/org/h2/util/NetUtils.java
+++ b/h2/src/main/org/h2/util/NetUtils.java
@@ -260,7 +260,7 @@ public class NetUtils {
         } else {
             address = bind.getHostAddress();
             if (bind instanceof Inet6Address) {
-                if (address.indexOf("%") >= 0) {
+                if (address.indexOf('%') >= 0) {
                     address = "localhost";
                 } else if (address.indexOf(':') >= 0 && !address.startsWith("[")) {
                     // adds'[' and ']' if required for

--- a/h2/src/main/org/h2/util/ToChar.java
+++ b/h2/src/main/org/h2/util/ToChar.java
@@ -178,7 +178,7 @@ public class ToChar {
             format = format.substring(0, format.length() - 2);
         }
 
-        int v = formatUp.indexOf("V");
+        int v = formatUp.indexOf('V');
         if (v >= 0) {
             int digits = 0;
             for (int i = v + 1; i < format.length(); i++) {

--- a/h2/src/test/org/h2/test/bench/Database.java
+++ b/h2/src/test/org/h2/test/bench/Database.java
@@ -247,7 +247,7 @@ class Database {
             String key = (String) k;
             if (key.startsWith(databaseType + ".")) {
                 String pattern = key.substring(databaseType.length() + 1);
-                pattern = StringUtils.replaceAll(pattern, "_", " ");
+                pattern = pattern.replace('_', ' ');
                 pattern = StringUtils.toUpperEnglish(pattern);
                 String replacement = prop.getProperty(key);
                 replace.add(new String[]{pattern, replacement});

--- a/h2/src/test/org/h2/test/coverage/Coverage.java
+++ b/h2/src/test/org/h2/test/coverage/Coverage.java
@@ -500,7 +500,7 @@ public class Coverage {
 
     private void nextDebug() throws IOException {
         if (perFunction) {
-            int i = function.indexOf("(");
+            int i = function.indexOf('(');
             String func = i < 0 ? function : function.substring(0, i);
             String fileLine = file + "." + func + "(";
             i = file.lastIndexOf('.');

--- a/h2/src/test/org/h2/test/db/TestCsv.java
+++ b/h2/src/test/org/h2/test/db/TestCsv.java
@@ -402,7 +402,7 @@ public class TestCsv extends TestBase {
         InputStreamReader reader = new InputStreamReader(
                 FileUtils.newInputStream(fileName));
         String text = IOUtils.readStringAndClose(reader, -1).trim();
-        text = StringUtils.replaceAll(text, "\n", " ");
+        text = text.replace('\n', ' ');
         assertEquals("ID|NAME 1|Hello", text);
         ResultSet rs = stat.executeQuery("select * from csvread('" +
                 fileName + "', null, null, '|', '')");

--- a/h2/src/test/org/h2/test/server/TestAutoServer.java
+++ b/h2/src/test/org/h2/test/server/TestAutoServer.java
@@ -80,7 +80,7 @@ public class TestAutoServer extends TestBase {
             String key = prop.getProperty("id");
             String server = prop.getProperty("server");
             if (server != null) {
-                String u2 = url.substring(url.indexOf(";"));
+                String u2 = url.substring(url.indexOf(';'));
                 u2 = "jdbc:h2:tcp://" + server + "/" + key + u2;
                 Connection conn = DriverManager.getConnection(u2, user, password);
                 conn.close();

--- a/h2/src/test/org/h2/test/server/WebClient.java
+++ b/h2/src/test/org/h2/test/server/WebClient.java
@@ -143,7 +143,7 @@ public class WebClient {
      */
     String getBaseUrl(String url) {
         int idx = url.indexOf("//");
-        idx = url.indexOf("/", idx + 2);
+        idx = url.indexOf('/', idx + 2);
         if (idx >= 0) {
             return url.substring(0, idx);
         }

--- a/h2/src/tools/org/h2/build/code/CheckJavadoc.java
+++ b/h2/src/tools/org/h2/build/code/CheckJavadoc.java
@@ -85,7 +85,7 @@ public class CheckJavadoc {
         int lineNumber = 1;
         boolean inComment = false;
         while (true) {
-            int next = text.indexOf("\n", pos);
+            int next = text.indexOf('\n', pos);
             if (next < 0) {
                 break;
             }

--- a/h2/src/tools/org/h2/build/doc/GenerateDoc.java
+++ b/h2/src/tools/org/h2/build/doc/GenerateDoc.java
@@ -176,9 +176,9 @@ public class GenerateDoc {
                 }
 
                 String link = topic.toLowerCase();
-                link = StringUtils.replaceAll(link, " ", "_");
+                link = link.replace(' ', '_');
                 // link = StringUtils.replaceAll(link, "_", "");
-                link = StringUtils.replaceAll(link, "@", "_");
+                link = link.replace('@', '_');
                 map.put("link", StringUtils.urlEncode(link));
 
                 list.add(map);

--- a/h2/src/tools/org/h2/build/doc/LinkChecker.java
+++ b/h2/src/tools/org/h2/build/doc/LinkChecker.java
@@ -181,7 +181,7 @@ public class LinkChecker {
                 break;
             }
             int start = idx + " id=\"".length();
-            int end = html.indexOf("\"", start);
+            int end = html.indexOf('"', start);
             if (end < 0) {
                 error(fileName, "Expected \" after id= " + html.substring(idx, idx + 100));
             }
@@ -196,11 +196,11 @@ public class LinkChecker {
             if (idx < 0) {
                 break;
             }
-            int start = html.indexOf("\"", idx);
+            int start = html.indexOf('"', idx);
             if (start < 0) {
                 error(fileName, "Expected \" after href= at " + html.substring(idx, idx + 100));
             }
-            int end = html.indexOf("\"", start + 1);
+            int end = html.indexOf('"', start + 1);
             if (end < 0) {
                 error(fileName, "Expected \" after href= at " + html.substring(idx, idx + 100));
             }
@@ -237,16 +237,16 @@ public class LinkChecker {
             if (idx < 0) {
                 break;
             }
-            int equals = html.indexOf("=", idx);
+            int equals = html.indexOf('=', idx);
             if (equals < 0) {
                 error(fileName, "Expected = after <a at " + html.substring(idx, idx + 100));
             }
             String type = html.substring(idx + 2, equals).trim();
-            int start = html.indexOf("\"", idx);
+            int start = html.indexOf('"', idx);
             if (start < 0) {
                 error(fileName, "Expected \" after <a at " + html.substring(idx, idx + 100));
             }
-            int end = html.indexOf("\"", start + 1);
+            int end = html.indexOf('"', start + 1);
             if (end < 0) {
                 error(fileName, "Expected \" after <a at " + html.substring(idx, idx + 100));
             }

--- a/h2/src/tools/org/h2/build/doc/WebSite.java
+++ b/h2/src/tools/org/h2/build/doc/WebSite.java
@@ -77,7 +77,7 @@ public class WebSite {
             return page;
         }
         String language = "";
-        int index = fileName.indexOf("_");
+        int index = fileName.indexOf('_');
         if (index >= 0) {
             int end = fileName.indexOf('.');
             language = fileName.substring(index, end);

--- a/h2/src/tools/org/h2/dev/ftp/server/FtpControl.java
+++ b/h2/src/tools/org/h2/dev/ftp/server/FtpControl.java
@@ -160,7 +160,7 @@ public class FtpControl extends Thread {
                 }
             } else if ("CDUP".equals(command)) {
                 if (currentDir.length() > 1) {
-                    int idx = currentDir.lastIndexOf("/", currentDir.length() - 2);
+                    int idx = currentDir.lastIndexOf('/', currentDir.length() - 2);
                     currentDir = currentDir.substring(0, idx + 1);
                     reply(250, "Ok");
                 } else {

--- a/h2/src/tools/org/h2/jcr/Railroads.java
+++ b/h2/src/tools/org/h2/jcr/Railroads.java
@@ -109,9 +109,9 @@ public class Railroads {
             }
 
             String link = topic.toLowerCase();
-            link = StringUtils.replaceAll(link, " ", "_");
+            link = link.replace(' ', '_');
             // link = StringUtils.replaceAll(link, "_", "");
-            link = StringUtils.replaceAll(link, "@", "_");
+            link = link.replace('@', '_');
             map.put("link", StringUtils.urlEncode(link));
             list.add(map);
         }


### PR DESCRIPTION
1. `String.indexOf(char)` and similar methods are used instead of `String.indexOf(String)` with 1-char strings.
2. `String.replace(char, char)` are used instead of `StringUtils.replaceAll(String, String)` where both arguments were a 1-char strings.
3. Redundant type arguments are replaced with `<>` where it is allowed by Java 7.