### PR TITLE
Sort files in generated jars

### DIFF
--- a/h2/src/tools/org/h2/build/BuildBase.java
+++ b/h2/src/tools/org/h2/build/BuildBase.java
@@ -857,7 +857,10 @@ public class BuildBase {
                         }
                         return 2;
                     }
-                    return 3;
+                    if (!path.endsWith(".zip")) {
+                        return 3;
+                    }
+                    return 4;
                 }
 
                 @Override

--- a/h2/src/tools/org/h2/build/BuildBase.java
+++ b/h2/src/tools/org/h2/build/BuildBase.java
@@ -845,6 +845,32 @@ public class BuildBase {
                     return comp;
                 }
             });
+        } else if (jar) {
+            Collections.sort(files, new Comparator<File>() {
+                private int priority(String path) {
+                    if (path.startsWith("META-INF/")) {
+                        if (path.equals("META-INF/MANIFEST.MF")) {
+                            return 0;
+                        }
+                        if (path.startsWith("services/", 9)) {
+                            return 1;
+                        }
+                        return 2;
+                    }
+                    return 3;
+                }
+
+                @Override
+                public int compare(File f1, File f2) {
+                    String p1 = f1.getPath();
+                    String p2 = f2.getPath();
+                    int comp = Integer.compare(priority(p1), priority(p2));
+                    if (comp != 0) {
+                        return comp;
+                    }
+                    return p1.compareTo(p2);
+                }
+            });
         }
         mkdirs(new File(destFile).getAbsoluteFile().getParentFile());
         // normalize the path (replace / with \ if required)


### PR DESCRIPTION
It's better to have `MANIFEST.MF` at start of jar archive.

This code places `MANIFEST.MF` on the first place, next `services`, then other `META-INF` files, after that classes, and finally zip with resources. Total size of generated jar is not changed.

After this change output of utilities that shows content of archive as is (like `7z l h2.jar` and others) is much more readable and comparable between builds.