### PR TITLE
Issues with Boolean.parseBoolean()

### DIFF
--- a/h2/src/main/org/h2/engine/SettingsBase.java
+++ b/h2/src/main/org/h2/engine/SettingsBase.java
@@ -30,10 +30,10 @@ public class SettingsBase {
      * @return the setting
      */
     protected boolean get(String key, boolean defaultValue) {
-        String s = get(key, "" + defaultValue);
+        String s = get(key, null);
         try {
-            return Boolean.parseBoolean(s);
-        } catch (NumberFormatException e) {
+            return Utils.parseBoolean(s, defaultValue, true);
+        } catch (IllegalArgumentException e) {
             throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1,
                     e, "key:" + key + " value:" + s);
         }

--- a/h2/src/main/org/h2/engine/SettingsBase.java
+++ b/h2/src/main/org/h2/engine/SettingsBase.java
@@ -30,7 +30,7 @@ public class SettingsBase {
      * @return the setting
      */
     protected boolean get(String key, boolean defaultValue) {
-        String s = get(key, null);
+        String s = get(key, Boolean.toString(defaultValue));
         try {
             return Utils.parseBoolean(s, defaultValue, true);
         } catch (IllegalArgumentException e) {

--- a/h2/src/main/org/h2/tools/SimpleResultSet.java
+++ b/h2/src/main/org/h2/tools/SimpleResultSet.java
@@ -8,6 +8,7 @@ package org.h2.tools;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
@@ -478,10 +479,26 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
     @Override
     public boolean getBoolean(int columnIndex) throws SQLException {
         Object o = get(columnIndex);
-        if (o != null && !(o instanceof Boolean)) {
-            o = Boolean.valueOf(o.toString());
+        if (o == null) {
+            return false;
         }
-        return o == null ? false : ((Boolean) o).booleanValue();
+        if (o instanceof Boolean) {
+            return (Boolean) o;
+        }
+        if (o instanceof Number) {
+            Number n = (Number) o;
+            if (n instanceof Double || n instanceof Float) {
+                return n.doubleValue() != 0;
+            }
+            if (n instanceof BigDecimal) {
+                return ((BigDecimal) n).signum() != 0;
+            }
+            if (n instanceof BigInteger) {
+                return ((BigInteger) n).signum() != 0;
+            }
+            return n.longValue() != 0;
+        }
+        return Boolean.parseBoolean(o.toString());
     }
 
     /**

--- a/h2/src/main/org/h2/util/SortedProperties.java
+++ b/h2/src/main/org/h2/util/SortedProperties.java
@@ -52,10 +52,9 @@ public class SortedProperties extends Properties {
      */
     public static boolean getBooleanProperty(Properties prop, String key,
             boolean def) {
-        String value = prop.getProperty(key, "" + def);
         try {
-            return Boolean.parseBoolean(value);
-        } catch (Exception e) {
+            return Utils.parseBoolean(prop.getProperty(key, null), def, true);
+        } catch (IllegalArgumentException e) {
             e.printStackTrace();
             return def;
         }

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -643,6 +643,35 @@ public class Utils {
     }
 
     /**
+     * Parses the specified string to boolean value.
+     *
+     * @param value
+     *            string to parse
+     * @param defaultValue
+     *            value to return if value is null or on parsing error
+     * @param throwException
+     *            throw exception on parsing error or return default value instead
+     * @return parsed or default value
+     * @throws IllegalArgumentException
+     *             on parsing error if {@code throwException} is true
+     */
+    public static boolean parseBoolean(String value, boolean defaultValue, boolean throwException) {
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value.equalsIgnoreCase("true")) {
+            return true;
+        }
+        if (value.equalsIgnoreCase("false")) {
+            return false;
+        }
+        if (throwException) {
+            throw new IllegalArgumentException(value);
+        }
+        return defaultValue;
+    }
+
+    /**
      * Get the system property. If the system property is not set, or if a
      * security exception occurs, the default value is returned.
      *
@@ -687,15 +716,7 @@ public class Utils {
      * @return the value
      */
     public static boolean getProperty(String key, boolean defaultValue) {
-        String s = getProperty(key, null);
-        if (s != null) {
-            try {
-                return Boolean.parseBoolean(s);
-            } catch (NumberFormatException e) {
-                // ignore
-            }
-        }
-        return defaultValue;
+        return parseBoolean(getProperty(key, null), defaultValue, false);
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -216,7 +216,7 @@ public class ValueTimestamp extends Value {
                         tz, year, month, day, hour, minute, (int) second, (int) ms);
                 ms = DateTimeUtils.convertToLocal(
                         new Date(millis),
-                        DateTimeUtils.createGregorianCalendar(TimeZone.getTimeZone("UTC")));
+                        DateTimeUtils.createGregorianCalendar(DateTimeUtils.UTC));
                 long md = DateTimeUtils.MILLIS_PER_DAY;
                 long absoluteDay = (ms >= 0 ? ms : ms - md + 1) / md;
                 dateValue = DateTimeUtils.dateValueFromAbsoluteDay(absoluteDay);

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -18,6 +18,7 @@ import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -257,6 +258,8 @@ public class TestTools extends TestBase {
         Clob clob = new SimpleClob("Hello World");
         Blob blob = new SimpleBlob(new byte[]{(byte) 1, (byte) 2});
         rs.addRow(1, b, true, d, "10.3", Math.PI, "-3", a, t, ts, clob, blob);
+        rs.addRow(BigInteger.ONE, null, true, null, BigDecimal.ONE, 1d, null, null, null, null, null);
+        rs.addRow(BigInteger.ZERO, null, false, null, BigDecimal.ZERO, 0d, null, null, null, null, null);
         rs.addRow(null, null, null, null, null, null, null, null, null, null, null);
 
         rs.next();
@@ -270,6 +273,7 @@ public class TestTools extends TestBase {
         assertEquals((short) 1, rs.getShort("a"));
         assertTrue(rs.getObject(1).getClass() == Integer.class);
         assertTrue(rs.getObject("a").getClass() == Integer.class);
+        assertTrue(rs.getBoolean(1));
 
         assertEquals(b, rs.getBytes(2));
         assertEquals(b, rs.getBytes("b"));
@@ -288,6 +292,7 @@ public class TestTools extends TestBase {
         assertTrue(Math.PI == rs.getDouble("f"));
         assertTrue((float) Math.PI == rs.getFloat(6));
         assertTrue((float) Math.PI == rs.getFloat("f"));
+        assertTrue(rs.getBoolean(6));
 
         assertEquals(-3, rs.getInt(7));
         assertEquals(-3, rs.getByte(7));
@@ -323,6 +328,20 @@ public class TestTools extends TestBase {
                 getString(13);
         assertThrows(ErrorCode.COLUMN_NOT_FOUND_1, (ResultSet) rs).
                 getString("NOT_FOUND");
+
+        rs.next();
+
+        assertTrue(rs.getBoolean(1));
+        assertTrue(rs.getBoolean(3));
+        assertTrue(rs.getBoolean(5));
+        assertTrue(rs.getBoolean(6));
+
+        rs.next();
+
+        assertFalse(rs.getBoolean(1));
+        assertFalse(rs.getBoolean(3));
+        assertFalse(rs.getBoolean(5));
+        assertFalse(rs.getBoolean(6));
 
         rs.next();
 
@@ -453,6 +472,8 @@ public class TestTools extends TestBase {
         assertTrue(rs.next());
         assertFalse(rs.isClosed());
         assertEquals(1, rs.getRow());
+        assertTrue(rs.next());
+        assertTrue(rs.next());
         assertTrue(rs.next());
         assertFalse(rs.next());
         assertThrows(ErrorCode.NO_DATA_AVAILABLE, (ResultSet) rs).


### PR DESCRIPTION
1. `Boolean.parseBoolean()` only checks for case-insensitive equiality with `"true"`, so illegal values are not detected at all. It is possible to specify `MULTI_THREADED=1` and silently get `MULTI_THREADED=false` or do something like this. New method `Utils.parseBoolean()` returns default value on bad input and optionally throws an exception.

2. `SimpleResultSet.getBoolean()` always return `true` for numeric types. Make it compatible for such types with `Value.getBoolean()`.

Also constant `DateTimeUtils.UTC` now used in one more place.