### PR TITLE
getBinaryStream() and getCharacterStream() with pos and length

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcBlob.java
+++ b/h2/src/main/org/h2/jdbc/JdbcBlob.java
@@ -304,7 +304,7 @@ public class JdbcBlob extends TraceObject implements Blob {
     }
 
     /**
-     * [Not supported] Returns the input stream, starting from an offset.
+     * Returns the input stream, starting from an offset.
      *
      * @param pos where to start reading
      * @param length the number of bytes that will be read
@@ -312,7 +312,13 @@ public class JdbcBlob extends TraceObject implements Blob {
      */
     @Override
     public InputStream getBinaryStream(long pos, long length) throws SQLException {
-        throw unsupported("LOB update");
+        try {
+            debugCodeCall("getBinaryStream(pos, length)");
+            checkClosed();
+            return value.getInputStream(pos, length);
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
     }
 
     private void checkClosed() {

--- a/h2/src/main/org/h2/jdbc/JdbcClob.java
+++ b/h2/src/main/org/h2/jdbc/JdbcClob.java
@@ -261,11 +261,17 @@ public class JdbcClob extends TraceObject implements NClob
     }
 
     /**
-     * [Not supported] Returns the reader, starting from an offset.
+     * Returns the reader, starting from an offset.
      */
     @Override
     public Reader getCharacterStream(long pos, long length) throws SQLException {
-        throw unsupported("LOB subset");
+        try {
+            debugCodeCall("getCharacterStream(pos, length)");
+            checkClosed();
+            return value.getReader(pos, length);
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
     }
 
     private void checkClosed() {

--- a/h2/src/main/org/h2/store/RangeInputStream.java
+++ b/h2/src/main/org/h2/store/RangeInputStream.java
@@ -1,0 +1,87 @@
+package org.h2.store;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class RangeInputStream extends FilterInputStream {
+    private long offset, limit;
+
+    public RangeInputStream(InputStream in, long offset, long limit) {
+        super(in);
+        this.offset = offset;
+        this.limit = limit;
+    }
+
+    private void before() throws IOException {
+        while (offset > 0) {
+            offset -= in.skip(offset);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        before();
+        if (limit < 1) {
+            return -1;
+        }
+        int b = in.read();
+        if (b >= 0) {
+            limit--;
+        }
+        return b;
+    }
+
+    @Override
+    public int read(byte b[], int off, int len) throws IOException {
+        before();
+        if (len > limit) {
+            len = (int) limit;
+        }
+        int cnt = in.read(b, off, len);
+        if (cnt > 0) {
+            limit -= cnt;
+        }
+        return cnt;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        before();
+        if (n > limit) {
+            n = (int) limit;
+        }
+        n = in.skip(n);
+        limit -= n;
+        return n;
+    }
+
+    @Override
+    public int available() throws IOException {
+        before();
+        int cnt = in.available();
+        if (cnt > limit) {
+            return (int) limit;
+        }
+        return cnt;
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    @Override
+    public void mark(int readlimit) {
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        throw new IOException("mark/reset not supported");
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+}

--- a/h2/src/main/org/h2/store/RangeReader.java
+++ b/h2/src/main/org/h2/store/RangeReader.java
@@ -1,0 +1,88 @@
+package org.h2.store;
+
+import java.io.IOException;
+import java.io.Reader;
+
+public final class RangeReader extends Reader {
+    private final Reader r;
+
+    private long offset, limit;
+
+    public RangeReader(Reader r, long offset, long limit) {
+        this.r = r;
+        this.offset = offset;
+        this.limit = limit;
+    }
+
+    private void before() throws IOException {
+        while (offset > 0) {
+            offset -= r.skip(offset);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        before();
+        if (limit < 1) {
+            return -1;
+        }
+        int c = r.read();
+        if (c >= 0) {
+            limit--;
+        }
+        return c;
+    }
+
+    @Override
+    public int read(char cbuf[], int off, int len) throws IOException {
+        before();
+        if (len > limit) {
+            len = (int) limit;
+        }
+        int cnt = r.read(cbuf, off, len);
+        if (cnt > 0) {
+            limit -= cnt;
+        }
+        return cnt;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        before();
+        if (n > limit) {
+            n = (int) limit;
+        }
+        n = r.skip(n);
+        limit -= n;
+        return n;
+    }
+
+    @Override
+    public boolean ready() throws IOException {
+        before();
+        if (limit > 0) {
+            return r.ready();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public void mark(int readAheadLimit) throws IOException {
+        throw new IOException("mark() not supported");
+    }
+
+    @Override
+    public void reset() throws IOException {
+        throw new IOException("reset() not supported");
+    }
+
+    @Override
+    public void close() throws IOException {
+        r.close();
+    }
+}

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -375,6 +375,11 @@ public class ValueLobDb extends Value implements Value.ValueClob,
     }
 
     @Override
+    public Reader getReader(long oneBasedOffset, long length) {
+        return ValueLob.rangeReader(getReader(), oneBasedOffset, length);
+    }
+
+    @Override
     public InputStream getInputStream() {
         if (small != null) {
             return new ByteArrayInputStream(small);
@@ -390,6 +395,14 @@ public class ValueLobDb extends Value implements Value.ValueClob,
         } catch (IOException e) {
             throw DbException.convertIOException(e, toString());
         }
+    }
+
+    @Override
+    public InputStream getInputStream(long oneBasedOffset, long length) {
+        if (small != null) {
+            return super.getInputStream(oneBasedOffset, length);
+        }
+        return ValueLob.rangeInputStream(getInputStream(), oneBasedOffset, length);
     }
 
     @Override

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -1074,18 +1074,34 @@ public class TestLob extends TestBase {
         prep2.getQueryTimeout();
         prep2.close();
         conn0.getAutoCommit();
-        Reader r = clob0.getCharacterStream();
+        Reader r;
+        int ch;
+        r = clob0.getCharacterStream();
         for (int i = 0; i < 10000; i++) {
-            int ch = r.read();
+            ch = r.read();
             if (ch != ('0' + (i % 10))) {
                 fail("expected " + (char) ('0' + (i % 10)) +
                         " got: " + ch + " (" + (char) ch + ")");
             }
         }
-        int ch = r.read();
+        ch = r.read();
         if (ch != -1) {
             fail("expected -1 got: " + ch);
         }
+        r.close();
+        r = clob0.getCharacterStream(1235, 1000);
+        for (int i = 1234; i < 2234; i++) {
+            ch = r.read();
+            if (ch != ('0' + (i % 10))) {
+                fail("expected " + (char) ('0' + (i % 10)) +
+                        " got: " + ch + " (" + (char) ch + ")");
+            }
+        }
+        ch = r.read();
+        if (ch != -1) {
+            fail("expected -1 got: " + ch);
+        }
+        r.close();
         conn0.close();
     }
 

--- a/h2/src/test/org/h2/test/jdbc/TestLobApi.java
+++ b/h2/src/test/org/h2/test/jdbc/TestLobApi.java
@@ -92,8 +92,6 @@ public class TestLobApi extends TestBase {
                 position("", 0);
         assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, clob).
                 position((Clob) null, 0);
-        assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, clob).
-                getCharacterStream(1, 1);
 
         Blob blob = rs.getBlob(3);
         assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, blob).
@@ -104,8 +102,6 @@ public class TestLobApi extends TestBase {
                 position(new byte[1], 0);
         assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, blob).
                 position((Blob) null, 0);
-        assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, blob).
-                getBinaryStream(1, 1);
         assertTrue(blob.toString().endsWith("X'00'"));
         blob.free();
         assertTrue(blob.toString().endsWith("null"));


### PR DESCRIPTION
This pull request adds implementations of `JdbcBlob.getBinaryStream(long pos, long length)` and `JdbcClob.getCharacterStream(long pos, long length)`.

`getBinaryStream(long pos, long length)` for the small LOBs and objects of other types implemented by passing additonal arguments to `ByteArrayInputStream` to limit its output. For large LOBs this method is implemented via wrapper class over InputStream, efficiency of this imlementation depends on implementation of `skip()` method in underlying stream.

`getCharacterStream((long pos, long length)` for the small LOBs and objects of other types implemented by passing substring of the full string to the `StringReader`. For large LOBs this method is implemented via wrapper class over Reader. H2 encodes characters into bytes with variable-length encoding, so `skip()` method here reads all data before `pos` in all cases.