### PR TITLE
Inherit classpath from parent process

### DIFF
--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -1415,7 +1415,7 @@ public abstract class TestBase {
      * @return the classpath list
      */
     protected String getClassPath() {
-        return "bin" + File.pathSeparator + "temp" + File.pathSeparator + ".";
+        return System.getProperty("java.class.path");
     }
 
     /**


### PR DESCRIPTION
AFAIK, there is no real reason why child java processes, which are spawned during unit tests, can not inherit whole parent's class path instead of hard-coded "bin:temp:.". This allows put compiled classes elsewhere if desired, i.e. at maven's standard locations 8-)