### PR TITLE
Add MDY to DateStyle in PgServerThread

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -67,7 +67,7 @@ public class PgServerThread implements Runnable {
     private final int secret;
     private JdbcStatement activeRequest;
     private String clientEncoding = SysProperties.PG_DEFAULT_CLIENT_ENCODING;
-    private String dateStyle = "ISO";
+    private String dateStyle = "ISO, MDY";
     private final HashMap<String, Prepared> prepared =
             new CaseInsensitiveMap<>();
     private final HashMap<String, Portal> portals =
@@ -183,6 +183,9 @@ public class PgServerThread implements Runnable {
                         // UTF8
                         clientEncoding = value;
                     } else if ("DateStyle".equals(param)) {
+                        if (value.indexOf(',') < 0) {
+                            value += ", MDY";
+                        }
                         dateStyle = value;
                     }
                     // extra_float_digits 2


### PR DESCRIPTION
Client may send just ISO but expect value with secord part just after that, so append it to client setting too. `ISO, MDY` is a default for PostgreSQL, so use this variant.

This mostly fixes modern JDBC client, except for warnings about unsupported version of server.

There are more issues with ODBC clients too, but they are more complex.