### PR TITLE
Switch to JaCoCo code coverage

### DIFF
--- a/h2/.gitignore
+++ b/h2/.gitignore
@@ -4,6 +4,7 @@
 .settings
 benchmark.html
 bin
+coverage
 data
 docs
 ext

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -63,7 +63,6 @@ To use this database, it is not required to install this software however.
     <a href="http://subclipse.tigris.org">Subclipse</a>,
     <a href="http://eclipse-cs.sourceforge.net">Eclipse Checkstyle Plug-in</a>,
     <a href="http://www.eclemma.org">EclEmma Java Code Coverage</a>
-</li><li><a href="http://emma.sourceforge.net">Emma Java Code Coverage</a>
 </li><li><a href="http://www.mozilla.com/firefox">Mozilla Firefox</a>
 </li><li><a href="http://www.openoffice.org">OpenOffice</a>
 </li><li><a href="http://nsis.sourceforge.net">NSIS</a> (Nullsoft Scriptable Install System)

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -304,11 +304,6 @@ java org.h2.test.TestAll timer
     public boolean memory;
 
     /**
-     * Whether the test is running with code coverage.
-     */
-    public boolean coverage;
-
-    /**
      * If code coverage is enabled.
      */
     public boolean codeCoverage;
@@ -548,7 +543,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
                 test.testEverything();
             } else if ("codeCoverage".equals(args[0])) {
                 test.codeCoverage = true;
-                test.runTests();
+                test.runCoverage();
             } else if ("multiThread".equals(args[0])) {
                 new TestMulti().runTest(test);
             } else if ("halt".equals(args[0])) {
@@ -610,8 +605,6 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         if (Boolean.getBoolean("abba")) {
             abbaLockingDetector = new AbbaLockingDetector().startCollecting();
         }
-
-        coverage = isCoverage();
 
         smallLog = big = networked = memory = ssl = false;
         diskResult = traceSystemOut = diskUndo = false;
@@ -697,18 +690,24 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         }
     }
 
-    /**
-     * Check whether this method is running with "Emma" code coverage turned on.
-     *
-     * @return true if the stack trace contains ".emma."
-     */
-    private static boolean isCoverage() {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-            if (e.toString().contains(".emma.")) {
-                return true;
-            }
-        }
-        return false;
+    private void runCoverage() throws SQLException {
+        smallLog = big = networked = memory = ssl = false;
+        diskResult = traceSystemOut = diskUndo = false;
+        traceTest = stopOnError = false;
+        defrag = false;
+        traceLevelFile = throttle = 0;
+        cipher = null;
+
+        memory = true;
+        multiThreaded = true;
+        test();
+        testUnit();
+
+        multiThreaded = false;
+        mvStore = false;
+        mvcc = false;
+        test();
+        // testUnit();
     }
 
     /**

--- a/h2/src/test/org/h2/test/store/TestMVStoreBenchmark.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreBenchmark.java
@@ -40,7 +40,7 @@ public class TestMVStoreBenchmark extends TestBase {
         if (!config.big) {
             return;
         }
-        if (config.coverage || config.codeCoverage) {
+        if (config.codeCoverage) {
             // run only when _not_ using a code coverage tool,
             // because the tool might instrument our code but not
             // java.util.*

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -6,15 +6,22 @@
 package org.h2.build;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.h2.build.code.SwitchSource;
 import org.h2.build.doc.XMLParser;
@@ -114,17 +121,67 @@ public class Build extends BuildBase {
         javac(args, files);
     }
 
+    private static void copy(InputStream in, OutputStream out) throws IOException {
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = in.read(buffer, 0, buffer.length)) >= 0) {
+            out.write(buffer, 0, read);
+        }
+    }
+
     /**
-     * Run the Emma code coverage.
+     * Run the JaCoco code coverage.
      */
-    @Description(summary = "Run the Emma code coverage.")
+    @Description(summary = "Run the JaCoco code coverage.")
     public void coverage() {
+        compile();
         downloadTest();
-        downloadUsingMaven("ext/emma-2.0.5312.jar",
-                "emma", "emma", "2.0.5312",
-                "30a40933caf67d88d9e75957950ccf353b181ab7");
-        String cp = "temp" + File.pathSeparator + "bin" +
-            File.pathSeparator + "ext/emma-2.0.5312.jar" +
+        downloadUsingMaven("ext/org.jacoco.agent-0.8.0.jar",
+                "org.jacoco", "org.jacoco.agent", "0.8.0",
+                "f2748b949b5fc661e089e2eeef39891dfd10a7e5");
+        try (ZipFile zipFile = new ZipFile(new File("ext/org.jacoco.agent-0.8.0.jar"))) {
+            final Enumeration<? extends ZipEntry> e = zipFile.entries();
+            while (e.hasMoreElements()) {
+                final ZipEntry zipEntry = e.nextElement();
+                final String name = zipEntry.getName();
+                if (name.equals("jacocoagent.jar")) {
+                    try (InputStream in = zipFile.getInputStream(zipEntry);
+                            FileOutputStream out = new FileOutputStream("ext/jacocoagent.jar")) {
+                        copy(in, out);
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        downloadUsingMaven("ext/org.jacoco.cli-0.8.0.jar",
+                "org.jacoco", "org.jacoco.cli", "0.8.0",
+                "69e55ba110e6ffa91d72ed3df8e09aecf043b0ab");
+        downloadUsingMaven("ext/org.jacoco.core-0.8.0.jar",
+                "org.jacoco", "org.jacoco.core", "0.8.0",
+                "cc2ebdc1da53665ec788903bad65ee64345e4455");
+        downloadUsingMaven("ext/org.jacoco.report-0.8.0.jar",
+                "org.jacoco", "org.jacoco.report", "0.8.0",
+                "1bcab2a451f5a382bc674857c8f3f6d3fa52151d");
+        downloadUsingMaven("ext/asm-6.1-beta.jar",
+                "org.ow2.asm", "asm", "6.1-beta",
+                "bac2f84e42b7db902103a9ec8c4ca1293223e0ea");
+        downloadUsingMaven("ext/asm-commons-6.1-beta.jar",
+                "org.ow2.asm", "asm-commons", "6.1-beta",
+                "4ec77cde3be41559f92d25cdb39b9c55ee479253");
+        downloadUsingMaven("ext/asm-tree-6.1-beta.jar",
+                "org.ow2.asm", "asm-tree", "6.1-beta",
+                "539d3b0f5f7f5b04b1c286de8e76655b59ab2d43");
+        downloadUsingMaven("ext/args4j-2.33.jar",
+                "args4j", "args4j", "2.33",
+                "bd87a75374a6d6523de82fef51fc3cfe9baf9fc9");
+
+        delete(files("coverage"));
+        // Use own copy
+        copy("coverage/bin", files("temp"), "temp");
+        // JaCoCo does not support multiple versions of the same classes
+        delete(files("coverage/bin/META-INF/versions"));
+        String cp = "coverage/bin" +
             File.pathSeparator + "ext/postgresql-9.4.1209.jre6.jar" +
             File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
             File.pathSeparator + "ext/lucene-core-3.6.2.jar" +
@@ -135,17 +192,43 @@ public class Build extends BuildBase {
             File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
             File.pathSeparator + "ext/slf4j-nop-1.6.0.jar" +
             File.pathSeparator + javaToolsJar;
-        // -XX:-UseSplitVerifier is for Java 7 compatibility
+        // Run tests
         execJava(args(
                 "-Xmx128m",
-                "-XX:-UseSplitVerifier",
-                "-cp", cp, "emma", "run",
-                "-cp", "temp",
-                "-sp", "src/main",
-                "-r", "html,txt",
-                "-ix", "-org.h2.test.*,-org.h2.dev.*," +
-                "-org.h2.jaqu.*,-org.h2.mode.*,-org.h2.server.pg.*",
-                "org.h2.test.TestAll"));
+                "-javaagent:ext/jacocoagent.jar=destfile=coverage/jacoco.exec,"
+                        + "excludes=org.h2.test.*:org.h2.tools.*:org.h2.sample.*:android.*",
+                "-cp", cp,
+                "org.h2.test.TestAll", "codeCoverage"));
+        // Remove classes that we don't want to include in report
+        delete(files("coverage/bin/android"));
+        delete(files("coverage/bin/org/h2/test"));
+        delete(files("coverage/bin/org/h2/tools"));
+        delete(files("coverage/bin/org/h2/sample"));
+        // Generate report
+        execJava(args("-cp",
+                "ext/org.jacoco.cli-0.8.0.jar" + File.pathSeparator
+                + "ext/org.jacoco.core-0.8.0.jar" + File.pathSeparator
+                + "ext/org.jacoco.report-0.8.0.jar" + File.pathSeparator
+                + "ext/asm-6.1-beta.jar" + File.pathSeparator
+                + "ext/asm-commons-6.1-beta.jar" + File.pathSeparator
+                + "ext/asm-tree-6.1-beta.jar" + File.pathSeparator
+                + "ext/args4j-2.33.jar",
+                "org.jacoco.cli.internal.Main", "report", "coverage/jacoco.exec",
+                "--classfiles", "coverage/bin",
+                "--html", "coverage/report", "--sourcefiles", "h2/src/main"));
+        try {
+            tryOpenCoverageInBrowser();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void tryOpenCoverageInBrowser() throws Exception {
+        Class<?> desktop = Class.forName("java.awt.Desktop");
+        Method m = desktop.getMethod("getDesktop");
+        Object d = m.invoke(null);
+        m = d.getClass().getMethod("open", File.class);
+        m.invoke(d, new File("coverage/report/index.html"));
     }
 
     /**


### PR DESCRIPTION
This pull request replaces Emma code coverage (that does not work at all with Java 7 and later) with JaCoCo.

There are nothing to test on Travis. To test this `build coverage` is required.

Determining of what tests should be used for coverage is not a part of this pull request. Now it uses only some modes, see `TestAll.testCoverage()` for details. I commented `testUnit()` for PageStore because it probably catches a deadlock somewhere. Many tests do not support PageStore, but also do not have checks for current mode.

To speed up testing (to ensure that coverage itself working) some tests may be commented.

Unfortunately, JaCoCo CLI generates not so advanced reports without showing actual executed and not executed lines of code, as it does EclEmma for example (that uses JaCoCo by itself). But it still good enough to check which packages, classes, and methods have a low percentage of checked code.

I don't know which architectures build script should support, so I launch browser via reflection to be safe. May be this code can be replaced with direct access to `java.awt.Desktop`.