### PR TITLE
Add support for = ANY(?)

### DIFF
--- a/h2/src/docsrc/html/performance.html
+++ b/h2/src/docsrc/html/performance.html
@@ -490,7 +490,7 @@ Instead, use a prepared statement with arrays as in the following example:
 </p>
 <pre>
 PreparedStatement prep = conn.prepareStatement(
-    "SELECT * FROM TABLE(X INT=?) T INNER JOIN TEST ON T.X=TEST.ID");
+    "SELECT * TEST.ID = ANY(?)");
 prep.setObject(1, new Object[] { "1", "2" });
 ResultSet rs = prep.executeQuery();
 </pre>

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -112,6 +112,7 @@ import org.h2.expression.Comparison;
 import org.h2.expression.ConditionAndOr;
 import org.h2.expression.ConditionExists;
 import org.h2.expression.ConditionIn;
+import org.h2.expression.ConditionInParameter;
 import org.h2.expression.ConditionInSelect;
 import org.h2.expression.ConditionNot;
 import org.h2.expression.Expression;
@@ -2504,9 +2505,14 @@ public class Parser {
                     read(")");
                 } else if (readIf("ANY") || readIf("SOME")) {
                     read("(");
-                    Query query = parseSelect();
-                    r = new ConditionInSelect(database, r, query, false,
-                            compareType);
+                    if (currentTokenType == PARAMETER && compareType == 0) {
+                        Parameter p = readParameter();
+                        r = new ConditionInParameter(database, r, p);
+                    } else {
+                        Query query = parseSelect();
+                        r = new ConditionInSelect(database, r, query, false,
+                                compareType);
+                    }
                     read(")");
                 } else {
                     Expression right = readConcat();

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3001,6 +3001,53 @@ public class Parser {
         return new ExpressionColumn(database, null, objectName, name);
     }
 
+    private Parameter readParameter() {
+        // there must be no space between ? and the number
+        boolean indexed = Character.isDigit(sqlCommandChars[parseIndex]);
+
+        Parameter p;
+        if (indexed) {
+            readParameterIndex();
+            if (indexedParameterList == null) {
+                if (parameters == null) {
+                    // this can occur when parsing expressions only (for
+                    // example check constraints)
+                    throw getSyntaxError();
+                } else if (parameters.size() > 0) {
+                    throw DbException
+                            .get(ErrorCode.CANNOT_MIX_INDEXED_AND_UNINDEXED_PARAMS);
+                }
+                indexedParameterList = New.arrayList();
+            }
+            int index = currentValue.getInt() - 1;
+            if (index < 0 || index >= Constants.MAX_PARAMETER_INDEX) {
+                throw DbException.getInvalidValueException(
+                        "parameter index", index);
+            }
+            if (indexedParameterList.size() <= index) {
+                indexedParameterList.ensureCapacity(index + 1);
+                while (indexedParameterList.size() <= index) {
+                    indexedParameterList.add(null);
+                }
+            }
+            p = indexedParameterList.get(index);
+            if (p == null) {
+                p = new Parameter(index);
+                indexedParameterList.set(index, p);
+            }
+            read();
+        } else {
+            read();
+            if (indexedParameterList != null) {
+                throw DbException
+                        .get(ErrorCode.CANNOT_MIX_INDEXED_AND_UNINDEXED_PARAMS);
+            }
+            p = new Parameter(parameters.size());
+        }
+        parameters.add(p);
+        return p;
+    }
+
     private Expression readTerm() {
         Expression r;
         switch (currentTokenType) {
@@ -3016,50 +3063,7 @@ public class Parser {
             }
             break;
         case PARAMETER:
-            // there must be no space between ? and the number
-            boolean indexed = Character.isDigit(sqlCommandChars[parseIndex]);
-
-            Parameter p;
-            if (indexed) {
-                readParameterIndex();
-                if (indexedParameterList == null) {
-                    if (parameters == null) {
-                        // this can occur when parsing expressions only (for
-                        // example check constraints)
-                        throw getSyntaxError();
-                    } else if (parameters.size() > 0) {
-                        throw DbException
-                                .get(ErrorCode.CANNOT_MIX_INDEXED_AND_UNINDEXED_PARAMS);
-                    }
-                    indexedParameterList = New.arrayList();
-                }
-                int index = currentValue.getInt() - 1;
-                if (index < 0 || index >= Constants.MAX_PARAMETER_INDEX) {
-                    throw DbException.getInvalidValueException(
-                            "parameter index", index);
-                }
-                if (indexedParameterList.size() <= index) {
-                    indexedParameterList.ensureCapacity(index + 1);
-                    while (indexedParameterList.size() <= index) {
-                        indexedParameterList.add(null);
-                    }
-                }
-                p = indexedParameterList.get(index);
-                if (p == null) {
-                    p = new Parameter(index);
-                    indexedParameterList.set(index, p);
-                }
-                read();
-            } else {
-                read();
-                if (indexedParameterList != null) {
-                    throw DbException
-                            .get(ErrorCode.CANNOT_MIX_INDEXED_AND_UNINDEXED_PARAMS);
-                }
-                p = new Parameter(parameters.size());
-            }
-            parameters.add(p);
-            r = p;
+            r = readParameter();
             break;
         case KEYWORD:
             if (isToken("SELECT") || isToken("FROM") || isToken("WITH")) {

--- a/h2/src/main/org/h2/expression/ConditionInParameter.java
+++ b/h2/src/main/org/h2/expression/ConditionInParameter.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression;
+
+import java.util.AbstractList;
+
+import org.h2.engine.Database;
+import org.h2.engine.Session;
+import org.h2.index.IndexCondition;
+import org.h2.table.ColumnResolver;
+import org.h2.table.TableFilter;
+import org.h2.value.Value;
+import org.h2.value.ValueArray;
+import org.h2.value.ValueBoolean;
+import org.h2.value.ValueNull;
+
+/**
+ * A condition with parameter as {@code = ANY(?)}.
+ */
+public class ConditionInParameter extends Condition {
+    private static final class ParameterList extends AbstractList<Expression> {
+        private final Parameter parameter;
+
+        ParameterList(Parameter parameter) {
+            this.parameter = parameter;
+        }
+
+        @Override
+        public Expression get(int index) {
+            Value value = parameter.getParamValue();
+            if (value instanceof ValueArray) {
+                return ValueExpression.get(((ValueArray) value).getList()[index]);
+            }
+            if (index != 0) {
+                throw new IndexOutOfBoundsException();
+            }
+            return ValueExpression.get(value);
+        }
+
+        @Override
+        public int size() {
+            if (!parameter.isValueSet()) {
+                return 0;
+            }
+            Value value = parameter.getParamValue();
+            if (value instanceof ValueArray) {
+                return ((ValueArray) value).getList().length;
+            }
+            return 1;
+        }
+    }
+
+    private final Database database;
+
+    private Expression left;
+
+    final Parameter parameter;
+
+    /**
+     * Create a new {@code = ANY(?)} condition.
+     *
+     * @param database
+     *            the database
+     * @param left
+     *            the expression before {@code = ANY(?)}
+     * @param parameter
+     *            parameter
+     */
+    public ConditionInParameter(Database database, Expression left, Parameter parameter) {
+        this.database = database;
+        this.left = left;
+        this.parameter = parameter;
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        Value l = left.getValue(session);
+        if (l == ValueNull.INSTANCE) {
+            return l;
+        }
+        boolean result = false;
+        boolean hasNull = false;
+        Value value = parameter.getValue(session);
+        if (value instanceof ValueArray) {
+            for (Value r : ((ValueArray) value).getList()) {
+                if (r == ValueNull.INSTANCE) {
+                    hasNull = true;
+                } else {
+                    r = r.convertTo(l.getType());
+                    result = Comparison.compareNotNull(database, l, r, Comparison.EQUAL);
+                    if (result) {
+                        break;
+                    }
+                }
+            }
+        } else {
+            if (value == ValueNull.INSTANCE) {
+                hasNull = true;
+            } else {
+                value = value.convertTo(l.getType());
+                result = Comparison.compareNotNull(database, l, value, Comparison.EQUAL);
+            }
+        }
+        if (!result && hasNull) {
+            return ValueNull.INSTANCE;
+        }
+        return ValueBoolean.get(result);
+    }
+
+    @Override
+    public void mapColumns(ColumnResolver resolver, int level) {
+        left.mapColumns(resolver, level);
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        left = left.optimize(session);
+        if (left.isConstant() && left == ValueExpression.getNull()) {
+            return left;
+        }
+        return this;
+    }
+
+    @Override
+    public void createIndexConditions(Session session, TableFilter filter) {
+        if (!(left instanceof ExpressionColumn)) {
+            return;
+        }
+        ExpressionColumn l = (ExpressionColumn) left;
+        if (filter != l.getTableFilter()) {
+            return;
+        }
+        filter.addIndexCondition(IndexCondition.getInList(l, new ParameterList(parameter)));
+    }
+
+    @Override
+    public void setEvaluatable(TableFilter tableFilter, boolean b) {
+        left.setEvaluatable(tableFilter, b);
+    }
+
+    @Override
+    public String getSQL() {
+        return '(' + left.getSQL() + " = ANY(" + parameter.getSQL() + "))";
+    }
+
+    @Override
+    public void updateAggregate(Session session) {
+        left.updateAggregate(session);
+    }
+
+    @Override
+    public boolean isEverything(ExpressionVisitor visitor) {
+        return left.isEverything(visitor) && parameter.isEverything(visitor);
+    }
+
+    @Override
+    public int getCost() {
+        return left.getCost();
+    }
+
+}

--- a/h2/src/main/org/h2/jdbcx/JdbcDataSource.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcDataSource.java
@@ -405,6 +405,7 @@ public class JdbcDataSource extends TraceObject implements XADataSource,
      * Return an object of this class if possible.
      *
      * @param iface the class
+     * @return this
      */
     @Override
     @SuppressWarnings("unchecked")
@@ -423,6 +424,7 @@ public class JdbcDataSource extends TraceObject implements XADataSource,
      * Checks if unwrap can return an object of this class.
      *
      * @param iface the class
+     * @return whether or not the interface is assignable from this class
      */
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -99,6 +99,7 @@ public class TestPreparedStatement extends TestBase {
         conn.close();
         testPreparedStatementWithLiteralsNone();
         testPreparedStatementWithIndexedParameterAndLiteralsNone();
+        testPreparedStatementWithAnyParameter();
         deleteDb("preparedStatement");
     }
 
@@ -1491,7 +1492,43 @@ public class TestPreparedStatement extends TestBase {
         deleteDb("preparedStatement");
     }
 
+    private void testPreparedStatementWithAnyParameter() throws SQLException {
+        deleteDb("preparedStatement");
+        Connection conn = getConnection("preparedStatement");
+        conn.prepareStatement("CREATE TABLE TEST(ID INT PRIMARY KEY, VALUE INT UNIQUE)").execute();
+        PreparedStatement ps = conn.prepareStatement("INSERT INTO TEST(ID, VALUE) VALUES (?, ?)");
+        for (int i = 0; i < 10_000; i++) {
+            ps.setInt(1, i);
+            ps.setInt(2, i * 10);
+            ps.executeUpdate();
+        }
+        Object[] values = {-100, 10, 200, 3_000, 40_000, 500_000};
+        int[] expected = {1, 20, 300, 4_000};
+        // Ensure that other methods return the same results
+        ps = conn.prepareStatement("SELECT ID FROM TEST WHERE VALUE IN (SELECT * FROM TABLE(X INT=?)) ORDER BY ID");
+        anyParameterCheck(ps, values, expected);
+        ps = conn.prepareStatement("SELECT ID FROM TEST INNER JOIN TABLE(X INT=?) T ON TEST.VALUE = T.X");
+        anyParameterCheck(ps, values, expected);
+        // Test expression = ANY(?)
+        ps = conn.prepareStatement("SELECT ID FROM TEST WHERE VALUE = ANY(?)");
+        assertThrows(ErrorCode.PARAMETER_NOT_SET_1, ps).executeQuery();
+        anyParameterCheck(ps, values, expected);
+        anyParameterCheck(ps, 300, new int[] {30});
+        anyParameterCheck(ps, -5, new int[0]);
+        conn.close();
+        deleteDb("preparedStatement");
+    }
 
+    private void anyParameterCheck(PreparedStatement ps, Object values, int[] expected) throws SQLException {
+        ps.setObject(1, values);
+        try (ResultSet rs = ps.executeQuery()) {
+            for (int exp : expected) {
+                assertTrue(rs.next());
+                assertEquals(exp, rs.getInt(1));
+            }
+            assertFalse(rs.next());
+        }
+    }
 
     private void checkBigDecimal(ResultSet rs, String[] value) throws SQLException {
         for (String v : value) {


### PR DESCRIPTION
This pull reqest adds support for `= ANY(?)` expression with `Object[]` parameter. This allows to query multiple rows at once without writing of complex expressions with join or nested select.

Index conditions are created so this implementation expected to be fast if column has an index.

This pull request fixes issue #502.