### PR TITLE
Hardcoded port numbers should not be used in unit tests

### DIFF
--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -1056,8 +1056,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         DeleteDbFiles.execute(TestBase.BASE_TEST_DIR, null, true);
         FileUtils.deleteRecursive("trace.db", false);
         if (networked) {
-            String[] args = ssl ? new String[] { "-tcpSSL", "-tcpPort", "9192" }
-                    : new String[] { "-tcpPort", "9192" };
+            String[] args = ssl ? new String[] { "-tcpSSL" } : new String[0];
             server = Server.createTcpServer(args);
             try {
                 server.start();
@@ -1077,6 +1076,10 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         }
         FileUtils.deleteRecursive("trace.db", true);
         FileUtils.deleteRecursive(TestBase.BASE_TEST_DIR, true);
+    }
+
+    public int getPort() {
+        return server == null ? 9192 : server.getPort();
     }
 
     /**

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -265,9 +265,9 @@ public abstract class TestBase {
         }
         if (config.networked) {
             if (config.ssl) {
-                url = "ssl://localhost:9192/" + name;
+                url = "ssl://localhost:"+config.getPort()+"/" + name;
             } else {
-                url = "tcp://localhost:9192/" + name;
+                url = "tcp://localhost:"+config.getPort()+"/" + name;
             }
         } else if (config.googleAppEngine) {
             url = "gae://" + name +

--- a/h2/src/test/org/h2/test/db/TestCluster.java
+++ b/h2/src/test/org/h2/test/db/TestCluster.java
@@ -49,8 +49,6 @@ public class TestCluster extends TestBase {
         if (config.memory || config.networked || config.cipher != null) {
             return;
         }
-        int port1 = 9191, port2 = 9192;
-        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         deleteFiles();
 
         org.h2.Driver.load();
@@ -58,9 +56,9 @@ public class TestCluster extends TestBase {
         Connection conn;
         Statement stat;
 
+        Server n1 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node1").start();
+        int port1 = n1.getPort();
         String url1 = getURL("jdbc:h2:tcp://localhost:" + port1 + "/test", false);
-        Server n1 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port1, "-baseDir", getBaseDir() + "/node1").start();
 
         conn = getConnection(url1, user, password);
         stat = conn.createStatement();
@@ -68,10 +66,11 @@ public class TestCluster extends TestBase {
         stat.execute("insert into t1 values(1, repeat('Hello', 50))");
         conn.close();
 
+        Server n2 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node2").start();
+        int port2 = n2.getPort();
         String url2 = getURL("jdbc:h2:tcp://localhost:" + port2 + "/test", false);
-        Server n2 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port2 , "-baseDir", getBaseDir() + "/node2").start();
 
+        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         String urlCluster = getURL("jdbc:h2:tcp://" + serverList + "/test", true);
         CreateCluster.main("-urlSource", url1, "-urlTarget", url2,
                 "-user", user, "-password", password, "-serverList",
@@ -89,8 +88,6 @@ public class TestCluster extends TestBase {
         if (config.memory || config.networked || config.cipher != null) {
             return;
         }
-        int port1 = 9191, port2 = 9192;
-        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         deleteFiles();
 
         org.h2.Driver.load();
@@ -99,14 +96,16 @@ public class TestCluster extends TestBase {
         Statement stat;
         ResultSet rs;
 
+
+        Server server1 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node1").start();
+        int port1 = server1.getPort();
+        Server server2 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node2").start();
+        int port2 = server2.getPort();
+
         String url1 = getURL("jdbc:h2:tcp://localhost:" + port1 + "/test", true);
         String url2 = getURL("jdbc:h2:tcp://localhost:" + port2 + "/test", true);
+        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         String urlCluster = getURL("jdbc:h2:tcp://" + serverList + "/test", true);
-
-        Server server1 = org.h2.tools.Server.createTcpServer(
-                "-tcpPort", "" + port1, "-baseDir", getBaseDir() + "/node1").start();
-        Server server2 = org.h2.tools.Server.createTcpServer(
-                "-tcpPort", "" + port2 , "-baseDir", getBaseDir() + "/node2").start();
 
         CreateCluster.main("-urlSource", url1, "-urlTarget", url2,
                 "-user", user, "-password", password, "-serverList",
@@ -152,8 +151,6 @@ public class TestCluster extends TestBase {
         if (config.memory || config.networked || config.cipher != null) {
             return;
         }
-        int port1 = 9191, port2 = 9192;
-        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         deleteFiles();
 
         org.h2.Driver.load();
@@ -162,14 +159,15 @@ public class TestCluster extends TestBase {
         Statement stat;
         ResultSet rs;
 
+        Server n1 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node1").start();
+        int port1 = n1.getPort();
+        Server n2 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node2").start();
+        int port2 = n2.getPort();
+
         String url1 = getURL("jdbc:h2:tcp://localhost:" + port1 + "/test", true);
         String url2 = getURL("jdbc:h2:tcp://localhost:" + port2 + "/test", true);
+        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         String urlCluster = getURL("jdbc:h2:tcp://" + serverList + "/test", true);
-
-        Server n1 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port1, "-baseDir", getBaseDir() + "/node1").start();
-        Server n2 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port2 , "-baseDir", getBaseDir() + "/node2").start();
 
         CreateCluster.main("-urlSource", url1, "-urlTarget", url2,
                 "-user", user, "-password", password, "-serverList",
@@ -200,8 +198,6 @@ public class TestCluster extends TestBase {
         if (config.memory || config.networked || config.cipher != null) {
             return;
         }
-        int port1 = 9191, port2 = 9192;
-        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         deleteFiles();
 
         org.h2.Driver.load();
@@ -210,14 +206,15 @@ public class TestCluster extends TestBase {
         Statement stat;
         ResultSet rs;
 
+
+        Server n1 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node1").start();
+        int port1 = n1.getPort();
+        Server n2 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node2").start();
+        int port2 = n2.getPort();
+        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         String url1 = getURL("jdbc:h2:tcp://localhost:" + port1 + "/test", true);
         String url2 = getURL("jdbc:h2:tcp://localhost:" + port2 + "/test", true);
         String urlCluster = getURL("jdbc:h2:tcp://" + serverList + "/test", true);
-
-        Server n1 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port1, "-baseDir", getBaseDir() + "/node1").start();
-        Server n2 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port2 , "-baseDir", getBaseDir() + "/node2").start();
 
         CreateCluster.main("-urlSource", url1, "-urlTarget", url2,
                 "-user", user, "-password", password, "-serverList",
@@ -257,22 +254,22 @@ public class TestCluster extends TestBase {
         if (config.memory || config.networked || config.cipher != null) {
             return;
         }
-        int port1 = 9191, port2 = 9192;
-        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         deleteFiles();
 
         org.h2.Driver.load();
         String user = getUser(), password = getPassword();
         Connection conn;
 
+
+        Server n1 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node1").start();
+        int port1 = n1.getPort();
+        Server n2 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node2").start();
+        int port2 = n2.getPort();
+
+        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         String url1 = getURL("jdbc:h2:tcp://localhost:" + port1 + "/test", true);
         String url2 = getURL("jdbc:h2:tcp://localhost:" + port2 + "/test", true);
         String urlCluster = getURL("jdbc:h2:tcp://" + serverList + "/test", true);
-
-        Server n1 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port1, "-baseDir", getBaseDir() + "/node1").start();
-        Server n2 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port2 , "-baseDir", getBaseDir() + "/node2").start();
 
         CreateCluster.main("-urlSource", url1, "-urlTarget", url2,
                 "-user", user, "-password", password, "-serverList",
@@ -309,22 +306,18 @@ public class TestCluster extends TestBase {
         if (config.memory || config.networked || config.cipher != null) {
             return;
         }
-        int port1 = 9191, port2 = 9192;
-        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         deleteFiles();
 
         org.h2.Driver.load();
         String user = getUser(), password = getPassword();
         Connection conn;
         Statement stat;
-        String url1 = getURL("jdbc:h2:tcp://localhost:" + port1 + "/test", false);
-        String url2 = getURL("jdbc:h2:tcp://localhost:" + port2 + "/test", false);
-        String urlCluster = getURL("jdbc:h2:tcp://" + serverList + "/test", false);
         int len = 10;
 
         // initialize the database
-        Server n1 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port1, "-baseDir", getBaseDir() + "/node1").start();
+        Server n1 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node1").start();
+        int port1 = n1.getPort();
+        String url1 = getURL("jdbc:h2:tcp://localhost:" + port1 + "/test", false);
         conn = getConnection(url1, user, password);
         stat = conn.createStatement();
         stat.execute("create table test(id int primary key, name varchar) as " +
@@ -333,10 +326,12 @@ public class TestCluster extends TestBase {
         stat.execute("grant all on test to test");
 
         // start the second server
-        Server n2 = org.h2.tools.Server.createTcpServer("-tcpPort",
-                "" + port2 , "-baseDir", getBaseDir() + "/node2").start();
+        Server n2 = org.h2.tools.Server.createTcpServer("-baseDir", getBaseDir() + "/node2").start();
+        int port2 = n2.getPort();
+        String url2 = getURL("jdbc:h2:tcp://localhost:" + port2 + "/test", false);
 
         // copy the database and initialize the cluster
+        String serverList = "localhost:" + port1 + ",localhost:" + port2;
         CreateCluster.main("-urlSource", url1, "-urlTarget", url2,
                 "-user", user, "-password", password, "-serverList",
                 serverList);
@@ -347,6 +342,7 @@ public class TestCluster extends TestBase {
         JdbcUtils.closeSilently(conn);
 
         // test the cluster connection
+        String urlCluster = getURL("jdbc:h2:tcp://" + serverList + "/test", false);
         Connection connApp = getConnection(urlCluster +
                 ";AUTO_RECONNECT=TRUE", user, password);
         check(connApp, len, "'" + serverList + "'");

--- a/h2/src/test/org/h2/test/db/TestReadOnly.java
+++ b/h2/src/test/org/h2/test/db/TestReadOnly.java
@@ -66,17 +66,18 @@ public class TestReadOnly extends TestBase {
                 "jdbc:h2:zip:"+dir+"/readonly.zip!/readonlyInZip", getUser(), getPassword());
         conn.createStatement().execute("select * from test where id=1");
         conn.close();
-        Server server = Server.createTcpServer("-tcpPort", "9081", "-baseDir", dir);
+        Server server = Server.createTcpServer("-baseDir", dir);
         server.start();
+        int port = server.getPort();
         try {
             conn = getConnection(
-                    "jdbc:h2:tcp://localhost:9081/zip:readonly.zip!/readonlyInZip",
+                    "jdbc:h2:tcp://localhost:" + port + "/zip:readonly.zip!/readonlyInZip",
                         getUser(), getPassword());
             conn.createStatement().execute("select * from test where id=1");
             conn.close();
             FilePathZip2.register();
             conn = getConnection(
-                    "jdbc:h2:tcp://localhost:9081/zip2:readonly.zip!/readonlyInZip",
+                    "jdbc:h2:tcp://localhost:" + port + "/zip2:readonly.zip!/readonlyInZip",
                         getUser(), getPassword());
             conn.createStatement().execute("select * from test where id=1");
             conn.close();

--- a/h2/src/test/org/h2/test/unit/TestAutoReconnect.java
+++ b/h2/src/test/org/h2/test/unit/TestAutoReconnect.java
@@ -93,8 +93,9 @@ public class TestAutoReconnect extends TestBase {
                 "AUTO_SERVER=TRUE;OPEN_NEW=TRUE";
             restart();
         } else {
-            server = Server.createTcpServer("-tcpPort", "8181").start();
-            url = "jdbc:h2:tcp://localhost:8181/" + getBaseDir() + "/" + getTestName() + ";" +
+            server = Server.createTcpServer().start();
+            int port = server.getPort();
+            url = "jdbc:h2:tcp://localhost:" + port + "/" + getBaseDir() + "/" + getTestName() + ";" +
                 "FILE_LOCK=SOCKET;AUTO_RECONNECT=TRUE";
         }
 

--- a/h2/src/test/org/h2/test/unit/TestOldVersion.java
+++ b/h2/src/test/org/h2/test/unit/TestOldVersion.java
@@ -114,17 +114,18 @@ public class TestOldVersion extends TestBase {
     }
 
     private void testOldClientNewServer() throws Exception {
-        Server server = org.h2.tools.Server.createTcpServer("-tcpPort", "9001");
+        Server server = org.h2.tools.Server.createTcpServer();
         server.start();
+        int port = server.getPort();
         assertThrows(ErrorCode.DRIVER_VERSION_ERROR_2, driver).connect(
-                "jdbc:h2:tcp://localhost:9001/mem:test", null);
+                "jdbc:h2:tcp://localhost:" + port + "/mem:test", null);
         server.stop();
 
         Class<?> serverClass = cl.loadClass("org.h2.tools.Server");
         Method m;
         m = serverClass.getMethod("createTcpServer", String[].class);
         Object serverOld = m.invoke(null, new Object[] { new String[] {
-                "-tcpPort", "9001" } });
+                "-tcpPort", "" + port } });
         m = serverOld.getClass().getMethod("start");
         m.invoke(serverOld);
         Connection conn;

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -826,10 +826,9 @@ public class TestTools extends TestBase {
         int count = getSize(2, 10);
         for (int i = 0; i < count; i++) {
             Server tcpServer = Server.
-                    createTcpServer("-tcpPort", "9192").start();
+                    createTcpServer().start();
             tcpServer.stop();
-            tcpServer = Server.createTcpServer("-tcpPassword", "abc",
-                    "-tcpPort", "9192").start();
+            tcpServer = Server.createTcpServer("-tcpPassword", "abc").start();
             tcpServer.stop();
         }
     }
@@ -1066,67 +1065,67 @@ public class TestTools extends TestBase {
             deleteDb("test");
             Server tcpServer = Server.createTcpServer(
                             "-baseDir", getBaseDir(),
-                            "-tcpPort", "9192",
                             "-tcpAllowOthers").start();
             remainingServers.add(tcpServer);
-            conn = getConnection("jdbc:h2:tcp://localhost:9192/test", "sa", "");
+            final int port = tcpServer.getPort();
+            conn = getConnection("jdbc:h2:tcp://localhost:"+ port +"/test", "sa", "");
             conn.close();
             // must not be able to use a different base dir
             new AssertThrows(ErrorCode.IO_EXCEPTION_1) {
                 @Override
                 public void test() throws SQLException {
-                    getConnection("jdbc:h2:tcp://localhost:9192/../test", "sa", "");
+                    getConnection("jdbc:h2:tcp://localhost:"+ port +"/../test", "sa", "");
             }};
             new AssertThrows(ErrorCode.IO_EXCEPTION_1) {
                 @Override
                 public void test() throws SQLException {
-                    getConnection("jdbc:h2:tcp://localhost:9192/../test2/test", "sa", "");
+                    getConnection("jdbc:h2:tcp://localhost:"+port+"/../test2/test", "sa", "");
             }};
             tcpServer.stop();
             Server tcpServerWithPassword = Server.createTcpServer(
                             "-ifExists",
                             "-tcpPassword", "abc",
-                            "-baseDir", getBaseDir(),
-                            "-tcpPort", "9192").start();
+                            "-baseDir", getBaseDir()).start();
+            final int prt = tcpServerWithPassword.getPort();
             remainingServers.add(tcpServerWithPassword);
             // must not be able to create new db
             new AssertThrows(ErrorCode.DATABASE_NOT_FOUND_1) {
                 @Override
                 public void test() throws SQLException {
-                    getConnection("jdbc:h2:tcp://localhost:9192/test2", "sa", "");
+                    getConnection("jdbc:h2:tcp://localhost:"+prt+"/test2", "sa", "");
             }};
             new AssertThrows(ErrorCode.DATABASE_NOT_FOUND_1) {
                 @Override
                 public void test() throws SQLException {
-                    getConnection("jdbc:h2:tcp://localhost:9192/test2;ifexists=false", "sa", "");
+                    getConnection("jdbc:h2:tcp://localhost:"+prt+"/test2;ifexists=false", "sa", "");
             }};
-            conn = getConnection("jdbc:h2:tcp://localhost:9192/test", "sa", "");
+            conn = getConnection("jdbc:h2:tcp://localhost:"+prt+"/test", "sa", "");
             conn.close();
             new AssertThrows(ErrorCode.WRONG_USER_OR_PASSWORD) {
                 @Override
                 public void test() throws SQLException {
-                    Server.shutdownTcpServer("tcp://localhost:9192", "", true, false);
+                    Server.shutdownTcpServer("tcp://localhost:"+prt, "", true, false);
             }};
-            conn = getConnection("jdbc:h2:tcp://localhost:9192/test", "sa", "");
+            conn = getConnection("jdbc:h2:tcp://localhost:"+prt+"/test", "sa", "");
             // conn.close();
-            Server.shutdownTcpServer("tcp://localhost:9192", "abc", true, false);
+            Server.shutdownTcpServer("tcp://localhost:"+prt, "abc", true, false);
             // check that the database is closed
             deleteDb("test");
             // server must have been closed
             assertThrows(ErrorCode.CONNECTION_BROKEN_1, this).
-                    getConnection("jdbc:h2:tcp://localhost:9192/test", "sa", "");
+                    getConnection("jdbc:h2:tcp://localhost:"+prt+"/test", "sa", "");
             JdbcUtils.closeSilently(conn);
             // Test filesystem prefix and escape from baseDir
             deleteDb("testSplit");
             server = Server.createTcpServer(
                             "-baseDir", getBaseDir(),
-                            "-tcpPort", "9192",
                             "-tcpAllowOthers").start();
-            conn = getConnection("jdbc:h2:tcp://localhost:9192/split:testSplit", "sa", "");
+            final int p = server.getPort();
+            conn = getConnection("jdbc:h2:tcp://localhost:"+p+"/split:testSplit", "sa", "");
             conn.close();
 
             assertThrows(ErrorCode.IO_EXCEPTION_1, this).
-                    getConnection("jdbc:h2:tcp://localhost:9192/../test", "sa", "");
+                    getConnection("jdbc:h2:tcp://localhost:"+p+"/../test", "sa", "");
 
             server.stop();
             deleteDb("testSplit");


### PR DESCRIPTION
This change is indented to minimize "port in use" test failures by replasing "standard"/hardcoded port numbers by dynamically allocated ones.