### PR TITLE
More fixes in date-time types for ODBC drivers

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -625,14 +625,17 @@ public class PgServerThread implements Runnable {
                     writeInt(8);
                     long m = t.getTime();
                     m += TimeZone.getDefault().getOffset(m);
+                    m = toPostgreSeconds(m);
+                    int nanos = t.getNanos();
+                    if (m < 0 && nanos != 0) {
+                        m--;
+                    }
                     if (INTEGER_DATE_TYPES) {
                         // long format
-                        m = toPostgreSeconds(m);
-                        m = m * 1000000 + t.getNanos() / 1000;
+                        m = m * 1000000 + nanos / 1000;
                     } else {
                         // double format
-                        m = toPostgreSeconds(m);
-                        m = Double.doubleToLongBits(m + t.getNanos() * 0.000000001);
+                        m = Double.doubleToLongBits(m + nanos * 0.000000001);
                     }
                     writeInt((int) (m >>> 32));
                     writeInt((int) m);

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -31,6 +31,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.SimpleTimeZone;
 import java.util.concurrent.TimeUnit;
 import org.h2.jdbc.JdbcConnection;
@@ -641,11 +642,14 @@ public abstract class TestBase {
      * @throws AssertionError if the values are not equal
      */
     public void assertEquals(java.util.Date expected, java.util.Date actual) {
-        if (expected != actual && !expected.equals(actual)) {
+        if (!Objects.equals(expected, actual)) {
             DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
             SimpleTimeZone gmt = new SimpleTimeZone(0, "Z");
             df.setTimeZone(gmt);
-            fail("Expected: " + df.format(expected) + " actual: " + df.format(actual));
+            fail("Expected: " +
+                    (expected != null ? df.format(expected) : "null") +
+                    " actual: " +
+                    (actual != null ? df.format(actual) : "null"));
         }
     }
 

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -473,9 +473,15 @@ public class TestPgServer extends TestBase {
             stat.execute(
                     "create table test(x1 date, x2 time, x3 timestamp)");
 
-            Date[] dates = { null, Date.valueOf("2017-02-20") };
-            Time[] times = { null, Time.valueOf("14:15:16") };
-            Timestamp[] timestamps = { null, Timestamp.valueOf("2017-02-20 14:15:16.763") };
+            Date[] dates = { null, Date.valueOf("2017-02-20"),
+                    Date.valueOf("1970-01-01"), Date.valueOf("1969-12-31"),
+                    Date.valueOf("1940-01-10"), Date.valueOf("1950-11-10") };
+            Time[] times = { null, Time.valueOf("14:15:16"),
+                    Time.valueOf("00:00:00"), Time.valueOf("23:59:59"),
+                    Time.valueOf("00:10:59"), Time.valueOf("08:30:42") };
+            Timestamp[] timestamps = { null, Timestamp.valueOf("2017-02-20 14:15:16.763"),
+                    Timestamp.valueOf("1970-01-01 00:00:00"), Timestamp.valueOf("1969-12-31 23:59:59"),
+                    Timestamp.valueOf("1940-01-10 00:10:59"), Timestamp.valueOf("1950-11-10 08:30:42.12") };
             int count = dates.length;
 
             PreparedStatement ps = conn.prepareStatement(


### PR DESCRIPTION
1. NPE on `NULL` date-times is fixed.
2. Server sends value of `integer_datetimes` setting to clients. I don't know which value is better, so I introduce constant `PgServerThread.INTEGER_DATE_TYPES` and wrote code for both variants. If somebody determines that another value is better it will be enough just to change value of this constant. Also I don't think that this value should be configurable by end users.
3. Handling of older timestamps are fixed. Julian/Gregorian transitions are still not implemented, however.
4. NPE in `TestBase.assertEquals(Date, Date)` is fixed.