### PR TITLE
Fix building of documentation

### DIFF
--- a/h2/src/main/org/h2/engine/GeneratedKeys.java
+++ b/h2/src/main/org/h2/engine/GeneratedKeys.java
@@ -120,6 +120,8 @@ public final class GeneratedKeys {
     /**
      * Returns generated keys.
      *
+     * @param session
+     *            session
      * @return local result with generated keys
      */
     public LocalResult getKeys(Session session) {

--- a/h2/src/main/org/h2/util/ToDateParser.java
+++ b/h2/src/main/org/h2/util/ToDateParser.java
@@ -215,7 +215,7 @@ public class ToDateParser {
         this.minute = minute;
     }
 
-    void setSecord(int second) {
+    void setSecond(int second) {
         this.second = second;
     }
 

--- a/h2/src/main/org/h2/util/ToDateTokenizer.java
+++ b/h2/src/main/org/h2/util/ToDateTokenizer.java
@@ -389,7 +389,7 @@ class ToDateTokenizer {
                 inputFragmentStr = matchStringOrThrow(
                         PATTERN_TWO_DIGITS_OR_LESS, params, formatTokenEnum);
                 dateNr = Integer.parseInt(inputFragmentStr);
-                params.setSecord(dateNr);
+                params.setSecond(dateNr);
                 break;
             case SSSSS: {
                 inputFragmentStr = matchStringOrThrow(PATTERN_NUMBER, params,
@@ -402,7 +402,7 @@ class ToDateTokenizer {
                 int hour = dateNr % 24;
                 params.setHour(hour);
                 params.setMinute(minute);
-                params.setSecord(second);
+                params.setSecond(second);
                 break;
             }
             case FF:

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -1453,9 +1453,9 @@ public abstract class TestBase {
      *
      * @return the path to java
      */
-    private String getJVM() {
-        return System.getProperty("java.home") + File.separatorChar + "bin" +
-                                                 File.separator + "java";
+    private static String getJVM() {
+        return System.getProperty("java.home") + File.separatorChar + "bin"
+                + File.separator + "java";
     }
 
     /**
@@ -1702,7 +1702,7 @@ public abstract class TestBase {
     }
 
     public ProcessBuilder buildChild(String name, Class<? extends TestBase> childClass,
-                                     String... jvmArgs) {
+            String... jvmArgs) {
         List<String> args = new ArrayList<>(16);
         args.add(getJVM());
         Collections.addAll(args, jvmArgs);

--- a/h2/src/test/org/h2/test/jdbc/TestGetGeneratedKeys.java
+++ b/h2/src/test/org/h2/test/jdbc/TestGetGeneratedKeys.java
@@ -61,7 +61,7 @@ public class TestGetGeneratedKeys extends TestBase {
         deleteDb("getGeneratedKeys");
         Connection conn = getConnection("getGeneratedKeys");
         testBatchAndMergeInto(conn);
-        testCalledSequenses(conn);
+        testCalledSequences(conn);
         testInsertWithSelect(conn);
         testMergeUsing(conn);
         testMultithreaded(conn);
@@ -171,7 +171,7 @@ public class TestGetGeneratedKeys extends TestBase {
      * @throws Exception
      *             on exception
      */
-    private void testCalledSequenses(Connection conn) throws Exception {
+    private void testCalledSequences(Connection conn) throws Exception {
         Statement stat = conn.createStatement();
 
         stat.execute("CREATE SEQUENCE SEQ");

--- a/h2/src/test/org/h2/test/jdbc/TestGetGeneratedKeys.java
+++ b/h2/src/test/org/h2/test/jdbc/TestGetGeneratedKeys.java
@@ -418,7 +418,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String)}.{@link PreparedStatement#execute()}.
+     * {@link Connection#prepareStatement(String)}
+     * .{@link PreparedStatement#execute()}.
      *
      * @param conn
      *            connection
@@ -439,7 +440,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String)}.{@link PreparedStatement#executeBatch()}.
+     * {@link Connection#prepareStatement(String)}
+     * .{@link PreparedStatement#executeBatch()}.
      *
      * @param conn
      *            connection
@@ -462,7 +464,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String)}.{@link PreparedStatement#executeLargeBatch()}.
+     * {@link Connection#prepareStatement(String)}
+     * .{@link PreparedStatement#executeLargeBatch()}.
      *
      * @param conn
      *            connection
@@ -486,7 +489,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String)}.{@link PreparedStatement#executeLargeUpdate()}.
+     * {@link Connection#prepareStatement(String)}
+     * .{@link PreparedStatement#executeLargeUpdate()}.
      *
      * @param conn
      *            connection
@@ -508,7 +512,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String)}.{@link PreparedStatement#executeUpdate()}.
+     * {@link Connection#prepareStatement(String)}
+     * .{@link PreparedStatement#executeUpdate()}.
      *
      * @param conn
      *            connection
@@ -529,7 +534,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int)}.{@link PreparedStatement#execute()}.
+     * {@link Connection#prepareStatement(String, int)}
+     * .{@link PreparedStatement#execute()}.
      *
      * @param conn
      *            connection
@@ -562,7 +568,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int)}.{@link PreparedStatement#executeBatch()}.
+     * {@link Connection#prepareStatement(String, int)}
+     * .{@link PreparedStatement#executeBatch()}.
      *
      * @param conn
      *            connection
@@ -601,8 +608,8 @@ public class TestGetGeneratedKeys extends TestBase {
     }
 
     /**
-     * Test method for
-     * {@link Connection#prepareStatement(String, int)}.{@link PreparedStatement#executeLargeBatch()}.
+     * Test method for {@link Connection#prepareStatement(String, int)}
+     * .{@link PreparedStatement#executeLargeBatch()}.
      *
      * @param conn
      *            connection
@@ -643,7 +650,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int)}.{@link PreparedStatement#executeLargeUpdate()}.
+     * {@link Connection#prepareStatement(String, int)}
+     * .{@link PreparedStatement#executeLargeUpdate()}.
      *
      * @param conn
      *            connection
@@ -677,7 +685,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int)}.{@link PreparedStatement#executeUpdate()}.
+     * {@link Connection#prepareStatement(String, int)}
+     * .{@link PreparedStatement#executeUpdate()}.
      *
      * @param conn
      *            connection
@@ -710,7 +719,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int[])}.{@link PreparedStatement#execute()}.
+     * {@link Connection#prepareStatement(String, int[])}
+     * .{@link PreparedStatement#execute()}.
      *
      * @param conn
      *            connection
@@ -762,7 +772,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int[])}.{@link PreparedStatement#executeBatch()}.
+     * {@link Connection#prepareStatement(String, int[])}
+     * .{@link PreparedStatement#executeBatch()}.
      *
      * @param conn
      *            connection
@@ -830,7 +841,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int[])}.{@link PreparedStatement#executeLargeBatch()}.
+     * {@link Connection#prepareStatement(String, int[])}
+     * .{@link PreparedStatement#executeLargeBatch()}.
      *
      * @param conn
      *            connection
@@ -849,7 +861,8 @@ public class TestGetGeneratedKeys extends TestBase {
         ResultSet rs = prep.getGeneratedKeys();
         assertFalse(rs.next());
         rs.close();
-        prep = (JdbcPreparedStatement) conn.prepareStatement("INSERT INTO TEST(VALUE) VALUES (20)", new int[] { 1, 2 });
+        prep = (JdbcPreparedStatement) conn.prepareStatement("INSERT INTO TEST(VALUE) VALUES (20)",
+                new int[] { 1, 2 });
         prep.addBatch();
         prep.addBatch();
         prep.executeLargeBatch();
@@ -865,7 +878,8 @@ public class TestGetGeneratedKeys extends TestBase {
         assertEquals(UUID.class, rs.getObject(2).getClass());
         assertFalse(rs.next());
         rs.close();
-        prep = (JdbcPreparedStatement) conn.prepareStatement("INSERT INTO TEST(VALUE) VALUES (30)", new int[] { 2, 1 });
+        prep = (JdbcPreparedStatement) conn.prepareStatement("INSERT INTO TEST(VALUE) VALUES (30)",
+                new int[] { 2, 1 });
         prep.addBatch();
         prep.addBatch();
         prep.executeLargeBatch();
@@ -899,7 +913,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int[])}.{@link PreparedStatement#executeLargeUpdate()}.
+     * {@link Connection#prepareStatement(String, int[])}
+     * .{@link PreparedStatement#executeLargeUpdate()}.
      *
      * @param conn
      *            connection
@@ -916,7 +931,8 @@ public class TestGetGeneratedKeys extends TestBase {
         ResultSet rs = prep.getGeneratedKeys();
         assertFalse(rs.next());
         rs.close();
-        prep = (JdbcPreparedStatement) conn.prepareStatement("INSERT INTO TEST(VALUE) VALUES (20)", new int[] { 1, 2 });
+        prep = (JdbcPreparedStatement) conn.prepareStatement("INSERT INTO TEST(VALUE) VALUES (20)",
+                new int[] { 1, 2 });
         prep.executeLargeUpdate();
         rs = prep.getGeneratedKeys();
         assertEquals(2, rs.getMetaData().getColumnCount());
@@ -927,7 +943,8 @@ public class TestGetGeneratedKeys extends TestBase {
         assertEquals(UUID.class, rs.getObject(2).getClass());
         assertFalse(rs.next());
         rs.close();
-        prep = (JdbcPreparedStatement) conn.prepareStatement("INSERT INTO TEST(VALUE) VALUES (30)", new int[] { 2, 1 });
+        prep = (JdbcPreparedStatement) conn.prepareStatement("INSERT INTO TEST(VALUE) VALUES (30)",
+                new int[] { 2, 1 });
         prep.executeLargeUpdate();
         rs = prep.getGeneratedKeys();
         assertEquals(2, rs.getMetaData().getColumnCount());
@@ -952,7 +969,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, int[])}.{@link PreparedStatement#executeUpdate()}.
+     * {@link Connection#prepareStatement(String, int[])}
+     * .{@link PreparedStatement#executeUpdate()}.
      *
      * @param conn
      *            connection
@@ -1004,7 +1022,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, String[])}.{@link PreparedStatement#execute()}.
+     * {@link Connection#prepareStatement(String, String[])}
+     * .{@link PreparedStatement#execute()}.
      *
      * @param conn
      *            connection
@@ -1056,7 +1075,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, String[])}.{@link PreparedStatement#executeBatch()}.
+     * {@link Connection#prepareStatement(String, String[])}
+     * .{@link PreparedStatement#executeBatch()}.
      *
      * @param conn
      *            connection
@@ -1124,7 +1144,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, String[])}.{@link PreparedStatement#executeLargeBatch()}.
+     * {@link Connection#prepareStatement(String, String[])}
+     * .{@link PreparedStatement#executeLargeBatch()}.
      *
      * @param conn
      *            connection
@@ -1196,7 +1217,8 @@ public class TestGetGeneratedKeys extends TestBase {
 
     /**
      * Test method for
-     * {@link Connection#prepareStatement(String, String[])}.{@link PreparedStatement#executeLargeUpdate()}.
+     * {@link Connection#prepareStatement(String, String[])}
+     * .{@link PreparedStatement#executeLargeUpdate()}.
      *
      * @param conn
      *            connection
@@ -1251,8 +1273,8 @@ public class TestGetGeneratedKeys extends TestBase {
     }
 
     /**
-     * Test method for
-     * {@link Connection#prepareStatement(String, String[])}.{@link PreparedStatement#executeUpdate()}.
+     * Test method for {@link Connection#prepareStatement(String, String[])}
+     * .{@link PreparedStatement#executeUpdate()}.
      *
      * @param conn
      *            connection

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -765,4 +765,4 @@ jacoco xdata invokes sourcefiles classfiles duplication crypto stacktraces prt d
 interpolated thead
 
 die weekdiff osx subprocess dow proleptic microsecond microseconds divisible cmp denormalized suppressed saturated mcs
-london
+london dfs weekdays intermittent looked


### PR DESCRIPTION
1. Some typos are fixed. `dictionary.txt` is updated.

2. Long lines are wrapped, bad indentation is fixed. Eclipse sometimes incorrectly allows 121 character in a line.

3. Missing javadoc parameter is added.