### PR TITLE
Fix ResultSet.getObject() for BigInteger and remove unneeded check

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3773,7 +3773,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
         if (type == BigDecimal.class) {
             return type.cast(value.getBigDecimal());
         } else if (type == BigInteger.class) {
-            return type.cast(BigInteger.valueOf(value.getLong()));
+            return type.cast(value.getBigDecimal().toBigInteger());
         } else if (type == String.class) {
             return type.cast(value.getString());
         } else if (type == Boolean.class) {

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -60,7 +60,6 @@ import org.h2.value.ValueShort;
 import org.h2.value.ValueString;
 import org.h2.value.ValueTime;
 import org.h2.value.ValueTimestamp;
-import org.h2.value.ValueTimestampTimeZone;
 
 /**
  * <p>
@@ -3827,8 +3826,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             return type.cast(LocalDateTimeUtils.valueToLocalDateTime(value));
         } else if (LocalDateTimeUtils.isInstant(type)) {
             return type.cast(LocalDateTimeUtils.valueToInstant(value));
-        } else if (LocalDateTimeUtils.isOffsetDateTime(type) &&
-                value instanceof ValueTimestampTimeZone) {
+        } else if (LocalDateTimeUtils.isOffsetDateTime(type)) {
             return type.cast(LocalDateTimeUtils.valueToOffsetDateTime(value));
         } else {
             throw unsupported(type.getName());

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1152,6 +1152,18 @@ public class TestResultSet extends TestBase {
 
         assertTrue(!rs.next());
         stat.execute("DROP TABLE TEST");
+
+        stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY,VALUE DECIMAL(22,2))");
+        stat.execute("INSERT INTO TEST VALUES(1,-12345678909876543210)");
+        stat.execute("INSERT INTO TEST VALUES(2,12345678901234567890.12345)");
+        rs = stat.executeQuery("SELECT * FROM TEST ORDER BY ID");
+        rs.next();
+        assertEquals(new BigDecimal("-12345678909876543210.00"), rs.getBigDecimal(2));
+        assertEquals(new BigInteger("-12345678909876543210"), rs.getObject(2, BigInteger.class));
+        rs.next();
+        assertEquals(new BigDecimal("12345678901234567890.12"), rs.getBigDecimal(2));
+        assertEquals(new BigInteger("12345678901234567890"), rs.getObject(2, BigInteger.class));
+        stat.execute("DROP TABLE TEST");
     }
 
     private void testDoubleFloat() throws SQLException {


### PR DESCRIPTION
1. Conversion from `DECIMAL` to `BigInteger` was wrong — not all values can fit into `long`.
2. Remove redundant check for `ValueTimestampTimeZone` in the same method. `LocalDateTimeUtils.valueToOffsetDateTime()` will throw `ErrorCode.DATA_CONVERSION_ERROR_1` if type is not compatible that's better than fallback `ErrorCode.FEATURE_NOT_SUPPORTED_1` because `OffsetDateTime` is supported, but should be used with `TIMESTAMP WITH TIME ZONE` columns.