### PR TITLE
Better checks for arguments of partial LOB reading methods 

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcClob.java
+++ b/h2/src/main/org/h2/jdbc/JdbcClob.java
@@ -262,6 +262,10 @@ public class JdbcClob extends TraceObject implements NClob
 
     /**
      * Returns the reader, starting from an offset.
+     *
+     * @param pos 1-based offset
+     * @param length length of requested area
+     * @return the reader
      */
     @Override
     public Reader getCharacterStream(long pos, long length) throws SQLException {

--- a/h2/src/main/org/h2/store/RangeInputStream.java
+++ b/h2/src/main/org/h2/store/RangeInputStream.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
 package org.h2.store;
 
 import java.io.FilterInputStream;
@@ -6,9 +11,24 @@ import java.io.InputStream;
 
 import org.h2.util.IOUtils;
 
+/**
+ * Input stream that reads only a specified range from the source stream.
+ */
 public final class RangeInputStream extends FilterInputStream {
     private long limit;
 
+    /**
+     * Creates new instance of range input stream.
+     *
+     * @param in
+     *            source stream
+     * @param offset
+     *            offset of the range
+     * @param limit
+     *            length of the range
+     * @throws IOException
+     *             on I/O exception during seeking to the specified offset
+     */
     public RangeInputStream(InputStream in, long offset, long limit) throws IOException {
         super(in);
         this.limit = limit;

--- a/h2/src/main/org/h2/store/RangeInputStream.java
+++ b/h2/src/main/org/h2/store/RangeInputStream.java
@@ -1,9 +1,10 @@
 package org.h2.store;
 
-import java.io.EOFException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.h2.util.IOUtils;
 
 public final class RangeInputStream extends FilterInputStream {
     private long limit;
@@ -11,17 +12,7 @@ public final class RangeInputStream extends FilterInputStream {
     public RangeInputStream(InputStream in, long offset, long limit) throws IOException {
         super(in);
         this.limit = limit;
-        while (offset > 0) {
-            long skip = in.skip(offset);
-            if (skip <= 0) {
-                int b = read();
-                if (b < 0)
-                    throw new EOFException();
-                offset--;
-            } else {
-                offset -= skip;
-            }
-        }
+        IOUtils.skipFully(in, offset);
     }
 
     @Override

--- a/h2/src/main/org/h2/store/RangeReader.java
+++ b/h2/src/main/org/h2/store/RangeReader.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
 package org.h2.store;
 
 import java.io.IOException;
@@ -5,11 +10,26 @@ import java.io.Reader;
 
 import org.h2.util.IOUtils;
 
+/**
+ * Reader that reads only a specified range from the source reader.
+ */
 public final class RangeReader extends Reader {
     private final Reader r;
 
     private long limit;
 
+    /**
+     * Creates new instance of range reader.
+     *
+     * @param r
+     *            source reader
+     * @param offset
+     *            offset of the range
+     * @param limit
+     *            length of the range
+     * @throws IOException
+     *             on I/O exception during seeking to the specified offset
+     */
     public RangeReader(Reader r, long offset, long limit) throws IOException {
         this.r = r;
         this.limit = limit;

--- a/h2/src/main/org/h2/store/RangeReader.java
+++ b/h2/src/main/org/h2/store/RangeReader.java
@@ -1,8 +1,9 @@
 package org.h2.store;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
+
+import org.h2.util.IOUtils;
 
 public final class RangeReader extends Reader {
     private final Reader r;
@@ -12,17 +13,7 @@ public final class RangeReader extends Reader {
     public RangeReader(Reader r, long offset, long limit) throws IOException {
         this.r = r;
         this.limit = limit;
-        while (offset > 0) {
-            long skip = r.skip(offset);
-            if (skip <= 0) {
-                int ch = read();
-                if (ch < 0)
-                    throw new EOFException();
-                offset--;
-            } else {
-                offset -= skip;
-            }
-        }
+        IOUtils.skipFully(r, offset);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -188,7 +188,7 @@ public abstract class Value {
     private static final BigDecimal MIN_LONG_DECIMAL =
             BigDecimal.valueOf(Long.MIN_VALUE);
 
-    private static void rangeCheck(long zeroBasedOffset, long length, long dataSize) {
+    static void rangeCheck(long zeroBasedOffset, long length, long dataSize) {
         if ((zeroBasedOffset | length) < 0 || length > dataSize - zeroBasedOffset) {
             if (zeroBasedOffset < 0 || zeroBasedOffset > dataSize) {
                 throw DbException.getInvalidValueException("offset", zeroBasedOffset + 1);

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -60,7 +60,7 @@ public class ValueLob extends Value {
     }
 
     static InputStream rangeInputStream(InputStream inputStream, long oneBasedOffset, long length, long dataSize) {
-        if (dataSize >= 0)
+        if (dataSize > 0)
             rangeCheck(oneBasedOffset - 1, length, dataSize);
         else
             rangeCheckUnknown(oneBasedOffset - 1, length);
@@ -71,8 +71,11 @@ public class ValueLob extends Value {
         }
     }
 
-    static Reader rangeReader(Reader reader, long oneBasedOffset, long length) {
-        rangeCheckUnknown(oneBasedOffset, length);
+    static Reader rangeReader(Reader reader, long oneBasedOffset, long length, long dataSize) {
+        if (dataSize > 0)
+            rangeCheck(oneBasedOffset - 1, length, dataSize);
+        else
+            rangeCheckUnknown(oneBasedOffset - 1, length);
         try {
             return new RangeReader(reader, oneBasedOffset - 1, length);
         } catch (IOException e) {
@@ -666,7 +669,7 @@ public class ValueLob extends Value {
 
     @Override
     public Reader getReader(long oneBasedOffset, long length) {
-        return rangeReader(getReader(), oneBasedOffset, length);
+        return rangeReader(getReader(), oneBasedOffset, length, type == Value.CLOB ? precision : -1);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -60,13 +60,21 @@ public class ValueLob extends Value {
     }
 
     static InputStream rangeInputStream(InputStream inputStream, long oneBasedOffset, long length) {
-        rangeCheckUnknown(--oneBasedOffset, length);
-        return new RangeInputStream(inputStream, /* 0-based */ oneBasedOffset, length);
+        rangeCheckUnknown(oneBasedOffset, length);
+        try {
+            return new RangeInputStream(inputStream, oneBasedOffset - 1, length);
+        } catch (IOException e) {
+            throw DbException.getInvalidValueException("offset", oneBasedOffset);
+        }
     }
 
     static Reader rangeReader(Reader reader, long oneBasedOffset, long length) {
-        rangeCheckUnknown(--oneBasedOffset, length);
-        return new RangeReader(reader, /* 0-based */ oneBasedOffset, length);
+        rangeCheckUnknown(oneBasedOffset, length);
+        try {
+            return new RangeReader(reader, oneBasedOffset - 1, length);
+        } catch (IOException e) {
+            throw DbException.getInvalidValueException("offset", oneBasedOffset);
+        }
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -399,10 +399,25 @@ public class ValueLobDb extends Value implements Value.ValueClob,
 
     @Override
     public InputStream getInputStream(long oneBasedOffset, long length) {
+        long byteCount;
+        InputStream inputStream;
         if (small != null) {
             return super.getInputStream(oneBasedOffset, length);
+        } else if (fileName != null) {
+            FileStore store = handler.openFile(fileName, "r", true);
+            boolean alwaysClose = SysProperties.lobCloseBetweenReads;
+            byteCount = store.length();
+            inputStream = new BufferedInputStream(new FileStoreInputStream(store,
+                    handler, false, alwaysClose), Constants.IO_BUFFER_SIZE);
+        } else {
+            byteCount = (type == Value.BLOB) ? precision : -1;
+            try {
+                inputStream = handler.getLobStorage().getInputStream(this, hmac, byteCount);
+            } catch (IOException e) {
+                throw DbException.convertIOException(e, toString());
+            }
         }
-        return ValueLob.rangeInputStream(getInputStream(), oneBasedOffset, length);
+        return ValueLob.rangeInputStream(inputStream, oneBasedOffset, length, byteCount);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -376,7 +376,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
 
     @Override
     public Reader getReader(long oneBasedOffset, long length) {
-        return ValueLob.rangeReader(getReader(), oneBasedOffset, length);
+        return ValueLob.rangeReader(getReader(), oneBasedOffset, length, type == Value.CLOB ? precision : -1);
     }
 
     @Override

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -1103,7 +1103,7 @@ public class TestLob extends TestBase {
             fail("expected -1 got: " + ch);
         }
         r.close();
-        // TODO assertThrows(ErrorCode.INVALID_VALUE_2, clob0).getCharacterStream(10001, 1);
+        assertThrows(ErrorCode.INVALID_VALUE_2, clob0).getCharacterStream(10001, 1);
         assertThrows(ErrorCode.INVALID_VALUE_2, clob0).getCharacterStream(10002, 0);
         conn0.close();
     }

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;
 import org.h2.jdbc.JdbcConnection;
+import org.h2.jdbc.JdbcSQLException;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
@@ -1102,6 +1103,8 @@ public class TestLob extends TestBase {
             fail("expected -1 got: " + ch);
         }
         r.close();
+        // TODO assertThrows(ErrorCode.INVALID_VALUE_2, clob0).getCharacterStream(10001, 1);
+        assertThrows(ErrorCode.INVALID_VALUE_2, clob0).getCharacterStream(10002, 0);
         conn0.close();
     }
 

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1615,6 +1615,7 @@ public class TestResultSet extends TestBase {
             assertEqualsWithNull(new byte[] { (byte) 0x03,
                     (byte) 0x03 }, readAllBytes(blob.getBinaryStream(2, 2)));
             assertTrue(!rs.wasNull());
+            assertThrows(ErrorCode.INVALID_VALUE_2, blob).getBinaryStream(5, 1);
         } finally {
             blob.free();
         }
@@ -1632,6 +1633,8 @@ public class TestResultSet extends TestBase {
             byte[] got = readAllBytes(blob.getBinaryStream(101, 50002));
             assertEqualsWithNull(expected, got);
             assertTrue(!rs.wasNull());
+            // TODO assertThrows(ErrorCode.INVALID_VALUE_2, blob).getBinaryStream(0x10001, 1);
+            assertThrows(ErrorCode.INVALID_VALUE_2, blob).getBinaryStream(0x10002, 0);
         } finally {
             blob.free();
         }
@@ -1695,6 +1698,8 @@ public class TestResultSet extends TestBase {
         Clob clob = rs.getClob(2);
         try {
             assertEquals("all", readString(clob.getCharacterStream(2, 3)));
+            // TODO assertThrows(ErrorCode.INVALID_VALUE_2, clob).getCharacterStream(6, 1);
+            assertThrows(ErrorCode.INVALID_VALUE_2, clob).getCharacterStream(7, 0);
         } finally {
             clob.free();
         }

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1633,7 +1633,7 @@ public class TestResultSet extends TestBase {
             byte[] got = readAllBytes(blob.getBinaryStream(101, 50002));
             assertEqualsWithNull(expected, got);
             assertTrue(!rs.wasNull());
-            // TODO assertThrows(ErrorCode.INVALID_VALUE_2, blob).getBinaryStream(0x10001, 1);
+            assertThrows(ErrorCode.INVALID_VALUE_2, blob).getBinaryStream(0x10001, 1);
             assertThrows(ErrorCode.INVALID_VALUE_2, blob).getBinaryStream(0x10002, 0);
         } finally {
             blob.free();

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1698,7 +1698,7 @@ public class TestResultSet extends TestBase {
         Clob clob = rs.getClob(2);
         try {
             assertEquals("all", readString(clob.getCharacterStream(2, 3)));
-            // TODO assertThrows(ErrorCode.INVALID_VALUE_2, clob).getCharacterStream(6, 1);
+            assertThrows(ErrorCode.INVALID_VALUE_2, clob).getCharacterStream(6, 1);
             assertThrows(ErrorCode.INVALID_VALUE_2, clob).getCharacterStream(7, 0);
         } finally {
             clob.free();


### PR DESCRIPTION
1. When size of large LOB is available it used in initial check of preconditions to throw SQL exceptions as specified in Javadoc of `Blob` and `Clob`. Unfortunately, Javadoc definitely contains off-by-one errors and JDBC specification does not contain information about this exceptions at all, so it's not clear if reading exactly 0 byte (chars) at end of LOB is allowed or not, so I just decide to allow it for compatibility with other APIs.

2. In any cases `pos - 1` bytes or chars are now skipped immediately. So even if size of LOB is not available we still can get proper exception at least if `pos` is too large. Usually LOB knows its size, but somebody can try to read BLOB as CLOB, for example, and in this case this size is not useful. It's possible to read and decode the whole CLOB to get this size, but this is not efficient.

3. Possible infinite loop in skipping of `pos - 1` characters with invalid `pos` value is fixed.