### PR TITLE
Implement conversions for TIMESTAMP WITH TIME ZONE

### DIFF
--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -1020,9 +1020,9 @@ public class DataType {
             return Value.DATE;
         } else if (LocalDateTimeUtils.LOCAL_TIME == x) {
             return Value.TIME;
-        } else if (LocalDateTimeUtils.LOCAL_DATE_TIME == x || LocalDateTimeUtils.INSTANT == x) {
+        } else if (LocalDateTimeUtils.LOCAL_DATE_TIME == x) {
             return Value.TIMESTAMP;
-        } else if (LocalDateTimeUtils.OFFSET_DATE_TIME == x) {
+        } else if (LocalDateTimeUtils.OFFSET_DATE_TIME == x || LocalDateTimeUtils.INSTANT == x) {
             return Value.TIMESTAMP_TZ;
         } else {
             if (JdbcUtils.customDataTypesHandler != null) {

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -148,7 +148,7 @@ public class ValueTimestampTimeZone extends Value {
 
     @Override
     public Timestamp getTimestamp() {
-        throw new UnsupportedOperationException("unimplemented");
+        return DateTimeUtils.convertTimestampTimeZoneToTimestamp(dateValue, timeNanos, timeZoneOffsetMins);
     }
 
     @Override

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -765,4 +765,4 @@ jacoco xdata invokes sourcefiles classfiles duplication crypto stacktraces prt d
 interpolated thead
 
 die weekdiff osx subprocess dow proleptic microsecond microseconds divisible cmp denormalized suppressed saturated mcs
-london dfs weekdays intermittent looked
+london dfs weekdays intermittent looked msec tstz africa monrovia


### PR DESCRIPTION
Conversions from / to `DATE` and `TIMESTAMP` are implemented as described in SQL standard.

Conversion from / to `TIME` marked in standard as not supported, but I implement it just like conversions from `TIMESTAMP` to `TIME` in H2 database (such conversions are also marked as not supported in the standard).

I also remapped `java.time.Instant` to `ValueTimestampTimeZone`. This type now can be used to set both `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` values. For `TIMESTAMP` columns UTC value will be converted to local like it was done before, but for `TIMESTAMP WITH TIME ZONE` UTC value will be stored directly with 0 offset, that makes more sense than conversion to local time that have an issue on transition from DST to regular time and following conversion to offset-based time.