### PR TITLE
Change return type of Value.getBoolean() to boolean (unwrapped)

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3390,7 +3390,7 @@ public class Parser {
 
     private boolean readBooleanSetting() {
         if (currentTokenType == VALUE) {
-            boolean result = currentValue.getBoolean().booleanValue();
+            boolean result = currentValue.getBoolean();
             read();
             return result;
         }

--- a/h2/src/main/org/h2/command/dml/Delete.java
+++ b/h2/src/main/org/h2/command/dml/Delete.java
@@ -78,8 +78,7 @@ public class Delete extends Prepared {
             int count = 0;
             while (limitRows != 0 && targetTableFilter.next()) {
                 setCurrentRowNumber(rows.size() + 1);
-                if (condition == null || Boolean.TRUE.equals(
-                        condition.getBooleanValue(session))) {
+                if (condition == null || condition.getBooleanValue(session)) {
                     Row row = targetTableFilter.get();
                     boolean done = false;
                     if (table.fireRow()) {

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -195,13 +195,7 @@ public class Select extends Query {
 
     private boolean isHavingNullOrFalse(Value[] row) {
         if (havingIndex >= 0) {
-            Value v = row[havingIndex];
-            if (v == ValueNull.INSTANCE) {
-                return true;
-            }
-            if (!Boolean.TRUE.equals(v.getBoolean())) {
-                return true;
-            }
+            return !row[havingIndex].getBoolean();
         }
         return false;
     }
@@ -281,8 +275,7 @@ public class Select extends Query {
     }
 
     boolean isConditionMet() {
-        return condition == null ||
-                Boolean.TRUE.equals(condition.getBooleanValue(session));
+        return condition == null || condition.getBooleanValue(session);
     }
 
     private void queryGroup(int columnCount, LocalResult result) {

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -112,8 +112,7 @@ public class Update extends Prepared {
                 if (limitRows >= 0 && count >= limitRows) {
                     break;
                 }
-                if (condition == null ||
-                        Boolean.TRUE.equals(condition.getBooleanValue(session))) {
+                if (condition == null || condition.getBooleanValue(session)) {
                     Row oldRow = targetTableFilter.get();
                     Row newRow = table.getTemplateRow();
                     for (int i = 0; i < columnCount; i++) {

--- a/h2/src/main/org/h2/constraint/ConstraintCheck.java
+++ b/h2/src/main/org/h2/constraint/ConstraintCheck.java
@@ -20,6 +20,8 @@ import org.h2.table.Column;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
 import org.h2.util.StringUtils;
+import org.h2.value.Value;
+import org.h2.value.ValueNull;
 
 /**
  * A check constraint.
@@ -92,15 +94,16 @@ public class ConstraintCheck extends Constraint {
             return;
         }
         filter.set(newRow);
-        Boolean b;
+        boolean b;
         try {
-            b = expr.getValue(session).getBoolean();
+            Value v = expr.getValue(session);
+            b = v == ValueNull.INSTANCE || v.getBoolean();
         } catch (DbException ex) {
             throw DbException.get(ErrorCode.CHECK_CONSTRAINT_INVALID, ex,
                     getShortDescription());
         }
         // Both TRUE and NULL are ok
-        if (Boolean.FALSE.equals(b)) {
+        if (!b) {
             throw DbException.get(ErrorCode.CHECK_CONSTRAINT_VIOLATED_1,
                     getShortDescription());
         }

--- a/h2/src/main/org/h2/constraint/ConstraintCheck.java
+++ b/h2/src/main/org/h2/constraint/ConstraintCheck.java
@@ -97,12 +97,12 @@ public class ConstraintCheck extends Constraint {
         boolean b;
         try {
             Value v = expr.getValue(session);
+            // Both TRUE and NULL are ok
             b = v == ValueNull.INSTANCE || v.getBoolean();
         } catch (DbException ex) {
             throw DbException.get(ErrorCode.CHECK_CONSTRAINT_INVALID, ex,
                     getShortDescription());
         }
-        // Both TRUE and NULL are ok
         if (!b) {
             throw DbException.get(ErrorCode.CHECK_CONSTRAINT_VIOLATED_1,
                     getShortDescription());

--- a/h2/src/main/org/h2/expression/AggregateDataDefault.java
+++ b/h2/src/main/org/h2/expression/AggregateDataDefault.java
@@ -95,8 +95,7 @@ class AggregateDataDefault extends AggregateData {
             if (value == null) {
                 value = v;
             } else {
-                value = ValueBoolean.get(value.getBoolean().booleanValue() &&
-                        v.getBoolean().booleanValue());
+                value = ValueBoolean.get(value.getBoolean() && v.getBoolean());
             }
             break;
         case Aggregate.BOOL_OR:
@@ -104,8 +103,7 @@ class AggregateDataDefault extends AggregateData {
             if (value == null) {
                 value = v;
             } else {
-                value = ValueBoolean.get(value.getBoolean().booleanValue() ||
-                        v.getBoolean().booleanValue());
+                value = ValueBoolean.get(value.getBoolean() || v.getBoolean());
             }
             break;
         case Aggregate.BIT_AND:

--- a/h2/src/main/org/h2/expression/ConditionAndOr.java
+++ b/h2/src/main/org/h2/expression/ConditionAndOr.java
@@ -87,11 +87,11 @@ public class ConditionAndOr extends Condition {
         Value r;
         switch (andOrType) {
         case AND: {
-            if (Boolean.FALSE.equals(l.getBoolean())) {
+            if (l != ValueNull.INSTANCE && !l.getBoolean()) {
                 return l;
             }
             r = right.getValue(session);
-            if (Boolean.FALSE.equals(r.getBoolean())) {
+            if (r != ValueNull.INSTANCE && !r.getBoolean()) {
                 return r;
             }
             if (l == ValueNull.INSTANCE) {
@@ -103,11 +103,11 @@ public class ConditionAndOr extends Condition {
             return ValueBoolean.get(true);
         }
         case OR: {
-            if (Boolean.TRUE.equals(l.getBoolean())) {
+            if (l.getBoolean()) {
                 return l;
             }
             r = right.getValue(session);
-            if (Boolean.TRUE.equals(r.getBoolean())) {
+            if (r.getBoolean()) {
                 return r;
             }
             if (l == ValueNull.INSTANCE) {
@@ -212,30 +212,30 @@ public class ConditionAndOr extends Condition {
         switch (andOrType) {
         case AND:
             if (l != null) {
-                if (Boolean.FALSE.equals(l.getBoolean())) {
+                if (l != ValueNull.INSTANCE && !l.getBoolean()) {
                     return ValueExpression.get(l);
-                } else if (Boolean.TRUE.equals(l.getBoolean())) {
+                } else if (l.getBoolean()) {
                     return right;
                 }
             } else if (r != null) {
-                if (Boolean.FALSE.equals(r.getBoolean())) {
+                if (r != ValueNull.INSTANCE && !r.getBoolean()) {
                     return ValueExpression.get(r);
-                } else if (Boolean.TRUE.equals(r.getBoolean())) {
+                } else if (r.getBoolean()) {
                     return left;
                 }
             }
             break;
         case OR:
             if (l != null) {
-                if (Boolean.TRUE.equals(l.getBoolean())) {
+                if (l.getBoolean()) {
                     return ValueExpression.get(l);
-                } else if (Boolean.FALSE.equals(l.getBoolean())) {
+                } else if (l != ValueNull.INSTANCE) {
                     return right;
                 }
             } else if (r != null) {
-                if (Boolean.TRUE.equals(r.getBoolean())) {
+                if (r.getBoolean()) {
                     return ValueExpression.get(r);
-                } else if (Boolean.FALSE.equals(r.getBoolean())) {
+                } else if (r != ValueNull.INSTANCE) {
                     return left;
                 }
             }

--- a/h2/src/main/org/h2/expression/Expression.java
+++ b/h2/src/main/org/h2/expression/Expression.java
@@ -168,13 +168,13 @@ public abstract class Expression {
 
     /**
      * Get the value in form of a boolean expression.
-     * Returns true, false, or null.
+     * Returns true or false.
      * In this database, everything can be a condition.
      *
      * @param session the session
      * @return the result
      */
-    public Boolean getBooleanValue(Session session) {
+    public boolean getBooleanValue(Session session) {
         return getValue(session).getBoolean();
     }
 

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -989,8 +989,7 @@ public class Function extends Expression implements FunctionCall {
         }
         case CASEWHEN: {
             Value v;
-            if (v0 == ValueNull.INSTANCE ||
-                    !v0.getBoolean().booleanValue()) {
+            if (!v0.getBoolean()) {
                 v = getNullOrValue(session, args, values, 2);
             } else {
                 v = getNullOrValue(session, args, values, 1);
@@ -1067,8 +1066,7 @@ public class Function extends Expression implements FunctionCall {
                 // (null, when, then, when, then, else)
                 for (int i = 1, len = args.length - 1; i < len; i += 2) {
                     Value when = args[i].getValue(session);
-                    if (!(when == ValueNull.INSTANCE) &&
-                            when.getBoolean().booleanValue()) {
+                    if (when.getBoolean()) {
                         then = args[i + 1];
                         break;
                     }

--- a/h2/src/main/org/h2/expression/ValueExpression.java
+++ b/h2/src/main/org/h2/expression/ValueExpression.java
@@ -81,7 +81,7 @@ public class ValueExpression extends Expression {
     @Override
     public void createIndexConditions(Session session, TableFilter filter) {
         if (value.getType() == Value.BOOLEAN) {
-            boolean v = ((ValueBoolean) value).getBoolean().booleanValue();
+            boolean v = ((ValueBoolean) value).getBoolean();
             if (!v) {
                 filter.addIndexCondition(IndexCondition.get(Comparison.FALSE, null, this));
             }

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -586,9 +586,7 @@ public class JdbcConnection extends TraceObject
             getReadOnly = prepareCommand("CALL READONLY()", getReadOnly);
             ResultInterface result = getReadOnly.executeQuery(0, false);
             result.next();
-            boolean readOnly = result.currentRow()[0].getBoolean()
-                    .booleanValue();
-            return readOnly;
+            return result.currentRow()[0].getBoolean();
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -548,8 +548,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public boolean getBoolean(int columnIndex) throws SQLException {
         try {
             debugCodeCall("getBoolean", columnIndex);
-            Boolean v = get(columnIndex).getBoolean();
-            return v == null ? false : v.booleanValue();
+            return get(columnIndex).getBoolean();
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -567,8 +566,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public boolean getBoolean(String columnLabel) throws SQLException {
         try {
             debugCodeCall("getBoolean", columnLabel);
-            Boolean v = get(columnLabel).getBoolean();
-            return v == null ? false : v.booleanValue();
+            return get(columnLabel).getBoolean();
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -192,8 +192,7 @@ public class ValueDataType implements DataType {
         int type = v.getType();
         switch (type) {
         case Value.BOOLEAN:
-            buff.put((byte) (v.getBoolean().booleanValue() ?
-                    BOOLEAN_TRUE : BOOLEAN_FALSE));
+            buff.put((byte) (v.getBoolean() ? BOOLEAN_TRUE : BOOLEAN_FALSE));
             break;
         case Value.BYTE:
             buff.put((byte) type).put(v.getByte());

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -418,8 +418,7 @@ public class Data {
         int type = v.getType();
         switch (type) {
         case Value.BOOLEAN:
-            writeByte((byte) (v.getBoolean().booleanValue() ?
-                    BOOLEAN_TRUE : BOOLEAN_FALSE));
+            writeByte((byte) (v.getBoolean() ? BOOLEAN_TRUE : BOOLEAN_FALSE));
             break;
         case Value.BYTE:
             writeByte((byte) type);

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -362,7 +362,7 @@ public class Column {
                 v = checkConstraint.getValue(session);
             }
             // Both TRUE and NULL are ok
-            if (Boolean.FALSE.equals(v.getBoolean())) {
+            if (v != ValueNull.INSTANCE && !v.getBoolean()) {
                 throw DbException.get(
                         ErrorCode.CHECK_CONSTRAINT_VIOLATED_1,
                         checkConstraint.getSQL());

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -577,10 +577,7 @@ public class TableFilter implements ColumnResolver {
      * @return true if yes
      */
     boolean isOk(Expression condition) {
-        if (condition == null) {
-            return true;
-        }
-        return Boolean.TRUE.equals(condition.getBooleanValue(session));
+        return condition == null || condition.getBooleanValue(session);
     }
 
     /**

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -342,7 +342,7 @@ public class Transfer {
             break;
         }
         case Value.BOOLEAN:
-            writeBoolean(v.getBoolean().booleanValue());
+            writeBoolean(v.getBoolean());
             break;
         case Value.BYTE:
             writeByte(v.getByte());

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -423,7 +423,7 @@ public abstract class Value {
         softCache = null;
     }
 
-    public Boolean getBoolean() {
+    public boolean getBoolean() {
         return ((ValueBoolean) convertTo(Value.BOOLEAN)).getBoolean();
     }
 
@@ -630,7 +630,7 @@ public abstract class Value {
             case BYTE: {
                 switch (getType()) {
                 case BOOLEAN:
-                    return ValueByte.get(getBoolean().booleanValue() ? (byte) 1 : (byte) 0);
+                    return ValueByte.get(getBoolean() ? (byte) 1 : (byte) 0);
                 case SHORT:
                     return ValueByte.get(convertToByte(getShort(), column));
                 case ENUM:
@@ -655,7 +655,7 @@ public abstract class Value {
             case SHORT: {
                 switch (getType()) {
                 case BOOLEAN:
-                    return ValueShort.get(getBoolean().booleanValue() ? (short) 1 : (short) 0);
+                    return ValueShort.get(getBoolean() ? (short) 1 : (short) 0);
                 case BYTE:
                     return ValueShort.get(getByte());
                 case ENUM:
@@ -680,7 +680,7 @@ public abstract class Value {
             case INT: {
                 switch (getType()) {
                 case BOOLEAN:
-                    return ValueInt.get(getBoolean().booleanValue() ? 1 : 0);
+                    return ValueInt.get(getBoolean() ? 1 : 0);
                 case BYTE:
                     return ValueInt.get(getByte());
                 case ENUM:
@@ -706,7 +706,7 @@ public abstract class Value {
             case LONG: {
                 switch (getType()) {
                 case BOOLEAN:
-                    return ValueLong.get(getBoolean().booleanValue() ? 1 : 0);
+                    return ValueLong.get(getBoolean() ? 1 : 0);
                 case BYTE:
                     return ValueLong.get(getByte());
                 case SHORT:
@@ -737,8 +737,7 @@ public abstract class Value {
             case DECIMAL: {
                 switch (getType()) {
                 case BOOLEAN:
-                    return ValueDecimal.get(BigDecimal.valueOf(
-                            getBoolean().booleanValue() ? 1 : 0));
+                    return ValueDecimal.get(BigDecimal.valueOf(getBoolean() ? 1 : 0));
                 case BYTE:
                     return ValueDecimal.get(BigDecimal.valueOf(getByte()));
                 case SHORT:
@@ -774,7 +773,7 @@ public abstract class Value {
             case DOUBLE: {
                 switch (getType()) {
                 case BOOLEAN:
-                    return ValueDouble.get(getBoolean().booleanValue() ? 1 : 0);
+                    return ValueDouble.get(getBoolean() ? 1 : 0);
                 case BYTE:
                     return ValueDouble.get(getByte());
                 case SHORT:
@@ -797,7 +796,7 @@ public abstract class Value {
             case FLOAT: {
                 switch (getType()) {
                 case BOOLEAN:
-                    return ValueFloat.get(getBoolean().booleanValue() ? 1 : 0);
+                    return ValueFloat.get(getBoolean() ? 1 : 0);
                 case BYTE:
                     return ValueFloat.get(getByte());
                 case SHORT:

--- a/h2/src/main/org/h2/value/ValueBoolean.java
+++ b/h2/src/main/org/h2/value/ValueBoolean.java
@@ -30,10 +30,10 @@ public class ValueBoolean extends Value {
     private static final Object TRUE = new ValueBoolean(true);
     private static final Object FALSE = new ValueBoolean(false);
 
-    private final Boolean value;
+    private final boolean value;
 
     private ValueBoolean(boolean value) {
-        this.value = Boolean.valueOf(value);
+        this.value = value;
     }
 
     @Override
@@ -48,24 +48,23 @@ public class ValueBoolean extends Value {
 
     @Override
     public String getString() {
-        return value.booleanValue() ? "TRUE" : "FALSE";
+        return value ? "TRUE" : "FALSE";
     }
 
     @Override
     public Value negate() {
-        return (ValueBoolean) (value.booleanValue() ? FALSE : TRUE);
+        return (ValueBoolean) (value ? FALSE : TRUE);
     }
 
     @Override
-    public Boolean getBoolean() {
+    public boolean getBoolean() {
         return value;
     }
 
     @Override
     protected int compareSecure(Value o, CompareMode mode) {
-        boolean v2 = ((ValueBoolean) o).value.booleanValue();
-        boolean v = value.booleanValue();
-        return (v == v2) ? 0 : (v ? 1 : -1);
+        ValueBoolean v = (ValueBoolean) o;
+        return Boolean.compare(value, v.value);
     }
 
     @Override
@@ -75,7 +74,7 @@ public class ValueBoolean extends Value {
 
     @Override
     public int hashCode() {
-        return value.booleanValue() ? 1 : 0;
+        return value ? 1 : 0;
     }
 
     @Override
@@ -86,7 +85,7 @@ public class ValueBoolean extends Value {
     @Override
     public void set(PreparedStatement prep, int parameterIndex)
             throws SQLException {
-        prep.setBoolean(parameterIndex, value.booleanValue());
+        prep.setBoolean(parameterIndex, value);
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueNull.java
+++ b/h2/src/main/org/h2/value/ValueNull.java
@@ -63,8 +63,8 @@ public class ValueNull extends Value {
     }
 
     @Override
-    public Boolean getBoolean() {
-        return null;
+    public boolean getBoolean() {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
It the most places `NULL` handled as `FALSE`, so only two possible results of `getBoolean()` makes code more clear. Remanling few places can have explicit checks for `ValueNull`.

This also slightly reduces size of compiled code and makes `get***()` methods of `Value` more consistent.