### PR TITLE
Use Arrays.copyOf() and Arrays.copyOfRange()

### DIFF
--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -188,9 +188,7 @@ public class Select extends Query {
             return row;
         }
         // remove columns so that 'distinct' can filter duplicate rows
-        Value[] r2 = new Value[distinctColumnCount];
-        System.arraycopy(row, 0, r2, 0, distinctColumnCount);
-        return r2;
+        return Arrays.copyOf(row, distinctColumnCount);
     }
 
     private boolean isHavingNullOrFalse(Value[] row) {

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -305,10 +305,8 @@ public class ConnectionInfo implements Cloneable {
             if (space < 0) {
                 throw DbException.get(ErrorCode.WRONG_PASSWORD_FORMAT);
             }
-            char[] np = new char[password.length - space - 1];
-            char[] filePassword = new char[space];
-            System.arraycopy(password, space + 1, np, 0, np.length);
-            System.arraycopy(password, 0, filePassword, 0, space);
+            char[] np = Arrays.copyOfRange(password, space + 1, password.length);
+            char[] filePassword = Arrays.copyOf(password, space);
             Arrays.fill(password, (char) 0);
             password = np;
             fileEncryptionKey = FilePathEncrypt.getPasswordBytes(filePassword);

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1786,9 +1786,7 @@ public class Function extends Expression implements FunctionCall {
 
     private static byte[] getPaddedArrayCopy(byte[] data, int blockSize) {
         int size = MathUtils.roundUpInt(data.length, blockSize);
-        byte[] newData = DataUtils.newBytes(size);
-        System.arraycopy(data, 0, newData, 0, data.length);
-        return newData;
+        return DataUtils.copyBytes(data, size);
     }
 
     private static byte[] decrypt(String algorithm, byte[] key, byte[] data) {

--- a/h2/src/main/org/h2/jdbc/JdbcArray.java
+++ b/h2/src/main/org/h2/jdbc/JdbcArray.java
@@ -9,6 +9,7 @@ import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.h2.api.ErrorCode;
@@ -283,9 +284,8 @@ public class JdbcArray extends TraceObject implements Array {
             throw DbException.getInvalidValueException("index (1.."
                     + array.length + ")", index);
         }
-        Object[] subset = new Object[count];
-        System.arraycopy(array, (int) (index - 1), subset, 0, count);
-        return subset;
+        int offset = (int) (index - 1);
+        return Arrays.copyOfRange(array, offset, offset + count);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -13,6 +13,7 @@ import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -913,6 +914,7 @@ public final class DataUtils {
      * This method should be used if the size of the array is user defined, or
      * stored in a file, so wrong size data can be distinguished from regular
      * out-of-memory.
+     * </p>
      *
      * @param len the number of bytes requested
      * @return the byte array
@@ -924,6 +926,35 @@ public final class DataUtils {
         }
         try {
             return new byte[len];
+        } catch (OutOfMemoryError e) {
+            Error e2 = new OutOfMemoryError("Requested memory: " + len);
+            e2.initCause(e);
+            throw e2;
+        }
+    }
+
+    /**
+     * Creates a copy of array of bytes with the new size. If this is not possible
+     * because not enough memory is available, an OutOfMemoryError with the
+     * requested size in the message is thrown.
+     * <p>
+     * This method should be used if the size of the array is user defined, or
+     * stored in a file, so wrong size data can be distinguished from regular
+     * out-of-memory.
+     * </p>
+     *
+     * @param bytes source array
+     * @param len the number of bytes in the new array
+     * @return the byte array
+     * @throws OutOfMemoryError if the allocation was too large
+     * @see Arrays#copyOf(byte[], int)
+     */
+    public static byte[] copyBytes(byte[] bytes, int len) {
+        if (len == 0) {
+            return EMPTY_BYTES;
+        }
+        try {
+            return Arrays.copyOf(bytes, len);
         } catch (OutOfMemoryError e) {
             Error e2 = new OutOfMemoryError("Requested memory: " + len);
             e2.initCause(e);

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -8,6 +8,8 @@ package org.h2.result;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.h2.engine.Database;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
@@ -281,9 +283,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
 
     private ValueArray getArrayOfVisible(Value[] values) {
         if (values.length > visibleColumnCount) {
-            Value[] v2 = new Value[visibleColumnCount];
-            System.arraycopy(values, 0, v2, 0, visibleColumnCount);
-            values = v2;
+            values = Arrays.copyOf(values, visibleColumnCount);
         }
         return ValueArray.get(values);
     }

--- a/h2/src/main/org/h2/result/RowImpl.java
+++ b/h2/src/main/org/h2/result/RowImpl.java
@@ -5,6 +5,8 @@
  */
 package org.h2.result;
 
+import java.util.Arrays;
+
 import org.h2.engine.Constants;
 import org.h2.store.Data;
 import org.h2.util.StatementBuilder;
@@ -35,8 +37,7 @@ public class RowImpl implements Row {
      */
     @Override
     public Row getCopy() {
-        Value[] d2 = new Value[data.length];
-        System.arraycopy(data, 0, d2, 0, data.length);
+        Value[] d2 = Arrays.copyOf(data, data.length);
         RowImpl r2 = new RowImpl(d2, memory);
         r2.key = key;
         r2.version = version + 1;

--- a/h2/src/main/org/h2/schema/TriggerObject.java
+++ b/h2/src/main/org/h2/schema/TriggerObject.java
@@ -8,6 +8,7 @@ package org.h2.schema;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Arrays;
 
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
@@ -243,8 +244,7 @@ public class TriggerObject extends SchemaObjectBase {
         newList = convertToObjectList(newRow);
         Object[] newListBackup;
         if (before && newList != null) {
-            newListBackup = new Object[newList.length];
-            System.arraycopy(newList, 0, newListBackup, 0, newList.length);
+            newListBackup = Arrays.copyOf(newList, newList.length);
         } else {
             newListBackup = null;
         }

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -17,6 +17,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Arrays;
+
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
@@ -1171,8 +1173,7 @@ public class Data {
      */
     public void truncate(int size) {
         if (pos > size) {
-            byte[] buff = new byte[size];
-            System.arraycopy(data, 0, buff, 0, size);
+            byte[] buff = Arrays.copyOf(data, size);
             this.pos = size;
             data = buff;
         }
@@ -1313,11 +1314,9 @@ public class Data {
     }
 
     private void expand(int plus) {
-        byte[] d = DataUtils.newBytes((data.length + plus) * 2);
         // must copy everything, because pos could be 0 and data may be
         // still required
-        System.arraycopy(data, 0, d, 0, data.length);
-        data = d;
+        data = DataUtils.copyBytes(data, (data.length + plus) * 2);
     }
 
     /**

--- a/h2/src/main/org/h2/store/FileStoreOutputStream.java
+++ b/h2/src/main/org/h2/store/FileStoreOutputStream.java
@@ -6,6 +6,8 @@
 package org.h2.store;
 
 import java.io.OutputStream;
+import java.util.Arrays;
+
 import org.h2.engine.Constants;
 import org.h2.tools.CompressTool;
 
@@ -49,9 +51,7 @@ public class FileStoreOutputStream extends OutputStream {
             page.reset();
             if (compress != null) {
                 if (off != 0 || len != buff.length) {
-                    byte[] b2 = new byte[len];
-                    System.arraycopy(buff, off, b2, 0, len);
-                    buff = b2;
+                    buff = Arrays.copyOfRange(buff, off, off + len);
                     off = 0;
                 }
                 int uncompressed = len;

--- a/h2/src/main/org/h2/store/LobStorageBackend.java
+++ b/h2/src/main/org/h2/store/LobStorageBackend.java
@@ -368,8 +368,7 @@ public class LobStorageBackend implements LobStorageInterface {
                     // if we had a short read, trim the buffer
                     byte[] b;
                     if (len != buff.length) {
-                        b = new byte[len];
-                        System.arraycopy(buff, 0, b, 0, len);
+                        b = Arrays.copyOf(buff, len);
                     } else {
                         b = buff;
                     }

--- a/h2/src/main/org/h2/store/fs/FilePathMem.java
+++ b/h2/src/main/org/h2/store/fs/FilePathMem.java
@@ -444,8 +444,7 @@ class FileMemData {
     static {
         byte[] n = new byte[BLOCK_SIZE];
         int len = LZF.compress(n, BLOCK_SIZE, BUFFER, 0);
-        COMPRESSED_EMPTY_BLOCK = new byte[len];
-        System.arraycopy(BUFFER, 0, COMPRESSED_EMPTY_BLOCK, 0, len);
+        COMPRESSED_EMPTY_BLOCK = Arrays.copyOf(BUFFER, len);
     }
 
     @SuppressWarnings("unchecked")
@@ -631,8 +630,7 @@ class FileMemData {
         synchronized (LZF) {
             int len = LZF.compress(old, BLOCK_SIZE, BUFFER, 0);
             if (len <= BLOCK_SIZE) {
-                byte[] d = new byte[len];
-                System.arraycopy(BUFFER, 0, d, 0, len);
+                byte[] d = Arrays.copyOf(BUFFER, len);
                 // maybe data was changed in the meantime
                 setPage(page, old, d, false);
             }

--- a/h2/src/main/org/h2/store/fs/FilePathRec.java
+++ b/h2/src/main/org/h2/store/fs/FilePathRec.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.util.Arrays;
 
 /**
  * A file system that records all write operations and can re-play them.
@@ -182,9 +183,8 @@ class FileRec extends FileBase {
         byte[] buff = src.array();
         int len = src.remaining();
         if (src.position() != 0 || len != buff.length) {
-            byte[] b = new byte[len];
-            System.arraycopy(buff, src.arrayOffset() + src.position(), b, 0, len);
-            buff = b;
+            int offset = src.arrayOffset() + src.position();
+            buff = Arrays.copyOfRange(buff, offset, offset + len);
         }
         int result = channel.write(src);
         rec.log(Recorder.WRITE, name, buff, channel.position());
@@ -196,9 +196,8 @@ class FileRec extends FileBase {
         byte[] buff = src.array();
         int len = src.remaining();
         if (src.position() != 0 || len != buff.length) {
-            byte[] b = new byte[len];
-            System.arraycopy(buff, src.arrayOffset() + src.position(), b, 0, len);
-            buff = b;
+            int offset = src.arrayOffset() + src.position();
+            buff = Arrays.copyOfRange(buff, offset, offset + len);
         }
         int result = channel.write(src, position);
         rec.log(Recorder.WRITE, name, buff, position);

--- a/h2/src/main/org/h2/tools/CompressTool.java
+++ b/h2/src/main/org/h2/tools/CompressTool.java
@@ -79,9 +79,7 @@ public class CompressTool {
         Compressor compress = getCompressor(algorithm);
         byte[] buff = getBuffer((len < 100 ? len + 100 : len) * 2);
         int newLen = compress(in, in.length, compress, buff);
-        byte[] out = DataUtils.newBytes(newLen);
-        System.arraycopy(buff, 0, out, 0, newLen);
-        return out;
+        return DataUtils.copyBytes(buff, newLen);
     }
 
     private static int compress(byte[] in, int len, Compressor compress,

--- a/h2/src/main/org/h2/util/BitField.java
+++ b/h2/src/main/org/h2/util/BitField.java
@@ -5,6 +5,8 @@
  */
 package org.h2.util;
 
+import java.util.Arrays;
+
 /**
  * A list of bits.
  */
@@ -132,9 +134,7 @@ public final class BitField {
     private void expandCapacity(int size) {
         while (size >= data.length) {
             int newSize = data.length == 0 ? 1 : data.length * 2;
-            long[] d = new long[newSize];
-            System.arraycopy(data, 0, d, 0, data.length);
-            data = d;
+            data = Arrays.copyOf(data, newSize);
         }
     }
 

--- a/h2/src/main/org/h2/util/IntArray.java
+++ b/h2/src/main/org/h2/util/IntArray.java
@@ -5,6 +5,8 @@
  */
 package org.h2.util;
 
+import java.util.Arrays;
+
 import org.h2.engine.SysProperties;
 
 /**
@@ -93,9 +95,7 @@ public class IntArray {
     public void ensureCapacity(int minCapacity) {
         minCapacity = Math.max(4, minCapacity);
         if (minCapacity >= data.length) {
-            int[] d = new int[minCapacity];
-            System.arraycopy(data, 0, d, 0, data.length);
-            data = d;
+            data = Arrays.copyOf(data, minCapacity);
         }
     }
 

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -9,6 +9,7 @@ import java.lang.ref.SoftReference;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
@@ -828,9 +829,7 @@ public class StringUtils {
         if (len == 0) {
             return chars;
         }
-        char[] copy = new char[len];
-        System.arraycopy(chars, 0, copy, 0, len);
-        return copy;
+        return Arrays.copyOf(chars, len);
     }
 
     /**

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -225,9 +225,7 @@ public class Utils {
         if (len == 0) {
             return EMPTY_BYTES;
         }
-        byte[] copy = new byte[len];
-        System.arraycopy(b, 0, copy, 0, len);
-        return copy;
+        return Arrays.copyOf(b, len);
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueBytes.java
+++ b/h2/src/main/org/h2/value/ValueBytes.java
@@ -149,8 +149,7 @@ public class ValueBytes extends Value {
             return this;
         }
         int len = MathUtils.convertLongToInt(precision);
-        byte[] buff = new byte[len];
-        System.arraycopy(value, 0, buff, 0, len);
+        byte[] buff = Arrays.copyOf(value, len);
         return get(buff);
     }
 

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -416,8 +416,7 @@ public class ValueLob extends Value {
                 len = IOUtils.readFully(in, buff, len);
             }
             if (len <= handler.getMaxLengthInplaceLob()) {
-                byte[] small = DataUtils.newBytes(len);
-                System.arraycopy(buff, 0, small, 0, len);
+                byte[] small = DataUtils.copyBytes(buff, len);
                 return ValueLob.createSmallLob(Value.BLOB, small);
             }
             ValueLob lob = new ValueLob(Value.BLOB, null);

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -600,8 +600,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
                 len = IOUtils.readFully(in, buff, len);
             }
             if (len <= handler.getMaxLengthInplaceLob()) {
-                byte[] small = DataUtils.newBytes(len);
-                System.arraycopy(buff, 0, small, 0, len);
+                byte[] small = DataUtils.copyBytes(buff, len);
                 return ValueLobDb.createSmallLob(Value.BLOB, small, small.length);
             }
             ValueLobDb lob = new ValueLobDb(handler, buff, len, in, remaining);

--- a/h2/src/test/org/h2/test/coverage/Tokenizer.java
+++ b/h2/src/test/org/h2/test/coverage/Tokenizer.java
@@ -8,6 +8,7 @@ package org.h2.test.coverage;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Arrays;
 
 /**
  * Helper class for the java file parser.
@@ -154,9 +155,7 @@ public class Tokenizer {
             int i = 0;
             do {
                 if (i >= chars.length) {
-                    char[] nb = new char[chars.length * 2];
-                    System.arraycopy(chars, 0, nb, 0, chars.length);
-                    chars = nb;
+                    chars = Arrays.copyOf(chars, chars.length * 2);
                 }
                 chars[i++] = (char) c;
                 c = read();
@@ -221,9 +220,7 @@ public class Tokenizer {
                 }
 
                 if (i >= chars.length) {
-                    char[] nb = new char[chars.length * 2];
-                    System.arraycopy(chars, 0, nb, 0, chars.length);
-                    chars = nb;
+                    chars = Arrays.copyOf(chars, chars.length * 2);
                 }
                 chars[i++] = (char) c;
             }

--- a/h2/src/test/org/h2/test/db/TaskDef.java
+++ b/h2/src/test/org/h2/test/db/TaskDef.java
@@ -8,6 +8,8 @@ package org.h2.test.db;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Arrays;
+
 import org.h2.test.utils.SelfDestructor;
 
 /**
@@ -34,9 +36,7 @@ public abstract class TaskDef {
             return;
         }
         try {
-            String[] taskArgs = new String[args.length - 1];
-            System.arraycopy(args, 0, taskArgs, 0, args.length - 1);
-            task.run(taskArgs);
+            task.run(Arrays.copyOf(args, args.length - 1));
         } catch (Throwable t) {
             System.out.println("error: " + t);
             t.printStackTrace();

--- a/h2/src/test/org/h2/test/unit/TestCompress.java
+++ b/h2/src/test/org/h2/test/unit/TestCompress.java
@@ -187,8 +187,7 @@ public class TestCompress extends TestBase {
                     break;
                 }
                 int b = compress.compress(buff2, pageSize, test, 0);
-                byte[] data = new byte[b];
-                System.arraycopy(test, 0, data, 0, b);
+                byte[] data = Arrays.copyOf(test, b);
                 comp.add(data);
             }
             in.close();

--- a/h2/src/tools/org/h2/build/doc/XMLParser.java
+++ b/h2/src/tools/org/h2/build/doc/XMLParser.java
@@ -5,6 +5,8 @@
  */
 package org.h2.build.doc;
 
+import java.util.Arrays;
+
 /**
  * This class implements a simple XML pull parser.
  * Only a subset of the XML pull parser API is implemented.
@@ -94,9 +96,7 @@ public class XMLParser {
 
     private void addAttributeName(String pre, String name) {
         if (attributeValues.length <= currentAttribute) {
-            String[] temp = new String[attributeValues.length * 2];
-            System.arraycopy(attributeValues, 0, temp, 0, attributeValues.length);
-            attributeValues = temp;
+            attributeValues = Arrays.copyOf(attributeValues, attributeValues.length * 2);
         }
         attributeValues[currentAttribute++] = pre;
         attributeValues[currentAttribute++] = name;

--- a/h2/src/tools/org/h2/dev/fs/ArchiveTool.java
+++ b/h2/src/tools/org/h2/dev/fs/ArchiveTool.java
@@ -426,8 +426,7 @@ public class ArchiveTool {
             for (int pos = 0; pos < len;) {
                 int[] key = getKey(bytes, pos, len);
                 int l = key[3];
-                byte[] buff = new byte[l];
-                System.arraycopy(bytes, pos, buff, 0, l);
+                byte[] buff = Arrays.copyOfRange(bytes, pos, pos + l);
                 pos += l;
                 Chunk c = new Chunk(null, key, buff);
                 Chunk old = map.get(c);

--- a/h2/src/tools/org/h2/dev/fs/ArchiveToolStore.java
+++ b/h2/src/tools/org/h2/dev/fs/ArchiveToolStore.java
@@ -117,11 +117,11 @@ public class ArchiveToolStore {
                     if (buff.remaining() == 0) {
                         break;
                     }
-                    int c = getChunkLength(buff.array(), buff.position(),
-                            buff.limit()) - buff.position();
-                    byte[] bytes = new byte[c];
-                    System.arraycopy(buff.array(), buff.position(), bytes, 0, c);
-                    buff.position(buff.position() + c);
+                    int position = buff.position();
+                    int c = getChunkLength(buff.array(), position,
+                            buff.limit()) - position;
+                    byte[] bytes = Arrays.copyOfRange(buff.array(), position, position + c);
+                    buff.position(position + c);
                     int[] key = getKey(bucket, bytes);
                     key[3] = segmentId;
                     while (true) {

--- a/h2/src/tools/org/h2/dev/util/ImmutableArray.java
+++ b/h2/src/tools/org/h2/dev/util/ImmutableArray.java
@@ -5,6 +5,7 @@
  */
 package org.h2.dev.util;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import org.h2.mvstore.DataUtils;
 
@@ -97,11 +98,7 @@ public final class ImmutableArray<K> implements Iterable<K> {
      * @return the new immutable array
      */
     public ImmutableArray<K> subArray(int fromIndex, int toIndex) {
-        int len = toIndex - fromIndex;
-        @SuppressWarnings("unchecked")
-        K[] array = (K[]) new Object[len];
-        System.arraycopy(this.array, fromIndex, array, 0, toIndex - fromIndex);
-        return new ImmutableArray<>(array);
+        return new ImmutableArray<>(Arrays.copyOfRange(array, fromIndex, toIndex));
     }
 
     /**

--- a/h2/src/tools/org/h2/dev/util/ImmutableArray2.java
+++ b/h2/src/tools/org/h2/dev/util/ImmutableArray2.java
@@ -138,10 +138,7 @@ public final class ImmutableArray2<K> implements Iterable<K> {
         if (fromIndex == 0) {
             return new ImmutableArray2<>(array, len);
         }
-        @SuppressWarnings("unchecked")
-        K[] a2 = (K[]) new Object[len];
-        System.arraycopy(array, fromIndex, a2, 0, toIndex - fromIndex);
-        return new ImmutableArray2<>(a2, len);
+        return new ImmutableArray2<>(Arrays.copyOfRange(array, fromIndex, toIndex), len);
     }
 
     /**


### PR DESCRIPTION
`Arrays.copyOf()` and `Arrays.copyOfRange()` are used in many places instead of manual allocations of arrays followed by `System.arraycopy()`.

This reduces amout of code and improves readability of the sources.

A new method `DataUtils.copyBytes()` is introduced to use in the places where `DataUtils.newBytes()` was used with following `System.arraycopy()`.

Unclosed tag in `DataUtils.newBytes()` is fixed.

Performance of these methods also may be better:
https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_uninitialized_arrays

I touched only `DataUtils` class in `mvstore` package because Andrei Tokar have massive changes in this area in own repository. There are places where `System.arraycopy()` can also be avoided, but they are going to be replaced at some point in future.