### PR TITLE
Use HmacSHA256 provided by JRE

### DIFF
--- a/h2/src/main/org/h2/security/SHA256.java
+++ b/h2/src/main/org/h2/security/SHA256.java
@@ -78,13 +78,7 @@ public class SHA256 {
      * @return the hash
      */
     public static byte[] getHMAC(byte[] key, byte[] message) {
-        Mac mac = initMac(key);
-        return calculateHMAC(mac, message, message.length);
-    }
-
-    private static byte[] calculateHMAC(Mac mac, byte[] message, int len) {
-        mac.update(message, 0, len);
-        return mac.doFinal();
+        return initMac(key).doFinal(message);
     }
 
     private static Mac initMac(byte[] key) {
@@ -127,7 +121,8 @@ public class SHA256 {
                     System.arraycopy(macRes, 0, message, 0, 32);
                     len = 32;
                 }
-                macRes = calculateHMAC(mac, message, len);
+                mac.update(message, 0, len);
+                macRes = mac.doFinal();
                 for (int j = 0; j < 32 && j + offset < resultLen; j++) {
                     result[j + offset] ^= macRes[j];
                 }

--- a/h2/src/main/org/h2/security/SHA256.java
+++ b/h2/src/main/org/h2/security/SHA256.java
@@ -78,7 +78,6 @@ public class SHA256 {
      * @return the hash
      */
     public static byte[] getHMAC(byte[] key, byte[] message) {
-        key = normalizeKeyForHMAC(key);
         Mac mac = initMac(key);
         return calculateHMAC(mac, message, message.length);
     }
@@ -88,17 +87,11 @@ public class SHA256 {
         return mac.doFinal();
     }
 
-    private static byte[] normalizeKeyForHMAC(byte[] key) {
-        if (key.length > 64) {
-            key = getHash(key, false);
-        }
-        if (key.length < 64) {
-            key = Arrays.copyOf(key, 64);
-        }
-        return key;
-    }
-
     private static Mac initMac(byte[] key) {
+        // Java forbids empty keys
+        if (key.length == 0) {
+            key = new byte[1];
+        }
         try {
             Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(key, "HmacSHA256"));
@@ -120,8 +113,7 @@ public class SHA256 {
     public static byte[] getPBKDF2(byte[] password, byte[] salt,
             int iterations, int resultLen) {
         byte[] result = new byte[resultLen];
-        byte[] key = normalizeKeyForHMAC(password);
-        Mac mac = initMac(key);
+        Mac mac = initMac(password);
         int len = 64 + Math.max(32, salt.length + 4);
         byte[] message = new byte[len];
         byte[] macRes = null;
@@ -142,7 +134,6 @@ public class SHA256 {
             }
         }
         Arrays.fill(password, (byte) 0);
-        Arrays.fill(key, (byte) 0);
         return result;
     }
 

--- a/h2/src/main/org/h2/security/SHA256.java
+++ b/h2/src/main/org/h2/security/SHA256.java
@@ -169,13 +169,16 @@ public class SHA256 {
      * @return the hash code
      */
     public static byte[] getHash(byte[] data, boolean nullData) {
-        int len = data.length;
-        SHA256 sha = new SHA256();
-        sha.calculateHash(data, len);
+        byte[] result;
+        try {
+            result = MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
         if (nullData) {
             Arrays.fill(data, (byte) 0);
         }
-        return sha.result;
+        return result;
     }
 
     private void calculateHash(byte[] data, int len) {


### PR DESCRIPTION
We don't use `HmacSHA256` directly in H2 codebase, but we use it as a part of `PBKDF2WithHmacSHA256` computation. This pull request replaces own implementation of `HmacSHA256` with provided by JRE and Android to reduce code size.

1. Because after all these changes `SHA-256` digest is not used more that one time in any of `SHA256` methods caching of `MessageDigest` in temporary instance of `SHA256` is removed.

2. Built-in implementation of `HmacSHA256` is used instead of own one. Instance of `Mac` object is reused in a loop in `SHA256.getPBKDF2()`.

3. There is no need in normalization of key to 64 bytes for built-in implementation, so this code is also removed with one exception for empty key. Such key is not supported by Java so it replaced with an one-element array.  We have test for such key for some reason. May be we don't acutally need it. (Block size of `HmacSHA256` is really a 64 bytes, not 32. This size is not directly related to size of hash function's results.)