### PR TITLE
Encode date and time in fast and proper way in PgServerThread

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3222,7 +3222,14 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
         }
     }
 
-    private Value get(int columnIndex) {
+    /**
+     * INTERNAL
+     *
+     * @param columnIndex
+     *            index of a column
+     * @return internal representation of the value in the specified column
+     */
+    public Value get(int columnIndex) {
         checkColumnIndex(columnIndex);
         checkOnValidRow();
         Value[] list;

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -20,20 +20,16 @@ import java.net.Socket;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Properties;
-import java.util.TimeZone;
 
 import org.h2.command.CommandInterface;
 import org.h2.engine.ConnectionInfo;
@@ -44,6 +40,7 @@ import org.h2.jdbc.JdbcResultSet;
 import org.h2.jdbc.JdbcStatement;
 import org.h2.message.DbException;
 import org.h2.mvstore.DataUtils;
+import org.h2.util.DateTimeUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.ScriptReader;
@@ -51,7 +48,10 @@ import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 import org.h2.value.CaseInsensitiveMap;
 import org.h2.value.Value;
+import org.h2.value.ValueDate;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueTime;
+import org.h2.value.ValueTimestamp;
 
 /**
  * One server thread is opened for each client.
@@ -530,9 +530,8 @@ public class PgServerThread implements Runnable {
         sendMessage();
     }
 
-    private static long toPostgreSeconds(long millis) {
-        // TODO handle Julian/Gregorian transitions
-        return millis / 1000 - 946684800L;
+    private static long toPostgreDays(long dateValue) {
+        return DateTimeUtils.prolepticGregorianAbsoluteDayFromDateValue(dateValue) - 10_957;
     }
 
     private void writeDataColumn(ResultSet rs, int column, int pgType, boolean text)
@@ -584,45 +583,36 @@ public class PgServerThread implements Runnable {
                 break;
             }
             case PgServer.PG_TYPE_DATE: {
-                Date d = v.getDate();
+                ValueDate d = (ValueDate) v.convertTo(Value.DATE);
                 writeInt(4);
-                long millis = d.getTime();
-                millis += TimeZone.getDefault().getOffset(millis);
-                writeInt((int) (toPostgreSeconds(millis) / 86400));
+                writeInt((int) (toPostgreDays(d.getDateValue())));
                 break;
             }
             case PgServer.PG_TYPE_TIME: {
-                Time t = v.getTime();
+                ValueTime t = (ValueTime) v.convertTo(Value.TIME);
                 writeInt(8);
-                long m = t.getTime();
-                m += TimeZone.getDefault().getOffset(m);
+                long m = t.getNanos();
                 if (INTEGER_DATE_TYPES) {
                     // long format
-                    m *= 1000;
+                    m /= 1_000;
                 } else {
                     // double format
-                    m /= 1000;
-                    m = Double.doubleToLongBits(m);
+                    m = Double.doubleToLongBits(m * 0.000_000_001);
                 }
                 dataOut.writeLong(m);
                 break;
             }
             case PgServer.PG_TYPE_TIMESTAMP_NO_TMZONE: {
-                Timestamp t = v.getTimestamp();
+                ValueTimestamp t = (ValueTimestamp) v.convertTo(Value.TIMESTAMP);
                 writeInt(8);
-                long m = t.getTime();
-                m += TimeZone.getDefault().getOffset(m);
-                m = toPostgreSeconds(m);
-                int nanos = t.getNanos();
-                if (m < 0 && nanos != 0) {
-                    m--;
-                }
+                long m = toPostgreDays(t.getDateValue()) * 86_400;
+                long nanos = t.getTimeNanos();
                 if (INTEGER_DATE_TYPES) {
                     // long format
-                    m = m * 1000000 + nanos / 1000;
+                    m = m * 1_000_000 + nanos / 1_000;
                 } else {
                     // double format
-                    m = Double.doubleToLongBits(m + nanos * 0.000000001);
+                    m = Double.doubleToLongBits(m + nanos * 0.000_000_001);
                 }
                 dataOut.writeLong(m);
                 break;

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -40,6 +40,7 @@ import org.h2.engine.ConnectionInfo;
 import org.h2.engine.SysProperties;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.jdbc.JdbcPreparedStatement;
+import org.h2.jdbc.JdbcResultSet;
 import org.h2.jdbc.JdbcStatement;
 import org.h2.message.DbException;
 import org.h2.mvstore.DataUtils;
@@ -49,6 +50,8 @@ import org.h2.util.ScriptReader;
 import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 import org.h2.value.CaseInsensitiveMap;
+import org.h2.value.Value;
+import org.h2.value.ValueNull;
 
 /**
  * One server thread is opened for each client.
@@ -534,146 +537,94 @@ public class PgServerThread implements Runnable {
 
     private void writeDataColumn(ResultSet rs, int column, int pgType, boolean text)
             throws Exception {
+        Value v = ((JdbcResultSet) rs).get(column);
+        if (v == ValueNull.INSTANCE) {
+            writeInt(-1);
+            return;
+        }
         if (text) {
             // plain text
             switch (pgType) {
-            case PgServer.PG_TYPE_BOOL: {
-                boolean b = rs.getBoolean(column);
-                if (rs.wasNull()) {
-                    writeInt(-1);
-                } else {
-                    writeInt(1);
-                    dataOut.writeByte(b ? 't' : 'f');
-                }
+            case PgServer.PG_TYPE_BOOL:
+                writeInt(1);
+                dataOut.writeByte(v.getBoolean() ? 't' : 'f');
                 break;
-            }
             default:
-                String s = rs.getString(column);
-                if (s == null) {
-                    writeInt(-1);
-                } else {
-                    byte[] data = s.getBytes(getEncoding());
-                    writeInt(data.length);
-                    write(data);
-                }
+                byte[] data = v.getString().getBytes(getEncoding());
+                writeInt(data.length);
+                write(data);
             }
         } else {
             // binary
             switch (pgType) {
-            case PgServer.PG_TYPE_INT2: {
-                short s = rs.getShort(column);
-                if (rs.wasNull()) {
-                    writeInt(-1);
-                } else {
-                    writeInt(2);
-                    writeShort(s);
-                }
+            case PgServer.PG_TYPE_INT2:
+                writeInt(2);
+                writeShort(v.getShort());
                 break;
-            }
-            case PgServer.PG_TYPE_INT4: {
-                int i = rs.getInt(column);
-                if (rs.wasNull()) {
-                    writeInt(-1);
-                } else {
-                    writeInt(4);
-                    writeInt(i);
-                }
+            case PgServer.PG_TYPE_INT4:
+                writeInt(4);
+                writeInt(v.getInt());
                 break;
-            }
-            case PgServer.PG_TYPE_INT8: {
-                long l = rs.getLong(column);
-                if (rs.wasNull()) {
-                    writeInt(-1);
-                } else {
-                    writeInt(8);
-                    dataOut.writeLong(l);
-                }
+            case PgServer.PG_TYPE_INT8:
+                writeInt(8);
+                dataOut.writeLong(v.getLong());
                 break;
-            }
-            case PgServer.PG_TYPE_FLOAT4: {
-                float f = rs.getFloat(column);
-                if (rs.wasNull()) {
-                    writeInt(-1);
-                } else {
-                    writeInt(4);
-                    dataOut.writeFloat(f);
-                }
+            case PgServer.PG_TYPE_FLOAT4:
+                writeInt(4);
+                dataOut.writeFloat(v.getFloat());
                 break;
-            }
-            case PgServer.PG_TYPE_FLOAT8: {
-                double d = rs.getDouble(column);
-                if (rs.wasNull()) {
-                    writeInt(-1);
-                } else {
-                    writeInt(8);
-                    dataOut.writeDouble(d);
-                }
+            case PgServer.PG_TYPE_FLOAT8:
+                writeInt(8);
+                dataOut.writeDouble(v.getDouble());
                 break;
-            }
             case PgServer.PG_TYPE_BYTEA: {
-                byte[] data = rs.getBytes(column);
-                if (data == null) {
-                    writeInt(-1);
-                } else {
-                    writeInt(data.length);
-                    write(data);
-                }
+                byte[] data = v.getBytesNoCopy();
+                writeInt(data.length);
+                write(data);
                 break;
             }
             case PgServer.PG_TYPE_DATE: {
-                Date d = rs.getDate(column);
-                if (d == null) {
-                    writeInt(-1);
-                } else {
-                    writeInt(4);
-                    long millis = d.getTime();
-                    millis += TimeZone.getDefault().getOffset(millis);
-                    writeInt((int) (toPostgreSeconds(millis) / 86400));
-                }
+                Date d = v.getDate();
+                writeInt(4);
+                long millis = d.getTime();
+                millis += TimeZone.getDefault().getOffset(millis);
+                writeInt((int) (toPostgreSeconds(millis) / 86400));
                 break;
             }
             case PgServer.PG_TYPE_TIME: {
-                Time t = rs.getTime(column);
-                if (t == null) {
-                    writeInt(-1);
+                Time t = v.getTime();
+                writeInt(8);
+                long m = t.getTime();
+                m += TimeZone.getDefault().getOffset(m);
+                if (INTEGER_DATE_TYPES) {
+                    // long format
+                    m *= 1000;
                 } else {
-                    writeInt(8);
-                    long m = t.getTime();
-                    m += TimeZone.getDefault().getOffset(m);
-                    if (INTEGER_DATE_TYPES) {
-                        // long format
-                        m *= 1000;
-                    } else {
-                        // double format
-                        m /= 1000;
-                        m = Double.doubleToLongBits(m);
-                    }
-                    dataOut.writeLong(m);
+                    // double format
+                    m /= 1000;
+                    m = Double.doubleToLongBits(m);
                 }
+                dataOut.writeLong(m);
                 break;
             }
             case PgServer.PG_TYPE_TIMESTAMP_NO_TMZONE: {
-                Timestamp t = rs.getTimestamp(column);
-                if (t == null) {
-                    writeInt(-1);
-                } else {
-                    writeInt(8);
-                    long m = t.getTime();
-                    m += TimeZone.getDefault().getOffset(m);
-                    m = toPostgreSeconds(m);
-                    int nanos = t.getNanos();
-                    if (m < 0 && nanos != 0) {
-                        m--;
-                    }
-                    if (INTEGER_DATE_TYPES) {
-                        // long format
-                        m = m * 1000000 + nanos / 1000;
-                    } else {
-                        // double format
-                        m = Double.doubleToLongBits(m + nanos * 0.000000001);
-                    }
-                    dataOut.writeLong(m);
+                Timestamp t = v.getTimestamp();
+                writeInt(8);
+                long m = t.getTime();
+                m += TimeZone.getDefault().getOffset(m);
+                m = toPostgreSeconds(m);
+                int nanos = t.getNanos();
+                if (m < 0 && nanos != 0) {
+                    m--;
                 }
+                if (INTEGER_DATE_TYPES) {
+                    // long format
+                    m = m * 1000000 + nanos / 1000;
+                } else {
+                    // double format
+                    m = Double.doubleToLongBits(m + nanos * 0.000000001);
+                }
+                dataOut.writeLong(m);
                 break;
             }
             default: throw new IllegalStateException("output binary format is undefined");

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -1042,6 +1042,29 @@ public class DateTimeUtils {
     }
 
     /**
+     * Calculate the absolute day from an encoded date value in proleptic Gregorian
+     * calendar.
+     *
+     * @param dateValue the date value
+     * @return the absolute day in proleptic Gregorian calendar
+     */
+    public static long prolepticGregorianAbsoluteDayFromDateValue(long dateValue) {
+        long y = yearFromDateValue(dateValue);
+        int m = monthFromDateValue(dateValue);
+        int d = dayFromDateValue(dateValue);
+        if (m <= 2) {
+            y--;
+            m += 12;
+        }
+        long a = ((y * 2922L) >> 3) + DAYS_OFFSET[m - 3] + d - 719484;
+        if (y < 1901 || y > 2099) {
+            // Slow mode
+            a += (y / 400) - (y / 100) + 15;
+        }
+        return a;
+    }
+
+    /**
      * Calculate the encoded date value from an absolute day.
      *
      * @param absoluteDay the absolute day

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -487,13 +487,16 @@ public class TestPgServer extends TestBase {
 
             Date[] dates = { null, Date.valueOf("2017-02-20"),
                     Date.valueOf("1970-01-01"), Date.valueOf("1969-12-31"),
-                    Date.valueOf("1940-01-10"), Date.valueOf("1950-11-10") };
+                    Date.valueOf("1940-01-10"), Date.valueOf("1950-11-10"),
+                    Date.valueOf("1500-01-01")};
             Time[] times = { null, Time.valueOf("14:15:16"),
                     Time.valueOf("00:00:00"), Time.valueOf("23:59:59"),
-                    Time.valueOf("00:10:59"), Time.valueOf("08:30:42") };
+                    Time.valueOf("00:10:59"), Time.valueOf("08:30:42"),
+                    Time.valueOf("10:00:00")};
             Timestamp[] timestamps = { null, Timestamp.valueOf("2017-02-20 14:15:16.763"),
                     Timestamp.valueOf("1970-01-01 00:00:00"), Timestamp.valueOf("1969-12-31 23:59:59"),
-                    Timestamp.valueOf("1940-01-10 00:10:59"), Timestamp.valueOf("1950-11-10 08:30:42.12") };
+                    Timestamp.valueOf("1940-01-10 00:10:59"), Timestamp.valueOf("1950-11-10 08:30:42.12"),
+                    Timestamp.valueOf("1500-01-01 10:00:10")};
             int count = dates.length;
 
             PreparedStatement ps = conn.prepareStatement(


### PR DESCRIPTION
1. ODBC server now reads `Value` types directly from `JdbcResultSet`.

2. All null checks in `writeDataColumn()` merged into one.

3. writeDataColum() now encodes date and time values exactly in the way that PostgreSQL does.
- PostgreSQL uses proleptic Gregorian calendar for encoding, so there is a new method in `DateTimeUtils` to endode dates for this calendar. I decided to create a new method instead of introducing a new parameter to existing method for standard calendar to simplify usages of these methods, new method is only used in ODBC server. This fixes issues with old dates.
- PostgreSQL encodes local date in network layer, and new code encodes it directly without useless conversion to UTC and back.