### PR TITLE
Assorted changes

### DIFF
--- a/h2/.gitattributes
+++ b/h2/.gitattributes
@@ -1,2 +1,3 @@
 *.bat eol=crlf
 *.sh eol=lf
+*.java diff=java

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -23,7 +23,7 @@ Change Log
 <ul>
 <li>Make ALL a reserved keyword
 </li>
-<li>Issue #311: Avoid calling list.toArray(new X[list.size()]) for performance 
+<li>Issue #311: Avoid calling list.toArray(new X[list.size()]) for performance
 </li>
 <li>PR #715: Better getObject error message
 </li>
@@ -43,11 +43,11 @@ Change Log
 </li>
 <li>Issue #699: When using an index for sorting, the index is ignored when also using NULLS LAST/FIRST
 </li>
-<li>Issue #697: FilePathDisk.newInputStream fails for contextual class loading          
+<li>Issue #697: FilePathDisk.newInputStream fails for contextual class loading
 </li>
 <li>Issue #695: jdbc:postgresql protocol connection issue in H2 Console Application in case of redshift driver in classpath
 </li>
-<li>Fix 'file not closed' when using FILE_READ 
+<li>Fix 'file not closed' when using FILE_READ
 </li>
 <li>Fix bug in LinkSchema tool when object exists with same name in different schemas
 </li>
@@ -57,9 +57,9 @@ Change Log
 </li>
 <li>Issue #654: List ENUM type values in INFORMATION_SCHEMA.COLUMNS
 </li>
-<li>Issue #650: Simple nested SELECT causes error for table with TIMESTAMP WITH TIMEZONE column 
+<li>Issue #650: Simple nested SELECT causes error for table with TIMESTAMP WITH TIMEZONE column
 </li>
-<li>Issue #654: List ENUM type values in INFORMATION_SCHEMA.COLUMNS 
+<li>Issue #654: List ENUM type values in INFORMATION_SCHEMA.COLUMNS
 </li>
 <li>Issue #668: Fail of an update command on large table with ENUM column
 </li>

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -43,19 +43,19 @@ import java.util.HashSet;
  * @author Joel Turkel (Group sorted query)
  */
 public class Select extends Query {
-    private TableFilter topTableFilter;
+    TableFilter topTableFilter;
     private final ArrayList<TableFilter> filters = New.arrayList();
     private final ArrayList<TableFilter> topFilters = New.arrayList();
-    private ArrayList<Expression> expressions;
+    ArrayList<Expression> expressions;
     private Expression[] expressionArray;
     private Expression having;
     private Expression condition;
-    private int visibleColumnCount, distinctColumnCount;
+    int visibleColumnCount, distinctColumnCount;
     private ArrayList<SelectOrderBy> orderList;
     private ArrayList<Expression> group;
-    private int[] groupIndex;
-    private boolean[] groupByExpression;
-    private HashMap<Expression, Object> currentGroup;
+    int[] groupIndex;
+    boolean[] groupByExpression;
+    HashMap<Expression, Object> currentGroup;
     private int havingIndex;
     private boolean isGroupQuery, isGroupSortedQuery;
     private boolean isForUpdate, isForUpdateMvcc;
@@ -64,7 +64,7 @@ public class Select extends Query {
     private boolean isPrepared, checkInit;
     private boolean sortUsingIndex;
     private SortOrder sort;
-    private int currentGroupRowId;
+    int currentGroupRowId;
 
     public Select(Session session) {
         super(session);
@@ -164,7 +164,7 @@ public class Select extends Query {
         return null;
     }
 
-    private Value[] createGroupSortedRow(Value[] keyValues, int columnCount) {
+    Value[] createGroupSortedRow(Value[] keyValues, int columnCount) {
         Value[] row = new Value[columnCount];
         for (int j = 0; groupIndex != null && j < groupIndex.length; j++) {
             row[groupIndex[j]] = keyValues[j];
@@ -280,7 +280,7 @@ public class Select extends Query {
         return count;
     }
 
-    private boolean isConditionMet() {
+    boolean isConditionMet() {
         return condition == null ||
                 Boolean.TRUE.equals(condition.getBooleanValue(session));
     }
@@ -640,7 +640,7 @@ public class Select extends Query {
         return null;
     }
 
-    private void resetJoinBatchAfterQuery() {
+    void resetJoinBatchAfterQuery() {
         JoinBatch jb = getJoinBatch();
         if (jb != null) {
             jb.reset(false);

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -59,8 +59,8 @@ public class SelectUnion extends Query {
     public static final int INTERSECT = 3;
 
     private int unionType;
-    private final Query left;
-    private Query right;
+    final Query left;
+    Query right;
     private ArrayList<Expression> expressions;
     private Expression[] expressionArray;
     private ArrayList<SelectOrderBy> orderList;

--- a/h2/src/main/org/h2/fulltext/FullText.java
+++ b/h2/src/main/org/h2/fulltext/FullText.java
@@ -955,7 +955,7 @@ public class FullText {
             }
         }
 
-        private static boolean isMultiThread(Connection conn)
+        static boolean isMultiThread(Connection conn)
                 throws SQLException {
             try (Statement stat = conn.createStatement()) {
                 ResultSet rs = stat.executeQuery(

--- a/h2/src/main/org/h2/fulltext/FullTextLucene.java
+++ b/h2/src/main/org/h2/fulltext/FullTextLucene.java
@@ -581,7 +581,7 @@ public class FullTextLucene extends FullText {
         /**
          * Commit all changes to the Lucene index.
          */
-        private void commitIndex() throws SQLException {
+        void commitIndex() throws SQLException {
             try {
                 indexAccess.commit();
             } catch (IOException e) {
@@ -697,18 +697,18 @@ public class FullTextLucene extends FullText {
          */
         private IndexSearcher searcher;
 
-        private IndexAccess(IndexWriter writer) throws IOException {
+        IndexAccess(IndexWriter writer) throws IOException {
             this.writer = writer;
             IndexReader reader = IndexReader.open(writer, true);
             searcher = new IndexSearcher(reader);
         }
 
-        private synchronized IndexSearcher getSearcher() {
+        synchronized IndexSearcher getSearcher() {
             ++counter;
             return searcher;
         }
 
-        private synchronized void returnSearcher(IndexSearcher searcher) {
+        synchronized void returnSearcher(IndexSearcher searcher) {
             if (this.searcher == searcher) {
                 --counter;
                 assert counter >= 0;

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -43,7 +43,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
     /**
      * The multi-value table.
      */
-    private final MVTable                     mvTable;
+    final MVTable                             mvTable;
     private final int                         keyColumns;
     private final TransactionMap<Value,Value> dataMap;
 
@@ -85,7 +85,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
 
     private static final class Source {
         private final Iterator<ValueArray> iterator;
-        private       ValueArray           currentRowData;
+                      ValueArray           currentRowData;
 
         public Source(Iterator<ValueArray> iterator) {
             this.iterator = iterator;
@@ -338,7 +338,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
      * @param key the index key
      * @return the row
      */
-    private SearchRow convertToSearchRow(ValueArray key) {
+    SearchRow convertToSearchRow(ValueArray key) {
         Value[] array = key.getList();
         SearchRow searchRow = mvTable.getTemplateRow();
         searchRow.setKey((array[array.length - 1]).getLong());
@@ -481,7 +481,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         private SearchRow searchRow;
         private Row row;
 
-        private MVStoreCursor(Session session, Iterator<Value> it, SearchRow last) {
+        MVStoreCursor(Session session, Iterator<Value> it, SearchRow last) {
             this.session = session;
             this.it = it;
             this.last = last;

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -896,7 +896,7 @@ public class TransactionStore {
          */
         final MVMap<K, VersionedValue> map;
 
-        private final Transaction transaction;
+        final Transaction transaction;
 
         TransactionMap(Transaction transaction, MVMap<K, VersionedValue> map,
                 int mapId) {

--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TimeZone;
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -497,6 +497,7 @@ public class Column {
                     }
                 }
                 buff.append(')');
+                break;
             case Value.BYTES:
             case Value.STRING:
             case Value.STRING_IGNORECASE:

--- a/h2/src/main/org/h2/util/MathUtils.java
+++ b/h2/src/main/org/h2/util/MathUtils.java
@@ -205,7 +205,7 @@ public class MathUtils {
      * @param s the message to print
      * @param t the stack trace
      */
-    private static void warn(String s, Throwable t) {
+    static void warn(String s, Throwable t) {
         // not a fatal problem, but maybe reduced security
         System.out.println("Warning: " + s);
         if (t != null) {

--- a/h2/src/main/org/h2/util/ToChar.java
+++ b/h2/src/main/org/h2/util/ToChar.java
@@ -914,7 +914,7 @@ public class ToChar {
          * @return the capitalization / casing strategy which should be used
          *         when the first and second letters have the specified casing
          */
-        private static Capitalization toCapitalization(Boolean up1, Boolean up2) {
+        static Capitalization toCapitalization(Boolean up1, Boolean up2) {
             if (up1 == null) {
                 return Capitalization.CAPITALIZE;
             } else if (up2 == null) {

--- a/h2/src/main/org/h2/value/CharsetCollator.java
+++ b/h2/src/main/org/h2/value/CharsetCollator.java
@@ -15,7 +15,7 @@ import java.util.Comparator;
  */
 public class CharsetCollator extends Collator {
 
-    private static final Comparator<byte[]> COMPARATOR = new Comparator<byte[]>() {
+    static final Comparator<byte[]> COMPARATOR = new Comparator<byte[]>() {
         @Override
         public int compare(byte[] b1, byte[] b2) {
             int minLength = Math.min(b1.length, b2.length);
@@ -43,7 +43,7 @@ public class CharsetCollator extends Collator {
         return COMPARATOR.compare(toBytes(source), toBytes(target));
     }
 
-    private byte[] toBytes(String source) {
+    byte[] toBytes(String source) {
         return source.getBytes(charset);
     }
 

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -985,6 +985,7 @@ public abstract class Value {
                     if (DataType.isGeometry(object)) {
                         return ValueGeometry.getFromGeometry(object);
                     }
+                    //$FALL-THROUGH$
                 case TIMESTAMP_TZ:
                     throw DbException.get(
                             ErrorCode.DATA_CONVERSION_ERROR_1, getString());

--- a/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
+++ b/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
@@ -554,13 +554,13 @@ public class TestGeneralCommonTableQueries extends AbstractBaseForCommonTableExp
             config = backupConfig;
         }
     }
-    
-   private void testSimple3RowRecursiveQueryDropAllObjects() throws Exception {
-        
+
+    private void testSimple3RowRecursiveQueryDropAllObjects() throws Exception {
+
         String[] expectedRowData = new String[]{"|6"};
         String[] expectedColumnTypes = new String[]{"BIGINT"};
         String[] expectedColumnNames = new String[]{"SUM(N)"};
-        
+
         String setupSQL = "DROP ALL OBJECTS;";
         String withQuery = "select sum(n) from ("
             +"    with recursive r(n) as ("
@@ -574,8 +574,8 @@ public class TestGeneralCommonTableQueries extends AbstractBaseForCommonTableExp
 
         int maxRetries = 10;
         int expectedNumberOfRows = expectedRowData.length;
-        
+
         testRepeatedQueryWithSetup(maxRetries, expectedRowData, expectedColumnNames, expectedNumberOfRows, setupSQL,
-                withQuery, maxRetries - 1, expectedColumnTypes);      
-    }     
+                withQuery, maxRetries - 1, expectedColumnTypes);
+    }
 }

--- a/h2/src/test/org/h2/test/db/TestPersistentCommonTableExpressions.java
+++ b/h2/src/test/org/h2/test/db/TestPersistentCommonTableExpressions.java
@@ -5,6 +5,7 @@
  */
 package org.h2.test.db;
 
+import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
 
 /**
@@ -32,8 +33,14 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
     }
 
     private void testRecursiveTable() throws Exception {
+        String numericName;
+        if (SysProperties.BIG_DECIMAL_IS_DECIMAL) {
+            numericName = "DECIMAL";
+        } else {
+            numericName = "NUMERIC";
+        }
         String[] expectedRowData = new String[]{"|meat|null", "|fruit|3", "|veg|2"};
-        String[] expectedColumnTypes = new String[]{"VARCHAR", "DECIMAL"};
+        String[] expectedColumnTypes = new String[]{"VARCHAR", numericName};
         String[] expectedColumnNames = new String[]{"VAL",
                 "SUM(SELECT\n" +
                 "    X\n" +

--- a/h2/src/test/org/h2/test/db/TestPersistentCommonTableExpressions.java
+++ b/h2/src/test/org/h2/test/db/TestPersistentCommonTableExpressions.java
@@ -28,7 +28,7 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
         testPersistentNonRecursiveTableInCreateView();
         testPersistentRecursiveTableInCreateView();
         testPersistentNonRecursiveTableInCreateViewDropAllObjects();
-        testPersistentRecursiveTableInCreateViewDropAllObjects();        
+        testPersistentRecursiveTableInCreateViewDropAllObjects();
     }
 
     private void testRecursiveTable() throws Exception {
@@ -181,8 +181,8 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
         testRepeatedQueryWithSetup(maxRetries, expectedRowData, expectedColumnNames, expectedNumberOfRows, setupSQL,
                 withQuery, maxRetries - 1, expectedColumnTypes);
     }
-    
-    private void testPersistentNonRecursiveTableInCreateViewDropAllObjects() throws Exception {    
+
+    private void testPersistentNonRecursiveTableInCreateViewDropAllObjects() throws Exception {
         String setupSQL = ""
                 +"DROP ALL OBJECTS;                                                                            \n"
                 +"CREATE TABLE my_table (                                                                      \n"
@@ -203,7 +203,7 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
                 +"),                                                                                            \n"
                 +"unused_cte AS ( SELECT 1 AS unUsedColumn )                                                   \n"
                 +"SELECT sub_tree_root_id, tree_level, parent_fk, child_fk FROM tree_cte_nr;                   \n";
-        
+
         String withQuery = "SELECT * FROM v_my_nr_tree";
         int maxRetries = 6;
         String[] expectedRowData = new String[]{
@@ -214,13 +214,13 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
                 "|121|0|12|121",
                 };
         String[] expectedColumnNames = new String[]{"SUB_TREE_ROOT_ID", "TREE_LEVEL", "PARENT_FK", "CHILD_FK"};
-        String[] expectedColumnTypes = new String[]{"INTEGER", "INTEGER", "INTEGER", "INTEGER"};        
+        String[] expectedColumnTypes = new String[]{"INTEGER", "INTEGER", "INTEGER", "INTEGER"};
         int expectedNumberOfRows = 5;
         testRepeatedQueryWithSetup(maxRetries, expectedRowData, expectedColumnNames, expectedNumberOfRows, setupSQL,
                 withQuery, maxRetries - 1, expectedColumnTypes);
     }
 
-    private void testPersistentRecursiveTableInCreateViewDropAllObjects() throws Exception {    
+    private void testPersistentRecursiveTableInCreateViewDropAllObjects() throws Exception {
         String setuoSQL = "--SET TRACE_LEVEL_SYSTEM_OUT 3;\n"
                 +"DROP ALL OBJECTS;                                                                            \n"
                 +"CREATE TABLE my_tree (                                                                       \n"
@@ -245,7 +245,7 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
                 +"),                                                                                           \n"
                 +"unused_cte AS ( SELECT 1 AS unUsedColumn )                                                   \n"
                 +"SELECT sub_tree_root_id, tree_level, parent_fk, child_fk FROM tree_cte;                      \n";
-        
+
         String withQuery = "SELECT * FROM v_my_tree";
         int maxRetries = 4;
         String[] expectedRowData = new String[]{"|1|0|null|1",
@@ -261,9 +261,9 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
                 "|1|2|null|121"
                 };
         String[] expectedColumnNames = new String[]{"SUB_TREE_ROOT_ID", "TREE_LEVEL", "PARENT_FK", "CHILD_FK"};
-        String[] expectedColumnTypes = new String[]{"INTEGER", "INTEGER", "INTEGER", "INTEGER"};        
+        String[] expectedColumnTypes = new String[]{"INTEGER", "INTEGER", "INTEGER", "INTEGER"};
         int expectedNumberOfRows = 11;
         testRepeatedQueryWithSetup(maxRetries, expectedRowData, expectedColumnNames, expectedNumberOfRows, setuoSQL,
                 withQuery, maxRetries - 1, expectedColumnTypes);
-    }                    
+    }
 }

--- a/h2/src/test/org/h2/test/db/TestSetCollation.java
+++ b/h2/src/test/org/h2/test/db/TestSetCollation.java
@@ -156,7 +156,6 @@ public class TestSetCollation extends TestBase {
     private List<String> orderedWithCollator(String collator) throws SQLException {
         deleteDb(DB_NAME);
         try (Connection con = getConnection(DB_NAME); Statement statement = con.createStatement()) {
-            ;
             if (collator != null) {
                 statement.execute("SET COLLATION " + collator);
             }

--- a/h2/src/test/org/h2/test/jdbc/TestCustomDataTypesHandler.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCustomDataTypesHandler.java
@@ -439,12 +439,12 @@ public class TestCustomDataTypesHandler extends TestBase {
         /**
          * Real part
          */
-        private double re;
+        double re;
 
         /**
          * Imaginary part
          */
-        private double im;
+        double im;
 
         /**
          * @param re real part

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
@@ -111,6 +111,9 @@ public class TestMvccMultiThreaded2 extends TestBase {
 
         public int iterationsProcessed;
 
+        SelectForUpdate() {
+        }
+
         @Override
         public void run() {
             final long start = System.currentTimeMillis();

--- a/h2/src/tools/org/h2/dev/fs/ArchiveTool.java
+++ b/h2/src/tools/org/h2/dev/fs/ArchiveTool.java
@@ -656,7 +656,7 @@ public class ArchiveTool {
             }
         }
         int[] key = new int[4];
-        ; // TODO test if cs makes a difference
+        // TODO test if cs makes a difference
         key[0] = (int) (min >>> 32);
         key[1] = (int) min;
         key[2] = cs;


### PR DESCRIPTION
1. Access checks in Java and JVM are not the same and sometimes Java compiler generates synthetic methods so Java code can access fields or methods not accessible in JVM. I replace private access modifiers to default (package-private)  to prevent generation of such methods, that reduces size of compiled code.

2. Stray meaningless semicolons and usused import are removed.

3. I placed missing `break` statement in `switch` operator and a `//$FALL-THROUGH$` mark in another one.

4. `./build.sh docs` automatically fixed some traling whitespace. I also fixed bad identation in one place.

5. TestPersistentCommonTableExpressions now works if `-Dh2.bigDecimalIsDecimal=false` is specified.

6. I put `*.java diff=java` to .gitattributes