### PR TITLE
Add DataUtils.getMapName()

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2462,7 +2462,7 @@ public final class MVStore {
     public synchronized String getMapName(int id) {
         checkOpen();
         String m = meta.get(MVMap.getMapKey(id));
-        return m == null ? null : DataUtils.parseMap(m).get("name");
+        return m == null ? null : DataUtils.getMapName(m);
     }
 
     /**

--- a/h2/src/test/org/h2/test/store/TestDataUtils.java
+++ b/h2/src/test/org/h2/test/store/TestDataUtils.java
@@ -99,16 +99,34 @@ public class TestDataUtils extends TestBase {
         DataUtils.appendMap(buff,  "c", "1,2");
         DataUtils.appendMap(buff,  "d", "\"test\"");
         DataUtils.appendMap(buff,  "e", "}");
-        assertEquals(":,a:1,b:\",\",c:\"1,2\",d:\"\\\"test\\\"\",e:}", buff.toString());
+        DataUtils.appendMap(buff,  "name", "1:1\",");
+        String encoded = buff.toString();
+        assertEquals(":,a:1,b:\",\",c:\"1,2\",d:\"\\\"test\\\"\",e:},name:\"1:1\\\",\"", encoded);
 
-        HashMap<String, String> m = DataUtils.parseMap(buff.toString());
-        assertEquals(6, m.size());
+        HashMap<String, String> m = DataUtils.parseMap(encoded);
+        assertEquals(7, m.size());
         assertEquals("", m.get(""));
         assertEquals("1", m.get("a"));
         assertEquals(",", m.get("b"));
         assertEquals("1,2", m.get("c"));
         assertEquals("\"test\"", m.get("d"));
         assertEquals("}", m.get("e"));
+        assertEquals("1:1\",", m.get("name"));
+        assertEquals("1:1\",", DataUtils.getMapName(encoded));
+
+        buff.setLength(0);
+        DataUtils.appendMap(buff,  "1", "1");
+        DataUtils.appendMap(buff,  "name", "2");
+        DataUtils.appendMap(buff,  "3", "3");
+        encoded = buff.toString();
+        assertEquals("2", DataUtils.parseMap(encoded).get("name"));
+        assertEquals("2", DataUtils.getMapName(encoded));
+
+        buff.setLength(0);
+        DataUtils.appendMap(buff,  "name", "xx");
+        encoded = buff.toString();
+        assertEquals("xx", DataUtils.parseMap(encoded).get("name"));
+        assertEquals("xx", DataUtils.getMapName(encoded));
     }
 
     private void testMapRandomized() {


### PR DESCRIPTION
This pull request introduces new method `DataUtils.getMapName()` as optimized version of `DataUtils.parseMap().get("name")`. Tests shows that it is a common use case because `MVStore.getMapName()` called very often and this specialized implementation increases its speed and significally reduces amout of allocated objects during this call.

This optimization is only partially related to issue #636 and is not related to pull request 666 at all.