### PR TITLE
Fix building of documentation and zip

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -85,7 +85,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
 
     private static final class Source {
         private final Iterator<ValueArray> iterator;
-                      ValueArray           currentRowData;
+        ValueArray currentRowData;
 
         public Source(Iterator<ValueArray> iterator) {
             this.iterator = iterator;

--- a/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
+++ b/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
@@ -566,7 +566,7 @@ public class TestGeneralCommonTableQueries extends AbstractBaseForCommonTableExp
             +"    with recursive r(n) as ("
             +"        (select 1) union all (select n+1 from r where n < 3)"
             +"    ),"
-            +"   dummyUnsedCte(n) as ("
+            +"   dummyUnusedCte(n) as ("
             +"   select 1 "
             +"   )"
             +"    select n from r"

--- a/h2/src/test/org/h2/test/db/TestPersistentCommonTableExpressions.java
+++ b/h2/src/test/org/h2/test/db/TestPersistentCommonTableExpressions.java
@@ -228,7 +228,7 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
     }
 
     private void testPersistentRecursiveTableInCreateViewDropAllObjects() throws Exception {
-        String setuoSQL = "--SET TRACE_LEVEL_SYSTEM_OUT 3;\n"
+        String setupSQL = "--SET TRACE_LEVEL_SYSTEM_OUT 3;\n"
                 +"DROP ALL OBJECTS;                                                                            \n"
                 +"CREATE TABLE my_tree (                                                                       \n"
                 +" id INTEGER,                                                                                 \n"
@@ -270,7 +270,7 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
         String[] expectedColumnNames = new String[]{"SUB_TREE_ROOT_ID", "TREE_LEVEL", "PARENT_FK", "CHILD_FK"};
         String[] expectedColumnTypes = new String[]{"INTEGER", "INTEGER", "INTEGER", "INTEGER"};
         int expectedNumberOfRows = 11;
-        testRepeatedQueryWithSetup(maxRetries, expectedRowData, expectedColumnNames, expectedNumberOfRows, setuoSQL,
+        testRepeatedQueryWithSetup(maxRetries, expectedRowData, expectedColumnNames, expectedNumberOfRows, setupSQL,
                 withQuery, maxRetries - 1, expectedColumnTypes);
     }
 }

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -369,11 +369,24 @@ public class Build extends BuildBase {
         delete(files("bin").keep("*.jar"));
         jar();
         docs();
+        boolean pdfReady = false;
         try {
-            exec("soffice", args("-invisible", "macro:///Standard.Module1.H2Pdf"));
-            copy("docs", files("../h2web/h2.pdf"), "../h2web");
-        } catch (Exception e) {
-            print("OpenOffice is not available: " + e);
+            if (exec("soffice", args("--convert-to", "pdf", "--outdir", "docs/html", "docs/html/onePage.html")) == 0) {
+                File f = new File("docs/html/onePage.pdf");
+                if (f.exists() && f.renameTo(new File("docs/h2.pdf"))) {
+                    pdfReady = true;
+                }
+            }
+        } catch (Exception ex) {
+        }
+        if (!pdfReady) {
+            // Old way
+            try {
+                exec("soffice", args("-invisible", "macro:///Standard.Module1.H2Pdf"));
+                copy("docs", files("../h2web/h2.pdf"), "../h2web");
+            } catch (Exception e) {
+                print("OpenOffice is not available: " + e);
+            }
         }
         delete("docs/html/onePage.html");
         FileList files = files("../h2").keep("../h2/build.*");

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -369,23 +369,20 @@ public class Build extends BuildBase {
         delete(files("bin").keep("*.jar"));
         jar();
         docs();
-        boolean pdfReady = false;
         try {
-            if (exec("soffice", args("--convert-to", "pdf", "--outdir", "docs/html", "docs/html/onePage.html")) == 0) {
-                File f = new File("docs/html/onePage.pdf");
-                if (f.exists() && f.renameTo(new File("docs/h2.pdf"))) {
-                    pdfReady = true;
-                }
-            }
-        } catch (Exception ex) {
-        }
-        if (!pdfReady) {
-            // Old way
+            exec("soffice", args("-invisible", "macro:///Standard.Module1.H2Pdf"));
+            copy("docs", files("../h2web/h2.pdf"), "../h2web");
+        } catch (Exception e) {
+            print("OpenOffice is not available: " + e);
             try {
-                exec("soffice", args("-invisible", "macro:///Standard.Module1.H2Pdf"));
-                copy("docs", files("../h2web/h2.pdf"), "../h2web");
-            } catch (Exception e) {
-                print("OpenOffice is not available: " + e);
+                if (exec("soffice", args("--convert-to", "pdf", "--outdir", "docs/html",
+                        "docs/html/onePage.html")) == 0) {
+                    File f = new File("docs/html/onePage.pdf");
+                    if (f.exists()) {
+                        f.renameTo(new File("docs/h2.pdf"));
+                    }
+                }
+            } catch (Exception ex) {
             }
         }
         delete("docs/html/onePage.html");

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -757,4 +757,4 @@ chittanoor carrot
 
 contextual unknowns enquote respectively sessionid reconnection selfreferential bbddbb instant subprotocol ddbbbb
 zzbbzz cldr booleans maria enquotes mtc cbuf checksummed nreturn despite bbzz readlimit retries cceecc reconnects
-unconditionally coco aren eecccc decimals charsets zzbb lsb msb usecount
+unconditionally coco aren eecccc decimals charsets zzbb lsb msb usecount outdir

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -754,3 +754,7 @@ joaquim overides altertable novalidate udomain managed rewritten unquote identif
 bellotti clemens donators domainusername
 veryveryveryveryveryverylongveryveryveryveryveryverylongveryveryveryveryveryverylong namer veryveryveryveryveryverylongve
 chittanoor carrot
+
+contextual unknowns enquote respectively sessionid reconnection selfreferential bbddbb instant subprotocol ddbbbb
+zzbbzz cldr booleans maria enquotes mtc cbuf checksummed nreturn despite bbzz readlimit retries cceecc reconnects
+unconditionally coco aren eecccc decimals charsets zzbb lsb msb usecount


### PR DESCRIPTION
1. Some typos and identation are fixed.
2. dictionary.txt is updated with new words. (Some of them are from tests.)
3. If PDF generation fails, LibreOffice (OpenOffice) will be invoked with --convert-to.

(This part of build process is not covered by automated tests.)