### PR TITLE
Assorted date-time related changes

### DIFF
--- a/h2/src/main/org/h2/expression/AggregateDataMedian.java
+++ b/h2/src/main/org/h2/expression/AggregateDataMedian.java
@@ -224,7 +224,8 @@ class AggregateDataMedian extends AggregateData {
         case Value.DOUBLE:
             return ValueDouble.get((v0.getFloat() + v1.getDouble()) / 2);
         case Value.TIME: {
-            return ValueTime.fromMillis((v0.getTime().getTime() + v1.getTime().getTime()) / 2);
+            ValueTime t0 = (ValueTime) v0.convertTo(Value.TIME), t1 = (ValueTime) v1.convertTo(Value.TIME);
+            return ValueTime.fromNanos((t0.getNanos() + t1.getNanos()) / 2);
         }
         case Value.DATE: {
             ValueDate d0 = (ValueDate) v0.convertTo(Value.DATE), d1 = (ValueDate) v1.convertTo(Value.DATE);

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -629,20 +629,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Get the year (positive or negative) from a calendar.
-     *
-     * @param calendar the calendar
-     * @return the year
-     */
-    private static int getYear(Calendar calendar) {
-        int year = calendar.get(Calendar.YEAR);
-        if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
-            year = 1 - year;
-        }
-        return year;
-    }
-
-    /**
      * Get the number of milliseconds since 1970-01-01 in the local timezone,
      * but without daylight saving time into account.
      *
@@ -1069,10 +1055,12 @@ public class DateTimeUtils {
      * @return the date value
      */
     private static long dateValueFromCalendar(Calendar cal) {
-        int year, month, day;
-        year = getYear(cal);
-        month = cal.get(Calendar.MONTH) + 1;
-        day = cal.get(Calendar.DAY_OF_MONTH);
+        int year = cal.get(Calendar.YEAR);
+        if (cal.get(Calendar.ERA) == GregorianCalendar.BC) {
+            year = 1 - year;
+        }
+        int month = cal.get(Calendar.MONTH) + 1;
+        int day = cal.get(Calendar.DAY_OF_MONTH);
         return ((long) year << SHIFT_YEAR) | (month << SHIFT_MONTH) | day;
     }
 

--- a/h2/src/test/org/h2/test/unit/TestClearReferences.java
+++ b/h2/src/test/org/h2/test/unit/TestClearReferences.java
@@ -26,6 +26,7 @@ public class TestClearReferences extends TestBase {
         "org.h2.compress.CompressLZF.cachedHashTable",
         "org.h2.engine.DbSettings.defaultSettings",
         "org.h2.engine.SessionRemote.sessionFactory",
+        "org.h2.expression.Function.MONTHS_AND_WEEKS",
         "org.h2.jdbcx.JdbcDataSourceFactory.cachedTraceSystem",
         "org.h2.store.RecoverTester.instance",
         "org.h2.store.fs.FilePath.defaultProvider",


### PR DESCRIPTION
1. `AggregateDataMedian` now uses `ValueTime.getNanos()` instead of `getTime()`. It's faster and resolution is not limited to milliseconds.

2. `MONTHNAME` and `DAYNAME` are reimplemented without `Calendar` and `SimpleDateFormat`. `DateFormatSymbols` cannot be shared between these methods and `TO_CHAR` / `TO_DATE` because these two methods use English locale instead of system default. MySQL documentation says that these methods are localized, but they returns English names in MySQL and MariaDB anyway and H2 documentation says that these methods in H2 returns English names.

3. `DateTimeUtils.getYear(Calendar)` was used only in one place after replacements of `Calendar`-based code in previous pull requests, so now it is inlined into `dateValueFromCalendar()`.