### PR TITLE
Method.isVarArgs() is available on all supported platforms

### DIFF
--- a/h2/src/main/org/h2/engine/FunctionAlias.java
+++ b/h2/src/main/org/h2/engine/FunctionAlias.java
@@ -302,29 +302,6 @@ public class FunctionAlias extends SchemaObjectBase {
     }
 
     /**
-     * Checks if the given method takes a variable number of arguments. For Java
-     * 1.4 and older, false is returned. Example:
-     * <pre>
-     * public static double mean(double... values)
-     * </pre>
-     *
-     * @param m the method to test
-     * @return true if the method takes a variable number of arguments.
-     */
-    static boolean isVarArgs(Method m) {
-        if ("1.5".compareTo(SysProperties.JAVA_SPECIFICATION_VERSION) > 0) {
-            return false;
-        }
-        try {
-            Method isVarArgs = m.getClass().getMethod("isVarArgs");
-            Boolean result = (Boolean) isVarArgs.invoke(m);
-            return result.booleanValue();
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    /**
      * Should the return value ResultSet be buffered in a local temporary file?
      *
      * @return true if yes
@@ -361,7 +338,7 @@ public class FunctionAlias extends SchemaObjectBase {
             }
             if (paramCount > 0) {
                 Class<?> lastArg = paramClasses[paramClasses.length - 1];
-                if (lastArg.isArray() && FunctionAlias.isVarArgs(method)) {
+                if (lastArg.isArray() && method.isVarArgs()) {
                     varArgs = true;
                     varArgClass = lastArg.getComponentType();
                 }

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -58,10 +58,10 @@ public class SysProperties {
 
     /**
      * System property <code>java.specification.version</code>.<br />
-     * It is set by the system. Examples: 1.4, 1.5, 1.6.
+     * It is set by the system. Examples: 0.9 (on Android), 1.7, 1.8, 9, 10.
      */
     public static final String JAVA_SPECIFICATION_VERSION =
-            Utils.getProperty("java.specification.version", "1.4");
+            Utils.getProperty("java.specification.version", "1.7");
 
     /**
      * System property <code>line.separator</code> (default: \n).<br />


### PR DESCRIPTION
1. Javadoc and default value of `SysProperties.JAVA_SPECIFICATION_VERSION` is updated for currently supported versions of Java.

2. `Method.isVarArgs()` now called directly because it is available on JRE 1.5 and later (H2 supports only 1.7 and later) and on all versions of Android. This method does not actually checks by itself if last argument is an array, so I decide not to remove such check.

After these changes `JAVA_SPECIFICATION_VERSION` is not used any more, so this field can be deleted or preserved for possible reuse.