### PR TITLE
Add MEDIAN to help.csv and fix building of documentation

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -498,7 +498,7 @@ qualified class name. The class must implement the interface
 Admin rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
-CREATE AGGREGATE MEDIAN FOR ""com.acme.db.Median""
+CREATE AGGREGATE SIMPLE_MEDIAN FOR ""com.acme.db.Median""
 "
 
 "Commands (DDL)","CREATE ALIAS","
@@ -821,7 +821,7 @@ Drops an existing user-defined aggregate function.
 Admin rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
-DROP AGGREGATE MEDIAN
+DROP AGGREGATE SIMPLE_MEDIAN
 "
 
 "Commands (DDL)","DROP ALIAS","
@@ -2799,6 +2799,19 @@ If no rows are selected, the result is NULL.
 Aggregates are only allowed in select statements.
 ","
 VAR_SAMP(X)
+"
+
+"Functions (Aggregate)","MEDIAN","
+MEDIAN( [ DISTINCT ] value )
+","
+The value separating the higher half of a values from the lower half.
+Returns the middle value or an interpolated value between two middle values if number of values is even.
+Interpolation is only supported for numeric, date, and time data types.
+NULL values are ignored in the calculation.
+If no rows are selected, the result is NULL.
+Aggregates are only allowed in select statements.
+","
+MEDIAN(X)
 "
 
 "Functions (Numeric)","ABS","

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -77,7 +77,7 @@ public class Select extends Query {
     boolean[] groupByExpression;
 
     /**
-     * Thhe current group-by values.
+     * The current group-by values.
      */
     HashMap<Expression, Object> currentGroup;
 

--- a/h2/src/main/org/h2/expression/Aggregate.java
+++ b/h2/src/main/org/h2/expression/Aggregate.java
@@ -131,7 +131,7 @@ public class Aggregate extends Expression {
         MEDIAN
     }
 
-    private static final HashMap<String, AggregateType> AGGREGATES = new HashMap<>(24);
+    private static final HashMap<String, AggregateType> AGGREGATES = new HashMap<>(25);
 
     private final AggregateType type;
     private final Select select;

--- a/h2/src/main/org/h2/expression/Operation.java
+++ b/h2/src/main/org/h2/expression/Operation.java
@@ -27,38 +27,38 @@ public class Operation extends Expression {
          * This operation represents a string concatenation as in
          * 'Hello' || 'World'.
          */
-         CONCAT,
+        CONCAT,
 
         /**
          * This operation represents an addition as in 1 + 2.
          */
-         PLUS,
+        PLUS,
 
         /**
          * This operation represents a subtraction as in 2 - 1.
          */
-         MINUS,
+        MINUS,
 
         /**
          * This operation represents a multiplication as in 2 * 3.
          */
-         MULTIPLY,
+        MULTIPLY,
 
         /**
          * This operation represents a division as in 4 * 2.
          */
-         DIVIDE,
+        DIVIDE,
 
         /**
          * This operation represents a negation as in - ID.
          */
-         NEGATE,
+        NEGATE,
 
         /**
          * This operation represents a modulus as in 5 % 2.
          */
-         MODULUS
-    };
+        MODULUS
+    }
 
     private OpType opType;
     private Expression left, right;

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -262,7 +262,8 @@ public class TestIndex extends TestBase {
         c.close();
     }
 
-    private void testConcurrentUpdateRun(ConcurrentUpdateThread[] threads, PreparedStatement check) throws SQLException {
+    private void testConcurrentUpdateRun(ConcurrentUpdateThread[] threads, PreparedStatement check)
+            throws SQLException {
         for (ConcurrentUpdateThread t : threads) {
             t.start();
         }

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -307,10 +307,10 @@ public class TestValue extends TestBase {
     }
 
     private void testTimestamp() {
-        ValueTimestamp vts = ValueTimestamp.parse("2000-01-15 10:20:30.333222111");
+        ValueTimestamp valueTs = ValueTimestamp.parse("2000-01-15 10:20:30.333222111");
         Timestamp ts = Timestamp.valueOf("2000-01-15 10:20:30.333222111");
-        assertEquals(ts.toString(), vts.getString());
-        assertEquals(ts, vts.getTimestamp());
+        assertEquals(ts.toString(), valueTs.getString());
+        assertEquals(ts, valueTs.getTimestamp());
         Calendar c = Calendar.getInstance(TimeZone.getTimeZone("Europe/Berlin"));
         c.set(2018, 02, 25, 1, 59, 00);
         c.set(Calendar.MILLISECOND, 123);

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -760,5 +760,6 @@ zzbbzz cldr booleans maria enquotes mtc cbuf checksummed nreturn despite bbzz re
 unconditionally coco aren eecccc decimals charsets zzbb lsb msb usecount outdir endian misleading precompiled
 assorted reimplemented hangups confirmation predefined
 
-mdy destfile hclf forbids spellchecking selfdestruct expects accident jacocoagent cli historic mitigate 
-jacoco xdata invokes sourcefiles classfiles duplication crypto stacktraces prt directions handled overly asm hardcoded 
+mdy destfile hclf forbids spellchecking selfdestruct expects accident jacocoagent cli historic mitigate
+jacoco xdata invokes sourcefiles classfiles duplication crypto stacktraces prt directions handled overly asm hardcoded
+interpolated thead


### PR DESCRIPTION
1. `MEDIAN` is described in `help.csv`. Sample name in `CREATE AGGREGATE` and `DROP AGGREGATE` changed to `SIMPLE_MEDIAN` name to avoid name collision if someone try to use this name. May be we need another name for sample aggregate.

2. Initiial capacity of `HashMap` with built-in aggregates updated to avoid resizing.

3. Typo, long line, and bad identation are fixed to allow building of documentation. `dictionary.txt` is also updated for the same reason.