### PR TITLE
Add simple implementations of isWrapperFor() and unwrap() to JdbcDataSource

### DIFF
--- a/h2/src/main/org/h2/jdbcx/JdbcDataSource.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcDataSource.java
@@ -23,6 +23,7 @@ import javax.sql.XAConnection;
 import javax.sql.XADataSource;
 import org.h2.Driver;
 import org.h2.jdbc.JdbcConnection;
+import org.h2.message.DbException;
 import org.h2.message.TraceObject;
 import org.h2.util.StringUtils;
 
@@ -401,23 +402,31 @@ public class JdbcDataSource extends TraceObject implements XADataSource,
     }
 
     /**
-     * [Not supported] Return an object of this class if possible.
+     * Return an object of this class if possible.
      *
      * @param iface the class
      */
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw unsupported("unwrap");
+        try {
+            if (isWrapperFor(iface)) {
+                return (T) this;
+            }
+            throw DbException.getInvalidValueException("iface", iface);
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
     }
 
     /**
-     * [Not supported] Checks if unwrap can return an object of this class.
+     * Checks if unwrap can return an object of this class.
      *
      * @param iface the class
      */
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw unsupported("isWrapperFor");
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /**

--- a/h2/src/test/org/h2/test/jdbcx/TestDataSource.java
+++ b/h2/src/test/org/h2/test/jdbcx/TestDataSource.java
@@ -15,9 +15,12 @@ import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
 import javax.sql.ConnectionEvent;
 import javax.sql.ConnectionEventListener;
+import javax.sql.DataSource;
 import javax.sql.XAConnection;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
+
+import org.h2.api.ErrorCode;
 import org.h2.jdbcx.JdbcDataSource;
 import org.h2.jdbcx.JdbcDataSourceFactory;
 import org.h2.jdbcx.JdbcXAConnection;
@@ -71,6 +74,7 @@ public class TestDataSource extends TestBase {
         }
         testDataSourceFactory();
         testDataSource();
+        testUnwrap();
         testXAConnection();
         deleteDb("dataSource");
     }
@@ -188,6 +192,22 @@ public class TestDataSource extends TestBase {
         stat = conn.createStatement();
         stat.execute("SELECT * FROM DUAL");
         conn.close();
+    }
+
+    private void testUnwrap() throws SQLException {
+        JdbcDataSource ds = new JdbcDataSource();
+        assertTrue(ds.isWrapperFor(Object.class));
+        assertTrue(ds.isWrapperFor(DataSource.class));
+        assertTrue(ds.isWrapperFor(JdbcDataSource.class));
+        assertFalse(ds.isWrapperFor(String.class));
+        assertTrue(ds == ds.unwrap(Object.class));
+        assertTrue(ds == ds.unwrap(DataSource.class));
+        try {
+            ds.unwrap(String.class);
+            fail();
+        } catch (SQLException ex) {
+            assertEquals(ErrorCode.INVALID_VALUE_2, ex.getErrorCode());
+        }
     }
 
 }


### PR DESCRIPTION
H2GIS uses wrappers for DataSource and calls these methods on `JdbcDataSource` too, so add simple implementations to avoid logging of useless exceptions.

https://github.com/orbisgis/h2gis/blob/master/h2gis-utilities/src/main/java/org/h2gis/utilities/SFSUtilities.java