### PR TITLE
Assorted minor changes in Parser

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6771,22 +6771,10 @@ public class Parser {
         if (s == null) {
             return "\"\"";
         }
-        if (isSimpleIdentifier(s, false)) {
+        if (ParserUtil.isSimpleIdentifier(s, false)) {
             return s;
         }
         return StringUtils.quoteIdentifier(s);
-    }
-
-    /**
-     * Is this a simple identifier (in the JDBC specification sense).
-     *
-     * @param s identifier to check
-     * @param functionsAsKeywords treat system functions as keywords
-     * @return is specified identifier may be used without quotes
-     * @throws NullPointerException if s is {@code null}
-     */
-    public static boolean isSimpleIdentifier(String s, boolean functionsAsKeywords) {
-        return ParserUtil.isSimpleIdentifier(s, functionsAsKeywords);
     }
 
     public void setLiteralsChecked(boolean literalsChecked) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6254,22 +6254,17 @@ public class Parser {
                 columnsToAdd.add(column);
             } while (readIf(","));
             read(")");
-            if (readIf("BEFORE")) {
-                command.setAddBefore(readColumnIdentifier());
-            } else if (readIf("AFTER")) {
-                command.setAddAfter(readColumnIdentifier());
-            }
         } else {
             boolean ifNotExists = readIfNotExists();
             command.setIfNotExists(ifNotExists);
             String columnName = readColumnIdentifier();
             Column column = parseColumnForTable(columnName, true);
             columnsToAdd.add(column);
-            if (readIf("BEFORE")) {
-                command.setAddBefore(readColumnIdentifier());
-            } else if (readIf("AFTER")) {
-                command.setAddAfter(readColumnIdentifier());
-            }
+        }
+        if (readIf("BEFORE")) {
+            command.setAddBefore(readColumnIdentifier());
+        } else if (readIf("AFTER")) {
+            command.setAddAfter(readColumnIdentifier());
         }
         command.setNewColumns(columnsToAdd);
         return command;

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -779,7 +779,7 @@ public class Parser {
         Update command = new Update(session);
         currentPrepared = command;
         int start = lastParseIndex;
-        TableFilter filter = readSimpleTableFilter(0);
+        TableFilter filter = readSimpleTableFilter(0, null);
         command.setTableFilter(filter);
         parseUpdateSetClause(command, filter, start);
         return command;
@@ -839,28 +839,14 @@ public class Parser {
         setSQL(command, "UPDATE", start);
     }
 
-    private TableFilter readSimpleTableFilter(int orderInFrom) {
+    private TableFilter readSimpleTableFilter(int orderInFrom, Collection<String> excludeTokens) {
         Table table = readTableOrView();
         String alias = null;
         if (readIf("AS")) {
             alias = readAliasIdentifier();
         } else if (currentTokenType == IDENTIFIER) {
-            if (!equalsToken("SET", currentToken)) {
-                // SET is not a keyword (PostgreSQL supports it as a table name)
-                alias = readAliasIdentifier();
-            }
-        }
-        return new TableFilter(session, table, alias, rightsChecked,
-                currentSelect, orderInFrom, null);
-    }
-
-    private TableFilter readSimpleTableFilterWithAliasExcludes(int orderInFrom, Collection<String> excludeTokens) {
-        Table table = readTableOrView();
-        String alias = null;
-        if (readIf("AS")) {
-            alias = readAliasIdentifier();
-        } else if (currentTokenType == IDENTIFIER) {
-            if (!equalsTokenIgnoreCase(currentToken, "SET") && !isTokenInList(excludeTokens)) {
+            if (!equalsTokenIgnoreCase(currentToken, "SET")
+                    && (excludeTokens == null || !isTokenInList(excludeTokens))) {
                 // SET is not a keyword (PostgreSQL supports it as a table name)
                 alias = readAliasIdentifier();
             }
@@ -881,7 +867,7 @@ public class Parser {
             readIdentifierWithSchema();
             read("FROM");
         }
-        TableFilter filter = readSimpleTableFilter(0);
+        TableFilter filter = readSimpleTableFilter(0, null);
         command.setTableFilter(filter);
         parseDeleteGivenTable(command, limit, start);
         return command;
@@ -1090,7 +1076,7 @@ public class Parser {
         int start = lastParseIndex;
         read("INTO");
         List<String> excludeIdentifiers = Arrays.asList("USING", "KEY", "VALUES");
-        TableFilter targetTableFilter = readSimpleTableFilterWithAliasExcludes(0, excludeIdentifiers);
+        TableFilter targetTableFilter = readSimpleTableFilter(0, excludeIdentifiers);
         command.setTargetTableFilter(targetTableFilter);
         Table table = command.getTargetTable();
 
@@ -1160,7 +1146,7 @@ public class Parser {
         } else {
             /* Its a table name, simulate a query by building a select query for the table */
             List<String> excludeIdentifiers = Arrays.asList("ON");
-            TableFilter sourceTableFilter = readSimpleTableFilterWithAliasExcludes(0, excludeIdentifiers);
+            TableFilter sourceTableFilter = readSimpleTableFilter(0, excludeIdentifiers);
             command.setSourceTableFilter(sourceTableFilter);
 
             StringBuilder buff = new StringBuilder("SELECT * FROM ")

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -35,7 +35,7 @@ public class ParserUtil {
     /**
      * The token "rownum".
      */
-public static final int ROWNUM = 6;
+    public static final int ROWNUM = 6;
 
     private ParserUtil() {
         // utility class


### PR DESCRIPTION
1. Methods `readSimpleTableFilter()` and `readSimpleTableFilterWithAliasExcludes()` are merged into one, they are very similar to each other.

2. `ParserUtil.isSimpleIdentifier()` now called directly, method `Parser.isSimpleIdentifier()` was removed.

3. Common parts in `parseAlterTableAddColumn()` are moved out of conditional blocks.

4. Indentation of `ParserUtil.ROWNUM` is fixed.