### PR TITLE
Fix issue #406: Return from ResultSet.getObject not in line with JDBC specification

### DIFF
--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -347,13 +347,13 @@ public class SysProperties {
                     Constants.VERSION_MINOR < 4);
 
     /**
-     * System property {@code h2.oldResultSetGetObject}, {@code false} by default.
+     * System property {@code h2.oldResultSetGetObject}, {@code true} by default.
      * Return {@code Byte} and {@code Short} instead of {@code Integer} from
      * {@code ResultSet#getObject(...)} for {@code TINYINT} and {@code SMALLINT}
      * values.
      */
     public static final boolean OLD_RESULT_SET_GET_OBJECT =
-            Utils.getProperty("h2.oldResultSetGetObject", false);
+            Utils.getProperty("h2.oldResultSetGetObject", true);
 
     /**
      * System property <code>h2.pgClientEncoding</code> (default: UTF-8).<br />

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -347,6 +347,15 @@ public class SysProperties {
                     Constants.VERSION_MINOR < 4);
 
     /**
+     * System property {@code h2.oldResultSetGetObject}, {@code false} by default.
+     * Return {@code Byte} and {@code Short} instead of {@code Integer} from
+     * {@code ResultSet#getObject(...)} for {@code TINYINT} and {@code SMALLINT}
+     * values.
+     */
+    public static final boolean OLD_RESULT_SET_GET_OBJECT =
+            Utils.getProperty("h2.oldResultSetGetObject", false);
+
+    /**
      * System property <code>h2.pgClientEncoding</code> (default: UTF-8).<br />
      * Default client encoding for PG server. It is used if the client does not
      * sends his encoding.

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -2037,28 +2037,29 @@ public class JdbcConnection extends TraceObject
      * @return the object
      */
     Object convertToDefaultObject(Value v) {
-        Object o;
         switch (v.getType()) {
         case Value.CLOB: {
             int id = getNextId(TraceObject.CLOB);
-            o = new JdbcClob(this, v, id);
-            break;
+            return new JdbcClob(this, v, id);
         }
         case Value.BLOB: {
             int id = getNextId(TraceObject.BLOB);
-            o = new JdbcBlob(this, v, id);
-            break;
+            return new JdbcBlob(this, v, id);
         }
         case Value.JAVA_OBJECT:
             if (SysProperties.serializeJavaObject) {
-                o = JdbcUtils.deserialize(v.getBytesNoCopy(),
+                return JdbcUtils.deserialize(v.getBytesNoCopy(),
                         session.getDataHandler());
-                break;
             }
-        default:
-            o = v.getObject();
+            break;
+        case Value.BYTE:
+        case Value.SHORT:
+            if (!SysProperties.OLD_RESULT_SET_GET_OBJECT) {
+                return v.getInt();
+            }
+            break;
         }
-        return o;
+        return v.getObject();
     }
 
     CompareMode getCompareMode() {

--- a/h2/src/main/org/h2/value/ValueArray.java
+++ b/h2/src/main/org/h2/value/ValueArray.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Array;
 import java.sql.PreparedStatement;
 import java.util.ArrayList;
 import org.h2.engine.Constants;
+import org.h2.engine.SysProperties;
 import org.h2.util.MathUtils;
 import org.h2.util.New;
 import org.h2.util.StatementBuilder;
@@ -124,7 +125,15 @@ public class ValueArray extends Value {
         int len = values.length;
         Object[] list = (Object[]) Array.newInstance(componentType, len);
         for (int i = 0; i < len; i++) {
-            list[i] = values[i].getObject();
+            final Value value = values[i];
+            if (!SysProperties.OLD_RESULT_SET_GET_OBJECT) {
+                final int type = value.getType();
+                if (type == Value.BYTE || type == Value.SHORT) {
+                    list[i] = value.getInt();
+                    continue;
+                }
+            }
+            list[i] = value.getObject();
         }
         return list;
     }

--- a/h2/src/main/org/h2/value/ValueByte.java
+++ b/h2/src/main/org/h2/value/ValueByte.java
@@ -103,6 +103,11 @@ public class ValueByte extends Value {
     }
 
     @Override
+    public int getInt() {
+        return value;
+    }
+
+    @Override
     protected int compareSecure(Value o, CompareMode mode) {
         ValueByte v = (ValueByte) o;
         return Integer.compare(value, v.value);

--- a/h2/src/main/org/h2/value/ValueShort.java
+++ b/h2/src/main/org/h2/value/ValueShort.java
@@ -103,6 +103,11 @@ public class ValueShort extends Value {
     }
 
     @Override
+    public int getInt() {
+        return value;
+    }
+
+    @Override
     protected int compareSecure(Value o, CompareMode mode) {
         ValueShort v = (ValueShort) o;
         return Integer.compare(value, v.value);

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -26,6 +26,7 @@ import java.sql.Types;
 import java.util.UUID;
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
+import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
 import org.h2.util.LocalDateTimeUtils;
 import org.h2.util.Task;
@@ -1118,7 +1119,7 @@ public class TestPreparedStatement extends TestBase {
         stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR(255))");
         stat.execute("INSERT INTO TEST VALUES(1, 'Hello')");
         PreparedStatement prep = conn.prepareStatement(
-                "SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? FROM TEST");
+                "SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? FROM TEST");
         prep.setObject(1, Boolean.TRUE);
         prep.setObject(2, "Abc");
         prep.setObject(3, new BigDecimal("10.2"));
@@ -1142,14 +1143,17 @@ public class TestPreparedStatement extends TestBase {
         prep.setObject(18, "3.725", Types.DOUBLE);
         prep.setObject(19, "23:22:21", Types.TIME);
         prep.setObject(20, new java.math.BigInteger("12345"), Types.OTHER);
+        prep.setArray(21, conn.createArrayOf("TINYINT", new Object[] {(byte) 1}));
+        prep.setArray(22, conn.createArrayOf("SMALLINT", new Object[] {(short) -2}));
         rs = prep.executeQuery();
         rs.next();
         assertTrue(rs.getObject(1).equals(Boolean.TRUE));
         assertTrue(rs.getObject(2).equals("Abc"));
         assertTrue(rs.getObject(3).equals(new BigDecimal("10.2")));
-        assertTrue(rs.getObject(4).equals((byte) 0xff));
-        assertTrue(rs.getObject(5).equals(
-                new Short(Short.MAX_VALUE)));
+        assertTrue(rs.getObject(4).equals(SysProperties.OLD_RESULT_SET_GET_OBJECT ?
+                (Object) Byte.valueOf((byte) 0xff) : (Object) Integer.valueOf(-1)));
+        assertTrue(rs.getObject(5).equals(SysProperties.OLD_RESULT_SET_GET_OBJECT ?
+                (Object) Short.valueOf(Short.MAX_VALUE) : (Object) Integer.valueOf(Short.MAX_VALUE)));
         assertTrue(rs.getObject(6).equals(
                 new Integer(Integer.MIN_VALUE)));
         assertTrue(rs.getObject(7).equals(
@@ -1178,6 +1182,12 @@ public class TestPreparedStatement extends TestBase {
                 java.sql.Time.valueOf("23:22:21")));
         assertTrue(rs.getObject(20).equals(
                 new java.math.BigInteger("12345")));
+        Object[] a = (Object[]) rs.getObject(21);
+        assertEquals(a[0], SysProperties.OLD_RESULT_SET_GET_OBJECT ?
+                (Object) Byte.valueOf((byte) 1) : (Object) Integer.valueOf(1));
+        a = (Object[]) rs.getObject(22);
+        assertEquals(a[0], SysProperties.OLD_RESULT_SET_GET_OBJECT ?
+                (Object) Short.valueOf((short) -2) : (Object) Integer.valueOf(-2));
 
         // } else if(x instanceof java.io.Reader) {
         // return session.createLob(Value.CLOB,

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.TimeZone;
 
 import org.h2.api.ErrorCode;
+import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
 import org.h2.util.DateTimeUtils;
 import org.h2.util.IOUtils;
@@ -793,16 +794,16 @@ public class TestResultSet extends TestBase {
 
         o = rs.getObject("value");
         trace(o.getClass().getName());
-        assertTrue(o instanceof Short);
-        assertTrue(((Short) o).shortValue() == -1);
+        assertTrue(o.getClass() == (SysProperties.OLD_RESULT_SET_GET_OBJECT ? Short.class : Integer.class));
+        assertTrue(((Number) o).intValue() == -1);
         o = rs.getObject("value", Short.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof Short);
         assertTrue(((Short) o).shortValue() == -1);
         o = rs.getObject(2);
         trace(o.getClass().getName());
-        assertTrue(o instanceof Short);
-        assertTrue(((Short) o).shortValue() == -1);
+        assertTrue(o.getClass() == (SysProperties.OLD_RESULT_SET_GET_OBJECT ? Short.class : Integer.class));
+        assertTrue(((Number) o).intValue() == -1);
         o = rs.getObject(2, Short.class);
         trace(o.getClass().getName());
         assertTrue(o instanceof Short);


### PR DESCRIPTION
`ResultSet.getObject(int)` and `ResultSet.getObject(String)` now return `TINYINT` and `SMALLINT` values as instances of `Integer`.

Looks like JDBC drivers of other databases do the same (I didn't check them all, of course).

Old behavior can be restored by setting `h2.oldResultSetGetObject` to `true`.