### PR TITLE
Leftover shared lock after release

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -434,6 +434,7 @@ public class MVTable extends TableBase {
         if (database != null) {
             traceLock(s, lockExclusiveSession == s, TraceLockEvent.TRACE_LOCK_UNLOCK, NO_EXTRA_INFO);
             if (lockExclusiveSession == s) {
+                lockSharedSessions.remove(s);
                 lockExclusiveSession = null;
                 if (SysProperties.THREAD_DEADLOCK_DETECTOR) {
                     if (EXCLUSIVE_LOCKS.get() != null) {


### PR DESCRIPTION
If lock was promoted from shared to exclusive, releasing it later will leave behind shared lock.