### PR TITLE
Do not copy result of DataUtils.parseMap() to a new maps

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -445,6 +445,7 @@ public final class MVStore {
      * @param builder the map builder
      * @return the map
      */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public synchronized <M extends MVMap<K, V>, K, V> M openMap(
             String name, MVMap.MapBuilder<M, K, V> builder) {
         checkOpen();
@@ -455,15 +456,14 @@ public final class MVStore {
         M map;
         if (x != null) {
             id = DataUtils.parseHexInt(x);
-            @SuppressWarnings("unchecked")
             M old = (M) maps.get(id);
             if (old != null) {
                 return old;
             }
             map = builder.create();
             String config = meta.get(MVMap.getMapKey(id));
-            c = New.hashMap();
-            c.putAll(DataUtils.parseMap(config));
+            // Cast from HashMap<String, String> to HashMap<String, Object> is safe
+            c = (HashMap) DataUtils.parseMap(config);
             c.put("id", id);
             map.init(this, c);
             root = getRootPos(meta, id);
@@ -2725,7 +2725,18 @@ public final class MVStore {
      */
     public static class Builder {
 
-        private final HashMap<String, Object> config = New.hashMap();
+        private final HashMap<String, Object> config;
+
+        private Builder(HashMap<String, Object> config) {
+            this.config = config;
+        }
+
+        /**
+         * Creates new instance of MVStore.Builder.
+         */
+        public Builder() {
+            config = New.hashMap();
+        }
 
         private Builder set(String key, Object value) {
             config.put(key, value);
@@ -2938,11 +2949,10 @@ public final class MVStore {
          * @param s the string representation
          * @return the builder
          */
+        @SuppressWarnings({ "unchecked", "rawtypes" })
         public static Builder fromString(String s) {
-            HashMap<String, String> config = DataUtils.parseMap(s);
-            Builder builder = new Builder();
-            builder.config.putAll(config);
-            return builder;
+            // Cast from HashMap<String, String> to HashMap<String, Object> is safe
+            return new Builder((HashMap) DataUtils.parseMap(s));
         }
 
     }


### PR DESCRIPTION
`DataUtils.parseMap()` returns map that can be used in any way, so do not copy content to a new map (with the same initial capacity, by the way).

This change introduces ugly (but safe) typecasts it two places, possibly we can change return type of `DataUtils.parseMap()` later, but now we have more usages of this method that should be checked before.