### PR TITLE
Inline getTimeTry() into DateTimeUtils.getMillis()

### DIFF
--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -519,9 +519,15 @@ public class DateTimeUtils {
      */
     public static long getMillis(TimeZone tz, int year, int month, int day,
             int hour, int minute, int second, int millis) {
+        Calendar c;
+        if (tz == null) {
+            c = getCalendar();
+        } else {
+            c = getCalendar(tz);
+        }
+        c.setLenient(false);
         try {
-            return getTimeTry(false, tz, year, month, day, hour, minute, second,
-                    millis);
+            return convertToMillis(c, year, month, day, hour, minute, second, millis);
         } catch (IllegalArgumentException e) {
             // special case: if the time simply doesn't exist because of
             // daylight saving time changes, use the lenient version
@@ -545,21 +551,9 @@ public class DateTimeUtils {
                 // for example for 2042-10-12 00:00:00.
                 hour += 6;
             }
-            return getTimeTry(true, tz, year, month, day, hour, minute,
-                    second, millis);
+            c.setLenient(true);
+            return convertToMillis(c, year, month, day, hour, minute, second, millis);
         }
-    }
-
-    private static long getTimeTry(boolean lenient, TimeZone tz, int year,
-            int month, int day, int hour, int minute, int second, int millis) {
-        Calendar c;
-        if (tz == null) {
-            c = getCalendar();
-        } else {
-            c = getCalendar(tz);
-        }
-        c.setLenient(lenient);
-        return convertToMillis(c, year, month, day, hour, minute, second, millis);
     }
 
     private static long convertToMillis(Calendar cal, int year, int month, int day,

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -530,8 +530,6 @@ public class DateTimeUtils {
                 if (hour < 0 || hour > 23) {
                     throw e;
                 }
-                return getTimeTry(true, tz, year, month, day, hour, minute,
-                        second, millis);
             } else if (message.indexOf("DAY_OF_MONTH") > 0) {
                 int maxDay;
                 if (month == 2) {
@@ -546,12 +544,9 @@ public class DateTimeUtils {
                 // using the timezone Brasilia and others,
                 // for example for 2042-10-12 00:00:00.
                 hour += 6;
-                return getTimeTry(true, tz, year, month, day, hour, minute,
-                        second, millis);
-            } else {
-                return getTimeTry(true, tz, year, month, day, hour, minute,
-                        second, millis);
             }
+            return getTimeTry(true, tz, year, month, day, hour, minute,
+                    second, millis);
         }
     }
 

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -64,12 +64,12 @@ public class DateTimeUtils {
      * have that problem, and while it is still a small memory leak, it is not a
      * class loader memory leak.
      */
-    private static final ThreadLocal<Calendar> CACHED_CALENDAR = new ThreadLocal<>();
+    private static final ThreadLocal<GregorianCalendar> CACHED_CALENDAR = new ThreadLocal<>();
 
     /**
      * A cached instance of Calendar used when a timezone is specified.
      */
-    private static final ThreadLocal<Calendar> CACHED_CALENDAR_NON_DEFAULT_TIMEZONE =
+    private static final ThreadLocal<GregorianCalendar> CACHED_CALENDAR_NON_DEFAULT_TIMEZONE =
             new ThreadLocal<>();
 
     /**
@@ -101,8 +101,8 @@ public class DateTimeUtils {
      *
      * @return a calendar instance. A cached instance is returned where possible
      */
-    private static Calendar getCalendar() {
-        Calendar c = CACHED_CALENDAR.get();
+    private static GregorianCalendar getCalendar() {
+        GregorianCalendar c = CACHED_CALENDAR.get();
         if (c == null) {
             c = DateTimeUtils.createGregorianCalendar();
             CACHED_CALENDAR.set(c);
@@ -117,8 +117,8 @@ public class DateTimeUtils {
      * @param tz timezone for the calendar, is never null
      * @return a calendar instance. A cached instance is returned where possible
      */
-    private static Calendar getCalendar(TimeZone tz) {
-        Calendar c = CACHED_CALENDAR_NON_DEFAULT_TIMEZONE.get();
+    private static GregorianCalendar getCalendar(TimeZone tz) {
+        GregorianCalendar c = CACHED_CALENDAR_NON_DEFAULT_TIMEZONE.get();
         if (c == null || !c.getTimeZone().equals(tz)) {
             c = DateTimeUtils.createGregorianCalendar(tz);
             CACHED_CALENDAR_NON_DEFAULT_TIMEZONE.set(c);
@@ -136,7 +136,7 @@ public class DateTimeUtils {
      *
      * @return a new calendar instance.
      */
-    public static Calendar createGregorianCalendar() {
+    public static GregorianCalendar createGregorianCalendar() {
         return new GregorianCalendar();
     }
 
@@ -150,7 +150,7 @@ public class DateTimeUtils {
      * @param tz timezone for the calendar, is never null
      * @return a new calendar instance.
      */
-    public static Calendar createGregorianCalendar(TimeZone tz) {
+    public static GregorianCalendar createGregorianCalendar(TimeZone tz) {
         return new GregorianCalendar(tz);
     }
 
@@ -519,7 +519,7 @@ public class DateTimeUtils {
      */
     public static long getMillis(TimeZone tz, int year, int month, int day,
             int hour, int minute, int second, int millis) {
-        Calendar c;
+        GregorianCalendar c;
         if (tz == null) {
             c = getCalendar();
         } else {
@@ -539,7 +539,7 @@ public class DateTimeUtils {
             } else if (message.indexOf("DAY_OF_MONTH") > 0) {
                 int maxDay;
                 if (month == 2) {
-                    maxDay = new GregorianCalendar().isLeapYear(year) ? 29 : 28;
+                    maxDay = c.isLeapYear(year) ? 29 : 28;
                 } else {
                     maxDay = 30 + ((month + (month > 7 ? 1 : 0)) & 1);
                 }


### PR DESCRIPTION
1. All three branches of code in catch block in `getMillis()` were ended with the same call. I moved it out of these branches.

2. `getTimeTry()` used only in `getMillis()`. This method is simple, so I inlined it and remove second lookup of the same `Calendar` in catch block after it.

3. `getMillis()` in catch block initialized additional `GregorianCalendar` just to call `isLeapYear()`. This method can be called on existing `Calendar` after inlining of `getTimeTry()`, but this method is available only on `GregorianCalendar`, so to avoid typecast return type of `getCalendar()` and `createGregorianCalendar()` methods was changed to `GregorialCalendar`.