### PR TITLE
Do not write each SQL error multiple times in TestScript

### DIFF
--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -464,6 +464,17 @@ public abstract class TestBase {
         throw new AssertionError(string);
     }
 
+   /**
+    * Log an error message.
+    *
+    * @param s the message
+    */
+   public static void logErrorMessage(String s) {
+       System.out.flush();
+       System.err.println("ERROR: " + s + "------------------------------");
+       logThrowable(s, null);
+   }
+
     /**
      * Log an error message.
      *
@@ -478,6 +489,10 @@ public abstract class TestBase {
         System.err.println("ERROR: " + s + " " + e.toString()
                 + " ------------------------------");
         e.printStackTrace();
+        logThrowable(null, e);
+    }
+
+    private static void logThrowable(String s, Throwable e) {
         // synchronize on this class, because file locks are only visible to
         // other JVMs
         synchronized (TestBase.class) {
@@ -494,9 +509,14 @@ public abstract class TestBase {
                 }
                 // append
                 FileWriter fw = new FileWriter("error.txt", true);
-                PrintWriter pw = new PrintWriter(fw);
-                e.printStackTrace(pw);
-                pw.close();
+                if (s != null) {
+                    fw.write(s);
+                }
+                if (e != null) {
+                    PrintWriter pw = new PrintWriter(fw);
+                    e.printStackTrace(pw);
+                    pw.close();
+                }
                 fw.close();
                 // unlock
                 lock.release();

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -172,7 +172,7 @@ public class TestScript extends TestBase {
         conn.close();
         out.close();
         if (errors.length() > 0) {
-            throw new Exception("errors:\n" + errors.toString());
+            throw new Exception("errors found");
         }
         // new File(outFile).delete();
     }
@@ -445,7 +445,7 @@ public class TestScript extends TestBase {
                 if (e != null) {
                     TestBase.logError("script", e);
                 }
-                TestBase.logError(errors.toString(), null);
+                TestBase.logErrorMessage(errors.toString());
                 if (failFast) {
                     conn.close();
                     System.exit(1);

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -41,6 +41,7 @@ public class TestScript extends TestBase {
     private boolean reconnectOften;
     private Connection conn;
     private Statement stat;
+    private String fileName;
     private LineNumberReader in;
     private int outputLineNo;
     private PrintStream out;
@@ -155,6 +156,7 @@ public class TestScript extends TestBase {
         // we processed.
         conn = null;
         stat = null;
+        fileName = null;
         in = null;
         outputLineNo = 0;
         out = null;
@@ -172,7 +174,7 @@ public class TestScript extends TestBase {
         conn.close();
         out.close();
         if (errors.length() > 0) {
-            throw new Exception("errors found");
+            throw new Exception("errors in " + scriptFileName + " found");
         }
         // new File(outFile).delete();
     }
@@ -200,6 +202,7 @@ public class TestScript extends TestBase {
         if (is == null) {
             throw new IOException("could not find " + inFile);
         }
+        fileName = inFile;
         in = new LineNumberReader(new InputStreamReader(is, "Cp1252"));
         StringBuilder buff = new StringBuilder();
         while (true) {
@@ -435,13 +438,10 @@ public class TestScript extends TestBase {
                 if (reconnectOften && sql.toUpperCase().startsWith("EXPLAIN")) {
                     return;
                 }
-                errors.append("line: ");
-                errors.append(outputLineNo);
-                errors.append("\n" + "exp: ");
-                errors.append(compare);
-                errors.append("\n" + "got: ");
-                errors.append(s);
-                errors.append("\n");
+                errors.append(fileName).append('\n');
+                errors.append("line: ").append(outputLineNo).append('\n');
+                errors.append("exp: ").append(compare).append('\n');
+                errors.append("got: ").append(s).append('\n');
                 if (e != null) {
                     TestBase.logError("script", e);
                 }


### PR DESCRIPTION
`TestScript` writes each error three times plus additional one is summary, so reading of log is complicated in case with multiple errors.

This pull request reduces amount of duplicated information in output to console and to errors.txt.

# Console output
## Before
```
10:53:58 02:24:23.755 org.h2.test.scripts.TestScript Running commands in testScript.sql
ERROR: script org.h2.jdbc.JdbcSQLException: Syntax error in SQL statement "BLA[*]-BLA-BLA "; expected "BACKUP, BEGIN, {"; SQL statement:
bla-bla-bla [42001-196] ------------------------------
org.h2.jdbc.JdbcSQLException: Syntax error in SQL statement "BLA[*]-BLA-BLA "; expected "BACKUP, BEGIN, {"; SQL statement:
bla-bla-bla [42001-196]
    at org.h2.message.DbException.getJdbcSQLException(DbException.java:357)
    at org.h2.message.DbException.getSyntaxError(DbException.java:217)
    at org.h2.command.Parser.getSyntaxError(Parser.java:555)
    at org.h2.command.Parser.parsePrepared(Parser.java:540)
    at org.h2.command.Parser.parse(Parser.java:335)
    at org.h2.command.Parser.parse(Parser.java:311)
    at org.h2.command.Parser.prepareCommand(Parser.java:272)
    at org.h2.engine.Session.prepareLocal(Session.java:612)
    at org.h2.engine.Session.prepareCommand(Session.java:550)
    at org.h2.jdbc.JdbcConnection.prepareCommand(JdbcConnection.java:1221)
    at org.h2.jdbc.JdbcStatement.executeInternal(JdbcStatement.java:206)
    at org.h2.jdbc.JdbcStatement.execute(JdbcStatement.java:194)
    at org.h2.test.scripts.TestScript.processStatement(TestScript.java:329)
    at org.h2.test.scripts.TestScript.process(TestScript.java:257)
    at org.h2.test.scripts.TestScript.testFile(TestScript.java:219)
    at org.h2.test.scripts.TestScript.testScript(TestScript.java:171)
    at org.h2.test.scripts.TestScript.test(TestScript.java:83)
    at org.h2.test.scripts.TestScript.main(TestScript.java:59)
ERROR: line: 9
exp: > ok
got: > exception
 java.lang.Exception: line: 9
exp: > ok
got: > exception
 ------------------------------
java.lang.Exception: line: 9
exp: > ok
got: > exception

    at org.h2.test.TestBase.logError(TestBase.java:475)
    at org.h2.test.scripts.TestScript.writeResult(TestScript.java:448)
    at org.h2.test.scripts.TestScript.writeException(TestScript.java:425)
    at org.h2.test.scripts.TestScript.processStatement(TestScript.java:336)
    at org.h2.test.scripts.TestScript.process(TestScript.java:257)
    at org.h2.test.scripts.TestScript.testFile(TestScript.java:219)
    at org.h2.test.scripts.TestScript.testScript(TestScript.java:171)
    at org.h2.test.scripts.TestScript.test(TestScript.java:83)
    at org.h2.test.scripts.TestScript.main(TestScript.java:59)
Exception in thread "main" java.lang.Exception: errors:
line: 9
exp: > ok
got: > exception

    at org.h2.test.scripts.TestScript.testScript(TestScript.java:175)
    at org.h2.test.scripts.TestScript.test(TestScript.java:83)
    at org.h2.test.scripts.TestScript.main(TestScript.java:59)
```
## After
```
11:34:52 03:05:17.715 org.h2.test.scripts.TestScript Running commands in testScript.sql
ERROR: script org.h2.jdbc.JdbcSQLException: Syntax error in SQL statement "BLA[*]-BLA-BLA "; expected "BACKUP, BEGIN, {"; SQL statement:
bla-bla-bla [42001-196] ------------------------------
org.h2.jdbc.JdbcSQLException: Syntax error in SQL statement "BLA[*]-BLA-BLA "; expected "BACKUP, BEGIN, {"; SQL statement:
bla-bla-bla [42001-196]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:357)
	at org.h2.message.DbException.getSyntaxError(DbException.java:217)
	at org.h2.command.Parser.getSyntaxError(Parser.java:555)
	at org.h2.command.Parser.parsePrepared(Parser.java:540)
	at org.h2.command.Parser.parse(Parser.java:335)
	at org.h2.command.Parser.parse(Parser.java:311)
	at org.h2.command.Parser.prepareCommand(Parser.java:272)
	at org.h2.engine.Session.prepareLocal(Session.java:612)
	at org.h2.engine.Session.prepareCommand(Session.java:550)
	at org.h2.jdbc.JdbcConnection.prepareCommand(JdbcConnection.java:1221)
	at org.h2.jdbc.JdbcStatement.executeInternal(JdbcStatement.java:206)
	at org.h2.jdbc.JdbcStatement.execute(JdbcStatement.java:194)
	at org.h2.test.scripts.TestScript.processStatement(TestScript.java:332)
	at org.h2.test.scripts.TestScript.process(TestScript.java:260)
	at org.h2.test.scripts.TestScript.testFile(TestScript.java:222)
	at org.h2.test.scripts.TestScript.testScript(TestScript.java:173)
	at org.h2.test.scripts.TestScript.test(TestScript.java:84)
	at org.h2.test.scripts.TestScript.main(TestScript.java:60)
ERROR: org/h2/test/scripts/testScript.sql
line: 9
exp: > ok
got: > exception
------------------------------
Exception in thread "main" java.lang.Exception: errors in testScript.sql found
	at org.h2.test.scripts.TestScript.testScript(TestScript.java:177)
	at org.h2.test.scripts.TestScript.test(TestScript.java:84)
	at org.h2.test.scripts.TestScript.main(TestScript.java:60)
```
# errors.txt
## Before
```
org.h2.jdbc.JdbcSQLException: Syntax error in SQL statement "BLA[*]-BLA-BLA "; expected "BACKUP, BEGIN, {"; SQL statement:
bla-bla-bla [42001-196]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:357)
	at org.h2.message.DbException.getSyntaxError(DbException.java:217)
	at org.h2.command.Parser.getSyntaxError(Parser.java:555)
	at org.h2.command.Parser.parsePrepared(Parser.java:540)
	at org.h2.command.Parser.parse(Parser.java:335)
	at org.h2.command.Parser.parse(Parser.java:311)
	at org.h2.command.Parser.prepareCommand(Parser.java:272)
	at org.h2.engine.Session.prepareLocal(Session.java:612)
	at org.h2.engine.Session.prepareCommand(Session.java:550)
	at org.h2.jdbc.JdbcConnection.prepareCommand(JdbcConnection.java:1221)
	at org.h2.jdbc.JdbcStatement.executeInternal(JdbcStatement.java:206)
	at org.h2.jdbc.JdbcStatement.execute(JdbcStatement.java:194)
	at org.h2.test.scripts.TestScript.processStatement(TestScript.java:329)
	at org.h2.test.scripts.TestScript.process(TestScript.java:257)
	at org.h2.test.scripts.TestScript.testFile(TestScript.java:219)
	at org.h2.test.scripts.TestScript.testScript(TestScript.java:171)
	at org.h2.test.scripts.TestScript.test(TestScript.java:83)
	at org.h2.test.scripts.TestScript.main(TestScript.java:59)
java.lang.Exception: line: 9
exp: > ok
got: > exception

	at org.h2.test.TestBase.logError(TestBase.java:475)
	at org.h2.test.scripts.TestScript.writeResult(TestScript.java:448)
	at org.h2.test.scripts.TestScript.writeException(TestScript.java:425)
	at org.h2.test.scripts.TestScript.processStatement(TestScript.java:336)
	at org.h2.test.scripts.TestScript.process(TestScript.java:257)
	at org.h2.test.scripts.TestScript.testFile(TestScript.java:219)
	at org.h2.test.scripts.TestScript.testScript(TestScript.java:171)
	at org.h2.test.scripts.TestScript.test(TestScript.java:83)
	at org.h2.test.scripts.TestScript.main(TestScript.java:59)
```
## After
```
org.h2.jdbc.JdbcSQLException: Syntax error in SQL statement "BLA[*]-BLA-BLA "; expected "BACKUP, BEGIN, {"; SQL statement:
bla-bla-bla [42001-196]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:357)
	at org.h2.message.DbException.getSyntaxError(DbException.java:217)
	at org.h2.command.Parser.getSyntaxError(Parser.java:555)
	at org.h2.command.Parser.parsePrepared(Parser.java:540)
	at org.h2.command.Parser.parse(Parser.java:335)
	at org.h2.command.Parser.parse(Parser.java:311)
	at org.h2.command.Parser.prepareCommand(Parser.java:272)
	at org.h2.engine.Session.prepareLocal(Session.java:612)
	at org.h2.engine.Session.prepareCommand(Session.java:550)
	at org.h2.jdbc.JdbcConnection.prepareCommand(JdbcConnection.java:1221)
	at org.h2.jdbc.JdbcStatement.executeInternal(JdbcStatement.java:206)
	at org.h2.jdbc.JdbcStatement.execute(JdbcStatement.java:194)
	at org.h2.test.scripts.TestScript.processStatement(TestScript.java:332)
	at org.h2.test.scripts.TestScript.process(TestScript.java:260)
	at org.h2.test.scripts.TestScript.testFile(TestScript.java:222)
	at org.h2.test.scripts.TestScript.testScript(TestScript.java:173)
	at org.h2.test.scripts.TestScript.test(TestScript.java:84)
	at org.h2.test.scripts.TestScript.main(TestScript.java:60)
org/h2/test/scripts/testScript.sql
line: 9
exp: > ok
got: > exception
```