### PR TITLE
Use dateValueFromDate() and nanosFromDate() in parseTimestamp()

### DIFF
--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -271,35 +271,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Convert a date to the specified time zone.
-     *
-     * @param x the date to convert
-     * @param target the calendar with the target timezone
-     * @return the milliseconds in UTC
-     */
-    public static long convertToLocal(java.util.Date x, Calendar target) {
-        if (target == null) {
-            throw DbException.getInvalidValueException("calendar", null);
-        }
-        target = (Calendar) target.clone();
-        Calendar local = DateTimeUtils.createGregorianCalendar();
-        local.setTime(x);
-        convertTime(local, target);
-        return target.getTimeInMillis();
-    }
-
-    private static void convertTime(Calendar from, Calendar to) {
-        to.set(Calendar.ERA, from.get(Calendar.ERA));
-        to.set(Calendar.YEAR, from.get(Calendar.YEAR));
-        to.set(Calendar.MONTH, from.get(Calendar.MONTH));
-        to.set(Calendar.DAY_OF_MONTH, from.get(Calendar.DAY_OF_MONTH));
-        to.set(Calendar.HOUR_OF_DAY, from.get(Calendar.HOUR_OF_DAY));
-        to.set(Calendar.MINUTE, from.get(Calendar.MINUTE));
-        to.set(Calendar.SECOND, from.get(Calendar.SECOND));
-        to.set(Calendar.MILLISECOND, from.get(Calendar.MILLISECOND));
-    }
-
-    /**
      * Convert the timestamp using the specified calendar.
      *
      * @param x the time
@@ -519,15 +490,9 @@ public class DateTimeUtils {
                         tzMinutes = (short) (tz.getOffset(millis) / 1000 / 60);
                     }
                 } else {
-                    long ms = nanos / 1000000;
-                    nanos -= ms * 1000000;
-                    long millis = convertDateTimeValueToMillis(tz, dateValue, ms);
-                    ms = convertToLocal(new Date(millis), createGregorianCalendar(UTC));
-                    long md = MILLIS_PER_DAY;
-                    long absoluteDay = (ms >= 0 ? ms : ms - md + 1) / md;
-                    dateValue = dateValueFromAbsoluteDay(absoluteDay);
-                    ms -= absoluteDay * md;
-                    nanos += ms * 1000000;
+                    long millis = convertDateTimeValueToMillis(tz, dateValue, nanos / 1000000);
+                    dateValue = dateValueFromDate(millis);
+                    nanos = nanos % 1000000 + nanosFromDate(millis);
                 }
             }
         }

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -15,6 +15,8 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import org.h2.api.ErrorCode;
@@ -35,6 +37,7 @@ import org.h2.value.ValueLobDb;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueResultSet;
 import org.h2.value.ValueString;
+import org.h2.value.ValueTimestamp;
 import org.h2.value.ValueUuid;
 
 /**
@@ -61,6 +64,7 @@ public class TestValue extends TestBase {
         testUUID();
         testDouble(false);
         testDouble(true);
+        testTimestamp();
         testModulusDouble();
         testModulusDecimal();
         testModulusOperator();
@@ -300,6 +304,30 @@ public class TestValue extends TestBase {
             assertTrue(values[i + 1].compareTypeSafe(values[i], null) > 0);
             assertTrue(!values[i].equals(values[i+1]));
         }
+    }
+
+    private void testTimestamp() {
+        ValueTimestamp vts = ValueTimestamp.parse("2000-01-15 10:20:30.333222111");
+        Timestamp ts = Timestamp.valueOf("2000-01-15 10:20:30.333222111");
+        assertEquals(ts.toString(), vts.getString());
+        assertEquals(ts, vts.getTimestamp());
+        Calendar c = Calendar.getInstance(TimeZone.getTimeZone("Europe/Berlin"));
+        c.set(2018, 02, 25, 1, 59, 00);
+        c.set(Calendar.MILLISECOND, 123);
+        long expected = c.getTimeInMillis();
+        ts = ValueTimestamp.parse("2018-03-25 01:59:00.123123123 Europe/Berlin").getTimestamp();
+        assertEquals(expected, ts.getTime());
+        assertEquals(123123123, ts.getNanos());
+        ts = ValueTimestamp.parse("2018-03-25 01:59:00.123123123+01").getTimestamp();
+        assertEquals(expected, ts.getTime());
+        assertEquals(123123123, ts.getNanos());
+        expected += 60000; // 1 minute
+        ts = ValueTimestamp.parse("2018-03-25 03:00:00.123123123 Europe/Berlin").getTimestamp();
+        assertEquals(expected, ts.getTime());
+        assertEquals(123123123, ts.getNanos());
+        ts = ValueTimestamp.parse("2018-03-25 03:00:00.123123123+02").getTimestamp();
+        assertEquals(expected, ts.getTime());
+        assertEquals(123123123, ts.getNanos());
     }
 
     private void testUUID() {


### PR DESCRIPTION
`parseTimestamp()` had own methods for converting milliseconds to `ValueTimestamp`. This pull request replaces them with calls to common methods used in other places.

I also add a test for timestamps near DST transition similar to recently added test for `TIMESTAMP WITH TIME ZONE`, but in Java form because in this test textual representations of `TIMESTAMP` will be different depending on local timezone. This test completes normally with old code too. 