### PR TITLE
TestTools should not leave testing thread in interrupted state

### DIFF
--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -139,7 +139,7 @@ public class TestTools extends TestBase {
             c.runTool("-web", "-webPort", "9002", "-tool", "-browser", "-tcp",
                     "-tcpPort", "9003", "-pg", "-pgPort", "9004");
             assertContains(lastUrl, ":9002");
-            c.shutdown();
+            shutdownConlose(c);
 
             // check if starting the browser works
             c.runTool("-web", "-webPort", "9002", "-tool");
@@ -169,7 +169,7 @@ public class TestTools extends TestBase {
                 // ignore
             }
 
-            c.shutdown();
+            shutdownConlose(c);
 
             // trying to use the same port for two services should fail,
             // but also stop the first service
@@ -184,7 +184,19 @@ public class TestTools extends TestBase {
             } else {
                 System.clearProperty(SysProperties.H2_BROWSER);
             }
-            c.shutdown();
+            shutdownConlose(c);
+        }
+    }
+
+    private static void shutdownConlose(Console c) {
+        c.shutdown();
+        if (Thread.currentThread().isInterrupted()) {
+            // Clear interrupted state so test can continue its work safely
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // Ignore
+            }
         }
     }
 

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -139,7 +139,7 @@ public class TestTools extends TestBase {
             c.runTool("-web", "-webPort", "9002", "-tool", "-browser", "-tcp",
                     "-tcpPort", "9003", "-pg", "-pgPort", "9004");
             assertContains(lastUrl, ":9002");
-            shutdownConlose(c);
+            shutdownConsole(c);
 
             // check if starting the browser works
             c.runTool("-web", "-webPort", "9002", "-tool");
@@ -169,7 +169,7 @@ public class TestTools extends TestBase {
                 // ignore
             }
 
-            shutdownConlose(c);
+            shutdownConsole(c);
 
             // trying to use the same port for two services should fail,
             // but also stop the first service
@@ -184,11 +184,11 @@ public class TestTools extends TestBase {
             } else {
                 System.clearProperty(SysProperties.H2_BROWSER);
             }
-            shutdownConlose(c);
+            shutdownConsole(c);
         }
     }
 
-    private static void shutdownConlose(Console c) {
+    private static void shutdownConsole(Console c) {
         c.shutdown();
         if (Thread.currentThread().isInterrupted()) {
             // Clear interrupted state so test can continue its work safely


### PR DESCRIPTION
`TestTools` causes failures in `TestSampleApps` and `TestStringCache` when called from `TestAll` on Java 9.

There reason is that `Console.shutdown()` calls `Thread.currentThread().interrupt()` in presence of `TrayIcon`. This is not reproducible on Java 8 on my system, probably because `java.awt.TrayIcon` from Java 8 does not work with some modern Linux desktops.

To fix this I added a helper methods that clears interrupted flag from the testing thread if this flag is set.