### PR TITLE
Fix OOME in Transfer.readValue() with large CLOB V2

### DIFF
--- a/h2/src/main/org/h2/store/DataReader.java
+++ b/h2/src/main/org/h2/store/DataReader.java
@@ -171,7 +171,7 @@ public class DataReader extends Reader {
         int i = 0;
         try {
             for (; i < len; i++) {
-                buff[i] = readChar();
+                buff[off + i] = readChar();
             }
             return len;
         } catch (EOFException e) {

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -14,7 +14,6 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -463,10 +462,6 @@ public class Transfer {
                 throw DbException.get(
                         ErrorCode.CONNECTION_BROKEN_1, "length=" + length);
             }
-            if (length > Integer.MAX_VALUE) {
-                throw DbException.get(
-                        ErrorCode.CONNECTION_BROKEN_1, "length="+ length);
-            }
             writeLong(length);
             Reader reader = v.getReader();
             Data.copyString(reader, out);
@@ -652,21 +647,10 @@ public class Transfer {
                     return ValueLobDb.create(
                             Value.CLOB, session.getDataHandler(), tableId, id, hmac, precision);
                 }
-                if (length < 0 || length > Integer.MAX_VALUE) {
+                if (length < 0) {
                     throw DbException.get(
                             ErrorCode.CONNECTION_BROKEN_1, "length="+ length);
                 }
-                DataReader reader = new DataReader(in);
-                int len = (int) length;
-                char[] buff = new char[len];
-                IOUtils.readFully(reader, buff, len);
-                int magic = readInt();
-                if (magic != LOB_MAGIC) {
-                    throw DbException.get(
-                            ErrorCode.CONNECTION_BROKEN_1, "magic=" + magic);
-                }
-                byte[] small = new String(buff).getBytes(StandardCharsets.UTF_8);
-                return ValueLobDb.createSmallLob(Value.CLOB, small, length);
             }
             Value v = session.getDataHandler().getLobStorage().
                     createClob(new DataReader(in), length);

--- a/h2/src/test/org/h2/test/jdbc/TestLobApi.java
+++ b/h2/src/test/org/h2/test/jdbc/TestLobApi.java
@@ -119,7 +119,20 @@ public class TestLobApi extends TestBase {
         prep.setString(1, "");
         prep.setBytes(2, new byte[0]);
         prep.execute();
+
         Random r = new Random(1);
+
+        char[] charsSmall = new char[20];
+        for (int i = 0; i < charsSmall.length; i++) {
+            charsSmall[i] = (char) r.nextInt(10000);
+        }
+        String dSmall = new String(charsSmall);
+        prep.setCharacterStream(1, new StringReader(dSmall), -1);
+        byte[] bytesSmall = new byte[20];
+        r.nextBytes(bytesSmall);
+        prep.setBinaryStream(2, new ByteArrayInputStream(bytesSmall), -1);
+        prep.execute();
+
         char[] chars = new char[100000];
         for (int i = 0; i < chars.length; i++) {
             chars[i] = (char) r.nextInt(10000);
@@ -130,6 +143,7 @@ public class TestLobApi extends TestBase {
         r.nextBytes(bytes);
         prep.setBinaryStream(2, new ByteArrayInputStream(bytes), -1);
         prep.execute();
+
         conn.setAutoCommit(false);
         ResultSet rs = stat.executeQuery("select * from test order by id");
         rs.next();
@@ -138,18 +152,27 @@ public class TestLobApi extends TestBase {
         rs.next();
         Clob c2 = rs.getClob(2);
         Blob b2 = rs.getBlob(3);
+        rs.next();
+        Clob c3 = rs.getClob(2);
+        Blob b3 = rs.getBlob(3);
         assertFalse(rs.next());
         // now close
         rs.close();
         // but the LOBs must stay open
         assertEquals(0, c1.length());
         assertEquals(0, b1.length());
-        assertEquals(chars.length, c2.length());
-        assertEquals(bytes.length, b2.length());
         assertEquals("", c1.getSubString(1, 0));
         assertEquals(new byte[0], b1.getBytes(1, 0));
-        assertEquals(d, c2.getSubString(1, (int) c2.length()));
-        assertEquals(bytes, b2.getBytes(1, (int) b2.length()));
+
+        assertEquals(charsSmall.length, c2.length());
+        assertEquals(bytesSmall.length, b2.length());
+        assertEquals(dSmall, c2.getSubString(1, (int) c2.length()));
+        assertEquals(bytesSmall, b2.getBytes(1, (int) b2.length()));
+
+        assertEquals(chars.length, c3.length());
+        assertEquals(bytes.length, b3.length());
+        assertEquals(d, c3.getSubString(1, (int) c3.length()));
+        assertEquals(bytes, b3.getBytes(1, (int) b3.length()));
         stat.execute("drop table test");
         conn.close();
     }


### PR DESCRIPTION
Issue reported in mailing list:
https://groups.google.com/forum/#!topic/h2-database/-3k0gjczqLA

`Value.CLOB` case in `Transfer.readValue` tries to read CLOBs into memory if protocol version is greater than or equal to 11. It was introduced in d2b7419c50e6d72fe76079e52d1a542649a6c997 for BLOB and CLOB values. In 376d098c861e4b7fa6fbacbb4123025ffdab81b1 normal BLOB processing has been restored, but CLOB case got only useless check that its size not greater than `Integer.MAX_VALUE`. This check is not enough to ensure that CLOB fits into available memory.

This pull requests restores normal CLOB processing too like it was done in 376d098c861e4b7fa6fbacbb4123025ffdab81b1 for BLOBs. Small CLOBs still will be read entirely in memory by LOB frontend, but larger CLOBs will be stored to disk.

`ValueLobDb.createTempClob()` had a deadlock with small CLOBs transferred over network, this issue is solved. It was previously reproducible only with protocol version below 11, but after this change it appears with any protocol version. New test covers this sutuation.

`DataReader.read(char[], off, len)` ignored the `offset` argument that also leads to silent data corruption that was revealed by `TestLobApi` after these changes. This issue is fixed too.

Reading of BLOBs and CLOBs with closed result set is still working, `TestLobApi` have a test for it.