### PR TITLE
Minor changes in DateUtils and Function

### DIFF
--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1471,7 +1471,7 @@ public class Function extends Expression implements FunctionCall {
                     v1 == null ? null : v1.getString()));
             break;
         case ADD_MONTHS:
-            result = ValueTimestamp.get(DateTimeUtils.addMonths(v0.getTimestamp(), v1.getInt()));
+            result = dateadd("MONTH", v1.getInt(), v0);
             break;
         case TRANSLATE: {
             String matching = v1.getString();

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1326,7 +1326,7 @@ public class Function extends Expression implements FunctionCall {
                 if (s2 == null) {
                     s2 = "";
                 }
-                result = ValueString.get(replace(s0, s1, s2),
+                result = ValueString.get(StringUtils.replaceAll(s0, s1, s2),
                         database.getMode().treatEmptyStringsAsNull);
             }
             break;
@@ -1978,13 +1978,6 @@ public class Function extends Expression implements FunctionCall {
             length = len - start;
         }
         return s.substring(start, start + length);
-    }
-
-    private static String replace(String s, String replace, String with) {
-        if (s == null || replace == null || with == null) {
-            return null;
-        }
-        return StringUtils.replaceAll(s, replace, with);
     }
 
     private static String repeat(String s, int count) {

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -525,7 +525,7 @@ public class DateTimeUtils {
                 if (month == 2) {
                     maxDay = c.isLeapYear(year) ? 29 : 28;
                 } else {
-                    maxDay = 30 + ((month + (month > 7 ? 1 : 0)) & 1);
+                    maxDay = NORMAL_DAYS_PER_MONTH[month];
                 }
                 if (day < 1 || day > maxDay) {
                     throw e;

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -1223,26 +1223,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Adds the number of months to the date. If the resulting month's number of
-     * days is less than the original's day-of-month, the resulting
-     * day-of-months gets adjusted accordingly: <br>
-     * 30.04.2007 - 2 months = 28.02.2007
-     *
-     * @param refDate the original date
-     * @param nrOfMonthsToAdd the number of months to add
-     * @return the new timestamp
-     */
-    public static Timestamp addMonths(Timestamp refDate, int nrOfMonthsToAdd) {
-        Calendar calendar = DateTimeUtils.createGregorianCalendar();
-        calendar.setTime(refDate);
-        calendar.add(Calendar.MONTH, nrOfMonthsToAdd);
-
-        Timestamp resultDate = new Timestamp(calendar.getTimeInMillis());
-        resultDate.setNanos(refDate.getNanos());
-        return resultDate;
-    }
-
-    /**
      * Append a date to the string builder.
      *
      * @param buff the target string builder

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -82,7 +82,6 @@ public class TestFunctions extends TestBase implements AggregateFunction {
         testIfNull();
         testToDate();
         testToDateException();
-        testAddMonths();
         testDataType();
         testVersion();
         testFunctionTable();
@@ -1426,39 +1425,6 @@ public class TestFunctions extends TestBase implements AggregateFunction {
         c.setTime(date);
         c.set(Calendar.MONTH, month);
         date.setTime(c.getTimeInMillis());
-    }
-
-    private void testAddMonths() throws ParseException {
-        Timestamp date;
-        Timestamp expected;
-
-        // 01-Aug-03 + 3 months = 01-Nov-03
-        date = new Timestamp(
-                new SimpleDateFormat("yyyy-MM-dd").parse("2003-08-01").getTime());
-        expected = new Timestamp(
-                new SimpleDateFormat("yyyy-MM-dd").parse("2003-11-01").getTime());
-        assertEquals(expected, DateTimeUtils.addMonths(new Timestamp(date.getTime()), 3));
-
-        // 31-Jan-03 + 1 month = 28-Feb-2003
-        date = new Timestamp(
-                new SimpleDateFormat("yyyy-MM-dd").parse("2003-01-31").getTime());
-        expected = new Timestamp(
-                new SimpleDateFormat("yyyy-MM-dd").parse("2003-02-28").getTime());
-        assertEquals(expected, DateTimeUtils.addMonths(new Timestamp(date.getTime()), 1));
-
-        // 21-Aug-2003 - 3 months = 21-May-2003
-        date = new Timestamp(
-                new SimpleDateFormat("yyyy-MM-dd").parse("2003-08-21").getTime());
-        expected = new Timestamp(
-                new SimpleDateFormat("yyyy-MM-dd").parse("2003-05-21").getTime());
-        assertEquals(expected, DateTimeUtils.addMonths(new Timestamp(date.getTime()), -3));
-
-        // 21-Aug-2003 00:00:00:333 - 3 months = 21-May-2003 00:00:00:333
-        date = new Timestamp(
-                new SimpleDateFormat("yyyy-MM-dd SSS").parse("2003-08-21 333").getTime());
-        expected = new Timestamp(
-                new SimpleDateFormat("yyyy-MM-dd SSS").parse("2003-05-21 333").getTime());
-        assertEquals(expected, DateTimeUtils.addMonths(new Timestamp(date.getTime()), -3));
     }
 
     private void testToCharFromDateTime() throws SQLException {

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -135,7 +135,7 @@ public class TestScript extends TestBase {
                 "set", "table", "transaction-id", "truncate-value", "user" }) {
             testScript("functions/system/" + s + ".sql");
         }
-        for (String s : new String[] { "current_date", "current_timestamp",
+        for (String s : new String[] { "add_months", "current_date", "current_timestamp",
                 "current-time", "dateadd", "datediff", "dayname",
                 "day-of-month", "day-of-week", "day-of-year", "extract",
                 "formatdatetime", "hour", "minute", "month", "monthname",

--- a/h2/src/test/org/h2/test/scripts/functions/timeanddate/add_months.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/timeanddate/add_months.sql
@@ -1,0 +1,32 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+-- 01-Aug-03 + 3 months = 01-Nov-03
+SELECT ADD_MONTHS('2003-08-01', 3) AS R;
+> R
+> ---------------------
+> 2003-11-01 00:00:00.0
+> rows: 1
+
+-- 31-Jan-03 + 1 month = 28-Feb-2003
+SELECT ADD_MONTHS('2003-01-31', 1) AS R;
+> R
+> ---------------------
+> 2003-02-28 00:00:00.0
+> rows: 1
+
+-- 21-Aug-2003 - 3 months = 21-May-2003
+SELECT ADD_MONTHS('2003-08-21', -3) AS R;
+> R
+> ---------------------
+> 2003-05-21 00:00:00.0
+> rows: 1
+
+-- 21-Aug-2003 00:00:00.333 - 3 months = 21-May-2003 00:00:00.333
+SELECT ADD_MONTHS('2003-08-21 00:00:00.333', -3) AS R;
+> R
+> -----------------------
+> 2003-05-21 00:00:00.333
+> rows: 1


### PR DESCRIPTION
`ADD_MONTH` from Oracle works like `DATEDIFF` in SQL Server with `MONTH` argument, so use the same function for it. This allows to avoid conversion from local to UTC millis, back to local, performing addition, conversion back to UTC millis, and again to local date-time and also removes method that only used in this place. Tests are moved into own SQL file.

`NORMAL_DAYS_PER_MONTH` used in `getMillis()` to reduce code size and improve its readability. Performance of lookup in array is also better, I tested it with JMH, but it does not matter in this case.

`Function.getValueWithArgs()` now calls `StringUtils.replaceAll()` directly. `replace()` function was removed, null checks in it are useless, because `getValueWithArgs()` performs check by itself. Also if this function returns null, we still got an NPE in `ValueString.get()`.