### PR TITLE
Fix 'String index out of range' for numbers with a very little scale in 'to_char'. Issue 115

### DIFF
--- a/h2/src/main/org/h2/util/ToChar.java
+++ b/h2/src/main/org/h2/util/ToChar.java
@@ -338,7 +338,7 @@ public class ToChar {
     }
 
     private static String zeroesAfterDecimalSeparator(BigDecimal number) {
-        final String numberStr = number.toString();
+        final String numberStr = number.toPlainString();
         final int idx = numberStr.indexOf('.');
         if (idx < 0) {
             return "";

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -1948,6 +1948,7 @@ public class TestFunctions extends TestBase implements AggregateFunction {
         final String twoDecimals = "0" + decimalSeparator + "00";
         assertResult(oneDecimal, stat, "select to_char(0, 'FM0D099') from dual;");
         assertResult(twoDecimals, stat, "select to_char(0., 'FM0D009') from dual;");
+        assertResult("0.000000000", stat, "select to_char(0.000000000, 'FM0D999999999') from dual;");
         assertResult("0" + decimalSeparator, stat, "select to_char(0, 'FM0D9') from dual;");
         assertResult(oneDecimal, stat, "select to_char(0.0, 'FM0D099') from dual;");
         assertResult(twoDecimals, stat, "select to_char(0.00, 'FM0D009') from dual;");


### PR DESCRIPTION
I have investigated the issue with small numbers that lead to 'String index out of range' exception from https://github.com/h2database/h2database/issues/115

In this method:
`org.h2.util.ToChar#zeroesAfterDecimalSeparator`
`BigDecimal#toString` is called, but `toString` method behaves differently for decimals with very little scale (approx. 10^-6) and for decimals with scale greater than 10^-6. I replaced it with `BigDecimal #toPlainString`.