### PR TITLE
Fix OOME in Transfer.readValue() with large CLOB

### DIFF
--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -14,7 +14,6 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -463,10 +462,6 @@ public class Transfer {
                 throw DbException.get(
                         ErrorCode.CONNECTION_BROKEN_1, "length=" + length);
             }
-            if (length > Integer.MAX_VALUE) {
-                throw DbException.get(
-                        ErrorCode.CONNECTION_BROKEN_1, "length="+ length);
-            }
             writeLong(length);
             Reader reader = v.getReader();
             Data.copyString(reader, out);
@@ -652,21 +647,6 @@ public class Transfer {
                     return ValueLobDb.create(
                             Value.CLOB, session.getDataHandler(), tableId, id, hmac, precision);
                 }
-                if (length < 0 || length > Integer.MAX_VALUE) {
-                    throw DbException.get(
-                            ErrorCode.CONNECTION_BROKEN_1, "length="+ length);
-                }
-                DataReader reader = new DataReader(in);
-                int len = (int) length;
-                char[] buff = new char[len];
-                IOUtils.readFully(reader, buff, len);
-                int magic = readInt();
-                if (magic != LOB_MAGIC) {
-                    throw DbException.get(
-                            ErrorCode.CONNECTION_BROKEN_1, "magic=" + magic);
-                }
-                byte[] small = new String(buff).getBytes(StandardCharsets.UTF_8);
-                return ValueLobDb.createSmallLob(Value.CLOB, small, length);
             }
             Value v = session.getDataHandler().getLobStorage().
                     createClob(new DataReader(in), length);


### PR DESCRIPTION
Issue reported in mailing list:
https://groups.google.com/forum/#!topic/h2-database/-3k0gjczqLA

`Value.CLOB` case in `Transfer.readValue` tries to read CLOBs into memory if protocol version is greater than or equal to 11. It was introduced in d2b7419c50e6d72fe76079e52d1a542649a6c997 for BLOB and CLOB values. In 376d098c861e4b7fa6fbacbb4123025ffdab81b1 normal BLOB processing has been restored, but CLOB case got only useless check that its size not greater than `Integer.MAX_VALUE`. This check is not enouch to ensure that CLOB fits into available memory.

This pull requests restores normal CLOB processing too like it was done in 376d098c861e4b7fa6fbacbb4123025ffdab81b1 for BLOBs. Small CLOBs still will be read entirely in memory by LOB frontend, but larger CLOBs will be stored to disk.

`ValueLobDb.createTempClob()` had a deadlock with small CLOBs transferred over network, this issue is solved. It was previously reproducible only with protocol version below 11, but after this change it appears with any protocol version.