### PR TITLE
Reimplement dateValueFromDate() and nanosFromDate() without a Calendar

### DIFF
--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -1063,8 +1063,9 @@ public class DateTimeUtils {
      */
     public static long dateValueFromDate(long ms) {
         ms += getTimeZone().getOffset(ms);
-        long absoluteDay = ms / 86_400_000;
-        if (ms < 0 && (absoluteDay * 86_400_000 != ms)) {
+        long absoluteDay = ms / MILLIS_PER_DAY;
+        // Round toward negative infinity
+        if (ms < 0 && (absoluteDay * MILLIS_PER_DAY != ms)) {
             absoluteDay--;
         }
         return dateValueFromAbsoluteDay(absoluteDay);
@@ -1095,11 +1096,12 @@ public class DateTimeUtils {
      */
     public static long nanosFromDate(long ms) {
         ms += getTimeZone().getOffset(ms);
-        long absoluteDay = ms / 86_400_000;
-        if (ms < 0 && (absoluteDay * 86_400_000 != ms)) {
+        long absoluteDay = ms / MILLIS_PER_DAY;
+        // Round toward negative infinity
+        if (ms < 0 && (absoluteDay * MILLIS_PER_DAY != ms)) {
             absoluteDay--;
         }
-        return (ms - absoluteDay * 86_400_000) * 1_000_000;
+        return (ms - absoluteDay * MILLIS_PER_DAY) * 1_000_000;
     }
 
     /**

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -1154,7 +1154,7 @@ public class DateTimeUtils {
             m += 12;
         }
         long a = ((y * 2922L) >> 3) + DAYS_OFFSET[m - 3] + d - 719484;
-        if (y <= 1582 && ((y < 1582) || (m * 100 + d < 1005))) {
+        if (y <= 1582 && ((y < 1582) || (m * 100 + d < 1015))) {
             // Julian calendar (cutover at 1582-10-04 / 1582-10-15)
             a += 13;
         } else if (y < 1901 || y > 2099) {

--- a/h2/src/test/org/h2/test/unit/TestClearReferences.java
+++ b/h2/src/test/org/h2/test/unit/TestClearReferences.java
@@ -37,6 +37,7 @@ public class TestClearReferences extends TestBase {
         "org.h2.tools.CompressTool.cachedBuffer",
         "org.h2.util.CloseWatcher.queue",
         "org.h2.util.CloseWatcher.refs",
+        "org.h2.util.DateTimeUtils.timeZone",
         "org.h2.util.MathUtils.cachedSecureRandom",
         "org.h2.util.NetUtils.cachedLocalAddress",
         "org.h2.util.StringUtils.softCache",

--- a/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
@@ -24,7 +24,10 @@ public class TestDateTimeUtils extends TestBase {
     /**
      * Run just this test.
      *
-     * @param a ignored
+     * @param a
+     *            if {@code "testUtc2Value"} only {@link #testUTC2Value(boolean)}
+     *            will be executed with all time zones (slow). Otherwise all tests
+     *            in this test unit will be executed with local time zone.
      */
     public static void main(String... a) throws Exception {
         if (a.length == 1) {

--- a/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
@@ -6,10 +6,15 @@
 package org.h2.test.unit;
 
 import static org.h2.util.DateTimeUtils.dateValue;
+
+import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
 import org.h2.test.TestBase;
 import org.h2.util.DateTimeUtils;
+import org.h2.value.ValueTimestamp;
 
 /**
  * Unit tests for the DateTimeUtils class
@@ -22,6 +27,12 @@ public class TestDateTimeUtils extends TestBase {
      * @param a ignored
      */
     public static void main(String... a) throws Exception {
+        if (a.length == 1) {
+            if ("testUtc2Value".equals(a[0])) {
+                new TestDateTimeUtils().testUTC2Value(true);
+                return;
+            }
+        }
         TestBase.createCaller().init().test();
     }
 
@@ -31,6 +42,7 @@ public class TestDateTimeUtils extends TestBase {
         testDayOfWeek();
         testWeekOfYear();
         testDateValueFromDenormalizedDate();
+        testUTC2Value(false);
     }
 
     private void testParseTimeNanosDB2Format() {
@@ -102,6 +114,47 @@ public class TestDateTimeUtils extends TestBase {
         assertEquals(dateValue(1999, 8, 1), DateTimeUtils.dateValueFromDenormalizedDate(2000, -4, -100));
         assertEquals(dateValue(2100, 12, 31), DateTimeUtils.dateValueFromDenormalizedDate(2100, 12, 2000));
         assertEquals(dateValue(-100, 2, 29), DateTimeUtils.dateValueFromDenormalizedDate(-100, 2, 30));
+    }
+
+    private void testUTC2Value(boolean allTimeZones) {
+        TimeZone def = TimeZone.getDefault();
+        GregorianCalendar gc = new GregorianCalendar();
+        if (allTimeZones) {
+            try {
+                for (String id : TimeZone.getAvailableIDs()) {
+                    System.out.println(id);
+                    TimeZone tz = TimeZone.getTimeZone(id);
+                    TimeZone.setDefault(tz);
+                    DateTimeUtils.resetCalendar();
+                    testUTC2ValueImpl(tz, gc);
+                }
+            } finally {
+                TimeZone.setDefault(def);
+                DateTimeUtils.resetCalendar();
+            }
+        } else {
+            testUTC2ValueImpl(def, gc);
+        }
+    }
+
+    private void testUTC2ValueImpl(TimeZone tz, GregorianCalendar gc) {
+        gc.setTimeZone(tz);
+        gc.set(Calendar.MILLISECOND, 0);
+        long absoluteStart = DateTimeUtils.absoluteDayFromDateValue(DateTimeUtils.dateValue(1950, 01, 01));
+        long absoluteEnd = DateTimeUtils.absoluteDayFromDateValue(DateTimeUtils.dateValue(2050, 01, 01));
+        for (long i = absoluteStart; i < absoluteEnd; i++) {
+            long dateValue = DateTimeUtils.dateValueFromAbsoluteDay(i);
+            int year = DateTimeUtils.yearFromDateValue(dateValue);
+            int month = DateTimeUtils.monthFromDateValue(dateValue);
+            int day = DateTimeUtils.dayFromDateValue(dateValue);
+            for (int j = 0; j < 48; j++) {
+                gc.set(year, month - 1, day, j / 2, (j & 1) * 30, 0);
+                long timeMillis = gc.getTimeInMillis();
+                ValueTimestamp ts = DateTimeUtils.convertTimestamp(new Timestamp(timeMillis), gc);
+                assertEquals(ts.getDateValue(), DateTimeUtils.dateValueFromDate(timeMillis));
+                assertEquals(ts.getTimeNanos(), DateTimeUtils.nanosFromDate(timeMillis));
+            }
+        }
     }
 
 }


### PR DESCRIPTION
`DateTimeUtils.dateValueFromDate()` and `DateTimeUtils.nanosFromDate()` are reimplemented without a `Calendar`. New implementations are faster and should be fully compatible. `TimeZone.getOffset(long)` works properly for conversions from UTC to local time.

Reverse conversion is not changed in this pull request. It's more problematic, not only because there is no exact mapping on DST boundaries, but also due to incompalibitilies of public API and internal API used by `Calendar` for many time zones. It's possible to use internal API directly (this speeds up conversion in three times), but since Java 9 access to internal API produces a warning and may be denied depending on configuration.