### PR TITLE
Parse also 1 as true and 0 as false in Utils.parseBoolean()

### DIFF
--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -334,15 +334,7 @@ public class ConnectionInfo implements Cloneable {
      * @return the value
      */
     boolean getProperty(String key, boolean defaultValue) {
-        String x = getProperty(key, null);
-        if (x == null) {
-            return defaultValue;
-        }
-        // support 0 / 1 (like the parser)
-        if (x.length() == 1 && Character.isDigit(x.charAt(0))) {
-            return Integer.parseInt(x) != 0;
-        }
-        return Boolean.parseBoolean(x);
+        return Utils.parseBoolean(getProperty(key, null), defaultValue, false);
     }
 
     /**

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -659,10 +659,10 @@ public class Utils {
         if (value == null) {
             return defaultValue;
         }
-        if (value.equalsIgnoreCase("true")) {
+        if (value.equalsIgnoreCase("true") || value.equals("1")) {
             return true;
         }
-        if (value.equalsIgnoreCase("false")) {
+        if (value.equalsIgnoreCase("false") || value.equals("0")) {
             return false;
         }
         if (throwException) {


### PR DESCRIPTION
Allow to use `1` as `true` and `0` as `false` in `Utils.parseBoolean()`.

Based on discussion after merge of #811 in commit 4de13b24.

Before PR 811 both `0` and `1` were handled as `false`. This PR restores compatibility with `0`, but in case of `1` result will be changed to expected one.