### PR TITLE
Add ceilingKey() and floorKey() to TransactionMap (version 2)

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -228,9 +228,9 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
     }
 
     private void requireUnique(SearchRow row, TransactionMap<Value, Value> map, ValueArray unique) {
-        Iterator<Value> it = map.keyIterator(unique);
-        if (it.hasNext()) {
-            ValueArray k = (ValueArray) it.next();
+        Value key = map.ceilingKey(unique);
+        if (key != null) {
+            ValueArray k = (ValueArray) key;
             if (compareRows(row, convertToSearchRow(k)) == 0) {
                 // committed
                 throw getDuplicateKeyException(k.toString());

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -1320,15 +1320,10 @@ public class TransactionStore {
          */
         public K lastKey() {
             K k = map.lastKey();
-            while (true) {
-                if (k == null) {
-                    return null;
-                }
-                if (get(k) != null) {
-                    return k;
-                }
+            while (k != null && get(k) == null) {
                 k = map.lowerKey(k);
             }
+            return k;
         }
 
         /**

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -1339,13 +1339,10 @@ public class TransactionStore {
          * @return the result
          */
         public K higherKey(K key) {
-            while (true) {
-                K k = map.higherKey(key);
-                if (k == null || get(k) != null) {
-                    return k;
-                }
-                key = k;
-            }
+            do {
+                key = map.higherKey(key);
+            } while (key != null && get(key) == null);
+            return key;
         }
 
         /**
@@ -1373,13 +1370,10 @@ public class TransactionStore {
          * @return the result
          */
         public K lowerKey(K key) {
-            while (true) {
-                K k = map.lowerKey(key);
-                if (k == null || get(k) != null) {
-                    return k;
-                }
-                key = k;
-            }
+            do {
+                key = map.lowerKey(key);
+            } while (key != null && get(key) == null);
+            return key;
         }
 
         /**

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -1346,6 +1346,22 @@ public class TransactionStore {
         }
 
         /**
+         * Get the smallest key that is larger than or equal to this key,
+         * or null if no such key exists.
+         *
+         * @param key the key (may not be null)
+         * @return the result
+         */
+        public K ceilingKey(K key) {
+            key = map.ceilingKey(key);
+            while (key != null && get(key) == null) {
+                // Use higherKey() for the next attempts, otherwise we'll get an infinite loop
+                key = higherKey(key);
+            }
+            return key;
+        }
+
+        /**
          * Get one of the previous or next keys. There might be no value
          * available for the returned key.
          *
@@ -1360,6 +1376,22 @@ public class TransactionStore {
             }
             long index = map.getKeyIndex(k);
             return map.getKey(index + offset);
+        }
+
+        /**
+         * Get the largest key that is smaller than or equal to this key,
+         * or null if no such key exists.
+         *
+         * @param key the key (may not be null)
+         * @return the result
+         */
+        public K floorKey(K key) {
+            key = map.floorKey(key);
+            while (key != null && get(key) == null) {
+                // Use lowerKey() for the next attempts, otherwise we'll get an infinite loop
+                key = lowerKey(key);
+            }
+            return key;
         }
 
         /**

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -1351,7 +1351,7 @@ public class TransactionStore {
             key = map.ceilingKey(key);
             while (key != null && get(key) == null) {
                 // Use higherKey() for the next attempts, otherwise we'll get an infinite loop
-                key = higherKey(key);
+                key = map.higherKey(key);
             }
             return key;
         }
@@ -1384,7 +1384,7 @@ public class TransactionStore {
             key = map.floorKey(key);
             while (key != null && get(key) == null) {
                 // Use lowerKey() for the next attempts, otherwise we'll get an infinite loop
-                key = lowerKey(key);
+                key = map.lowerKey(key);
             }
             return key;
         }

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -1348,12 +1348,8 @@ public class TransactionStore {
          * @return the result
          */
         public K ceilingKey(K key) {
-            key = map.ceilingKey(key);
-            while (key != null && get(key) == null) {
-                // Use higherKey() for the next attempts, otherwise we'll get an infinite loop
-                key = map.higherKey(key);
-            }
-            return key;
+            Iterator<K> it = keyIterator(key);
+            return it.hasNext() ? it.next() : null;
         }
 
         /**

--- a/h2/src/test/org/h2/test/store/TestTransactionStore.java
+++ b/h2/src/test/org/h2/test/store/TestTransactionStore.java
@@ -72,6 +72,10 @@ public class TestTransactionStore extends TestBase {
         Transaction t = ts.begin();
         ObjectDataType keyType = new ObjectDataType();
         TransactionMap<Long, Long> map = t.openMap("test", keyType, keyType);
+        // firstKey()
+        assertNull(map.firstKey());
+        // lastKey()
+        assertNull(map.lastKey());
         map.put(10L, 100L);
         map.put(20L, 200L);
         map.put(30L, 300L);

--- a/h2/src/test/org/h2/test/store/TestTransactionStore.java
+++ b/h2/src/test/org/h2/test/store/TestTransactionStore.java
@@ -19,9 +19,11 @@ import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.db.TransactionStore;
+import org.h2.mvstore.db.ValueDataType;
 import org.h2.mvstore.db.TransactionStore.Change;
 import org.h2.mvstore.db.TransactionStore.Transaction;
 import org.h2.mvstore.db.TransactionStore.TransactionMap;
+import org.h2.mvstore.type.ObjectDataType;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
 import org.h2.util.New;
@@ -44,6 +46,7 @@ public class TestTransactionStore extends TestBase {
     @Override
     public void test() throws Exception {
         FileUtils.createDirectories(getBaseDir());
+        testHCLFKey();
         testConcurrentAddRemove();
         testConcurrentAdd();
         testCountWithOpenTransactions();
@@ -60,6 +63,48 @@ public class TestTransactionStore extends TestBase {
         testSingleConnection();
         testCompareWithPostgreSQL();
         testStoreMultiThreadedReads();
+    }
+
+    private void testHCLFKey() {
+        MVStore s = MVStore.open(null);
+        final TransactionStore ts = new TransactionStore(s);
+        ts.init();
+        Transaction t = ts.begin();
+        ObjectDataType keyType = new ObjectDataType();
+        TransactionMap<Long, Long> map = t.openMap("test", keyType, keyType);
+        map.put(10L, 100L);
+        map.put(20L, 200L);
+        map.put(30L, 300L);
+        map.put(40L, 400L);
+        t.commit();
+        t = ts.begin();
+        map = t.openMap("test", keyType, keyType);
+        map.put(15L, 150L);
+        // The same transaction
+        assertEquals((Object) 15L, map.higherKey(10L));
+        t = ts.begin();
+        map = t.openMap("test", keyType, keyType);
+        // Another transaction
+        // higherKey()
+        assertEquals((Object) 20L, map.higherKey(10L));
+        assertEquals((Object) 20L, map.higherKey(15L));
+        assertNull(map.higherKey(40L));
+        // ceilingKey()
+        assertEquals((Object) 10L, map.ceilingKey(10L));
+        assertEquals((Object) 20L, map.ceilingKey(15L));
+        assertEquals((Object) 40L, map.ceilingKey(40L));
+        assertNull(map.higherKey(45L));
+        // lowerKey()
+        assertNull(map.lowerKey(10L));
+        assertEquals((Object) 10L, map.lowerKey(15L));
+        assertEquals((Object) 10L, map.lowerKey(20L));
+        assertEquals((Object) 20L, map.lowerKey(25L));
+        // floorKey()
+        assertNull(map.floorKey(5L));
+        assertEquals((Object) 10L, map.floorKey(10L));
+        assertEquals((Object) 10L, map.floorKey(15L));
+        assertEquals((Object) 30L, map.floorKey(35L));
+        s.close();
     }
 
     private static void testConcurrentAddRemove() throws InterruptedException {

--- a/h2/src/test/org/h2/test/store/TestTransactionStore.java
+++ b/h2/src/test/org/h2/test/store/TestTransactionStore.java
@@ -19,7 +19,6 @@ import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.db.TransactionStore;
-import org.h2.mvstore.db.ValueDataType;
 import org.h2.mvstore.db.TransactionStore.Change;
 import org.h2.mvstore.db.TransactionStore.Transaction;
 import org.h2.mvstore.db.TransactionStore.TransactionMap;


### PR DESCRIPTION
Cherry-picked from #795 with changes based on review.

1. Regular do-while loop used in `higherKey()` and `lowerKey()` instead of `while (true)` with return in the middle.

2. Regular while loop used in `lastKey()` instead of `while (true)` with return in the middle.

3. Missing `ceilingKey()` and `floorKey()` are implemented.

4. All five methods plus `firstKey()` now have tests including the corner cases and values from another transaction.

5. `MVSecondaryIndex.requireUnique()` now uses `ceilingKey()` instead of own call to `keyIterator()` for the same purpose.