### PR TITLE
Add partial support for INSERT IGNORE in MySQL mode

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1220,6 +1220,9 @@ public class Parser {
     private Insert parseInsert() {
         Insert command = new Insert(session);
         currentPrepared = command;
+        if (database.getMode().onDuplicateKeyUpdate && readIf("IGNORE")) {
+            command.setIgnore(true);
+        }
         read("INTO");
         Table table = readTableOrView();
         command.setTable(table);

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -158,7 +158,7 @@ public class Mode {
     public boolean isolationLevelInSelectOrInsertStatement;
 
     /**
-     * MySQL style INSERT ... ON DUPLICATE KEY UPDATE ...
+     * MySQL style INSERT ... ON DUPLICATE KEY UPDATE ... and INSERT IGNORE
      */
     public boolean onDuplicateKeyUpdate;
 

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -141,7 +141,7 @@ public class TestScript extends TestBase {
                 "parsedatetime", "quarter", "second", "week", "year" }) {
             testScript("functions/timeanddate/" + s + ".sql");
         }
-        for (String s : new String[] { "with", "mergeUsing" }) {
+        for (String s : new String[] { "insertIgnore", "mergeUsing", "with" }) {
             testScript("dml/" + s + ".sql");
         }
         deleteDb("script");

--- a/h2/src/test/org/h2/test/scripts/dml/insertIgnore.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/insertIgnore.sql
@@ -1,0 +1,41 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+SET MODE MySQL;
+> ok
+
+CREATE TABLE TEST(ID BIGINT PRIMARY KEY, VALUE INT NOT NULL);
+> ok
+
+INSERT INTO TEST VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+> update count: 4
+
+INSERT INTO TEST VALUES (3, 31), (5, 51);
+> exception
+
+SELECT * FROM TEST ORDER BY ID;
+> ID VALUE
+> -- -----
+> 1  10
+> 2  20
+> 3  30
+> 4  40
+> rows (ordered): 4
+
+INSERT IGNORE INTO TEST VALUES (3, 32), (5, 52);
+> update count: 1
+
+INSERT IGNORE INTO TEST VALUES (4, 43);
+> ok
+
+SELECT * FROM TEST ORDER BY ID;
+> ID VALUE
+> -- -----
+> 1  10
+> 2  20
+> 3  30
+> 4  40
+> 5  52
+> rows (ordered): 5


### PR DESCRIPTION
Limitations:

1. Only duplicate key errors are ignored. MySQL also ignores other errors, but generates warnings for them. For duplicate key error there are no warnings in MySQL and in this implementation too.

2. I didn't test behaviour of MySQL when both `IGNORE` and `ON DUPLICATE KEY UPDATE` are specified. This implementation allows, but otherwise ignores `IGNORE` if `ON DUPLICATE KEY UPDATE` was also specified.

We have issue #455 for `INSERT IGNORE`, but this issue does not mention which parts of `IGNORE` are desired.