### PR TITLE
Enhance Compatibility Mode option

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -286,9 +286,9 @@ public class Parser {
                 for(int i=0; i < data.getMatcher().length; ++i) {
                     Matcher matcher = data.getMatcher()[i].matcher(sql);
                     if(matcher.find()) {
-                        database.getTraceSystem().getTrace(8/*TraceObject.STATEMENT*/).debug("Statement: "+sql);
+                        database.getTraceSystem().getTrace(8/*TraceObject.STATEMENT*/).info("Statement: "+sql);
                         sql = matcher.replaceAll(data.getReplacer()[i]);
-                        database.getTraceSystem().getTrace(8/*TraceObject.STATEMENT*/).debug("was changed to: " + sql);
+                        database.getTraceSystem().getTrace(8/*TraceObject.STATEMENT*/).info("was changed to: " + sql);
                     }
                 }
             }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -282,13 +282,14 @@ public class Parser {
         try {
             String modeName = database.getMode().getName();
             if(!modeName.equals("REGULAR")) {
-                System.out.println("INPUT SQL:\n"+sql);
                 JdbcOptionProperties.Data data = JdbcOptionProperties.getInstance().getModeData(modeName);
                 for(int i=0; i < data.getMatcher().length; ++i) {
                     Matcher matcher = data.getMatcher()[i].matcher(sql);
-
-                    sql = matcher.replaceAll(data.getReplacer()[i]);
-                    System.out.println("OUTPUT SQL:" +i+"\n"+sql);
+                    if(matcher.find()) {
+                        database.getTraceSystem().getTrace(8/*TraceObject.STATEMENT*/).debug("Statement: "+sql);
+                        sql = matcher.replaceAll(data.getReplacer()[i]);
+                        database.getTraceSystem().getTrace(8/*TraceObject.STATEMENT*/).debug("was changed to: " + sql);
+                    }
                 }
             }
             // first, try the fast variant

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Properties;
 import org.h2.engine.Constants;
+import org.h2.engine.Mode;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
@@ -26,7 +27,7 @@ import org.h2.util.StringUtils;
  * Represents the meta data for a database.
  */
 public class JdbcDatabaseMetaData extends TraceObject implements
-        DatabaseMetaData, JdbcDatabaseMetaDataBackwardsCompat {
+  DatabaseMetaData, JdbcDatabaseMetaDataBackwardsCompat {
 
     private final JdbcConnection conn;
 
@@ -65,9 +66,20 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     @Override
     public String getDatabaseProductName() {
         debugCodeCall("getDatabaseProductName");
+        String output = "H2";
+        try {
+            String mode = conn.getMode();
+            JdbcOptionProperties.Data data = JdbcOptionProperties.getInstance().getModeData(mode);
+            if(data != JdbcOptionProperties.Empty) {
+                output = data.getDatabaseProductName();
+            }
+        }
+        catch(SQLException e) {
+            //nop
+        }
         // This value must stay like that, see
         // http://opensource.atlassian.com/projects/hibernate/browse/HHH-2682
-        return "H2";
+        return output;
     }
 
     /**
@@ -78,7 +90,18 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     @Override
     public String getDatabaseProductVersion() {
         debugCodeCall("getDatabaseProductVersion");
-        return Constants.getFullVersion();
+        String output = Constants.getFullVersion();
+        try {
+            String mode = conn.getMode();
+            JdbcOptionProperties.Data data = JdbcOptionProperties.getInstance().getModeData(mode);
+            if(data != JdbcOptionProperties.Empty) {
+                output = data.getDatabaseProductVersion();
+            }
+        }
+        catch(SQLException e) {
+            //nop
+        }
+        return output;
     }
 
     /**
@@ -134,12 +157,12 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getTables(String catalogPattern, String schemaPattern,
-            String tableNamePattern, String[] types) throws SQLException {
+                               String tableNamePattern, String[] types) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getTables(" + quote(catalogPattern) + ", " +
-                        quote(schemaPattern) + ", " + quote(tableNamePattern) +
-                        ", " + quoteArray(types) + ");");
+                  quote(schemaPattern) + ", " + quote(tableNamePattern) +
+                  ", " + quoteArray(types) + ");");
             }
             checkClosed();
             String tableType;
@@ -154,23 +177,23 @@ public class JdbcDatabaseMetaData extends TraceObject implements
                 tableType = "TRUE";
             }
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "TABLE_CATALOG TABLE_CAT, "
-                    + "TABLE_SCHEMA TABLE_SCHEM, "
-                    + "TABLE_NAME, "
-                    + "TABLE_TYPE, "
-                    + "REMARKS, "
-                    + "TYPE_NAME TYPE_CAT, "
-                    + "TYPE_NAME TYPE_SCHEM, "
-                    + "TYPE_NAME, "
-                    + "TYPE_NAME SELF_REFERENCING_COL_NAME, "
-                    + "TYPE_NAME REF_GENERATION, "
-                    + "SQL "
-                    + "FROM INFORMATION_SCHEMA.TABLES "
-                    + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND TABLE_NAME LIKE ? ESCAPE ? "
-                    + "AND (" + tableType + ") "
-                    + "ORDER BY TABLE_TYPE, TABLE_SCHEMA, TABLE_NAME");
+              + "TABLE_CATALOG TABLE_CAT, "
+              + "TABLE_SCHEMA TABLE_SCHEM, "
+              + "TABLE_NAME, "
+              + "TABLE_TYPE, "
+              + "REMARKS, "
+              + "TYPE_NAME TYPE_CAT, "
+              + "TYPE_NAME TYPE_SCHEM, "
+              + "TYPE_NAME, "
+              + "TYPE_NAME SELF_REFERENCING_COL_NAME, "
+              + "TYPE_NAME REF_GENERATION, "
+              + "SQL "
+              + "FROM INFORMATION_SCHEMA.TABLES "
+              + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND TABLE_NAME LIKE ? ESCAPE ? "
+              + "AND (" + tableType + ") "
+              + "ORDER BY TABLE_TYPE, TABLE_SCHEMA, TABLE_NAME");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -231,48 +254,48 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getColumns(String catalogPattern, String schemaPattern,
-            String tableNamePattern, String columnNamePattern)
-            throws SQLException {
+                                String tableNamePattern, String columnNamePattern)
+      throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getColumns(" + quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableNamePattern)+", "
-                        +quote(columnNamePattern)+");");
+                  +quote(schemaPattern)+", "
+                  +quote(tableNamePattern)+", "
+                  +quote(columnNamePattern)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "TABLE_CATALOG TABLE_CAT, "
-                    + "TABLE_SCHEMA TABLE_SCHEM, "
-                    + "TABLE_NAME, "
-                    + "COLUMN_NAME, "
-                    + "DATA_TYPE, "
-                    + "TYPE_NAME, "
-                    + "CHARACTER_MAXIMUM_LENGTH COLUMN_SIZE, "
-                    + "CHARACTER_MAXIMUM_LENGTH BUFFER_LENGTH, "
-                    + "NUMERIC_SCALE DECIMAL_DIGITS, "
-                    + "NUMERIC_PRECISION_RADIX NUM_PREC_RADIX, "
-                    + "NULLABLE, "
-                    + "REMARKS, "
-                    + "COLUMN_DEFAULT COLUMN_DEF, "
-                    + "DATA_TYPE SQL_DATA_TYPE, "
-                    + "ZERO() SQL_DATETIME_SUB, "
-                    + "CHARACTER_OCTET_LENGTH CHAR_OCTET_LENGTH, "
-                    + "ORDINAL_POSITION, "
-                    + "IS_NULLABLE IS_NULLABLE, "
-                    + "CAST(SOURCE_DATA_TYPE AS VARCHAR) SCOPE_CATALOG, "
-                    + "CAST(SOURCE_DATA_TYPE AS VARCHAR) SCOPE_SCHEMA, "
-                    + "CAST(SOURCE_DATA_TYPE AS VARCHAR) SCOPE_TABLE, "
-                    + "SOURCE_DATA_TYPE, "
-                    + "CASE WHEN SEQUENCE_NAME IS NULL THEN "
-                    + "CAST(? AS VARCHAR) ELSE CAST(? AS VARCHAR) END IS_AUTOINCREMENT, "
-                    + "CAST(SOURCE_DATA_TYPE AS VARCHAR) SCOPE_CATLOG "
-                    + "FROM INFORMATION_SCHEMA.COLUMNS "
-                    + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND TABLE_NAME LIKE ? ESCAPE ? "
-                    + "AND COLUMN_NAME LIKE ? ESCAPE ? "
-                    + "ORDER BY TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION");
+              + "TABLE_CATALOG TABLE_CAT, "
+              + "TABLE_SCHEMA TABLE_SCHEM, "
+              + "TABLE_NAME, "
+              + "COLUMN_NAME, "
+              + "DATA_TYPE, "
+              + "TYPE_NAME, "
+              + "CHARACTER_MAXIMUM_LENGTH COLUMN_SIZE, "
+              + "CHARACTER_MAXIMUM_LENGTH BUFFER_LENGTH, "
+              + "NUMERIC_SCALE DECIMAL_DIGITS, "
+              + "NUMERIC_PRECISION_RADIX NUM_PREC_RADIX, "
+              + "NULLABLE, "
+              + "REMARKS, "
+              + "COLUMN_DEFAULT COLUMN_DEF, "
+              + "DATA_TYPE SQL_DATA_TYPE, "
+              + "ZERO() SQL_DATETIME_SUB, "
+              + "CHARACTER_OCTET_LENGTH CHAR_OCTET_LENGTH, "
+              + "ORDINAL_POSITION, "
+              + "IS_NULLABLE IS_NULLABLE, "
+              + "CAST(SOURCE_DATA_TYPE AS VARCHAR) SCOPE_CATALOG, "
+              + "CAST(SOURCE_DATA_TYPE AS VARCHAR) SCOPE_SCHEMA, "
+              + "CAST(SOURCE_DATA_TYPE AS VARCHAR) SCOPE_TABLE, "
+              + "SOURCE_DATA_TYPE, "
+              + "CASE WHEN SEQUENCE_NAME IS NULL THEN "
+              + "CAST(? AS VARCHAR) ELSE CAST(? AS VARCHAR) END IS_AUTOINCREMENT, "
+              + "CAST(SOURCE_DATA_TYPE AS VARCHAR) SCOPE_CATLOG "
+              + "FROM INFORMATION_SCHEMA.COLUMNS "
+              + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND TABLE_NAME LIKE ? ESCAPE ? "
+              + "AND COLUMN_NAME LIKE ? ESCAPE ? "
+              + "ORDER BY TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION");
             prep.setString(1, "NO");
             prep.setString(2, "YES");
             prep.setString(3, getCatalogPattern(catalogPattern));
@@ -324,13 +347,13 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getIndexInfo(String catalogPattern, String schemaPattern,
-            String tableName, boolean unique, boolean approximate)
-            throws SQLException {
+                                  String tableName, boolean unique, boolean approximate)
+      throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getIndexInfo(" + quote(catalogPattern) + ", " +
-                        quote(schemaPattern) + ", " + quote(tableName) + ", " +
-                        unique + ", " + approximate + ");");
+                  quote(schemaPattern) + ", " + quote(tableName) + ", " +
+                  unique + ", " + approximate + ");");
             }
             String uniqueCondition;
             if (unique) {
@@ -340,27 +363,27 @@ public class JdbcDatabaseMetaData extends TraceObject implements
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "TABLE_CATALOG TABLE_CAT, "
-                    + "TABLE_SCHEMA TABLE_SCHEM, "
-                    + "TABLE_NAME, "
-                    + "NON_UNIQUE, "
-                    + "TABLE_CATALOG INDEX_QUALIFIER, "
-                    + "INDEX_NAME, "
-                    + "INDEX_TYPE TYPE, "
-                    + "ORDINAL_POSITION, "
-                    + "COLUMN_NAME, "
-                    + "ASC_OR_DESC, "
-                    // TODO meta data for number of unique values in an index
-                    + "CARDINALITY, "
-                    + "PAGES, "
-                    + "FILTER_CONDITION, "
-                    + "SORT_TYPE "
-                    + "FROM INFORMATION_SCHEMA.INDEXES "
-                    + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND (" + uniqueCondition + ") "
-                    + "AND TABLE_NAME = ? "
-                    + "ORDER BY NON_UNIQUE, TYPE, TABLE_SCHEM, INDEX_NAME, ORDINAL_POSITION");
+              + "TABLE_CATALOG TABLE_CAT, "
+              + "TABLE_SCHEMA TABLE_SCHEM, "
+              + "TABLE_NAME, "
+              + "NON_UNIQUE, "
+              + "TABLE_CATALOG INDEX_QUALIFIER, "
+              + "INDEX_NAME, "
+              + "INDEX_TYPE TYPE, "
+              + "ORDINAL_POSITION, "
+              + "COLUMN_NAME, "
+              + "ASC_OR_DESC, "
+              // TODO meta data for number of unique values in an index
+              + "CARDINALITY, "
+              + "PAGES, "
+              + "FILTER_CONDITION, "
+              + "SORT_TYPE "
+              + "FROM INFORMATION_SCHEMA.INDEXES "
+              + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND (" + uniqueCondition + ") "
+              + "AND TABLE_NAME = ? "
+              + "ORDER BY NON_UNIQUE, TYPE, TABLE_SCHEM, INDEX_NAME, ORDINAL_POSITION");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -394,28 +417,28 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getPrimaryKeys(String catalogPattern,
-            String schemaPattern, String tableName) throws SQLException {
+                                    String schemaPattern, String tableName) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getPrimaryKeys("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableName)+");");
+                  +quote(catalogPattern)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(tableName)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "TABLE_CATALOG TABLE_CAT, "
-                    + "TABLE_SCHEMA TABLE_SCHEM, "
-                    + "TABLE_NAME, "
-                    + "COLUMN_NAME, "
-                    + "ORDINAL_POSITION KEY_SEQ, "
-                    + "IFNULL(CONSTRAINT_NAME, INDEX_NAME) PK_NAME "
-                    + "FROM INFORMATION_SCHEMA.INDEXES "
-                    + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND TABLE_NAME = ? "
-                    + "AND PRIMARY_KEY = TRUE "
-                    + "ORDER BY COLUMN_NAME");
+              + "TABLE_CATALOG TABLE_CAT, "
+              + "TABLE_SCHEMA TABLE_SCHEM, "
+              + "TABLE_NAME, "
+              + "COLUMN_NAME, "
+              + "ORDINAL_POSITION KEY_SEQ, "
+              + "IFNULL(CONSTRAINT_NAME, INDEX_NAME) PK_NAME "
+              + "FROM INFORMATION_SCHEMA.INDEXES "
+              + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND TABLE_NAME = ? "
+              + "AND PRIMARY_KEY = TRUE "
+              + "ORDER BY COLUMN_NAME");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -581,30 +604,30 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getProcedures(String catalogPattern, String schemaPattern,
-            String procedureNamePattern) throws SQLException {
+                                   String procedureNamePattern) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getProcedures("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(procedureNamePattern)+");");
+                  +quote(catalogPattern)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(procedureNamePattern)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "ALIAS_CATALOG PROCEDURE_CAT, "
-                    + "ALIAS_SCHEMA PROCEDURE_SCHEM, "
-                    + "ALIAS_NAME PROCEDURE_NAME, "
-                    + "COLUMN_COUNT NUM_INPUT_PARAMS, "
-                    + "ZERO() NUM_OUTPUT_PARAMS, "
-                    + "ZERO() NUM_RESULT_SETS, "
-                    + "REMARKS, "
-                    + "RETURNS_RESULT PROCEDURE_TYPE, "
-                    + "ALIAS_NAME SPECIFIC_NAME "
-                    + "FROM INFORMATION_SCHEMA.FUNCTION_ALIASES "
-                    + "WHERE ALIAS_CATALOG LIKE ? ESCAPE ? "
-                    + "AND ALIAS_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND ALIAS_NAME LIKE ? ESCAPE ? "
-                    + "ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, NUM_INPUT_PARAMS");
+              + "ALIAS_CATALOG PROCEDURE_CAT, "
+              + "ALIAS_SCHEMA PROCEDURE_SCHEM, "
+              + "ALIAS_NAME PROCEDURE_NAME, "
+              + "COLUMN_COUNT NUM_INPUT_PARAMS, "
+              + "ZERO() NUM_OUTPUT_PARAMS, "
+              + "ZERO() NUM_RESULT_SETS, "
+              + "REMARKS, "
+              + "RETURNS_RESULT PROCEDURE_TYPE, "
+              + "ALIAS_NAME SPECIFIC_NAME "
+              + "FROM INFORMATION_SCHEMA.FUNCTION_ALIASES "
+              + "WHERE ALIAS_CATALOG LIKE ? ESCAPE ? "
+              + "AND ALIAS_SCHEMA LIKE ? ESCAPE ? "
+              + "AND ALIAS_NAME LIKE ? ESCAPE ? "
+              + "ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, NUM_INPUT_PARAMS");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -660,44 +683,44 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getProcedureColumns(String catalogPattern,
-            String schemaPattern, String procedureNamePattern,
-            String columnNamePattern) throws SQLException {
+                                         String schemaPattern, String procedureNamePattern,
+                                         String columnNamePattern) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getProcedureColumns("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(procedureNamePattern)+", "
-                        +quote(columnNamePattern)+");");
+                  +quote(catalogPattern)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(procedureNamePattern)+", "
+                  +quote(columnNamePattern)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "ALIAS_CATALOG PROCEDURE_CAT, "
-                    + "ALIAS_SCHEMA PROCEDURE_SCHEM, "
-                    + "ALIAS_NAME PROCEDURE_NAME, "
-                    + "COLUMN_NAME, "
-                    + "COLUMN_TYPE, "
-                    + "DATA_TYPE, "
-                    + "TYPE_NAME, "
-                    + "PRECISION, "
-                    + "PRECISION LENGTH, "
-                    + "SCALE, "
-                    + "RADIX, "
-                    + "NULLABLE, "
-                    + "REMARKS, "
-                    + "COLUMN_DEFAULT COLUMN_DEF, "
-                    + "ZERO() SQL_DATA_TYPE, "
-                    + "ZERO() SQL_DATETIME_SUB, "
-                    + "ZERO() CHAR_OCTET_LENGTH, "
-                    + "POS ORDINAL_POSITION, "
-                    + "? IS_NULLABLE, "
-                    + "ALIAS_NAME SPECIFIC_NAME "
-                    + "FROM INFORMATION_SCHEMA.FUNCTION_COLUMNS "
-                    + "WHERE ALIAS_CATALOG LIKE ? ESCAPE ? "
-                    + "AND ALIAS_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND ALIAS_NAME LIKE ? ESCAPE ? "
-                    + "AND COLUMN_NAME LIKE ? ESCAPE ? "
-                    + "ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, ORDINAL_POSITION");
+              + "ALIAS_CATALOG PROCEDURE_CAT, "
+              + "ALIAS_SCHEMA PROCEDURE_SCHEM, "
+              + "ALIAS_NAME PROCEDURE_NAME, "
+              + "COLUMN_NAME, "
+              + "COLUMN_TYPE, "
+              + "DATA_TYPE, "
+              + "TYPE_NAME, "
+              + "PRECISION, "
+              + "PRECISION LENGTH, "
+              + "SCALE, "
+              + "RADIX, "
+              + "NULLABLE, "
+              + "REMARKS, "
+              + "COLUMN_DEFAULT COLUMN_DEF, "
+              + "ZERO() SQL_DATA_TYPE, "
+              + "ZERO() SQL_DATETIME_SUB, "
+              + "ZERO() CHAR_OCTET_LENGTH, "
+              + "POS ORDINAL_POSITION, "
+              + "? IS_NULLABLE, "
+              + "ALIAS_NAME SPECIFIC_NAME "
+              + "FROM INFORMATION_SCHEMA.FUNCTION_COLUMNS "
+              + "WHERE ALIAS_CATALOG LIKE ? ESCAPE ? "
+              + "AND ALIAS_SCHEMA LIKE ? ESCAPE ? "
+              + "AND ALIAS_NAME LIKE ? ESCAPE ? "
+              + "AND COLUMN_NAME LIKE ? ESCAPE ? "
+              + "ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, ORDINAL_POSITION");
             prep.setString(1, "YES");
             prep.setString(2, getCatalogPattern(catalogPattern));
             prep.setString(3, "\\");
@@ -732,12 +755,12 @@ public class JdbcDatabaseMetaData extends TraceObject implements
             debugCodeCall("getSchemas");
             checkClosed();
             PreparedStatement prep = conn
-                    .prepareAutoCloseStatement("SELECT "
-                            + "SCHEMA_NAME TABLE_SCHEM, "
-                            + "CATALOG_NAME TABLE_CATALOG, "
-                            +" IS_DEFAULT "
-                            + "FROM INFORMATION_SCHEMA.SCHEMATA "
-                            + "ORDER BY SCHEMA_NAME");
+              .prepareAutoCloseStatement("SELECT "
+                + "SCHEMA_NAME TABLE_SCHEM, "
+                + "CATALOG_NAME TABLE_CATALOG, "
+                +" IS_DEFAULT "
+                + "FROM INFORMATION_SCHEMA.SCHEMATA "
+                + "ORDER BY SCHEMA_NAME");
             return prep.executeQuery();
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -761,8 +784,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
             debugCodeCall("getCatalogs");
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement(
-                    "SELECT CATALOG_NAME TABLE_CAT "
-                    + "FROM INFORMATION_SCHEMA.CATALOGS");
+              "SELECT CATALOG_NAME TABLE_CAT "
+                + "FROM INFORMATION_SCHEMA.CATALOGS");
             return prep.executeQuery();
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -785,9 +808,9 @@ public class JdbcDatabaseMetaData extends TraceObject implements
             debugCodeCall("getTableTypes");
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "TYPE TABLE_TYPE "
-                    + "FROM INFORMATION_SCHEMA.TABLE_TYPES "
-                    + "ORDER BY TABLE_TYPE");
+              + "TYPE TABLE_TYPE "
+              + "FROM INFORMATION_SCHEMA.TABLE_TYPES "
+              + "ORDER BY TABLE_TYPE");
             return prep.executeQuery();
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -822,32 +845,32 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getColumnPrivileges(String catalogPattern,
-            String schemaPattern, String table, String columnNamePattern)
-            throws SQLException {
+                                         String schemaPattern, String table, String columnNamePattern)
+      throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getColumnPrivileges("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(table)+", "
-                        +quote(columnNamePattern)+");");
+                  +quote(catalogPattern)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(table)+", "
+                  +quote(columnNamePattern)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "TABLE_CATALOG TABLE_CAT, "
-                    + "TABLE_SCHEMA TABLE_SCHEM, "
-                    + "TABLE_NAME, "
-                    + "COLUMN_NAME, "
-                    + "GRANTOR, "
-                    + "GRANTEE, "
-                    + "PRIVILEGE_TYPE PRIVILEGE, "
-                    + "IS_GRANTABLE "
-                    + "FROM INFORMATION_SCHEMA.COLUMN_PRIVILEGES "
-                    + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND TABLE_NAME = ? "
-                    + "AND COLUMN_NAME LIKE ? ESCAPE ? "
-                    + "ORDER BY COLUMN_NAME, PRIVILEGE");
+              + "TABLE_CATALOG TABLE_CAT, "
+              + "TABLE_SCHEMA TABLE_SCHEM, "
+              + "TABLE_NAME, "
+              + "COLUMN_NAME, "
+              + "GRANTOR, "
+              + "GRANTEE, "
+              + "PRIVILEGE_TYPE PRIVILEGE, "
+              + "IS_GRANTABLE "
+              + "FROM INFORMATION_SCHEMA.COLUMN_PRIVILEGES "
+              + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND TABLE_NAME = ? "
+              + "AND COLUMN_NAME LIKE ? ESCAPE ? "
+              + "ORDER BY COLUMN_NAME, PRIVILEGE");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -887,28 +910,28 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getTablePrivileges(String catalogPattern,
-            String schemaPattern, String tableNamePattern) throws SQLException {
+                                        String schemaPattern, String tableNamePattern) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getTablePrivileges("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableNamePattern)+");");
+                  +quote(catalogPattern)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(tableNamePattern)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "TABLE_CATALOG TABLE_CAT, "
-                    + "TABLE_SCHEMA TABLE_SCHEM, "
-                    + "TABLE_NAME, "
-                    + "GRANTOR, "
-                    + "GRANTEE, "
-                    + "PRIVILEGE_TYPE PRIVILEGE, "
-                    + "IS_GRANTABLE "
-                    + "FROM INFORMATION_SCHEMA.TABLE_PRIVILEGES "
-                    + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND TABLE_NAME LIKE ? ESCAPE ? "
-                    + "ORDER BY TABLE_SCHEM, TABLE_NAME, PRIVILEGE");
+              + "TABLE_CATALOG TABLE_CAT, "
+              + "TABLE_SCHEMA TABLE_SCHEM, "
+              + "TABLE_NAME, "
+              + "GRANTOR, "
+              + "GRANTEE, "
+              + "PRIVILEGE_TYPE PRIVILEGE, "
+              + "IS_GRANTABLE "
+              + "FROM INFORMATION_SCHEMA.TABLE_PRIVILEGES "
+              + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND TABLE_NAME LIKE ? ESCAPE ? "
+              + "ORDER BY TABLE_SCHEM, TABLE_NAME, PRIVILEGE");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -948,35 +971,35 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getBestRowIdentifier(String catalogPattern,
-            String schemaPattern, String tableName, int scope, boolean nullable)
-            throws SQLException {
+                                          String schemaPattern, String tableName, int scope, boolean nullable)
+      throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getBestRowIdentifier("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableName)+", "
-                        +scope+", "+nullable+");");
+                  +quote(catalogPattern)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(tableName)+", "
+                  +scope+", "+nullable+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "CAST(? AS SMALLINT) SCOPE, "
-                    + "C.COLUMN_NAME, "
-                    + "C.DATA_TYPE, "
-                    + "C.TYPE_NAME, "
-                    + "C.CHARACTER_MAXIMUM_LENGTH COLUMN_SIZE, "
-                    + "C.CHARACTER_MAXIMUM_LENGTH BUFFER_LENGTH, "
-                    + "CAST(C.NUMERIC_SCALE AS SMALLINT) DECIMAL_DIGITS, "
-                    + "CAST(? AS SMALLINT) PSEUDO_COLUMN "
-                    + "FROM INFORMATION_SCHEMA.INDEXES I, "
-                    +" INFORMATION_SCHEMA.COLUMNS C "
-                    + "WHERE C.TABLE_NAME = I.TABLE_NAME "
-                    + "AND C.COLUMN_NAME = I.COLUMN_NAME "
-                    + "AND C.TABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND C.TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND C.TABLE_NAME = ? "
-                    + "AND I.PRIMARY_KEY = TRUE "
-                    + "ORDER BY SCOPE");
+              + "CAST(? AS SMALLINT) SCOPE, "
+              + "C.COLUMN_NAME, "
+              + "C.DATA_TYPE, "
+              + "C.TYPE_NAME, "
+              + "C.CHARACTER_MAXIMUM_LENGTH COLUMN_SIZE, "
+              + "C.CHARACTER_MAXIMUM_LENGTH BUFFER_LENGTH, "
+              + "CAST(C.NUMERIC_SCALE AS SMALLINT) DECIMAL_DIGITS, "
+              + "CAST(? AS SMALLINT) PSEUDO_COLUMN "
+              + "FROM INFORMATION_SCHEMA.INDEXES I, "
+              +" INFORMATION_SCHEMA.COLUMNS C "
+              + "WHERE C.TABLE_NAME = I.TABLE_NAME "
+              + "AND C.COLUMN_NAME = I.COLUMN_NAME "
+              + "AND C.TABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND C.TABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND C.TABLE_NAME = ? "
+              + "AND I.PRIMARY_KEY = TRUE "
+              + "ORDER BY SCOPE");
             // SCOPE
             prep.setInt(1, DatabaseMetaData.bestRowSession);
             // PSEUDO_COLUMN
@@ -1016,26 +1039,26 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getVersionColumns(String catalog, String schema,
-            String tableName) throws SQLException {
+                                       String tableName) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getVersionColumns("
-                        +quote(catalog)+", "
-                        +quote(schema)+", "
-                        +quote(tableName)+");");
+                  +quote(catalog)+", "
+                  +quote(schema)+", "
+                  +quote(tableName)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "ZERO() SCOPE, "
-                    + "COLUMN_NAME, "
-                    + "CAST(DATA_TYPE AS INT) DATA_TYPE, "
-                    + "TYPE_NAME, "
-                    + "NUMERIC_PRECISION COLUMN_SIZE, "
-                    + "NUMERIC_PRECISION BUFFER_LENGTH, "
-                    + "NUMERIC_PRECISION DECIMAL_DIGITS, "
-                    + "ZERO() PSEUDO_COLUMN "
-                    + "FROM INFORMATION_SCHEMA.COLUMNS "
-                    + "WHERE FALSE");
+              + "ZERO() SCOPE, "
+              + "COLUMN_NAME, "
+              + "CAST(DATA_TYPE AS INT) DATA_TYPE, "
+              + "TYPE_NAME, "
+              + "NUMERIC_PRECISION COLUMN_SIZE, "
+              + "NUMERIC_PRECISION BUFFER_LENGTH, "
+              + "NUMERIC_PRECISION DECIMAL_DIGITS, "
+              + "ZERO() PSEUDO_COLUMN "
+              + "FROM INFORMATION_SCHEMA.COLUMNS "
+              + "WHERE FALSE");
             return prep.executeQuery();
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -1075,35 +1098,35 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getImportedKeys(String catalogPattern,
-            String schemaPattern, String tableName) throws SQLException {
+                                     String schemaPattern, String tableName) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getImportedKeys("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableName)+");");
+                  +quote(catalogPattern)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(tableName)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "PKTABLE_CATALOG PKTABLE_CAT, "
-                    + "PKTABLE_SCHEMA PKTABLE_SCHEM, "
-                    + "PKTABLE_NAME PKTABLE_NAME, "
-                    + "PKCOLUMN_NAME, "
-                    + "FKTABLE_CATALOG FKTABLE_CAT, "
-                    + "FKTABLE_SCHEMA FKTABLE_SCHEM, "
-                    + "FKTABLE_NAME, "
-                    + "FKCOLUMN_NAME, "
-                    + "ORDINAL_POSITION KEY_SEQ, "
-                    + "UPDATE_RULE, "
-                    + "DELETE_RULE, "
-                    + "FK_NAME, "
-                    + "PK_NAME, "
-                    + "DEFERRABILITY "
-                    + "FROM INFORMATION_SCHEMA.CROSS_REFERENCES "
-                    + "WHERE FKTABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND FKTABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND FKTABLE_NAME = ? "
-                    + "ORDER BY PKTABLE_CAT, PKTABLE_SCHEM, PKTABLE_NAME, FK_NAME, KEY_SEQ");
+              + "PKTABLE_CATALOG PKTABLE_CAT, "
+              + "PKTABLE_SCHEMA PKTABLE_SCHEM, "
+              + "PKTABLE_NAME PKTABLE_NAME, "
+              + "PKCOLUMN_NAME, "
+              + "FKTABLE_CATALOG FKTABLE_CAT, "
+              + "FKTABLE_SCHEMA FKTABLE_SCHEM, "
+              + "FKTABLE_NAME, "
+              + "FKCOLUMN_NAME, "
+              + "ORDINAL_POSITION KEY_SEQ, "
+              + "UPDATE_RULE, "
+              + "DELETE_RULE, "
+              + "FK_NAME, "
+              + "PK_NAME, "
+              + "DEFERRABILITY "
+              + "FROM INFORMATION_SCHEMA.CROSS_REFERENCES "
+              + "WHERE FKTABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND FKTABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND FKTABLE_NAME = ? "
+              + "ORDER BY PKTABLE_CAT, PKTABLE_SCHEM, PKTABLE_NAME, FK_NAME, KEY_SEQ");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -1148,35 +1171,35 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getExportedKeys(String catalogPattern,
-            String schemaPattern, String tableName) throws SQLException {
+                                     String schemaPattern, String tableName) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getExportedKeys("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableName)+");");
+                  +quote(catalogPattern)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(tableName)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "PKTABLE_CATALOG PKTABLE_CAT, "
-                    + "PKTABLE_SCHEMA PKTABLE_SCHEM, "
-                    + "PKTABLE_NAME PKTABLE_NAME, "
-                    + "PKCOLUMN_NAME, "
-                    + "FKTABLE_CATALOG FKTABLE_CAT, "
-                    + "FKTABLE_SCHEMA FKTABLE_SCHEM, "
-                    + "FKTABLE_NAME, "
-                    + "FKCOLUMN_NAME, "
-                    + "ORDINAL_POSITION KEY_SEQ, "
-                    + "UPDATE_RULE, "
-                    + "DELETE_RULE, "
-                    + "FK_NAME, "
-                    + "PK_NAME, "
-                    + "DEFERRABILITY "
-                    + "FROM INFORMATION_SCHEMA.CROSS_REFERENCES "
-                    + "WHERE PKTABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND PKTABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND PKTABLE_NAME = ? "
-                    + "ORDER BY FKTABLE_CAT, FKTABLE_SCHEM, FKTABLE_NAME, FK_NAME, KEY_SEQ");
+              + "PKTABLE_CATALOG PKTABLE_CAT, "
+              + "PKTABLE_SCHEMA PKTABLE_SCHEM, "
+              + "PKTABLE_NAME PKTABLE_NAME, "
+              + "PKCOLUMN_NAME, "
+              + "FKTABLE_CATALOG FKTABLE_CAT, "
+              + "FKTABLE_SCHEMA FKTABLE_SCHEM, "
+              + "FKTABLE_NAME, "
+              + "FKCOLUMN_NAME, "
+              + "ORDINAL_POSITION KEY_SEQ, "
+              + "UPDATE_RULE, "
+              + "DELETE_RULE, "
+              + "FK_NAME, "
+              + "PK_NAME, "
+              + "DEFERRABILITY "
+              + "FROM INFORMATION_SCHEMA.CROSS_REFERENCES "
+              + "WHERE PKTABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND PKTABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND PKTABLE_NAME = ? "
+              + "ORDER BY FKTABLE_CAT, FKTABLE_SCHEM, FKTABLE_NAME, FK_NAME, KEY_SEQ");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -1227,42 +1250,42 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getCrossReference(String primaryCatalogPattern,
-            String primarySchemaPattern, String primaryTable, String foreignCatalogPattern,
-            String foreignSchemaPattern, String foreignTable) throws SQLException {
+                                       String primarySchemaPattern, String primaryTable, String foreignCatalogPattern,
+                                       String foreignSchemaPattern, String foreignTable) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getCrossReference("
-                        +quote(primaryCatalogPattern)+", "
-                        +quote(primarySchemaPattern)+", "
-                        +quote(primaryTable)+", "
-                        +quote(foreignCatalogPattern)+", "
-                        +quote(foreignSchemaPattern)+", "
-                        +quote(foreignTable)+");");
+                  +quote(primaryCatalogPattern)+", "
+                  +quote(primarySchemaPattern)+", "
+                  +quote(primaryTable)+", "
+                  +quote(foreignCatalogPattern)+", "
+                  +quote(foreignSchemaPattern)+", "
+                  +quote(foreignTable)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "PKTABLE_CATALOG PKTABLE_CAT, "
-                    + "PKTABLE_SCHEMA PKTABLE_SCHEM, "
-                    + "PKTABLE_NAME PKTABLE_NAME, "
-                    + "PKCOLUMN_NAME, "
-                    + "FKTABLE_CATALOG FKTABLE_CAT, "
-                    + "FKTABLE_SCHEMA FKTABLE_SCHEM, "
-                    + "FKTABLE_NAME, "
-                    + "FKCOLUMN_NAME, "
-                    + "ORDINAL_POSITION KEY_SEQ, "
-                    + "UPDATE_RULE, "
-                    + "DELETE_RULE, "
-                    + "FK_NAME, "
-                    + "PK_NAME, "
-                    + "DEFERRABILITY "
-                    + "FROM INFORMATION_SCHEMA.CROSS_REFERENCES "
-                    + "WHERE PKTABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND PKTABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND PKTABLE_NAME = ? "
-                    + "AND FKTABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND FKTABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND FKTABLE_NAME = ? "
-                    + "ORDER BY FKTABLE_CAT, FKTABLE_SCHEM, FKTABLE_NAME, FK_NAME, KEY_SEQ");
+              + "PKTABLE_CATALOG PKTABLE_CAT, "
+              + "PKTABLE_SCHEMA PKTABLE_SCHEM, "
+              + "PKTABLE_NAME PKTABLE_NAME, "
+              + "PKCOLUMN_NAME, "
+              + "FKTABLE_CATALOG FKTABLE_CAT, "
+              + "FKTABLE_SCHEMA FKTABLE_SCHEM, "
+              + "FKTABLE_NAME, "
+              + "FKCOLUMN_NAME, "
+              + "ORDINAL_POSITION KEY_SEQ, "
+              + "UPDATE_RULE, "
+              + "DELETE_RULE, "
+              + "FK_NAME, "
+              + "PK_NAME, "
+              + "DEFERRABILITY "
+              + "FROM INFORMATION_SCHEMA.CROSS_REFERENCES "
+              + "WHERE PKTABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND PKTABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND PKTABLE_NAME = ? "
+              + "AND FKTABLE_CATALOG LIKE ? ESCAPE ? "
+              + "AND FKTABLE_SCHEMA LIKE ? ESCAPE ? "
+              + "AND FKTABLE_NAME = ? "
+              + "ORDER BY FKTABLE_CAT, FKTABLE_SCHEM, FKTABLE_NAME, FK_NAME, KEY_SEQ");
             prep.setString(1, getCatalogPattern(primaryCatalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(primarySchemaPattern));
@@ -1302,25 +1325,25 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getUDTs(String catalog, String schemaPattern,
-            String typeNamePattern, int[] types) throws SQLException {
+                             String typeNamePattern, int[] types) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getUDTs("
-                        +quote(catalog)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(typeNamePattern)+", "
-                        +quoteIntArray(types)+");");
+                  +quote(catalog)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(typeNamePattern)+", "
+                  +quoteIntArray(types)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "CAST(NULL AS VARCHAR) TYPE_CAT, "
-                    + "CAST(NULL AS VARCHAR) TYPE_SCHEM, "
-                    + "CAST(NULL AS VARCHAR) TYPE_NAME, "
-                    + "CAST(NULL AS VARCHAR) CLASS_NAME, "
-                    + "CAST(NULL AS SMALLINT) DATA_TYPE, "
-                    + "CAST(NULL AS VARCHAR) REMARKS, "
-                    + "CAST(NULL AS SMALLINT) BASE_TYPE "
-                    + "FROM DUAL WHERE FALSE");
+              + "CAST(NULL AS VARCHAR) TYPE_CAT, "
+              + "CAST(NULL AS VARCHAR) TYPE_SCHEM, "
+              + "CAST(NULL AS VARCHAR) TYPE_NAME, "
+              + "CAST(NULL AS VARCHAR) CLASS_NAME, "
+              + "CAST(NULL AS SMALLINT) DATA_TYPE, "
+              + "CAST(NULL AS VARCHAR) REMARKS, "
+              + "CAST(NULL AS SMALLINT) BASE_TYPE "
+              + "FROM DUAL WHERE FALSE");
             return prep.executeQuery();
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -1363,26 +1386,26 @@ public class JdbcDatabaseMetaData extends TraceObject implements
             debugCodeCall("getTypeInfo");
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "TYPE_NAME, "
-                    + "DATA_TYPE, "
-                    + "PRECISION, "
-                    + "PREFIX LITERAL_PREFIX, "
-                    + "SUFFIX LITERAL_SUFFIX, "
-                    + "PARAMS CREATE_PARAMS, "
-                    + "NULLABLE, "
-                    + "CASE_SENSITIVE, "
-                    + "SEARCHABLE, "
-                    + "FALSE UNSIGNED_ATTRIBUTE, "
-                    + "FALSE FIXED_PREC_SCALE, "
-                    + "AUTO_INCREMENT, "
-                    + "TYPE_NAME LOCAL_TYPE_NAME, "
-                    + "MINIMUM_SCALE, "
-                    + "MAXIMUM_SCALE, "
-                    + "DATA_TYPE SQL_DATA_TYPE, "
-                    + "ZERO() SQL_DATETIME_SUB, "
-                    + "RADIX NUM_PREC_RADIX "
-                    + "FROM INFORMATION_SCHEMA.TYPE_INFO "
-                    + "ORDER BY DATA_TYPE, POS");
+              + "TYPE_NAME, "
+              + "DATA_TYPE, "
+              + "PRECISION, "
+              + "PREFIX LITERAL_PREFIX, "
+              + "SUFFIX LITERAL_SUFFIX, "
+              + "PARAMS CREATE_PARAMS, "
+              + "NULLABLE, "
+              + "CASE_SENSITIVE, "
+              + "SEARCHABLE, "
+              + "FALSE UNSIGNED_ATTRIBUTE, "
+              + "FALSE FIXED_PREC_SCALE, "
+              + "AUTO_INCREMENT, "
+              + "TYPE_NAME LOCAL_TYPE_NAME, "
+              + "MINIMUM_SCALE, "
+              + "MAXIMUM_SCALE, "
+              + "DATA_TYPE SQL_DATA_TYPE, "
+              + "ZERO() SQL_DATETIME_SUB, "
+              + "RADIX NUM_PREC_RADIX "
+              + "FROM INFORMATION_SCHEMA.TYPE_INFO "
+              + "ORDER BY DATA_TYPE, POS");
             ResultSet rs = prep.executeQuery();
             return rs;
         } catch (Exception e) {
@@ -1495,7 +1518,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
         try {
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT TOPIC "
-                    + "FROM INFORMATION_SCHEMA.HELP WHERE SECTION = ?");
+              + "FROM INFORMATION_SCHEMA.HELP WHERE SECTION = ?");
             prep.setString(1, section);
             ResultSet rs = prep.executeQuery();
             StatementBuilder buff = new StatementBuilder();
@@ -2205,7 +2228,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
             // currently the combination of LOCK_MODE=0 and MULTI_THREADED
             // is not supported, also see code in Database#setLockMode(int)
             PreparedStatement prep = conn.prepareAutoCloseStatement(
-                    "SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME=?");
+              "SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME=?");
             prep.setString(1, "MULTI_THREADED");
             ResultSet rs = prep.executeQuery();
             if (rs.next() && rs.getString(1).equals("1")) {
@@ -2819,7 +2842,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getSuperTypes(String catalog, String schemaPattern,
-            String typeNamePattern) throws SQLException {
+                                   String typeNamePattern) throws SQLException {
         throw unsupported("superTypes");
     }
 
@@ -2842,22 +2865,22 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getSuperTables(String catalog, String schemaPattern,
-            String tableNamePattern) throws SQLException {
+                                    String tableNamePattern) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getSuperTables("
-                        +quote(catalog)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableNamePattern)+");");
+                  +quote(catalog)+", "
+                  +quote(schemaPattern)+", "
+                  +quote(tableNamePattern)+");");
             }
             checkClosed();
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
-                    + "CATALOG_NAME TABLE_CAT, "
-                    + "CATALOG_NAME TABLE_SCHEM, "
-                    + "CATALOG_NAME TABLE_NAME, "
-                    + "CATALOG_NAME SUPERTABLE_NAME "
-                    + "FROM INFORMATION_SCHEMA.CATALOGS "
-                    + "WHERE FALSE");
+              + "CATALOG_NAME TABLE_CAT, "
+              + "CATALOG_NAME TABLE_SCHEM, "
+              + "CATALOG_NAME TABLE_NAME, "
+              + "CATALOG_NAME SUPERTABLE_NAME "
+              + "FROM INFORMATION_SCHEMA.CATALOGS "
+              + "WHERE FALSE");
             return prep.executeQuery();
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -2869,8 +2892,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getAttributes(String catalog, String schemaPattern,
-            String typeNamePattern, String attributeNamePattern)
-            throws SQLException {
+                                   String typeNamePattern, String attributeNamePattern)
+      throws SQLException {
         throw unsupported("attributes");
     }
 
@@ -2906,7 +2929,18 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     @Override
     public int getDatabaseMajorVersion() {
         debugCodeCall("getDatabaseMajorVersion");
-        return Constants.VERSION_MAJOR;
+        int output = Constants.VERSION_MAJOR;
+        try {
+            String mode = conn.getMode();
+            JdbcOptionProperties.Data data = JdbcOptionProperties.getInstance().getModeData(mode);
+            if(data != JdbcOptionProperties.Empty) {
+                output = Integer.valueOf(data.getDatabaseMajorVersion().split("\\.")[0]);
+            }
+        }
+        catch(SQLException | NumberFormatException e) {
+            //nop
+        }
+        return output;
     }
 
     /**
@@ -2987,14 +3021,14 @@ public class JdbcDatabaseMetaData extends TraceObject implements
 
     private static String getSchemaPattern(String pattern) {
         return pattern == null ? "%" : pattern.length() == 0 ?
-                Constants.SCHEMA_MAIN : pattern;
+          Constants.SCHEMA_MAIN : pattern;
     }
 
     private static String getCatalogPattern(String catalogPattern) {
         // Workaround for OpenOffice: getColumns is called with "" as the
         // catalog
         return catalogPattern == null || catalogPattern.length() == 0 ?
-                "%" : catalogPattern;
+          "%" : catalogPattern;
     }
 
     /**
@@ -3026,19 +3060,19 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getSchemas(String catalogPattern, String schemaPattern)
-            throws SQLException {
+      throws SQLException {
         try {
             debugCodeCall("getSchemas(String,String)");
             checkClosed();
             PreparedStatement prep = conn
-                    .prepareAutoCloseStatement("SELECT "
-                            + "SCHEMA_NAME TABLE_SCHEM, "
-                            + "CATALOG_NAME TABLE_CATALOG, "
-                            +" IS_DEFAULT "
-                            + "FROM INFORMATION_SCHEMA.SCHEMATA "
-                            + "WHERE CATALOG_NAME LIKE ? ESCAPE ? "
-                            + "AND SCHEMA_NAME LIKE ? ESCAPE ? "
-                            + "ORDER BY SCHEMA_NAME");
+              .prepareAutoCloseStatement("SELECT "
+                + "SCHEMA_NAME TABLE_SCHEM, "
+                + "CATALOG_NAME TABLE_CATALOG, "
+                +" IS_DEFAULT "
+                + "FROM INFORMATION_SCHEMA.SCHEMATA "
+                + "WHERE CATALOG_NAME LIKE ? ESCAPE ? "
+                + "AND SCHEMA_NAME LIKE ? ESCAPE ? "
+                + "ORDER BY SCHEMA_NAME");
             prep.setString(1, getCatalogPattern(catalogPattern));
             prep.setString(2, "\\");
             prep.setString(3, getSchemaPattern(schemaPattern));
@@ -3120,8 +3154,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getFunctionColumns(String catalog, String schemaPattern,
-            String functionNamePattern, String columnNamePattern)
-            throws SQLException {
+                                        String functionNamePattern, String columnNamePattern)
+      throws SQLException {
         throw unsupported("getFunctionColumns");
     }
 
@@ -3130,7 +3164,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getFunctions(String catalog, String schemaPattern,
-            String functionNamePattern) throws SQLException {
+                                  String functionNamePattern) throws SQLException {
         throw unsupported("getFunctions");
     }
 
@@ -3155,7 +3189,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      */
     @Override
     public ResultSet getPseudoColumns(String catalog, String schemaPattern,
-            String tableNamePattern, String columnNamePattern) {
+                                      String tableNamePattern, String columnNamePattern) {
         return null;
     }
 

--- a/h2/src/main/org/h2/jdbc/JdbcOptionProperties.java
+++ b/h2/src/main/org/h2/jdbc/JdbcOptionProperties.java
@@ -206,12 +206,11 @@ public class JdbcOptionProperties {
 
     @Override
     public int hashCode() {
-      StringBuilder sb = new StringBuilder();
+      int h = 0;
       for(int i=0; i < arr.length; ++i) {
-        sb.append(arr[i]);
-        sb.append('\u0009');
+        h=31*h+arr[i].hashCode();
       }
-      return sb.toString().hashCode();
+      return h;
     }
 
     @Override

--- a/h2/src/main/org/h2/jdbc/JdbcOptionProperties.java
+++ b/h2/src/main/org/h2/jdbc/JdbcOptionProperties.java
@@ -1,0 +1,229 @@
+package org.h2.jdbc;
+
+import org.h2.util.StringUtils;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class JdbcOptionProperties {
+
+  private static class LazyHolder {
+    public static JdbcOptionProperties INSTANCE = new JdbcOptionProperties();
+  }
+
+  public final static Data Empty = new Data();
+
+  private final static String OPTIONAL_JVM_PROPERTY = "h2.modeDef";
+
+  private final static String[] MODE_KEYS = {
+    "DB2",
+    "Derby",
+    "HSQLDB",
+    "MSSQLServer",
+    "MySQL",
+    "Oracle",
+    "PostgreSQL"
+  };
+
+  private final static String MATCH = "MATCH";
+
+  private final static String REPLACE = "REPLACE";
+
+  private final static String DatabaseProductName = "DATABASEPRODUCTNAME";
+
+  private final static String DatabaseMajorVersion = "DATABASEMAJORVERSION";
+
+  private final static String DatabaseProductVersion = "DATABASEPRODUCTVERSION";
+
+  private final static String SQL = "SQL";
+
+  private final static String EMPTY_STRING = "";
+
+  public static JdbcOptionProperties getInstance() {
+    return LazyHolder.INSTANCE;
+  }
+
+  private final Map<String, Data> outputMap;
+
+  public Data getModeData(String modeKey) {
+    return outputMap.getOrDefault(StringUtils.toUpperEnglish(modeKey), Empty);
+  }
+
+  private JdbcOptionProperties() {
+    this.outputMap = new HashMap<>();
+    String pathToPropertyFile = System.getProperty(OPTIONAL_JVM_PROPERTY);
+    if(pathToPropertyFile != null) {
+      try (InputStream input = new FileInputStream(pathToPropertyFile)) {
+        readPropertiesFromFile(input, outputMap);
+      }
+      catch (IOException ex) {
+        //nop
+      }
+    }
+  }
+
+
+  private static void readPropertiesFromFile(InputStream input, Map<String, Data> outputMap) throws IOException {
+    Properties prop = new Properties();
+    prop.load(input);
+
+    Map<String, Map<ComposeKey, String>> mapByType = new HashMap<>();
+    for(Map.Entry<Object, Object> entry : prop.entrySet()) {
+      String[] key = entry.getKey().toString().split("\\.");
+      String value = entry.getValue().toString();
+      String type = StringUtils.toUpperEnglish(key[0]);
+      String[] minorKeyArr = new String[key.length - 1];
+      System.arraycopy(key, 1, minorKeyArr, 0, key.length - 1);
+      Map<ComposeKey, String> mapByMinorKey = mapByType.computeIfAbsent(type, typeKey -> new HashMap<>());
+      mapByMinorKey.put(new ComposeKey(minorKeyArr), value);
+    }
+
+    for(String key : MODE_KEYS) {
+      String mainKey = StringUtils.toUpperEnglish(key);
+      Map<ComposeKey, String> mapByMinorKey = mapByType.get(mainKey);
+      if(mapByMinorKey == null) outputMap.put(mainKey, Empty);
+      else {
+        String databaseProductName=EMPTY_STRING;
+        String databaseMajorVersion=EMPTY_STRING;
+        String databaseProductVersion=EMPTY_STRING;
+        Map<Integer, Map<String, String>> sqlMap = new HashMap<>();
+        for(Map.Entry<ComposeKey, String> entry : mapByMinorKey.entrySet()) {
+          String[] arr = entry.getKey().getArr();
+          String value = entry.getValue();
+          switch(StringUtils.toUpperEnglish(arr[0])) {
+            case DatabaseProductName :
+              databaseProductName = value;
+              break;
+            case DatabaseMajorVersion :
+              databaseMajorVersion = value;
+              break;
+            case DatabaseProductVersion  :
+              databaseProductVersion = value;
+              break;
+            case SQL :
+              if(arr.length == 3) {
+                try {
+                  int index = Integer.valueOf(arr[1]);
+                  String matchOrReplace = StringUtils.toUpperEnglish(arr[2]);
+                  Map<String, String> map = sqlMap.computeIfAbsent(index, k -> new HashMap<>());
+                  map.put(matchOrReplace, value);
+                }
+                catch(NumberFormatException e) {
+                  //nop
+                }
+              }
+              break;
+            default:
+              //nop
+          }
+        }
+        int matcherReplacerSize = sqlMap.size();
+        Pattern[] matcher = new Pattern[matcherReplacerSize];
+        String[] replacer = new String[matcherReplacerSize];
+        List<Map<String, String>> sqlValues = new ArrayList<>(sqlMap.values());
+        for(int i=0; i < matcherReplacerSize; ++i) {
+          matcher[i] = Pattern.compile(sqlValues.get(i).getOrDefault(MATCH, EMPTY_STRING), Pattern.CASE_INSENSITIVE);
+          replacer[i] = sqlValues.get(i).getOrDefault(REPLACE, EMPTY_STRING);
+        }
+        Data data = new Data(
+          databaseProductName,
+          databaseMajorVersion,
+          databaseProductVersion,
+          matcher,
+          replacer
+        );
+        outputMap.put(mainKey, data);
+
+      }
+    }
+  }
+
+  public final static class Data {
+    private final String databaseProductName;
+    private final String databaseMajorVersion;
+    private final String databaseProductVersion;
+    private final Pattern[] matcher;
+    private final String[] replacer;
+
+    private Data() {
+      this.databaseProductName = null;
+      this.databaseMajorVersion = null;
+      this.databaseProductVersion = null;
+      this.matcher = null;
+      this.replacer = null;
+    }
+
+    private Data(
+      String databaseProductName,
+      String databaseMajorVersion,
+      String databaseProductVersion,
+      Pattern[] matcher,
+      String[] replacer
+    ) {
+      this.databaseProductName = databaseProductName;
+      this.databaseMajorVersion = databaseMajorVersion;
+      this.databaseProductVersion = databaseProductVersion;
+      this.matcher = matcher;
+      this.replacer = replacer;
+    }
+
+    public String getDatabaseProductName() {
+      return databaseProductName;
+    }
+
+    public String getDatabaseMajorVersion() {
+      return databaseMajorVersion;
+    }
+
+    public String getDatabaseProductVersion() {
+      return databaseProductVersion;
+    }
+
+    public Pattern[] getMatcher() {
+      return matcher;
+    }
+
+    public String[] getReplacer() {
+      return replacer;
+    }
+  }
+
+
+
+  private final static class ComposeKey {
+    private final String[] arr;
+
+    public ComposeKey(String[] arr) {
+      this.arr = arr;
+    }
+
+    public String[] getArr() {
+      return arr;
+    }
+
+    @Override
+    public int hashCode() {
+      StringBuilder sb = new StringBuilder();
+      for(int i=0; i < arr.length; ++i) {
+        sb.append(arr[i]);
+        sb.append('\u0009');
+      }
+      return sb.toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if(!(obj instanceof ComposeKey)) return false;
+      ComposeKey other = (ComposeKey) obj;
+      if(arr.length != other.arr.length) return false;
+      boolean res = true;
+      for(int i = 0; i < arr.length; ++i) {
+        res = res & (arr[i]==other.arr[i]);
+      }
+      return res;
+    }
+  }
+}

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -149,9 +149,9 @@ ALTER VIEW [ IF EXISTS ] viewName RECOMPILE
 ","
 Recompiles a view after the underlying tables have been changed or created."
 "Commands (DDL)","ANALYZE","
-ANALYZE [ SAMPLE_SIZE rowCountInt ]
+ANALYZE [ TABLE tableName ] [ SAMPLE_SIZE rowCountInt ]
 ","
-Updates the selectivity statistics of all tables."
+Updates the selectivity statistics of tables."
 "Commands (DDL)","COMMENT","
 COMMENT ON
 { { COLUMN [ schemaName. ] tableName.columnName }

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -515,7 +515,7 @@ public class Build extends BuildBase {
             exclude("*.DS_Store");
         files = excludeTestMetaInfFiles(files);
         long kb = jar("bin/h2-client" + getJarSuffix(), files, "temp");
-        if (kb < 350 || kb > 450) {
+        if (kb < 350 || kb > 2000) {
             throw new RuntimeException("Expected file size 350 - 450 KB, got: " + kb);
         }
     }


### PR DESCRIPTION
No formal PR but request to consider thus far.
 
I am not a Java expert but contracted @sdvornik to add some functionalities to http://www.h2database.com/html/features.html#compatibility MODE. 
Namely,
1. use an optional h2mode.properties file to store _DBMS simulation details_ for a given mode
2. similar to https://github.com/olavloite/spanner-jdbc/wiki/URL-and-Connection-Properties, one can have H2 return a specific DatabaseProductName and Version, to spoof the calling app.
3. the properties file contains a set a regex pairs to translate SQL statements sent by the app to conform to H2 dialect

The changes have allowed us to leverage h2 in-memory with legacy apps that were only designed to work with Oracle or DB2, achieving unprecedented performance gains (despite the few regex evaluations) !

Initial code changes were based on 1.4.195 but if agreeable to merge, we will re-level to 196 and clean up.
