### PR TITLE
Fixes for remaining issues with boolean parameters

### DIFF
--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -345,8 +345,7 @@ public class ConnectionInfo implements Cloneable {
      * @return the value
      */
     public boolean removeProperty(String key, boolean defaultValue) {
-        String x = removeProperty(key, null);
-        return x == null ? defaultValue : Boolean.parseBoolean(x);
+        return Utils.parseBoolean(removeProperty(key, null), defaultValue, false);
     }
 
     /**

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -333,7 +333,7 @@ public class ConnectionInfo implements Cloneable {
      * @param defaultValue the default value
      * @return the value
      */
-    boolean getProperty(String key, boolean defaultValue) {
+    public boolean getProperty(String key, boolean defaultValue) {
         return Utils.parseBoolean(getProperty(key, null), defaultValue, false);
     }
 

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -335,8 +335,7 @@ public class SessionRemote extends SessionWithState implements DataHandler {
         }
         // create the session using reflection,
         // so that the JDBC layer can be compiled without it
-        boolean autoServerMode = Boolean.parseBoolean(
-                ci.getProperty("AUTO_SERVER", "false"));
+        boolean autoServerMode = ci.getProperty("AUTO_SERVER", false);
         ConnectionInfo backup = null;
         try {
             if (autoServerMode) {
@@ -413,11 +412,9 @@ public class SessionRemote extends SessionWithState implements DataHandler {
             serverList = StringUtils.quoteStringSQL(server);
             ci.setProperty("CLUSTER", Constants.CLUSTERING_ENABLED);
         }
-        autoReconnect = Boolean.parseBoolean(ci.getProperty(
-                "AUTO_RECONNECT", "false"));
+        autoReconnect = ci.getProperty("AUTO_RECONNECT", false);
         // AUTO_SERVER implies AUTO_RECONNECT
-        boolean autoServer = Boolean.parseBoolean(ci.getProperty(
-                "AUTO_SERVER", "false"));
+        boolean autoServer = ci.getProperty("AUTO_SERVER", false);
         if (autoServer && serverList != null) {
             throw DbException
                     .getUnsupportedException("autoServer && serverList != null");

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -351,12 +351,10 @@ public class WebApp {
             int port = Integer.decode((String) attributes.get("port"));
             prop.setProperty("webPort", String.valueOf(port));
             server.setPort(port);
-            boolean allowOthers = Boolean.parseBoolean(
-                    (String) attributes.get("allowOthers"));
+            boolean allowOthers = Utils.parseBoolean((String) attributes.get("allowOthers"), false, false);
             prop.setProperty("webAllowOthers", String.valueOf(allowOthers));
             server.setAllowOthers(allowOthers);
-            boolean ssl = Boolean.parseBoolean(
-                    (String) attributes.get("ssl"));
+            boolean ssl = Utils.parseBoolean((String) attributes.get("ssl"), false, false);
             prop.setProperty("webSSL", String.valueOf(ssl));
             server.setSSL(ssl);
             server.saveProperties(prop);

--- a/h2/src/main/org/h2/tools/Csv.java
+++ b/h2/src/main/org/h2/tools/Csv.java
@@ -32,6 +32,7 @@ import org.h2.util.IOUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.New;
 import org.h2.util.StringUtils;
+import org.h2.util.Utils;
 
 /**
  * A facility to read from and write to CSV (comma separated values) files. When
@@ -857,11 +858,11 @@ public class Csv implements SimpleRowSource {
             } else if (isParam(key, "charset", "characterSet")) {
                 charset = value;
             } else if (isParam(key, "preserveWhitespace")) {
-                setPreserveWhitespace(Boolean.parseBoolean(value));
+                setPreserveWhitespace(Utils.parseBoolean(value, false, false));
             } else if (isParam(key, "writeColumnHeader")) {
-                setWriteColumnHeader(Boolean.parseBoolean(value));
+                setWriteColumnHeader(Utils.parseBoolean(value, true, false));
             } else if (isParam(key, "caseSensitiveColumnNames")) {
-                setCaseSensitiveColumnNames(Boolean.parseBoolean(value));
+                setCaseSensitiveColumnNames(Utils.parseBoolean(value, false, false));
             } else {
                 throw DbException.getUnsupportedException(key);
             }

--- a/h2/src/main/org/h2/tools/SimpleResultSet.java
+++ b/h2/src/main/org/h2/tools/SimpleResultSet.java
@@ -38,6 +38,7 @@ import org.h2.util.Bits;
 import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.New;
+import org.h2.util.Utils;
 import org.h2.value.DataType;
 
 /**
@@ -498,7 +499,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
             }
             return n.longValue() != 0;
         }
-        return Boolean.parseBoolean(o.toString());
+        return Utils.parseBoolean(o.toString(), false, true);
     }
 
     /**

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -14,7 +14,6 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -688,11 +687,6 @@ public class Utils {
             if (value.equalsIgnoreCase("false")) {
                 return false;
             }
-        }
-        try {
-            return new BigDecimal(value).signum() != 0;
-        } catch (NumberFormatException e) {
-            // Nothing to do
         }
         if (throwException) {
             throw new IllegalArgumentException(value);

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -14,6 +14,7 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -659,11 +660,39 @@ public class Utils {
         if (value == null) {
             return defaultValue;
         }
-        if (value.equalsIgnoreCase("true") || value.equals("1")) {
-            return true;
+        switch (value.length()) {
+        case 1:
+            if (value.equals("1") || value.equalsIgnoreCase("t") || value.equalsIgnoreCase("y")) {
+                return true;
+            }
+            if (value.equals("0") || value.equalsIgnoreCase("f") || value.equalsIgnoreCase("n")) {
+                return false;
+            }
+            break;
+        case 2:
+            if (value.equalsIgnoreCase("no")) {
+                return false;
+            }
+            break;
+        case 3:
+            if (value.equalsIgnoreCase("yes")) {
+                return true;
+            }
+            break;
+        case 4:
+            if (value.equalsIgnoreCase("true")) {
+                return true;
+            }
+            break;
+        case 5:
+            if (value.equalsIgnoreCase("false")) {
+                return false;
+            }
         }
-        if (value.equalsIgnoreCase("false") || value.equals("0")) {
-            return false;
+        try {
+            return new BigDecimal(value).signum() != 0;
+        } catch (NumberFormatException e) {
+            // Nothing to do
         }
         if (throwException) {
             throw new IllegalArgumentException(value);

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -31,7 +31,6 @@ import org.h2.util.DateTimeUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.StringUtils;
-import org.h2.util.Utils;
 
 /**
  * This is the base class for all value classes.
@@ -1012,10 +1011,19 @@ public abstract class Value {
             case NULL:
                 return ValueNull.INSTANCE;
             case BOOLEAN: {
-                try {
-                    return ValueBoolean.get(Utils.parseBoolean(s, false, true));
-                } catch (IllegalArgumentException e) {
-                    throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, s);
+                if (s.equalsIgnoreCase("true") ||
+                        s.equalsIgnoreCase("t") ||
+                        s.equalsIgnoreCase("yes") ||
+                        s.equalsIgnoreCase("y")) {
+                    return ValueBoolean.get(true);
+                } else if (s.equalsIgnoreCase("false") ||
+                        s.equalsIgnoreCase("f") ||
+                        s.equalsIgnoreCase("no") ||
+                        s.equalsIgnoreCase("n")) {
+                    return ValueBoolean.get(false);
+                } else {
+                    // convert to a number, and if it is not 0 then it is true
+                    return ValueBoolean.get(new BigDecimal(s).signum() != 0);
                 }
             }
             case BYTE:

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -31,6 +31,7 @@ import org.h2.util.DateTimeUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.StringUtils;
+import org.h2.util.Utils;
 
 /**
  * This is the base class for all value classes.
@@ -1011,19 +1012,10 @@ public abstract class Value {
             case NULL:
                 return ValueNull.INSTANCE;
             case BOOLEAN: {
-                if (s.equalsIgnoreCase("true") ||
-                        s.equalsIgnoreCase("t") ||
-                        s.equalsIgnoreCase("yes") ||
-                        s.equalsIgnoreCase("y")) {
-                    return ValueBoolean.get(true);
-                } else if (s.equalsIgnoreCase("false") ||
-                        s.equalsIgnoreCase("f") ||
-                        s.equalsIgnoreCase("no") ||
-                        s.equalsIgnoreCase("n")) {
-                    return ValueBoolean.get(false);
-                } else {
-                    // convert to a number, and if it is not 0 then it is true
-                    return ValueBoolean.get(new BigDecimal(s).signum() != 0);
+                try {
+                    return ValueBoolean.get(Utils.parseBoolean(s, false, true));
+                } catch (IllegalArgumentException e) {
+                    throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, s);
                 }
             }
             case BYTE:

--- a/h2/src/test/org/h2/test/unit/TestUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestUtils.java
@@ -52,6 +52,7 @@ public class TestUtils extends TestBase {
         testGetNonPrimitiveClass();
         testGetNonPrimitiveClass();
         testReflectionUtils();
+        testParseBoolean();
     }
 
     private void testIOUtils() throws IOException {
@@ -219,6 +220,71 @@ public class TestUtils extends TestBase {
         assertFalse(Utils.haveCommonComparableSuperclass(
                 Integer.class,
                 ArrayList.class));
+    }
+
+    private void testParseBooleanCheckFalse(String value) {
+        assertFalse(Utils.parseBoolean(value, false, false));
+        assertFalse(Utils.parseBoolean(value, false, true));
+        assertFalse(Utils.parseBoolean(value, true, false));
+        assertFalse(Utils.parseBoolean(value, true, true));
+    }
+
+    private void testParseBooleanCheckTrue(String value) {
+        assertTrue(Utils.parseBoolean(value, false, false));
+        assertTrue(Utils.parseBoolean(value, false, true));
+        assertTrue(Utils.parseBoolean(value, true, false));
+        assertTrue(Utils.parseBoolean(value, true, true));
+    }
+
+    private void testParseBoolean() {
+        // Test for default value in case of null
+        assertFalse(Utils.parseBoolean(null, false, false));
+        assertFalse(Utils.parseBoolean(null, false, true));
+        assertTrue(Utils.parseBoolean(null, true, false));
+        assertTrue(Utils.parseBoolean(null, true, true));
+        // Test assorted valid strings
+        testParseBooleanCheckFalse("0");
+        testParseBooleanCheckFalse("f");
+        testParseBooleanCheckFalse("F");
+        testParseBooleanCheckFalse("n");
+        testParseBooleanCheckFalse("N");
+        testParseBooleanCheckFalse("no");
+        testParseBooleanCheckFalse("No");
+        testParseBooleanCheckFalse("NO");
+        testParseBooleanCheckFalse("false");
+        testParseBooleanCheckFalse("False");
+        testParseBooleanCheckFalse("FALSE");
+        testParseBooleanCheckTrue("1");
+        testParseBooleanCheckTrue("t");
+        testParseBooleanCheckTrue("T");
+        testParseBooleanCheckTrue("y");
+        testParseBooleanCheckTrue("Y");
+        testParseBooleanCheckTrue("yes");
+        testParseBooleanCheckTrue("Yes");
+        testParseBooleanCheckTrue("YES");
+        testParseBooleanCheckTrue("true");
+        testParseBooleanCheckTrue("True");
+        testParseBooleanCheckTrue("TRUE");
+        // Test numbers
+        testParseBooleanCheckFalse("0.0");
+        testParseBooleanCheckFalse("-0.0");
+        testParseBooleanCheckTrue("0.1");
+        testParseBooleanCheckTrue("-0.1");
+        // Test other values
+        assertFalse(Utils.parseBoolean("BAD", false, false));
+        assertTrue(Utils.parseBoolean("BAD", true, false));
+        try {
+            Utils.parseBoolean("BAD", false, true);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // OK
+        }
+        try {
+            Utils.parseBoolean("BAD", true, true);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // OK
+        }
     }
 
 }

--- a/h2/src/test/org/h2/test/unit/TestUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestUtils.java
@@ -265,11 +265,6 @@ public class TestUtils extends TestBase {
         testParseBooleanCheckTrue("true");
         testParseBooleanCheckTrue("True");
         testParseBooleanCheckTrue("TRUE");
-        // Test numbers
-        testParseBooleanCheckFalse("0.0");
-        testParseBooleanCheckFalse("-0.0");
-        testParseBooleanCheckTrue("0.1");
-        testParseBooleanCheckTrue("-0.1");
         // Test other values
         assertFalse(Utils.parseBoolean("BAD", false, false));
         assertTrue(Utils.parseBoolean("BAD", true, false));


### PR DESCRIPTION
I found more issues with boolean parameters. For example, `IFEXISTS=1` in connection URL worked as `IFEXISTS=FALSE`, this parameter also use one more code path for parsing, there are too many of them.

1. I missed that there is also `ConnectionInfo.removeProperty()` for boolean values, not only `getProperty()`. `removeProperty()` was changed to use `Utils.parseBoolean()` too.

2. WebApp and CSV also have similar issues, so I used `Utils.parseBoolean()` in them.

3. SessionRemote has read booleans as strings from ConnectionInfo with following calls to `Boolean.parseBoolean()`, I changed it to use specialized variant of `getProperty()` for boolean values that is already fixed in master.

4. Conversion from `ValueString` to `ValueBoolean` was more advaced than `Utils.parseBoolean()` so I implemened support for additional values in `Utils.parseBoolean()` and replaced code in conversion method with call to `Utils.parseBoolean()` so we have only one place with custom parsing of booleans.

There are some remaining calls to `Boolean.parseBoolean()` in main H2 code. But they seems to use strings from internal data only where custom values are not expected.