### PR TITLE
Map DATE in Oracle mode to ValueTimestamp

### DIFF
--- a/h2/src/main/org/h2/command/ddl/CreateUserDataType.java
+++ b/h2/src/main/org/h2/command/ddl/CreateUserDataType.java
@@ -55,7 +55,7 @@ public class CreateUserDataType extends DefineCommand {
                     ErrorCode.USER_DATA_TYPE_ALREADY_EXISTS_1,
                     typeName);
         }
-        DataType builtIn = DataType.getTypeByName(typeName);
+        DataType builtIn = DataType.getTypeByName(typeName, session.getDatabase().getMode());
         if (builtIn != null) {
             if (!builtIn.hidden) {
                 throw DbException.get(

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.h2.util.StringUtils;
+import org.h2.value.DataType;
+import org.h2.value.Value;
 
 /**
  * The compatibility modes. There is a fixed set of modes (for example
@@ -198,6 +200,11 @@ public class Mode {
      */
     public Set<String> disallowedTypes = Collections.emptySet();
 
+    /**
+     * Custom mappings from type names to data types.
+     */
+    public HashMap<String, DataType> typeByNameMap = new HashMap<>();
+
     private final String name;
 
     private ModeEnum modeEnum;
@@ -285,6 +292,7 @@ public class Mode {
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile(".*\\..*");
         mode.prohibitEmptyInPredicate = true;
+        mode.typeByNameMap.put("DATE", DataType.getDataType(Value.TIMESTAMP));
         add(mode);
 
         mode = new Mode(ModeEnum.PostgreSQL.name());

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -584,7 +584,7 @@ public class MetaTable extends Table {
                         Value.STRING_IGNORECASE : Value.STRING;
                 name = nameType;
             } else {
-                dataType = DataType.getTypeByName(nameType.substring(idx + 1)).type;
+                dataType = DataType.getTypeByName(nameType.substring(idx + 1), database.getMode()).type;
                 name = nameType.substring(0, idx);
             }
             cols[i] = new Column(name, dataType);

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.UUID;
 import org.h2.api.ErrorCode;
 import org.h2.api.TimestampWithTimeZone;
+import org.h2.engine.Mode;
 import org.h2.engine.SessionInterface;
 import org.h2.engine.SysProperties;
 import org.h2.jdbc.JdbcArray;
@@ -1192,12 +1193,16 @@ public class DataType {
      * Get a data type object from a type name.
      *
      * @param s the type name
+     * @param mode database mode
      * @return the data type object
      */
-    public static DataType getTypeByName(String s) {
-        DataType result = TYPES_BY_NAME.get(s);
-        if (result == null && JdbcUtils.customDataTypesHandler != null) {
-            result = JdbcUtils.customDataTypesHandler.getDataTypeByName(s);
+    public static DataType getTypeByName(String s, Mode mode) {
+        DataType result = mode.typeByNameMap.get(s);
+        if (result == null) {
+            result = TYPES_BY_NAME.get(s);
+            if (result == null && JdbcUtils.customDataTypesHandler != null) {
+                result = JdbcUtils.customDataTypesHandler.getDataTypeByName(s);
+            }
         }
         return result;
     }


### PR DESCRIPTION
Possible fix for issues #232 and #692.

In Oracle mode `DATE` type with this change handled as `TIMESTAMP`, so it can store time part of value. This does not provide full compatibility with `DATE` in Oracle because `DATE` and `TIMESTAMP` are not the same, in Oracle `DATE` stores values without fractional part of seconds, but probably it does not matter in the most cases.