### PR TITLE
Use type constants from LocalDateTimeUtils directly

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3815,15 +3815,15 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             return type.cast(value.getObject());
         } else if (DataType.isGeometryClass(type)) {
             return type.cast(value.getObject());
-        } else if (LocalDateTimeUtils.isLocalDate(type)) {
+        } else if (type == LocalDateTimeUtils.LOCAL_DATE) {
             return type.cast(LocalDateTimeUtils.valueToLocalDate(value));
-        } else if (LocalDateTimeUtils.isLocalTime(type)) {
+        } else if (type == LocalDateTimeUtils.LOCAL_TIME) {
             return type.cast(LocalDateTimeUtils.valueToLocalTime(value));
-        } else if (LocalDateTimeUtils.isLocalDateTime(type)) {
+        } else if (type == LocalDateTimeUtils.LOCAL_DATE_TIME) {
             return type.cast(LocalDateTimeUtils.valueToLocalDateTime(value));
-        } else if (LocalDateTimeUtils.isInstant(type)) {
+        } else if (type == LocalDateTimeUtils.INSTANT) {
             return type.cast(LocalDateTimeUtils.valueToInstant(value));
-        } else if (LocalDateTimeUtils.isOffsetDateTime(type)) {
+        } else if (type == LocalDateTimeUtils.OFFSET_DATE_TIME) {
             return type.cast(LocalDateTimeUtils.valueToOffsetDateTime(value));
         } else {
             throw unsupported(type.getName());

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -40,16 +40,27 @@ import org.h2.value.ValueTimestampTimeZone;
  */
 public class LocalDateTimeUtils {
 
-    // Class<java.time.LocalDate>
-    private static final Class<?> LOCAL_DATE;
-    // Class<java.time.LocalTime>
-    private static final Class<?> LOCAL_TIME;
-    // Class<java.time.LocalDateTime>
-    private static final Class<?> LOCAL_DATE_TIME;
-    // Class<java.time.Instant>
-    private static final Class<?> INSTANT;
-    // Class<java.time.OffsetDateTime>
-    private static final Class<?> OFFSET_DATE_TIME;
+    /**
+     * {@code Class<java.time.LocalDate>} or {@code null}.
+     */
+    public static final Class<?> LOCAL_DATE;
+    /**
+     * {@code Class<java.time.LocalTime>} or {@code null}.
+     */
+    public static final Class<?> LOCAL_TIME;
+    /**
+     * {@code Class<java.time.LocalDateTime>} or {@code null}.
+     */
+    public static final Class<?> LOCAL_DATE_TIME;
+    /**
+     * {@code Class<java.time.Instant>} or {@code null}.
+     */
+    public static final Class<?> INSTANT;
+    /**
+     * {@code Class<java.time.OffsetDateTime>} or {@code null}.
+     */
+    public static final Class<?> OFFSET_DATE_TIME;
+
     // Class<java.time.ZoneOffset>
     private static final Class<?> ZONE_OFFSET;
 
@@ -192,52 +203,6 @@ public class LocalDateTimeUtils {
     }
 
     /**
-     * Returns the class java.time.LocalDate.
-     *
-     * @return the class java.time.LocalDate, null on Java 7
-     */
-    public static Class<?> getLocalDateClass() {
-        return LOCAL_DATE;
-    }
-
-
-    /**
-     * Returns the class java.time.LocalTime.
-     *
-     * @return the class java.time.LocalTime, null on Java 7
-     */
-    public static Class<?> getLocalTimeClass() {
-        return LOCAL_TIME;
-    }
-
-    /**
-     * Returns the class java.time.LocalDateTime.
-     *
-     * @return the class java.time.LocalDateTime, null on Java 7
-     */
-    public static Class<?> getLocalDateTimeClass() {
-        return LOCAL_DATE_TIME;
-    }
-
-    /**
-     * Returns the class java.time.Instant.
-     *
-     * @return the class java.time.Instant, null on Java 7
-     */
-    public static Class<?> getInstantClass() {
-        return INSTANT;
-    }
-
-    /**
-     * Returns the class java.time.OffsetDateTime.
-     *
-     * @return the class java.time.OffsetDateTime, null on Java 7
-     */
-    public static Class<?> getOffsetDateTimeClass() {
-        return OFFSET_DATE_TIME;
-    }
-
-    /**
      * Parses an ISO date string into a java.time.LocalDate.
      *
      * @param text the ISO date string
@@ -310,66 +275,6 @@ public class LocalDateTimeUtils {
                     clazz.getName() + "#" + methodName + "(" +
                     Arrays.toString(parameterTypes) + ") is missing", e);
         }
-    }
-
-    /**
-     * Checks if the given class is LocalDate.
-     *
-     * <p>This method can be called from Java 7.</p>
-     *
-     * @param clazz the class to check
-     * @return if the class is LocalDate
-     */
-    public static boolean isLocalDate(Class<?> clazz) {
-        return LOCAL_DATE == clazz;
-    }
-
-    /**
-     * Checks if the given class is LocalTime.
-     *
-     * <p>This method can be called from Java 7.</p>
-     *
-     * @param clazz the class to check
-     * @return if the class is LocalTime
-     */
-    public static boolean isLocalTime(Class<?> clazz) {
-        return LOCAL_TIME == clazz;
-    }
-
-    /**
-     * Checks if the given class is LocalDateTime.
-     *
-     * <p>This method can be called from Java 7.</p>
-     *
-     * @param clazz the class to check
-     * @return if the class is LocalDateTime
-     */
-    public static boolean isLocalDateTime(Class<?> clazz) {
-        return LOCAL_DATE_TIME == clazz;
-    }
-
-    /**
-     * Checks if the given class is Instant.
-     *
-     * <p>This method can be called from Java 7.</p>
-     *
-     * @param clazz the class to check
-     * @return if the class is Instant
-     */
-    public static boolean isInstant(Class<?> clazz) {
-        return INSTANT == clazz;
-    }
-
-    /**
-     * Checks if the given class is OffsetDateTime.
-     *
-     * <p>This method can be called from Java 7.</p>
-     *
-     * @param clazz the class to check
-     * @return if the class is OffsetDateTime
-     */
-    public static boolean isOffsetDateTime(Class<?> clazz) {
-        return OFFSET_DATE_TIME == clazz;
     }
 
     /**

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.UUID;
@@ -1020,7 +1021,7 @@ public class DataType {
             return Value.DATE;
         } else if (LocalDateTimeUtils.LOCAL_TIME == x) {
             return Value.TIME;
-        } else if (LocalDateTimeUtils.LOCAL_DATE_TIME == x) {
+        } else if (LocalDateTimeUtils.LOCAL_DATE_TIME == x || LocalDateTimeUtils.INSTANT == x) {
             return Value.TIMESTAMP;
         } else if (LocalDateTimeUtils.OFFSET_DATE_TIME == x) {
             return Value.TIMESTAMP_TZ;

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -1016,13 +1016,13 @@ public class DataType {
             return Value.ARRAY;
         } else if (isGeometryClass(x)) {
             return Value.GEOMETRY;
-        } else if (LocalDateTimeUtils.isLocalDate(x)) {
+        } else if (LocalDateTimeUtils.LOCAL_DATE == x) {
             return Value.DATE;
-        } else if (LocalDateTimeUtils.isLocalTime(x)) {
+        } else if (LocalDateTimeUtils.LOCAL_TIME == x) {
             return Value.TIME;
-        } else if (LocalDateTimeUtils.isLocalDateTime(x)) {
+        } else if (LocalDateTimeUtils.LOCAL_DATE_TIME == x) {
             return Value.TIMESTAMP;
-        } else if (LocalDateTimeUtils.isOffsetDateTime(x)) {
+        } else if (LocalDateTimeUtils.OFFSET_DATE_TIME == x) {
             return Value.TIMESTAMP_TZ;
         } else {
             if (JdbcUtils.customDataTypesHandler != null) {
@@ -1141,15 +1141,15 @@ public class DataType {
             return ValueStringFixed.get(((Character) x).toString());
         } else if (isGeometry(x)) {
             return ValueGeometry.getFromGeometry(x);
-        } else if (LocalDateTimeUtils.isLocalDate(x.getClass())) {
+        } else if (x.getClass() == LocalDateTimeUtils.LOCAL_DATE) {
             return LocalDateTimeUtils.localDateToDateValue(x);
-        } else if (LocalDateTimeUtils.isLocalTime(x.getClass())) {
+        } else if (x.getClass() == LocalDateTimeUtils.LOCAL_TIME) {
             return LocalDateTimeUtils.localTimeToTimeValue(x);
-        } else if (LocalDateTimeUtils.isLocalDateTime(x.getClass())) {
+        } else if (x.getClass() == LocalDateTimeUtils.LOCAL_DATE_TIME) {
             return LocalDateTimeUtils.localDateTimeToValue(x);
-        } else if (LocalDateTimeUtils.isInstant(x.getClass())) {
+        } else if (x.getClass() == LocalDateTimeUtils.INSTANT) {
             return LocalDateTimeUtils.instantToValue(x);
-        } else if (LocalDateTimeUtils.isOffsetDateTime(x.getClass())) {
+        } else if (x.getClass() == LocalDateTimeUtils.OFFSET_DATE_TIME) {
             return LocalDateTimeUtils.offsetDateTimeToValue(x);
         } else if (x instanceof TimestampWithTimeZone) {
             return ValueTimestampTimeZone.get((TimestampWithTimeZone) x);

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.UUID;

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -1127,7 +1127,9 @@ public class DataType {
             return ValueResultSet.getCopy((ResultSet) x, Integer.MAX_VALUE);
         } else if (x instanceof UUID) {
             return ValueUuid.get((UUID) x);
-        } else if (x instanceof Object[]) {
+        }
+        Class<?> clazz = x.getClass();
+        if (x instanceof Object[]) {
             // (a.getClass().isArray());
             // (a.getClass().getComponentType().isPrimitive());
             Object[] o = (Object[]) x;
@@ -1136,20 +1138,20 @@ public class DataType {
             for (int i = 0; i < len; i++) {
                 v[i] = convertToValue(session, o[i], type);
             }
-            return ValueArray.get(x.getClass().getComponentType(), v);
+            return ValueArray.get(clazz.getComponentType(), v);
         } else if (x instanceof Character) {
             return ValueStringFixed.get(((Character) x).toString());
         } else if (isGeometry(x)) {
             return ValueGeometry.getFromGeometry(x);
-        } else if (x.getClass() == LocalDateTimeUtils.LOCAL_DATE) {
+        } else if (clazz == LocalDateTimeUtils.LOCAL_DATE) {
             return LocalDateTimeUtils.localDateToDateValue(x);
-        } else if (x.getClass() == LocalDateTimeUtils.LOCAL_TIME) {
+        } else if (clazz == LocalDateTimeUtils.LOCAL_TIME) {
             return LocalDateTimeUtils.localTimeToTimeValue(x);
-        } else if (x.getClass() == LocalDateTimeUtils.LOCAL_DATE_TIME) {
+        } else if (clazz == LocalDateTimeUtils.LOCAL_DATE_TIME) {
             return LocalDateTimeUtils.localDateTimeToValue(x);
-        } else if (x.getClass() == LocalDateTimeUtils.INSTANT) {
+        } else if (clazz == LocalDateTimeUtils.INSTANT) {
             return LocalDateTimeUtils.instantToValue(x);
-        } else if (x.getClass() == LocalDateTimeUtils.OFFSET_DATE_TIME) {
+        } else if (clazz == LocalDateTimeUtils.OFFSET_DATE_TIME) {
             return LocalDateTimeUtils.offsetDateTimeToValue(x);
         } else if (x instanceof TimestampWithTimeZone) {
             return ValueTimestampTimeZone.get((TimestampWithTimeZone) x);

--- a/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
@@ -177,7 +177,7 @@ public class TestCallableStatement extends TestBase {
         assertEquals("2000-01-01", call.getDate(1).toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2000-01-01", call.getObject(1,
-                            LocalDateTimeUtils.getLocalDateClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE).toString());
         }
 
         call.setTime(2, java.sql.Time.valueOf("01:02:03"));
@@ -186,7 +186,7 @@ public class TestCallableStatement extends TestBase {
         assertEquals("01:02:03", call.getTime(1).toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("01:02:03", call.getObject(1,
-                            LocalDateTimeUtils.getLocalTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_TIME).toString());
         }
 
         call.setTimestamp(2, java.sql.Timestamp.valueOf(
@@ -196,7 +196,7 @@ public class TestCallableStatement extends TestBase {
         assertEquals("2001-02-03 04:05:06.789", call.getTimestamp(1).toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2001-02-03T04:05:06.789", call.getObject(1,
-                            LocalDateTimeUtils.getLocalDateTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE_TIME).toString());
         }
 
         call.setBoolean(2, true);
@@ -283,25 +283,25 @@ public class TestCallableStatement extends TestBase {
         assertEquals("2001-02-03 10:20:30.0", call.getTimestamp("D").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2001-02-03T10:20:30", call.getObject(4,
-                            LocalDateTimeUtils.getLocalDateTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE_TIME).toString());
             assertEquals("2001-02-03T10:20:30", call.getObject("D",
-                            LocalDateTimeUtils.getLocalDateTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE_TIME).toString());
         }
         assertEquals("10:20:30", call.getTime(4).toString());
         assertEquals("10:20:30", call.getTime("D").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("10:20:30", call.getObject(4,
-                            LocalDateTimeUtils.getLocalTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_TIME).toString());
             assertEquals("10:20:30", call.getObject("D",
-                            LocalDateTimeUtils.getLocalTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_TIME).toString());
         }
         assertEquals("2001-02-03", call.getDate(4).toString());
         assertEquals("2001-02-03", call.getDate("D").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2001-02-03", call.getObject(4,
-                            LocalDateTimeUtils.getLocalDateClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE).toString());
             assertEquals("2001-02-03", call.getObject("D",
-                            LocalDateTimeUtils.getLocalDateClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE).toString());
         }
 
         assertEquals(100, call.getInt(1));

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -634,14 +634,14 @@ public class TestPreparedStatement extends TestBase {
         prep.setObject(1, localDate);
         ResultSet rs = prep.executeQuery();
         rs.next();
-        Object localDate2 = rs.getObject(1, LocalDateTimeUtils.getLocalDateClass());
+        Object localDate2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE);
         assertEquals(localDate, localDate2);
         rs.close();
         localDate = LocalDateTimeUtils.parseLocalDate("-0509-01-01");
         prep.setObject(1, localDate);
         rs = prep.executeQuery();
         rs.next();
-        localDate2 = rs.getObject(1, LocalDateTimeUtils.getLocalDateClass());
+        localDate2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE);
         assertEquals(localDate, localDate2);
         rs.close();
     }
@@ -655,14 +655,14 @@ public class TestPreparedStatement extends TestBase {
         prep.setObject(1, localTime);
         ResultSet rs = prep.executeQuery();
         rs.next();
-        Object localTime2 = rs.getObject(1, LocalDateTimeUtils.getLocalTimeClass());
+        Object localTime2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_TIME);
         assertEquals(localTime, localTime2);
         rs.close();
         localTime = LocalDateTimeUtils.parseLocalTime("04:05:06.123456789");
         prep.setObject(1, localTime);
         rs = prep.executeQuery();
         rs.next();
-        localTime2 = rs.getObject(1, LocalDateTimeUtils.getLocalTimeClass());
+        localTime2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_TIME);
         assertEquals(localTime, localTime2);
         rs.close();
     }
@@ -676,7 +676,7 @@ public class TestPreparedStatement extends TestBase {
         prep.setObject(1, localDateTime);
         ResultSet rs = prep.executeQuery();
         rs.next();
-        Object localDateTime2 = rs.getObject(1, LocalDateTimeUtils.getLocalDateTimeClass());
+        Object localDateTime2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE_TIME);
         assertEquals(localDateTime, localDateTime2);
         rs.close();
     }
@@ -691,7 +691,7 @@ public class TestPreparedStatement extends TestBase {
         prep.setObject(1, offsetDateTime);
         ResultSet rs = prep.executeQuery();
         rs.next();
-        Object offsetDateTime2 = rs.getObject(1, LocalDateTimeUtils.getOffsetDateTimeClass());
+        Object offsetDateTime2 = rs.getObject(1, LocalDateTimeUtils.OFFSET_DATE_TIME);
         assertEquals(offsetDateTime, offsetDateTime2);
         assertFalse(rs.next());
         rs.close();
@@ -699,7 +699,7 @@ public class TestPreparedStatement extends TestBase {
         prep.setObject(1, offsetDateTime, 2014); // Types.TIMESTAMP_WITH_TIMEZONE
         rs = prep.executeQuery();
         rs.next();
-        offsetDateTime2 = rs.getObject(1, LocalDateTimeUtils.getOffsetDateTimeClass());
+        offsetDateTime2 = rs.getObject(1, LocalDateTimeUtils.OFFSET_DATE_TIME);
         assertEquals(offsetDateTime, offsetDateTime2);
         assertFalse(rs.next());
         rs.close();
@@ -710,14 +710,14 @@ public class TestPreparedStatement extends TestBase {
             return;
         }
         Method timestampToInstant = Timestamp.class.getMethod("toInstant"),
-                now = LocalDateTimeUtils.getInstantClass().getMethod("now");
+                now = LocalDateTimeUtils.INSTANT.getMethod("now");
 
         PreparedStatement prep = conn.prepareStatement("SELECT ?");
         Object instant1 = now.invoke(null);
         prep.setObject(1, instant1);
         ResultSet rs = prep.executeQuery();
         rs.next();
-        Object instant2 = rs.getObject(1, LocalDateTimeUtils.getInstantClass());
+        Object instant2 = rs.getObject(1, LocalDateTimeUtils.INSTANT);
         assertEquals(instant1, instant2);
         Timestamp ts = rs.getTimestamp(1);
         assertEquals(instant1, timestampToInstant.invoke(ts));
@@ -727,7 +727,7 @@ public class TestPreparedStatement extends TestBase {
         prep.setTimestamp(1, ts);
         rs = prep.executeQuery();
         rs.next();
-        instant2 = rs.getObject(1, LocalDateTimeUtils.getInstantClass());
+        instant2 = rs.getObject(1, LocalDateTimeUtils.INSTANT);
         assertEquals(instant1, instant2);
         assertFalse(rs.next());
         rs.close();

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1350,34 +1350,34 @@ public class TestResultSet extends TestBase {
         assertEquals("1800-01-01", rs.getDate("value").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("1800-01-01", rs.getObject("value",
-                            LocalDateTimeUtils.getLocalDateClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE).toString());
         }
         assertEquals("00:00:00", rs.getTime("value").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("00:00", rs.getObject("value",
-                            LocalDateTimeUtils.getLocalTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_TIME).toString());
         }
         assertEquals("1800-01-01 00:00:00.0", rs.getTimestamp("value").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("1800-01-01T00:00", rs.getObject("value",
-                            LocalDateTimeUtils.getLocalDateTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE_TIME).toString());
         }
         rs.next();
 
         assertEquals("9999-12-31", rs.getDate("Value").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("9999-12-31", rs.getObject("Value",
-                            LocalDateTimeUtils.getLocalDateClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE).toString());
         }
         assertEquals("23:59:59", rs.getTime("Value").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("23:59:59", rs.getObject("Value",
-                            LocalDateTimeUtils.getLocalTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_TIME).toString());
         }
         assertEquals("9999-12-31 23:59:59.0", rs.getTimestamp("Value").toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("9999-12-31T23:59:59", rs.getObject("Value",
-                            LocalDateTimeUtils.getLocalDateTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE_TIME).toString());
         }
         rs.next();
 
@@ -1386,7 +1386,7 @@ public class TestResultSet extends TestBase {
         assertTrue(rs.getTimestamp(2) == null && rs.wasNull());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertTrue(rs.getObject(2,
-                            LocalDateTimeUtils.getLocalDateTimeClass()) == null && rs.wasNull());
+                            LocalDateTimeUtils.LOCAL_DATE_TIME) == null && rs.wasNull());
         }
         assertTrue(!rs.next());
 
@@ -1409,15 +1409,15 @@ public class TestResultSet extends TestBase {
         assertEquals("2007-08-09 10:11:12.141516171", ts.toString());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2001-02-03", rs.getObject(1,
-                            LocalDateTimeUtils.getLocalDateClass()).toString());
+                            LocalDateTimeUtils.LOCAL_DATE).toString());
         }
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("14:15:16", rs.getObject(2,
-                            LocalDateTimeUtils.getLocalTimeClass()).toString());
+                            LocalDateTimeUtils.LOCAL_TIME).toString());
         }
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2007-08-09T10:11:12.141516171",
-                    rs.getObject(3, LocalDateTimeUtils.getLocalDateTimeClass())
+                    rs.getObject(3, LocalDateTimeUtils.LOCAL_DATE_TIME)
                             .toString());
         }
 

--- a/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
+++ b/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
@@ -65,7 +65,7 @@ public class TestTimeStampWithTimeZone extends TestBase {
         assertEquals(new TimestampWithTimeZone(1008673L, 43200000000000L, (short) 15), ts);
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("1970-01-01T12:00+00:15", rs.getObject(1,
-                            LocalDateTimeUtils.getOffsetDateTimeClass()).toString());
+                            LocalDateTimeUtils.OFFSET_DATE_TIME).toString());
         }
         rs.next();
         ts = (TimestampWithTimeZone) rs.getObject(1);
@@ -76,7 +76,7 @@ public class TestTimeStampWithTimeZone extends TestBase {
         assertEquals(1L, ts.getNanosSinceMidnight());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2016-09-24T00:00:00.000000001+00:01", rs.getObject(1,
-                            LocalDateTimeUtils.getOffsetDateTimeClass()).toString());
+                            LocalDateTimeUtils.OFFSET_DATE_TIME).toString());
         }
         rs.next();
         ts = (TimestampWithTimeZone) rs.getObject(1);
@@ -87,7 +87,7 @@ public class TestTimeStampWithTimeZone extends TestBase {
         assertEquals(1L, ts.getNanosSinceMidnight());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2016-09-24T00:00:00.000000001-00:01", rs.getObject(1,
-                            LocalDateTimeUtils.getOffsetDateTimeClass()).toString());
+                            LocalDateTimeUtils.OFFSET_DATE_TIME).toString());
         }
         rs.next();
         ts = (TimestampWithTimeZone) rs.getObject(1);
@@ -96,7 +96,7 @@ public class TestTimeStampWithTimeZone extends TestBase {
         assertEquals(1, ts.getDay());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2016-01-01T05:00+10:00", rs.getObject(1,
-                            LocalDateTimeUtils.getOffsetDateTimeClass()).toString());
+                            LocalDateTimeUtils.OFFSET_DATE_TIME).toString());
         }
         rs.next();
         ts = (TimestampWithTimeZone) rs.getObject(1);
@@ -105,7 +105,7 @@ public class TestTimeStampWithTimeZone extends TestBase {
         assertEquals(31, ts.getDay());
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             assertEquals("2015-12-31T19:00-10:00", rs.getObject(1,
-                            LocalDateTimeUtils.getOffsetDateTimeClass()).toString());
+                            LocalDateTimeUtils.OFFSET_DATE_TIME).toString());
         }
 
         ResultSetMetaData metaData = rs.getMetaData();


### PR DESCRIPTION
1. `LocalDateTimeUtils` had a two one-line helper methods for each type. It looks like these methods inherited logic from `DataType.isGeometryClass()` and `DataType.isGeometry()`. But situation in `LocalDateTimeUtils` is different. All five classes are final, so checks are trivial. Such type checks are more intuitive without a helper method because checks like `type == LocalDateTimeUtils.OFFSET_DATE_TIME` looks more similar to `type == OffsetDateTime.class`. But the main reason is that we don't really need to waste space with such methods.

2. After this `x.getClass()` is extracted to local variable in `convertToValue1()`.

3. Missing mapping for `Instant` is added to `getTypeFromClass()` just for completeness.

