### PR TITLE
Fix some compiler warnings

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4006,8 +4006,10 @@ public class Parser {
             case '#':
                 if (database.getMode().supportPoundSymbolForColumnNames) {
                     type = CHAR_NAME;
-                    break;
+                } else {
+                    type = CHAR_SPECIAL_1;
                 }
+                break;
             default:
                 if (c >= 'a' && c <= 'z') {
                     if (identifiersToUpper) {

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -1483,7 +1483,7 @@ public class Select extends Query {
                     Value[] row = new Value[columnCount];
                     for (int i = 0; i < columnCount; i++) {
                         Expression expr = expressions.get(i);
-                        row[i] = expr.getValue(session);
+                        row[i] = expr.getValue(getSession());
                     }
                     return row;
                 }
@@ -1521,7 +1521,7 @@ public class Select extends Query {
                     for (int i = 0; i < groupIndex.length; i++) {
                         int idx = groupIndex[i];
                         Expression expr = expressions.get(idx);
-                        keyValues[i] = expr.getValue(session);
+                        keyValues[i] = expr.getValue(getSession());
                     }
 
                     Value[] row = null;
@@ -1538,7 +1538,7 @@ public class Select extends Query {
                     for (int i = 0; i < columnCount; i++) {
                         if (groupByExpression == null || !groupByExpression[i]) {
                             Expression expr = expressions.get(i);
-                            expr.updateAggregate(session);
+                            expr.updateAggregate(getSession());
                         }
                     }
                     if (row != null) {

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -956,7 +956,7 @@ public abstract class TestBase {
      * @param condition the condition
      * @throws AssertionError if the condition is false
      */
-    protected void assertTrue(String message, boolean condition) {
+    public void assertTrue(String message, boolean condition) {
         if (!condition) {
             fail(message);
         }
@@ -1058,7 +1058,7 @@ public abstract class TestBase {
      *
      * @param stat the statement
      */
-    protected void execute(PreparedStatement stat) throws SQLException {
+    public void execute(PreparedStatement stat) throws SQLException {
         execute(stat, null);
     }
 
@@ -1651,7 +1651,10 @@ public abstract class TestBase {
         throw (E) e;
     }
 
-    protected String getTestName() {
+    /**
+     * @return the name of the test class
+     */
+    public String getTestName() {
         return getClass().getSimpleName();
     }
 

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -389,7 +389,7 @@ public class TestPgServer extends TestBase {
         }
     }
 
-    private void testBinaryTypes() throws SQLException, InterruptedException {
+    private void testBinaryTypes() throws SQLException {
         if (!getPgJdbcDriver()) {
             return;
         }
@@ -464,7 +464,7 @@ public class TestPgServer extends TestBase {
         }
     }
 
-    private void testDateTime() throws SQLException, InterruptedException {
+    private void testDateTime() throws SQLException {
         if (!getPgJdbcDriver()) {
             return;
         }


### PR DESCRIPTION
This pull request fixes some warnings generated by JDT.

1. `PgServerThread.initDb()` allocates three result sets, but closes only last one. Moreover, first one is returned from `Connection.getMetaData().getTables()` and this result set uses own connection, so it's better to close it immediately after use.

2. Field `Prepared.session` was accessed from inner classes via synthetic accessor methods generated by Java compiler. `Prepared.getSession()` is now used instead, this method already exists and contains the same code as accessor method.

3. Remove leftover exceptions from TestPgServer. They are not thrown from these methods any more.

4. Some methods of `TestBase` is now public to allow access from inner classes in tests without synthetic access warnings.

5. Parser.initialize() had switch fall-through warning on parsing of `#` character. This warning can be suppressed by `//$FALL-THROUGH$` comment, but I added some code instead to make this case more readable, because the next `default` case is not oblivious.