### PR TITLE
Fix NULL support in PgServer for primitive types too

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -648,8 +648,7 @@ public class PgServerThread implements Runnable {
                         m /= 1000;
                         m = Double.doubleToLongBits(m);
                     }
-                    writeInt((int) (m >>> 32));
-                    writeInt((int) m);
+                    dataOut.writeLong(m);
                 }
                 break;
             }
@@ -673,8 +672,7 @@ public class PgServerThread implements Runnable {
                         // double format
                         m = Double.doubleToLongBits(m + nanos * 0.000000001);
                     }
-                    writeInt((int) (m >>> 32));
-                    writeInt((int) m);
+                    dataOut.writeLong(m);
                 }
                 break;
             }

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -537,10 +537,16 @@ public class PgServerThread implements Runnable {
         if (text) {
             // plain text
             switch (pgType) {
-            case PgServer.PG_TYPE_BOOL:
-                writeInt(1);
-                dataOut.writeByte(rs.getBoolean(column) ? 't' : 'f');
+            case PgServer.PG_TYPE_BOOL: {
+                boolean b = rs.getBoolean(column);
+                if (rs.wasNull()) {
+                    writeInt(-1);
+                } else {
+                    writeInt(1);
+                    dataOut.writeByte(b ? 't' : 'f');
+                }
                 break;
+            }
             default:
                 String s = rs.getString(column);
                 if (s == null) {
@@ -554,26 +560,56 @@ public class PgServerThread implements Runnable {
         } else {
             // binary
             switch (pgType) {
-            case PgServer.PG_TYPE_INT2:
-                writeInt(2);
-                writeShort(rs.getShort(column));
+            case PgServer.PG_TYPE_INT2: {
+                short s = rs.getShort(column);
+                if (rs.wasNull()) {
+                    writeInt(-1);
+                } else {
+                    writeInt(2);
+                    writeShort(s);
+                }
                 break;
-            case PgServer.PG_TYPE_INT4:
-                writeInt(4);
-                writeInt(rs.getInt(column));
+            }
+            case PgServer.PG_TYPE_INT4: {
+                int i = rs.getInt(column);
+                if (rs.wasNull()) {
+                    writeInt(-1);
+                } else {
+                    writeInt(4);
+                    writeInt(i);
+                }
                 break;
-            case PgServer.PG_TYPE_INT8:
-                writeInt(8);
-                dataOut.writeLong(rs.getLong(column));
+            }
+            case PgServer.PG_TYPE_INT8: {
+                long l = rs.getLong(column);
+                if (rs.wasNull()) {
+                    writeInt(-1);
+                } else {
+                    writeInt(8);
+                    dataOut.writeLong(l);
+                }
                 break;
-            case PgServer.PG_TYPE_FLOAT4:
-                writeInt(4);
-                dataOut.writeFloat(rs.getFloat(column));
+            }
+            case PgServer.PG_TYPE_FLOAT4: {
+                float f = rs.getFloat(column);
+                if (rs.wasNull()) {
+                    writeInt(-1);
+                } else {
+                    writeInt(4);
+                    dataOut.writeFloat(f);
+                }
                 break;
-            case PgServer.PG_TYPE_FLOAT8:
-                writeInt(8);
-                dataOut.writeDouble(rs.getDouble(column));
+            }
+            case PgServer.PG_TYPE_FLOAT8: {
+                double d = rs.getDouble(column);
+                if (rs.wasNull()) {
+                    writeInt(-1);
+                } else {
+                    writeInt(8);
+                    dataOut.writeDouble(d);
+                }
                 break;
+            }
             case PgServer.PG_TYPE_BYTEA: {
                 byte[] data = rs.getBytes(column);
                 if (data == null) {

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -5,6 +5,7 @@
  */
 package org.h2.test.unit;
 
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Date;
@@ -410,10 +411,10 @@ public class TestPgServer extends TestBase {
                     "create table test(x1 varchar, x2 int, " +
                     "x3 smallint, x4 bigint, x5 double, x6 float, " +
                     "x7 real, x8 boolean, x9 char, x10 bytea, " +
-                    "x11 date, x12 time, x13 timestamp)");
+                    "x11 date, x12 time, x13 timestamp, x14 numeric)");
 
             PreparedStatement ps = conn.prepareStatement(
-                    "insert into test values (?,?,?,?,?,?,?,?,?,?,?,?,?)");
+                    "insert into test values (?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
             ps.setString(1, "test");
             ps.setInt(2, 12345678);
             ps.setShort(3, (short) 12345);
@@ -427,8 +428,9 @@ public class TestPgServer extends TestBase {
             ps.setDate(11, Date.valueOf("2015-01-31"));
             ps.setTime(12, Time.valueOf("20:11:15"));
             ps.setTimestamp(13, Timestamp.valueOf("2001-10-30 14:16:10.111"));
+            ps.setBigDecimal(14, new BigDecimal("12345678901234567890.12345"));
             ps.execute();
-            for (int i = 1; i <= 13; i++) {
+            for (int i = 1; i <= 14; i++) {
                 ps.setNull(i, Types.NULL);
             }
             ps.execute();
@@ -449,8 +451,9 @@ public class TestPgServer extends TestBase {
             assertEquals(Date.valueOf("2015-01-31"), rs.getDate(11));
             assertEquals(Time.valueOf("20:11:15"), rs.getTime(12));
             assertEquals(Timestamp.valueOf("2001-10-30 14:16:10.111"), rs.getTimestamp(13));
+            assertEquals(new BigDecimal("12345678901234567890.12345"), rs.getBigDecimal(14));
             assertTrue(rs.next());
-            for (int i = 1; i <= 13; i++) {
+            for (int i = 1; i <= 14; i++) {
                 assertNull(rs.getObject(i));
             }
             assertFalse(rs.next());

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -428,6 +428,10 @@ public class TestPgServer extends TestBase {
             ps.setTime(12, Time.valueOf("20:11:15"));
             ps.setTimestamp(13, Timestamp.valueOf("2001-10-30 14:16:10.111"));
             ps.execute();
+            for (int i = 1; i <= 13; i++) {
+                ps.setNull(i, Types.NULL);
+            }
+            ps.execute();
 
             ResultSet rs = stat.executeQuery("select * from test");
             assertTrue(rs.next());
@@ -445,6 +449,11 @@ public class TestPgServer extends TestBase {
             assertEquals(Date.valueOf("2015-01-31"), rs.getDate(11));
             assertEquals(Time.valueOf("20:11:15"), rs.getTime(12));
             assertEquals(Timestamp.valueOf("2001-10-30 14:16:10.111"), rs.getTimestamp(13));
+            assertTrue(rs.next());
+            for (int i = 1; i <= 13; i++) {
+                assertNull(rs.getObject(i));
+            }
+            assertFalse(rs.next());
 
             conn.close();
         } finally {


### PR DESCRIPTION
Write `NULL` values as nulls for primitive types too.

Before this change default values (`0` / `false`) were returned.