### PR TITLE
Update lists of keywords

### DIFF
--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -500,10 +500,10 @@ There is a list of keywords that can't be used as identifiers (table names, colu
 unless they are quoted (surrounded with double quotes). The list is currently:
 </p><p>
 <code>
-CROSS, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, DISTINCT, EXCEPT, EXISTS, FALSE,
-FETCH, FOR, FROM, FULL, GROUP, HAVING, INNER, INTERSECT, IS, JOIN, LIKE, LIMIT, MINUS, NATURAL,
-NOT, NULL, OFFSET, ON, ORDER, PRIMARY, ROWNUM, SELECT, SYSDATE, SYSTIME, SYSTIMESTAMP, TODAY,
-TRUE, UNION, UNIQUE, WHERE
+ALL, CHECK, CONSTRAINT, CROSS, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, DISTINCT, EXCEPT,
+EXISTS, FALSE, FETCH, FOR, FOREIGN, FROM, FULL, GROUP, HAVING, INNER, INTERSECT, IS, JOIN,
+LIKE, LIMIT, MINUS, NATURAL, NOT, NULL, OFFSET, ON, ORDER, PRIMARY, ROWNUM, SELECT, SYSDATE,
+SYSTIME, SYSTIMESTAMP, TODAY, TRUE, UNION, UNIQUE, WHERE, WITH
 </code>
 </p><p>
 Certain words of this list are keywords because they are functions that can be used without '()' for compatibility,

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4145,7 +4145,7 @@ public class Parser {
             // if not yet converted to uppercase, do it now
             s = StringUtils.toUpperEnglish(s);
         }
-        return getSaveTokenType(s, database.getMode().supportOffsetFetch);
+        return getSaveTokenType(s, database.getMode().supportOffsetFetch, false);
     }
 
     private boolean isKeyword(String s) {
@@ -4167,20 +4167,27 @@ public class Parser {
         if (s == null || s.length() == 0) {
             return false;
         }
-        return getSaveTokenType(s, supportOffsetFetch) != IDENTIFIER;
+        return getSaveTokenType(s, supportOffsetFetch, false) != IDENTIFIER;
     }
 
-    private static int getSaveTokenType(String s, boolean supportOffsetFetch) {
+    private static int getSaveTokenType(String s, boolean supportOffsetFetch, boolean functionsAsKeywords) {
         switch (s.charAt(0)) {
         case 'A':
             return getKeywordOrIdentifier(s, "ALL", KEYWORD);
         case 'C':
-            if (s.equals("CHECK")) {
+            if ("CHECK".equals(s)) {
                 return KEYWORD;
             } else if ("CONSTRAINT".equals(s)) {
                 return KEYWORD;
+            } else if ("CROSS".equals(s)) {
+                return KEYWORD;
             }
-            return getKeywordOrIdentifier(s, "CROSS", KEYWORD);
+            if (functionsAsKeywords) {
+                if ("CURRENT_DATE".equals(s) || "CURRENT_TIME".equals(s) || "CURRENT_TIMESTAMP".equals(s)) {
+                    return KEYWORD;
+                }
+            }
+            return IDENTIFIER;
         case 'D':
             return getKeywordOrIdentifier(s, "DISTINCT", KEYWORD);
         case 'E':
@@ -4240,9 +4247,25 @@ public class Parser {
         case 'R':
             return getKeywordOrIdentifier(s, "ROWNUM", ROWNUM);
         case 'S':
-            return getKeywordOrIdentifier(s, "SELECT", KEYWORD);
+            if ("SELECT".equals(s)) {
+                return KEYWORD;
+            }
+            if (functionsAsKeywords) {
+                if ("SYSDATE".equals(s) || "SYSTIME".equals(s) || "SYSTIMESTAMP".equals(s)) {
+                    return KEYWORD;
+                }
+            }
+            return IDENTIFIER;
         case 'T':
-            return getKeywordOrIdentifier(s, "TRUE", TRUE);
+            if ("TRUE".equals(s)) {
+                return TRUE;
+            }
+            if (functionsAsKeywords) {
+                if ("TODAY".equals(s)) {
+                    return KEYWORD;
+                }
+            }
+            return IDENTIFIER;
         case 'U':
             if ("UNIQUE".equals(s)) {
                 return KEYWORD;
@@ -6849,7 +6872,7 @@ public class Parser {
         if (s == null) {
             return "\"\"";
         }
-        if (isSimpleIdentifier(s))
+        if (isSimpleIdentifier(s, false))
             return s;
         return StringUtils.quoteIdentifier(s);
     }
@@ -6857,10 +6880,12 @@ public class Parser {
     /**
      * @param s
      *            identifier to check
+     * @param functionsAsKeywords
+     *            treat system functions as keywords
      * @return is specified identifier may be used without quotes
      * @throws NullPointerException if s is {@code null}
      */
-    public static boolean isSimpleIdentifier(String s) {
+    public static boolean isSimpleIdentifier(String s, boolean functionsAsKeywords) {
         if (s.length() == 0) {
             return false;
         }
@@ -6876,7 +6901,7 @@ public class Parser {
                 return false;
             }
         }
-        return !isKeyword(s, true);
+        return getSaveTokenType(s, true, functionsAsKeywords) == IDENTIFIER;
     }
 
     public void setLiteralsChecked(boolean literalsChecked) {

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -1536,18 +1536,18 @@ public class JdbcDatabaseMetaData extends TraceObject implements
 
     /**
      * Gets the comma-separated list of all SQL keywords that are not supported
-     * as table/column/index name, in addition to the SQL-92 keywords. The list
+     * as table/column/index name, in addition to the SQL-2003 keywords. The list
      * returned is:
      * <pre>
-     * LIMIT,MINUS,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY
+     * LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY
      * </pre>
-     * The complete list of keywords (including SQL-92 keywords) is:
+     * The complete list of keywords (including SQL-2003 keywords) is:
      * <pre>
-     * CROSS, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, DISTINCT,
-     * EXCEPT, EXISTS, FALSE, FOR, FROM, FULL, GROUP, HAVING, INNER,
-     * INTERSECT, IS, JOIN, LIKE, LIMIT, MINUS, NATURAL, NOT, NULL, ON,
-     * ORDER, PRIMARY, ROWNUM, SELECT, SYSDATE, SYSTIME, SYSTIMESTAMP,
-     * TODAY, TRUE, UNION, UNIQUE, WHERE
+     * ALL, CHECK, CONSTRAINT, CROSS, CURRENT_DATE, CURRENT_TIME,
+     * CURRENT_TIMESTAMP, DISTINCT, EXCEPT, EXISTS, FALSE, FETCH, FOR, FOREIGN,
+     * FROM, FULL, GROUP, HAVING, INNER, INTERSECT, IS, JOIN, LIKE, LIMIT,
+     * MINUS, NATURAL, NOT, NULL, OFFSET, ON, ORDER, PRIMARY, ROWNUM, SELECT,
+     * SYSDATE, SYSTIME, SYSTIMESTAMP, TODAY, TRUE, UNION, UNIQUE, WHERE, WITH
      * </pre>
      *
      * @return a list of additional the keywords
@@ -1555,7 +1555,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     @Override
     public String getSQLKeywords() {
         debugCodeCall("getSQLKeywords");
-        return "LIMIT,MINUS,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY";
+        return "LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY";
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -1320,9 +1320,10 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
      */
     @Override
     public String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException {
-        if (alwaysQuote)
+        if (alwaysQuote || !isSimpleIdentifier(identifier)) {
             return StringUtils.quoteIdentifier(identifier);
-        return Parser.quoteIdentifier(identifier);
+        }
+        return identifier;
     }
 
     /**
@@ -1332,7 +1333,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
      */
     @Override
     public boolean isSimpleIdentifier(String identifier) throws SQLException {
-        return Parser.isSimpleIdentifier(identifier);
+        return Parser.isSimpleIdentifier(identifier, true);
     }
 
     /**

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -435,7 +435,7 @@ public class TestMetaData extends TestBase {
 
         assertEquals("schema", meta.getSchemaTerm());
         assertEquals("\\", meta.getSearchStringEscape());
-        assertEquals("LIMIT,MINUS,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY",
+        assertEquals("LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY",
                 meta.getSQLKeywords());
 
         assertTrue(meta.getURL().startsWith("jdbc:h2:"));

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -334,11 +334,13 @@ public class TestStatement extends TestBase {
         assertEquals("\"SOME_ID\"", statBC.enquoteIdentifier("SOME_ID", true));
         assertEquals("\"FROM\"", statBC.enquoteIdentifier("FROM", false));
         assertEquals("\"Test\"", statBC.enquoteIdentifier("Test", false));
+        assertEquals("\"TODAY\"", statBC.enquoteIdentifier("TODAY", false));
 
         assertTrue(statBC.isSimpleIdentifier("SOME_ID"));
         assertFalse(statBC.isSimpleIdentifier("SOME ID"));
         assertFalse(statBC.isSimpleIdentifier("FROM"));
         assertFalse(statBC.isSimpleIdentifier("Test"));
+        assertFalse(statBC.isSimpleIdentifier("TODAY"));
 
         stat.close();
     }


### PR DESCRIPTION
1. Handling of identifiers like `CURRENT_TIMESTAMP` in `enquoteIdentifier()` and `isSimpleIdentifier()` is fixed.

2. `JdbcDatabaseMetaData.getSQLKeywords()` now also returns `OFFSET`.

3. List of keywords in `advanced.html` is updated.