### PR TITLE
Read known fields directly from date-time types

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -254,7 +254,7 @@ public class ValueDataType implements DataType {
         }
         case Value.TIME: {
             ValueTime t = (ValueTime) v;
-            long nanos = t.getNanos();
+            long nanos = t.getTimeNanos();
             long millis = nanos / 1000000;
             nanos -= millis * 1000000;
             buff.put((byte) type).

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -490,7 +490,7 @@ public class Data {
             if (STORE_LOCAL_TIME) {
                 writeByte((byte) LOCAL_TIME);
                 ValueTime t = (ValueTime) v;
-                long nanos = t.getNanos();
+                long nanos = t.getTimeNanos();
                 long millis = nanos / 1000000;
                 nanos -= millis * 1000000;
                 writeVarLong(millis);
@@ -1002,7 +1002,7 @@ public class Data {
         }
         case Value.TIME:
             if (STORE_LOCAL_TIME) {
-                long nanos = ((ValueTime) v).getNanos();
+                long nanos = ((ValueTime) v).getTimeNanos();
                 long millis = nanos / 1000000;
                 nanos -= millis * 1000000;
                 return 1 + getVarLongLen(millis) + getVarLongLen(nanos);

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -194,7 +194,7 @@ public class DateTimeUtils {
         Calendar cal = (Calendar) calendar.clone();
         cal.clear();
         cal.setLenient(true);
-        long nanos = t.getNanos();
+        long nanos = t.getTimeNanos();
         long millis = nanos / 1000000;
         nanos -= millis * 1000000;
         long s = millis / 1000;

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -18,6 +18,7 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Mode;
 import org.h2.message.DbException;
 import org.h2.value.Value;
+import org.h2.value.ValueAbstractDateTime;
 import org.h2.value.ValueDate;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueTime;
@@ -598,15 +599,29 @@ public class DateTimeUtils {
      * @return the value
      */
     public static int getDatePart(Value date, int field) {
-        Calendar c = valueToCalendar(date);
-        if (field == Calendar.YEAR) {
-            return getYear(c);
+        ValueAbstractDateTime v;
+        if (date instanceof ValueAbstractDateTime) {
+            v = (ValueAbstractDateTime) date;
+        } else {
+            v = (ValueTimestamp) date.convertTo(Value.TIMESTAMP);
         }
-        int value = c.get(field);
-        if (field == Calendar.MONTH) {
-            return value + 1;
+        switch (field) {
+        case Calendar.YEAR:
+            return yearFromDateValue(v.getDateValue());
+        case Calendar.MONTH:
+            return monthFromDateValue(v.getDateValue());
+        case Calendar.DAY_OF_MONTH:
+            return dayFromDateValue(v.getDateValue());
+        case Calendar.HOUR_OF_DAY:
+            return (int) (v.getTimeNanos() / (60L * 60 * 1000000000) % 24);
+        case Calendar.MINUTE:
+            return (int) (v.getTimeNanos() / (60L * 1000000000) % 60);
+        case Calendar.SECOND:
+            return (int) (v.getTimeNanos() / 1000000000 % 60);
+        case Calendar.MILLISECOND:
+            return (int) (v.getTimeNanos() / 1000000 % 1000);
         }
-        return value;
+        return valueToCalendar(date).get(field);
     }
 
     /**

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -306,7 +306,7 @@ public class LocalDateTimeUtils {
     public static Object valueToLocalTime(Value value) {
         try {
             return LOCAL_TIME_OF_NANO.invoke(null,
-                    ((ValueTime) value.convertTo(Value.TIME)).getNanos());
+                    ((ValueTime) value.convertTo(Value.TIME)).getTimeNanos());
         } catch (IllegalAccessException e) {
             throw DbException.convert(e);
         } catch (InvocationTargetException e) {

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -350,7 +350,7 @@ public class Transfer {
             break;
         case Value.TIME:
             if (version >= Constants.TCP_PROTOCOL_VERSION_9) {
-                writeLong(((ValueTime) v).getNanos());
+                writeLong(((ValueTime) v).getTimeNanos());
             } else if (version >= Constants.TCP_PROTOCOL_VERSION_7) {
                 writeLong(DateTimeUtils.getTimeLocalWithoutDst(v.getTime()));
             } else {

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -870,7 +870,7 @@ public abstract class Value {
                 switch (getType()) {
                 case TIME:
                     return DateTimeUtils.normalizeTimestamp(
-                            0, ((ValueTime) this).getNanos());
+                            0, ((ValueTime) this).getTimeNanos());
                 case DATE:
                     return ValueTimestamp.fromDateValueAndNanos(
                             ((ValueDate) this).getDateValue(), 0);

--- a/h2/src/main/org/h2/value/ValueAbstractDateTime.java
+++ b/h2/src/main/org/h2/value/ValueAbstractDateTime.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.value;
+
+import java.util.TimeZone;
+
+import org.h2.util.DateTimeUtils;
+
+/**
+ * Abstract date-time value.
+ */
+public abstract class ValueAbstractDateTime extends Value {
+
+    /**
+     * A bit field with bits for the year, month, and day (see DateTimeUtils for
+     * encoding).
+     *
+     * @return the data value
+     */
+    public long getDateValue() {
+        return 0;
+    }
+
+    /**
+     * @return nanoseconds since midnight
+     */
+    public long getTimeNanos() {
+        return 0;
+    }
+
+    /**
+     * The timezone offset in minutes.
+     *
+     * @return the offset
+     */
+    public short getTimeZoneOffsetMins() {
+        TimeZone tz = TimeZone.getDefault();
+        long millis = DateTimeUtils.convertDateTimeValueToMillis(tz, getDateValue(), getTimeNanos() / 1000000);
+        return (short) (tz.getOffset(millis) / 60000);
+    }
+
+}

--- a/h2/src/main/org/h2/value/ValueDate.java
+++ b/h2/src/main/org/h2/value/ValueDate.java
@@ -16,7 +16,7 @@ import org.h2.util.DateTimeUtils;
 /**
  * Implementation of the DATE data type.
  */
-public class ValueDate extends Value {
+public class ValueDate extends ValueAbstractDateTime {
 
     /**
      * The precision in digits.
@@ -81,6 +81,7 @@ public class ValueDate extends Value {
         }
     }
 
+    @Override
     public long getDateValue() {
         return dateValue;
     }

--- a/h2/src/main/org/h2/value/ValueTime.java
+++ b/h2/src/main/org/h2/value/ValueTime.java
@@ -16,7 +16,7 @@ import org.h2.util.DateTimeUtils;
 /**
  * Implementation of the TIME data type.
  */
-public class ValueTime extends Value {
+public class ValueTime extends ValueAbstractDateTime {
 
     /**
      * The precision in digits.
@@ -95,10 +95,8 @@ public class ValueTime extends Value {
         }
     }
 
-    /**
-     * @return nanoseconds since midnight
-     */
-    public long getNanos() {
+    @Override
+    public long getTimeNanos() {
         return nanos;
     }
 
@@ -166,13 +164,13 @@ public class ValueTime extends Value {
     @Override
     public Value add(Value v) {
         ValueTime t = (ValueTime) v.convertTo(Value.TIME);
-        return ValueTime.fromNanos(nanos + t.getNanos());
+        return ValueTime.fromNanos(nanos + t.getTimeNanos());
     }
 
     @Override
     public Value subtract(Value v) {
         ValueTime t = (ValueTime) v.convertTo(Value.TIME);
-        return ValueTime.fromNanos(nanos - t.getNanos());
+        return ValueTime.fromNanos(nanos - t.getTimeNanos());
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -17,7 +17,7 @@ import org.h2.util.DateTimeUtils;
 /**
  * Implementation of the TIMESTAMP data type.
  */
-public class ValueTimestamp extends Value {
+public class ValueTimestamp extends ValueAbstractDateTime {
 
     /**
      * The precision in digits.
@@ -134,21 +134,12 @@ public class ValueTimestamp extends Value {
         }
     }
 
-    /**
-     * A bit field with bits for the year, month, and day (see DateTimeUtils for
-     * encoding).
-     *
-     * @return the data value
-     */
+    @Override
     public long getDateValue() {
         return dateValue;
     }
 
-    /**
-     * The nanoseconds since midnight.
-     *
-     * @return the nanoseconds
-     */
+    @Override
     public long getTimeNanos() {
         return timeNanos;
     }

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -22,7 +22,7 @@ import org.h2.util.DateTimeUtils;
  * @see <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators">
  *      ISO 8601 Time zone designators</a>
  */
-public class ValueTimestampTimeZone extends Value {
+public class ValueTimestampTimeZone extends ValueAbstractDateTime {
 
     /**
      * The precision in digits.
@@ -120,30 +120,17 @@ public class ValueTimestampTimeZone extends Value {
         }
     }
 
-    /**
-     * A bit field with bits for the year, month, and day (see DateTimeUtils for
-     * encoding).
-     *
-     * @return the data value
-     */
+    @Override
     public long getDateValue() {
         return dateValue;
     }
 
-    /**
-     * The nanoseconds since midnight.
-     *
-     * @return the nanoseconds
-     */
+    @Override
     public long getTimeNanos() {
         return timeNanos;
     }
 
-    /**
-     * The timezone offset in minutes.
-     *
-     * @return the offset
-     */
+    @Override
     public short getTimeZoneOffsetMins() {
         return timeZoneOffsetMins;
     }

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -161,7 +161,7 @@ public class TestDate extends TestBase {
         assertEquals("05:35:35.5", t1.multiply(ValueDouble.get(0.5)).getString());
         assertEquals("22:22:22", t1.divide(ValueDouble.get(0.5)).getString());
         assertEquals(Value.TIME, t1.getType());
-        long nanos = t1.getNanos();
+        long nanos = t1.getTimeNanos();
         assertEquals((int) ((nanos >>> 32) ^ nanos), t1.hashCode());
         assertEquals(t1.getString().length(), t1.getDisplaySize());
         assertEquals(ValueTime.PRECISION, t1.getPrecision());


### PR DESCRIPTION
1. New abstract class `ValueAbstractDateTime` used as a base class for date-time values so it can be used in functions instead of different code branches for different types.

2. `DateTimeUtils.getDatePart()` now reads years, days, months, hours, minutes, seconds, and milliseconds directly from date-time types. It makes no sense to convert them to UTC offset-based types and recover original fields with `Calendar` after that. All these operations are already covered by existing tests. Complex values are still calculated with `Calendar`.

This pull request is a re-send of #834 without a last commit and with fixed imports in second commit. The reason to re-send is that last commit was against the H2 roadmap that states that usages of `Calendar` should be avoided.