### PR TITLE
TestOutOfMemory stability

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1256,110 +1256,112 @@ public class Database implements DataHandler {
      *            hook
      */
     void close(boolean fromShutdownHook) {
-        synchronized (this) {
-            if (closing) {
-                return;
-            }
-            throwLastBackgroundException();
-            if (fileLockMethod == FileLockMethod.SERIALIZED &&
-                    !reconnectChangePending) {
-                // another connection may have written something - don't write
-                try {
-                    closeOpenFilesAndUnlock(false);
-                } catch (DbException e) {
-                    // ignore
-                }
-                traceSystem.close();
-                Engine.getInstance().close(databaseName);
-                return;
-            }
-            closing = true;
-            stopServer();
-            if (!userSessions.isEmpty()) {
-                if (!fromShutdownHook) {
+        try {
+            synchronized (this) {
+                if (closing) {
                     return;
                 }
-                trace.info("closing {0} from shutdown hook", databaseName);
-                closeAllSessionsException(null);
-            }
-            trace.info("closing {0}", databaseName);
-            if (eventListener != null) {
-                // allow the event listener to connect to the database
-                closing = false;
-                DatabaseEventListener e = eventListener;
-                // set it to null, to make sure it's called only once
-                eventListener = null;
-                e.closingDatabase();
-                if (!userSessions.isEmpty()) {
-                    // if a connection was opened, we can't close the database
+                throwLastBackgroundException();
+                if (fileLockMethod == FileLockMethod.SERIALIZED &&
+                        !reconnectChangePending) {
+                    // another connection may have written something - don't write
+                    try {
+                        closeOpenFilesAndUnlock(false);
+                    } catch (DbException e) {
+                        // ignore
+                    }
+                    traceSystem.close();
                     return;
                 }
                 closing = true;
+                stopServer();
+                if (!userSessions.isEmpty()) {
+                    if (!fromShutdownHook) {
+                        return;
+                    }
+                    trace.info("closing {0} from shutdown hook", databaseName);
+                    closeAllSessionsException(null);
+                }
+                trace.info("closing {0}", databaseName);
+                if (eventListener != null) {
+                    // allow the event listener to connect to the database
+                    closing = false;
+                    DatabaseEventListener e = eventListener;
+                    // set it to null, to make sure it's called only once
+                    eventListener = null;
+                    e.closingDatabase();
+                    if (!userSessions.isEmpty()) {
+                        // if a connection was opened, we can't close the database
+                        return;
+                    }
+                    closing = true;
+                }
             }
-        }
-        removeOrphanedLobs();
-        try {
-            if (systemSession != null) {
-                if (powerOffCount != -1) {
-                    for (Table table : getAllTablesAndViews(false)) {
-                        if (table.isGlobalTemporary()) {
-                            table.removeChildrenAndResources(systemSession);
-                        } else {
-                            table.close(systemSession);
+            removeOrphanedLobs();
+            try {
+                if (systemSession != null) {
+                    if (powerOffCount != -1) {
+                        for (Table table : getAllTablesAndViews(false)) {
+                            if (table.isGlobalTemporary()) {
+                                table.removeChildrenAndResources(systemSession);
+                            } else {
+                                table.close(systemSession);
+                            }
+                        }
+                        for (SchemaObject obj : getAllSchemaObjects(
+                                DbObject.SEQUENCE)) {
+                            Sequence sequence = (Sequence) obj;
+                            sequence.close();
                         }
                     }
                     for (SchemaObject obj : getAllSchemaObjects(
-                            DbObject.SEQUENCE)) {
-                        Sequence sequence = (Sequence) obj;
-                        sequence.close();
+                            DbObject.TRIGGER)) {
+                        TriggerObject trigger = (TriggerObject) obj;
+                        try {
+                            trigger.close();
+                        } catch (SQLException e) {
+                            trace.error(e, "close");
+                        }
+                    }
+                    if (powerOffCount != -1) {
+                        meta.close(systemSession);
+                        systemSession.commit(true);
                     }
                 }
-                for (SchemaObject obj : getAllSchemaObjects(
-                        DbObject.TRIGGER)) {
-                    TriggerObject trigger = (TriggerObject) obj;
-                    try {
-                        trigger.close();
-                    } catch (SQLException e) {
-                        trace.error(e, "close");
-                    }
-                }
-                if (powerOffCount != -1) {
-                    meta.close(systemSession);
-                    systemSession.commit(true);
-                }
+            } catch (DbException e) {
+                trace.error(e, "close");
             }
-        } catch (DbException e) {
-            trace.error(e, "close");
-        }
-        tempFileDeleter.deleteAll();
-        try {
-            closeOpenFilesAndUnlock(true);
-        } catch (DbException e) {
-            trace.error(e, "close");
-        }
-        trace.info("closed");
-        traceSystem.close();
-        if (closeOnExit != null) {
-            closeOnExit.reset();
+            tempFileDeleter.deleteAll();
             try {
-                Runtime.getRuntime().removeShutdownHook(closeOnExit);
-            } catch (IllegalStateException e) {
-                // ignore
-            } catch (SecurityException  e) {
-                // applets may not do that - ignore
+                closeOpenFilesAndUnlock(true);
+            } catch (DbException e) {
+                trace.error(e, "close");
             }
-            closeOnExit = null;
-        }
-        Engine.getInstance().close(databaseName);
-        if (deleteFilesOnDisconnect && persistent) {
-            deleteFilesOnDisconnect = false;
-            try {
-                String directory = FileUtils.getParent(databaseName);
-                String name = FileUtils.getName(databaseName);
-                DeleteDbFiles.execute(directory, name, true);
-            } catch (Exception e) {
-                // ignore (the trace is closed already)
+            trace.info("closed");
+            traceSystem.close();
+            if (closeOnExit != null) {
+                closeOnExit.reset();
+                try {
+                    Runtime.getRuntime().removeShutdownHook(closeOnExit);
+                } catch (IllegalStateException e) {
+                    // ignore
+                } catch (SecurityException e) {
+                    // applets may not do that - ignore
+                }
+                closeOnExit = null;
             }
+            if (deleteFilesOnDisconnect && persistent) {
+                deleteFilesOnDisconnect = false;
+                try {
+                    String directory = FileUtils.getParent(databaseName);
+                    String name = FileUtils.getName(databaseName);
+                    DeleteDbFiles.execute(directory, name, true);
+                } catch (Exception e) {
+                    // ignore (the trace is closed already)
+                }
+            }
+        } finally {
+            Engine.getInstance().close(databaseName);
         }
     }
 

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -209,6 +209,8 @@ public class Database implements DataHandler {
     private RowFactory rowFactory = RowFactory.DEFAULT;
 
     public Database(ConnectionInfo ci, String cipher) {
+        META_LOCK_DEBUGGING.set(null);
+        META_LOCK_DEBUGGING_STACK.set(null);
         String name = ci.getName();
         this.dbSettings = ci.getDbSettings();
         this.reconnectCheckDelayNs = TimeUnit.MILLISECONDS.toNanos(dbSettings.reconnectCheckDelay);

--- a/h2/src/main/org/h2/engine/DatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/DatabaseCloser.java
@@ -69,7 +69,8 @@ class DatabaseCloser extends Thread {
                     trace.error(e, "could not close the database");
                     // if this was successful, we ignore the exception
                     // otherwise not
-                } catch (RuntimeException e2) {
+                } catch (Throwable e2) {
+                    e.addSuppressed(e2);
                     throw e;
                 }
             }

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -5,7 +5,7 @@
  */
 package org.h2.engine;
 
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.h2.api.ErrorCode;
@@ -28,7 +28,7 @@ import org.h2.util.Utils;
 public class Engine implements SessionFactory {
 
     private static final Engine INSTANCE = new Engine();
-    private static final Map<String, Database> DATABASES = new Hashtable<>();
+    private static final Map<String, Database> DATABASES = new HashMap<>();
 
     private volatile long wrongPasswordDelay =
             SysProperties.DELAY_WRONG_PASSWORD_MIN;
@@ -51,30 +51,32 @@ public class Engine implements SessionFactory {
         Database database;
         ci.removeProperty("NO_UPGRADE", false);
         boolean openNew = ci.getProperty("OPEN_NEW", false);
-        if (openNew || ci.isUnnamedInMemory()) {
-            database = null;
-        } else {
-            database = DATABASES.get(name);
-        }
-        User user = null;
         boolean opened = false;
-        if (database == null) {
-            if (ifExists && !Database.exists(name)) {
-                throw DbException.get(ErrorCode.DATABASE_NOT_FOUND_1, name);
+        User user = null;
+        synchronized (DATABASES) {
+            if (openNew || ci.isUnnamedInMemory()) {
+                database = null;
+            } else {
+                database = DATABASES.get(name);
             }
-            database = new Database(ci, cipher);
-            opened = true;
-            if (database.getAllUsers().isEmpty()) {
-                // users is the last thing we add, so if no user is around,
-                // the database is new (or not initialized correctly)
-                user = new User(database, database.allocateObjectId(),
-                        ci.getUserName(), false);
-                user.setAdmin(true);
-                user.setUserPasswordHash(ci.getUserPasswordHash());
-                database.setMasterUser(user);
-            }
-            if (!ci.isUnnamedInMemory()) {
-                DATABASES.put(name, database);
+            if (database == null) {
+                if (ifExists && !Database.exists(name)) {
+                    throw DbException.get(ErrorCode.DATABASE_NOT_FOUND_1, name);
+                }
+                database = new Database(ci, cipher);
+                opened = true;
+                if (database.getAllUsers().isEmpty()) {
+                    // users is the last thing we add, so if no user is around,
+                    // the database is new (or not initialized correctly)
+                    user = new User(database, database.allocateObjectId(),
+                            ci.getUserName(), false);
+                    user.setAdmin(true);
+                    user.setUserPasswordHash(ci.getUserPasswordHash());
+                    database.setMasterUser(user);
+                }
+                if (!ci.isUnnamedInMemory()) {
+                    DATABASES.put(name, database);
+                }
             }
         }
         if (opened) {
@@ -273,7 +275,9 @@ public class Engine implements SessionFactory {
                 throw DbException.get(ErrorCode.FEATURE_NOT_SUPPORTED_1, e, "JMX");
             }
         }
-        DATABASES.remove(name);
+        synchronized (DATABASES) {
+            DATABASES.remove(name);
+        }
     }
 
     /**

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -5,7 +5,8 @@
  */
 package org.h2.engine;
 
-import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
 import java.util.Objects;
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
@@ -27,7 +28,7 @@ import org.h2.util.Utils;
 public class Engine implements SessionFactory {
 
     private static final Engine INSTANCE = new Engine();
-    private static final HashMap<String, Database> DATABASES = new HashMap<>();
+    private static final Map<String, Database> DATABASES = new Hashtable<>();
 
     private volatile long wrongPasswordDelay =
             SysProperties.DELAY_WRONG_PASSWORD_MIN;

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -411,7 +411,7 @@ public class JdbcConnection extends TraceObject
                     session = null;
                 }
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw logAndConvert(e);
         }
     }

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -248,7 +248,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             } finally {
                 afterWriting();
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw logAndConvert(e);
         }
     }

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -273,7 +273,7 @@ public class DbException extends RuntimeException {
      * @param e the root cause
      * @return the SQL exception object
      */
-    public static SQLException toSQLException(Exception e) {
+    public static SQLException toSQLException(Throwable e) {
         if (e instanceof SQLException) {
             return (SQLException) e;
         }

--- a/h2/src/main/org/h2/message/TraceObject.java
+++ b/h2/src/main/org/h2/message/TraceObject.java
@@ -351,17 +351,25 @@ public class TraceObject {
      * @param ex the exception
      * @return the SQL exception object
      */
-    protected SQLException logAndConvert(Exception ex) {
-        SQLException e = DbException.toSQLException(ex);
-        if (trace == null) {
-            DbException.traceThrowable(e);
-        } else {
-            int errorCode = e.getErrorCode();
-            if (errorCode >= 23000 && errorCode < 24000) {
-                trace.info(e, "exception");
+    protected SQLException logAndConvert(Throwable ex) {
+        SQLException e = null;
+        try {
+            e = DbException.toSQLException(ex);
+            if (trace == null) {
+                DbException.traceThrowable(e);
             } else {
-                trace.error(e, "exception");
+                int errorCode = e.getErrorCode();
+                if (errorCode >= 23000 && errorCode < 24000) {
+                    trace.info(e, "exception");
+                } else {
+                    trace.error(e, "exception");
+                }
             }
+        } catch(Throwable ignore) {
+            if (e == null) {
+                e = new SQLException("", "HY000", ex);
+            }
+            e.addSuppressed(ignore);
         }
         return e;
     }

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -79,6 +79,8 @@ public abstract class TestBase {
 
     private final LinkedList<byte[]> memory = new LinkedList<>();
 
+    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+
     /**
      * Get the test directory for this test.
      *
@@ -545,7 +547,6 @@ public abstract class TestBase {
      * @param s the message
      */
     static synchronized void printlnWithTime(long millis, String s) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
         s = dateFormat.format(new java.util.Date()) + " " +
                 formatTime(millis) + " " + s;
         System.out.println(s);
@@ -1470,6 +1471,12 @@ public abstract class TestBase {
      */
     protected void freeMemory() {
         memory.clear();
+        for (int i = 0; i < 5; i++) {
+            System.gc();
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException ignore) {/**/}
+        }
     }
 
     /**

--- a/h2/src/test/org/h2/test/db/TestOutOfMemory.java
+++ b/h2/src/test/org/h2/test/db/TestOutOfMemory.java
@@ -118,6 +118,10 @@ public class TestOutOfMemory extends TestBase {
                         ErrorCode.DATABASE_IS_CLOSED == e.getErrorCode() ||
                         ErrorCode.GENERAL_ERROR_1 == e.getErrorCode());
             }
+            for (int i = 0; i < 5; i++) {
+                System.gc();
+                Thread.sleep(20);
+            }
             try {
                 conn.close();
                 fail();


### PR DESCRIPTION
OOM was bubbling up uncaught in some places.
ThreadLocal META_LOCK_DEBUGGING was not cleared after database closure and present false-positives on subsequent database opening from the same thread.
Access to Engine.DATABASES map was not synchronized (was mentioned in [user group](https://groups.google.com/forum/#!topic/h2-database/B56p7bJpHvU)).
Added some pauses in test for GC to catch up, unrolled usage of assertThrows, which might generate secondary OOM.