### PR TITLE
Fix issue #710: Misleading exception message when INSERT has no value for self referential 'AS' column

### DIFF
--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -187,7 +187,11 @@ public class ExpressionColumn extends Expression {
         Value value = columnResolver.getValue(column);
         if (value == null) {
             columnResolver.getValue(column);
-            throw DbException.get(ErrorCode.MUST_GROUP_BY_COLUMN_1, getSQL());
+            if (select == null) {
+                throw DbException.get(ErrorCode.NULL_NOT_ALLOWED, getSQL());
+            } else {
+                throw DbException.get(ErrorCode.MUST_GROUP_BY_COLUMN_1, getSQL());
+            }
         }
         if (column.getEnumerators() != null && value != ValueNull.INSTANCE) {
             return ValueEnum.get(column.getEnumerators(), value.getInt());

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -186,7 +186,6 @@ public class ExpressionColumn extends Expression {
         }
         Value value = columnResolver.getValue(column);
         if (value == null) {
-            columnResolver.getValue(column);
             if (select == null) {
                 throw DbException.get(ErrorCode.NULL_NOT_ALLOWED, getSQL());
             } else {


### PR DESCRIPTION
Do not throw `ErrorCode.MUST_GROUP_BY_COLUMN_1` from ExpressionColumn.getValue() if `columnResolver` doesn't have a select statement. In this case we are not in `select *** group by ***` so throw exception with generic `ErrorCode.NULL_NOT_ALLOWED` to get reasonable error like `NULL not allowed for column "USECOUNT"`.