### PR TITLE
Minor clean up of DateTimeUtils

### DIFF
--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1926,7 +1926,7 @@ public class Function extends Expression implements FunctionCall {
         default:
             break;
         }
-        calendar = DateTimeUtils.createGregorianCalendar(TimeZone.getTimeZone("UTC"));
+        calendar = DateTimeUtils.createGregorianCalendar(DateTimeUtils.UTC);
         calendar.setTimeInMillis(t1);
         int year1 = calendar.get(Calendar.YEAR);
         int month1 = calendar.get(Calendar.MONTH);

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1856,8 +1856,7 @@ public class Function extends Expression implements FunctionCall {
         int nanos = d.getNanos() % 1000000;
         calendar.setTime(d);
         calendar.add(field, (int) count);
-        long t = calendar.getTime().getTime();
-        Timestamp ts = new Timestamp(t);
+        Timestamp ts = new Timestamp(calendar.getTimeInMillis());
         ts.setNanos(ts.getNanos() + nanos);
         return ts;
     }

--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -31,6 +31,7 @@ import org.h2.message.DbException;
 import org.h2.server.Service;
 import org.h2.server.ShutdownHandler;
 import org.h2.store.fs.FileUtils;
+import org.h2.util.DateTimeUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.NetUtils;
@@ -257,7 +258,7 @@ public class WebServer implements Service {
         if (startDateTime == null) {
             SimpleDateFormat format = new SimpleDateFormat(
                     "EEE, d MMM yyyy HH:mm:ss z", new Locale("en", ""));
-            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            format.setTimeZone(DateTimeUtils.UTC);
             startDateTime = format.format(System.currentTimeMillis());
         }
         return startDateTime;

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -288,7 +288,7 @@ public class DateTimeUtils {
         Calendar local = DateTimeUtils.createGregorianCalendar();
         local.setTime(x);
         convertTime(local, target);
-        return target.getTime().getTime();
+        return target.getTimeInMillis();
     }
 
     private static void convertTime(Calendar from, Calendar to) {
@@ -474,7 +474,7 @@ public class DateTimeUtils {
         }
         c.setLenient(lenient);
         setCalendarFields(c, year, month, day, hour, minute, second, millis);
-        return c.getTime().getTime();
+        return c.getTimeInMillis();
     }
 
     private static void setCalendarFields(Calendar cal, int year, int month,

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -35,6 +35,11 @@ public class DateTimeUtils {
      */
     public static final long MILLIS_PER_DAY = 24 * 60 * 60 * 1000L;
 
+    /**
+     * UTC time zone.
+     */
+    public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
     private static final long NANOS_PER_DAY = MILLIS_PER_DAY * 1000000;
 
     private static final int SHIFT_YEAR = 9;

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -471,7 +471,7 @@ public class DateTimeUtils {
         return convertToMillis(c, year, month, day, hour, minute, second, millis);
     }
 
-    static long convertToMillis(Calendar cal, int year, int month, int day,
+    private static long convertToMillis(Calendar cal, int year, int month, int day,
             int hour, int minute, int second, int millis) {
         if (year <= 0) {
             cal.set(Calendar.ERA, GregorianCalendar.BC);

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -168,10 +168,9 @@ public class DateTimeUtils {
         cal.clear();
         cal.setLenient(true);
         long dateValue = d.getDateValue();
-        setCalendarFields(cal, yearFromDateValue(dateValue),
+        long ms = convertToMillis(cal, yearFromDateValue(dateValue),
                 monthFromDateValue(dateValue), dayFromDateValue(dateValue), 0,
                 0, 0, 0);
-        long ms = cal.getTimeInMillis();
         return new Date(ms);
     }
 
@@ -199,10 +198,7 @@ public class DateTimeUtils {
         s -= m * 60;
         long h = m / 60;
         m -= h * 60;
-        setCalendarFields(cal, 1970, 1, 1, (int) h, (int) m, (int) s,
-                (int) millis);
-        long ms = cal.getTimeInMillis();
-        return new Time(ms);
+        return new Time(convertToMillis(cal, 1970, 1, 1, (int) h, (int) m, (int) s, (int) millis));
     }
 
     /**
@@ -230,10 +226,9 @@ public class DateTimeUtils {
         s -= m * 60;
         long h = m / 60;
         m -= h * 60;
-        setCalendarFields(cal, yearFromDateValue(dateValue),
+        long ms = convertToMillis(cal, yearFromDateValue(dateValue),
                 monthFromDateValue(dateValue), dayFromDateValue(dateValue),
                 (int) h, (int) m, (int) s, (int) millis);
-        long ms = cal.getTimeInMillis();
         Timestamp x = new Timestamp(ms);
         x.setNanos((int) (nanos + millis * 1000000));
         return x;
@@ -473,12 +468,11 @@ public class DateTimeUtils {
             c = getCalendar(tz);
         }
         c.setLenient(lenient);
-        setCalendarFields(c, year, month, day, hour, minute, second, millis);
-        return c.getTimeInMillis();
+        return convertToMillis(c, year, month, day, hour, minute, second, millis);
     }
 
-    private static void setCalendarFields(Calendar cal, int year, int month,
-            int day, int hour, int minute, int second, int millis) {
+    static long convertToMillis(Calendar cal, int year, int month, int day,
+            int hour, int minute, int second, int millis) {
         if (year <= 0) {
             cal.set(Calendar.ERA, GregorianCalendar.BC);
             cal.set(Calendar.YEAR, 1 - year);
@@ -493,6 +487,7 @@ public class DateTimeUtils {
         cal.set(Calendar.MINUTE, minute);
         cal.set(Calendar.SECOND, second);
         cal.set(Calendar.MILLISECOND, millis);
+        return cal.getTimeInMillis();
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -172,7 +172,7 @@ public class ValueTimestamp extends Value {
             int timeEnd = s.length();
             TimeZone tz = null;
             if (s.endsWith("Z")) {
-                tz = TimeZone.getTimeZone("UTC");
+                tz = DateTimeUtils.UTC;
                 timeEnd--;
             } else {
                 int timeZoneStart = s.indexOf('+', dateEnd + 1);

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -40,8 +40,6 @@ public class ValueTimestampTimeZone extends Value {
      */
     static final int DEFAULT_SCALE = 10;
 
-    private static final TimeZone GMT_TIMEZONE = TimeZone.getTimeZone("GMT");
-
     /**
      * A bit field with bits for the year, month, and day (see DateTimeUtils for
      * encoding)
@@ -165,7 +163,7 @@ public class ValueTimestampTimeZone extends Value {
                 }
                 if (tz != null) {
                     long millis = DateTimeUtils
-                            .convertDateValueToMillis(GMT_TIMEZONE, dateValue);
+                            .convertDateValueToMillis(DateTimeUtils.UTC, dateValue);
                     tzMinutes = (short) (tz.getOffset(millis) / 1000 / 60);
                 }
             }
@@ -294,7 +292,7 @@ public class ValueTimestampTimeZone extends Value {
 
         // convert to minutes and add timezone offset
         long a = DateTimeUtils.convertDateValueToMillis(
-                TimeZone.getTimeZone("UTC"), dateValue) /
+                DateTimeUtils.UTC, dateValue) /
                 (1000L * 60L);
         long ma = timeNanos / (1000L * 1000L * 1000L * 60L);
         a += ma;
@@ -302,7 +300,7 @@ public class ValueTimestampTimeZone extends Value {
 
         // convert to minutes and add timezone offset
         long b = DateTimeUtils.convertDateValueToMillis(
-                TimeZone.getTimeZone("UTC"), t.dateValue) /
+                DateTimeUtils.UTC, t.dateValue) /
                 (1000L * 60L);
         long mb = t.timeNanos / (1000L * 1000L * 1000L * 60L);
         b += mb;

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1309,7 +1309,7 @@ public class TestResultSet extends TestBase {
                         java.sql.Timestamp.valueOf("2011-11-11 00:00:00.0").getTime());
         o = rs.getObject(2, Calendar.class);
         assertTrue(o instanceof Calendar);
-        assertEquals(((Calendar) o).getTime().getTime(),
+        assertEquals(((Calendar) o).getTimeInMillis(),
                         java.sql.Timestamp.valueOf("2011-11-11 00:00:00.0").getTime());
         rs.next();
 

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -352,7 +352,7 @@ public class TestDate extends TestBase {
     }
 
     private void testValidDate() {
-        Calendar c = DateTimeUtils.createGregorianCalendar(TimeZone.getTimeZone("UTC"));
+        Calendar c = DateTimeUtils.createGregorianCalendar(DateTimeUtils.UTC);
         c.setLenient(false);
         for (int y = -2000; y < 3000; y++) {
             for (int m = -3; m <= 14; m++) {


### PR DESCRIPTION
1. A new constant `DateTimeUtils.UTC` is introduced.
2. Calls to `Calendar.getTime().getTime()` are replaced with simple `Calendar.getTimeInMillis()`. Please notice that `java.util.Date.getTime()` may perform normalization of its value, but `Calendar.getTime()` always returns dates without `cdate` field so normalization will be skipped anyway. So this calls return exactly the same results in all cases.
3. `DateTimeUtils.setCalendarFields()` is renamed to `convertToMillis()` and changed to return resulf of `getTimeInMillis()` to reduce code duplication because all four callers of this method call `getTimeInMillis()` next.