### PR TITLE
Use StringUtils.replaceAll() in Function.replace()

### DIFF
--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1947,23 +1947,7 @@ public class Function extends Expression implements FunctionCall {
         if (s == null || replace == null || with == null) {
             return null;
         }
-        if (replace.length() == 0) {
-            // avoid out of memory
-            return s;
-        }
-        StringBuilder buff = new StringBuilder(s.length());
-        int start = 0;
-        int len = replace.length();
-        while (true) {
-            int i = s.indexOf(replace, start);
-            if (i == -1) {
-                break;
-            }
-            buff.append(s.substring(start, i)).append(with);
-            start = i + len;
-        }
-        buff.append(s.substring(start));
-        return buff.toString();
+        return StringUtils.replaceAll(s, replace, with);
     }
 
     private static String repeat(String s, int count) {

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -726,11 +726,11 @@ public class StringUtils {
                 s.length() - before.length() + after.length());
         int index = 0;
         while (true) {
-            buff.append(s.substring(index, next)).append(after);
+            buff.append(s, index, next).append(after);
             index = next + before.length();
             next = s.indexOf(before, index);
             if (next < 0) {
-                buff.append(s.substring(index));
+                buff.append(s, index, s.length());
                 break;
             }
         }

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -707,7 +707,10 @@ public class StringUtils {
     }
 
     /**
-     * Replace all occurrences of the before string with the after string.
+     * Replace all occurrences of the before string with the after string. Unlike
+     * {@link String#replaceAll(String, String)} this method reads {@code before}
+     * and {@code after} arguments as plain strings and if {@code before} argument
+     * is an empty string this method returns original string {@code s}.
      *
      * @param s the string
      * @param before the old text
@@ -716,7 +719,7 @@ public class StringUtils {
      */
     public static String replaceAll(String s, String before, String after) {
         int next = s.indexOf(before);
-        if (next < 0) {
+        if (next < 0 || before.isEmpty()) {
             return s;
         }
         StringBuilder buff = new StringBuilder(

--- a/h2/src/test/org/h2/test/unit/TestStringUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestStringUtils.java
@@ -225,6 +225,8 @@ public class TestStringUtils extends TestBase {
                 StringUtils.replaceAll("abcabcabc", "abc", ""));
         assertEquals("abcabcabc",
                 StringUtils.replaceAll("abcabcabc", "aBc", ""));
+        assertEquals("abcabcabc",
+                StringUtils.replaceAll("abcabcabc", "", "abc"));
     }
 
     private void testTrim() {


### PR DESCRIPTION
1. `StringUtils.replaceAll()` now returns original stirng if search string is empty. This is not that `String.replaceAll()` does, but this is compatible with SQL `REPLACE` function in other databases (I tested Oracle, MySQL, PostgreSQL, SQL Server, and SQLite). Before this change this method throwed OOME with this argument.

2. I replace calls to `String.substring()` in this method to reduce amount of allocated objects and improve perfomance. Tests with JMH shows that usage of `StringBuilder.append(CharSequence, int, int)` instead of `StringBuilder.append(String.substring())` impoves perfomance of `replaceAll()` in 1,5x or so depending on input values.

3. `StringUtils.replaceAll()` is now used in `Function.replace()` to reduce code duplication.