### PR TITLE
Fix TestDateTimeUtils.testDayOfWeek() and example with ANY(?)

### DIFF
--- a/h2/src/docsrc/html/performance.html
+++ b/h2/src/docsrc/html/performance.html
@@ -490,7 +490,7 @@ Instead, use a prepared statement with arrays as in the following example:
 </p>
 <pre>
 PreparedStatement prep = conn.prepareStatement(
-    "SELECT * TEST.ID = ANY(?)");
+    "SELECT * FROM TEST WHERE ID = ANY(?)");
 prep.setObject(1, new Object[] { "1", "2" });
 ResultSet rs = prep.executeQuery();
 </pre>

--- a/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
@@ -45,7 +45,7 @@ public class TestDateTimeUtils extends TestBase {
      * {@link DateTimeUtils#getIsoDayOfWeek(long)}.
      */
     private void testDayOfWeek() {
-        GregorianCalendar gc = DateTimeUtils.createGregorianCalendar();
+        GregorianCalendar gc = DateTimeUtils.createGregorianCalendar(DateTimeUtils.UTC);
         for (int i = -1_000_000; i <= 1_000_000; i++) {
             gc.clear();
             gc.setTimeInMillis(i * 86400000L);


### PR DESCRIPTION
Simply use UTC time zone to avoid failures in western hemisphere. This test is not about time zones, so there is no need to test it with different time zones.

Fixes issue #853.