### PR TITLE
Improve date-time related parts of documentation

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2300,9 +2300,9 @@ Each table has a pseudo-column named ""_ROWID_"" that contains the unique row id
 "
 
 "Other Grammar","Time","
-TIME 'hh:mm:ss'
+TIME 'hh:mm:ss[.nnnnnnnnn]'
 ","
-A time literal. A value is between plus and minus 2 million hours
+A time literal. A value is between 0:00:00 and 23:59:59.999999999
 and has nanosecond resolution.
 ","
 TIME '23:59:59'
@@ -2316,6 +2316,19 @@ A timestamp literal. The limitations are the same as for the Java data type
 minimum and maximum years are 0001 and 9999.
 ","
 TIMESTAMP '2005-12-31 23:59:59'
+"
+
+"Other Grammar","Timestamp with time zone","
+TIMESTAMP 'yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]
+[Z | { - | + } timeZoneOffsetString | timeZoneNameString ]'
+","
+A timestamp with time zone literal.
+If name of time zone is specified it will be converted to time zone offset.
+","
+TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59Z'
+TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59-10:00'
+TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59.123+05'
+TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59.123456789 Europe/London'
 "
 
 "Other Grammar","Value","
@@ -3671,7 +3684,7 @@ CURRENT_TIMESTAMP()
 Adds units to a date-time value. The string indicates the unit.
 Use negative values to subtract units.
 addIntLong may be a long value when manipulating milliseconds,
-otherwise it's range is restricted to int.
+microseconds, or nanoseconds otherwise its range is restricted to int.
 The same units as in the EXTRACT function are supported.
 This method returns a value with the same type as specified value if unit is compatible with this value.
 If specified unit is a HOUR, MINUTE, SECOND, MILLISECOND, etc and value is a DATE value DATEADD returns combined TIMESTAMP.
@@ -3732,7 +3745,8 @@ EXTRACT ( { YEAR | YY | MONTH | MM | QUARTER | WEEK | ISO_WEEK
     FROM timestamp )
 ","
 Returns a specific value from a timestamps.
-This method returns an int.
+This method returns a numeric value with EPOCH unit and
+an int for all other time units.
 ","
 EXTRACT(SECOND FROM CURRENT_TIMESTAMP)
 "
@@ -3821,12 +3835,31 @@ This method uses the current system locale.
 WEEK(CREATED)
 "
 
+"Functions (Time and Date)","ISO_WEEK","
+ISO_WEEK(timestamp)
+","
+Returns the week (1-53) from a timestamp.
+This method uses the ISO definition when
+first week of year should have at least four days
+and week is started with Monday.
+","
+ISO_WEEK(CREATED)
+"
+
 "Functions (Time and Date)","YEAR","
 YEAR(timestamp)
 ","
 Returns the year from a timestamp.
 ","
 YEAR(CREATED)
+"
+
+"Functions (Time and Date)","ISO_YEAR","
+ISO_YEAR(timestamp)
+","
+Returns the ISO week year from a timestamp.
+","
+ISO_YEAR(CREATED)
 "
 
 "Functions (System)","ARRAY_GET","

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1504,7 +1504,7 @@ public class Function extends Expression implements FunctionCall {
             if (field != EPOCH) {
                 result = ValueInt.get(getIntDatePart(v1, field));
             } else {
-                
+
                 // Case where we retrieve the EPOCH time.
                 // First we retrieve the dateValue and his time in nanoseconds.
                 long[] a = DateTimeUtils.dateAndTimeFromValue(v1);
@@ -1515,37 +1515,40 @@ public class Function extends Expression implements FunctionCall {
                 BigDecimal numberOfDays = new BigDecimal(DateTimeUtils.absoluteDayFromDateValue(dateValue));
                 BigDecimal nanosSeconds = new BigDecimal(1_000_000_000);
                 BigDecimal secondsPerDay = new BigDecimal(DateTimeUtils.SECONDS_PER_DAY);
-                
+
                 // Case where the value is of type time e.g. '10:00:00'
                 if (v1 instanceof ValueTime) {
-                    
-                    // In order to retrieve the EPOCH time we only have to convert the time 
+
+                    // In order to retrieve the EPOCH time we only have to convert the time
                     // in nanoseconds (previously retrieved) in seconds.
                     result = ValueDecimal.get(timeNanosBigDecimal.divide(nanosSeconds));
-                    
+
                 } else if (v1 instanceof ValueDate) {
-                    
-                    // Case where the value is of type date '2000:01:01', we have to retrieve the total 
-                    // number of days and multiply it by the number of seconds in a day.
+
+                    // Case where the value is of type date '2000:01:01', we have to retrieve the
+                    // total number of days and multiply it by the number of seconds in a day.
                     result = ValueDecimal.get(numberOfDays.multiply(secondsPerDay));
-                    
+
                 } else if (v1 instanceof ValueTimestampTimeZone) {
-                    
-                    // Case where the value is a of type ValueTimestampTimeZone ('2000:01:01 10:00:00+05).
-                    // We retrieve the time zone offset in minute
+
+                    // Case where the value is a of type ValueTimestampTimeZone
+                    // ('2000:01:01 10:00:00+05').
+                    // We retrieve the time zone offset in minutes
                     ValueTimestampTimeZone v = (ValueTimestampTimeZone) v1;
                     BigDecimal timeZoneOffsetSeconds = new BigDecimal(v.getTimeZoneOffsetMins() * 60);
-                    // Sum the time in nanoseconds and the total number of days in seconds 
+                    // Sum the time in nanoseconds and the total number of days in seconds
                     // and adding the timeZone offset in seconds.
                     result = ValueDecimal.get(timeNanosBigDecimal.divide(nanosSeconds)
-                            .add(numberOfDays.multiply(secondsPerDay))
-                            .subtract(timeZoneOffsetSeconds));
-                    
+                            .add(numberOfDays.multiply(secondsPerDay)).subtract(timeZoneOffsetSeconds));
+
                 } else {
-                    
-                    // By default, we have the date and the time ('2000:01:01 10:00:00) if no type is given. 
-                    // We just have to sum the time in nanoseconds and the total number of days in seconds.
-                    result = ValueDecimal.get(timeNanosBigDecimal.divide(nanosSeconds).add(numberOfDays.multiply(secondsPerDay)));
+
+                    // By default, we have the date and the time ('2000:01:01 10:00:00') if no type
+                    // is given.
+                    // We just have to sum the time in nanoseconds and the total number of days in
+                    // seconds.
+                    result = ValueDecimal
+                            .get(timeNanosBigDecimal.divide(nanosSeconds).add(numberOfDays.multiply(secondsPerDay)));
                 }
             }
             break;

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1615,7 +1615,7 @@ public class MetaTable extends Table {
                 if (constraintType == Constraint.Type.CHECK) {
                     checkExpression = ((ConstraintCheck) constraint).getExpression().getSQL();
                 } else if (constraintType == Constraint.Type.UNIQUE ||
-                           constraintType == Constraint.Type.PRIMARY_KEY) {
+                        constraintType == Constraint.Type.PRIMARY_KEY) {
                     indexColumns = ((ConstraintUnique) constraint).getColumns();
                 } else if (constraintType == Constraint.Type.REFERENTIAL) {
                     indexColumns = ((ConstraintReferential) constraint).getColumns();

--- a/h2/src/main/org/h2/tools/ChangeFileEncryption.java
+++ b/h2/src/main/org/h2/tools/ChangeFileEncryption.java
@@ -224,7 +224,8 @@ public class ChangeFileEncryption extends Tool {
         try (FileChannel fileIn = getFileChannel(fileName, "r", decryptKey)){
             try(InputStream inStream = new FileChannelInputStream(fileIn, true)) {
                 FileUtils.delete(temp);
-                try (OutputStream outStream = new FileChannelOutputStream(getFileChannel(temp, "rw", encryptKey), true)) {
+                try (OutputStream outStream = new FileChannelOutputStream(getFileChannel(temp, "rw", encryptKey),
+                        true)) {
                     byte[] buffer = new byte[4 * 1024];
                     long remaining = fileIn.size();
                     long total = remaining;

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -36,7 +36,7 @@ public class DateTimeUtils {
      * The number of milliseconds per day.
      */
     public static final long MILLIS_PER_DAY = 24 * 60 * 60 * 1000L;
-    
+
     /**
      * The number of seconds per day.
      */

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -466,16 +466,16 @@ public abstract class TestBase {
         throw new AssertionError(string);
     }
 
-   /**
-    * Log an error message.
-    *
-    * @param s the message
-    */
-   public static void logErrorMessage(String s) {
-       System.out.flush();
-       System.err.println("ERROR: " + s + "------------------------------");
-       logThrowable(s, null);
-   }
+    /**
+     * Log an error message.
+     *
+     * @param s the message
+     */
+    public static void logErrorMessage(String s) {
+        System.out.flush();
+        System.err.println("ERROR: " + s + "------------------------------");
+        logThrowable(s, null);
+    }
 
     /**
      * Log an error message.

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -92,7 +92,7 @@ public class TestScript extends TestBase {
         } else {
             decimal2 = "decimal_numeric";
         }
-        
+
         for (String s : new String[] { "array", "bigint", "binary", "blob",
                 "boolean", "char", "clob", "date", "decimal", decimal2, "double", "enum",
                 "geometry", "identity", "int", "other", "real", "smallint",

--- a/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
+++ b/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
@@ -119,7 +119,7 @@ public class TestFuzzOptimizations extends TestBase {
             }
         }
         executeAndCompare("a >=0 and b in(?, 2) and a in(1, ?, null)", Arrays.asList("10", "2"),
-                          "seed=-6191135606105920350L");
+                "seed=-6191135606105920350L");
         db.execute("drop table test0, test1");
     }
 

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -764,5 +764,5 @@ mdy destfile hclf forbids spellchecking selfdestruct expects accident jacocoagen
 jacoco xdata invokes sourcefiles classfiles duplication crypto stacktraces prt directions handled overly asm hardcoded
 interpolated thead
 
-die weekdiff osx subprocess dow proleptic
-
+die weekdiff osx subprocess dow proleptic microsecond microseconds divisible cmp denormalized suppressed saturated mcs
+london


### PR DESCRIPTION
1. Default range of `TIME` values is specified instead of extended that can be enabled with a flag.

2. `TIME STAMP WITH TIME ZONE` literal is described somehow.

3. Descriptions for `ISO_WEEK` and `ISO_YEAR` are added.

4. Descriptions of `DATEADD` and `EXTRACT` are slightly adjusted.

5. Whitespace and long lines are fixed with one exception for `TestOutOfMemory` to avoid merge conflict with upcoming changes.