### PR TITLE
Assorted changes in help.csv

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -115,9 +115,7 @@ MERGE INTO tableName [ ( columnName [,...] ) ]
 ","
 Updates existing rows, and insert rows that don't exist. If no key column is
 specified, the primary key columns are used to find the row. If more than one
-row per new row is affected, an exception is thrown. If the table contains an
-auto-incremented key or identity column, and the row was updated, the generated
-key is set to 0; otherwise it is set to the new key.
+row per new row is affected, an exception is thrown.
 ","
 MERGE INTO TEST KEY(ID) VALUES(2, 'World')
 "

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4260,7 +4260,7 @@ CALL SCHEMA()
 SCOPE_IDENTITY()
 ","
 Returns the last inserted identity value for this session for the current scope
-(ie. the current statement).
+(the current statement).
 Changes within triggers and Java functions are ignored. See also IDENTITY().
 This method returns a long.
 ","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -230,7 +230,7 @@ Can be used to create a recursive or non-recursive query (common table expressio
 For recursive queries the first select has to be a UNION.
 One or more common table entries can be referred to by name.
 Column name declarations are now optional - the column names will be inferred from the named select queries.
-The final action in a WITH statement can be a select , insert , update , merge , delete or create table.
+The final action in a WITH statement can be a select, insert, update, merge, delete or create table.
 ","
 WITH RECURSIVE cte(n) AS (
         SELECT 1

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -125,7 +125,7 @@ MERGE INTO targetTableName [ [AS] targetAlias]
 USING { ( select ) | sourceTableName }[ [AS] sourceAlias ]
 ON ( expression )
 [ WHEN MATCHED THEN [ update ] [ delete] ]
-[ WHEN NOT MATCHED THEN insert  ]
+[ WHEN NOT MATCHED THEN insert ]
 ","
 Updates or deletes existing rows, and insert rows that don't exist. The ON clause
 specifies the matching column expression and must be specified. If more than one row
@@ -272,8 +272,8 @@ ALTER SCHEMA TEST RENAME TO PRODUCTION
 ALTER SEQUENCE [ IF EXISTS ] sequenceName [ RESTART WITH long ] [ INCREMENT BY long ]
 [ MINVALUE long | NOMINVALUE | NO MINVALUE ]
 [ MAXVALUE long | NOMAXVALUE | NO MAXVALUE ]
-[ CYCLE long | NOCYCLE |  NO CYCLE ]
-[ CACHE long |  NOCACHE |  NO CACHE ]
+[ CYCLE long | NOCYCLE | NO CYCLE ]
+[ CACHE long | NOCACHE | NO CACHE ]
 ","
 Changes the parameters of a sequence.
 This command does not commit the current transaction; however the new value is used by other
@@ -661,8 +661,8 @@ CREATE SEQUENCE [ IF NOT EXISTS ] newSequenceName [ START WITH long ]
 [ INCREMENT BY long ]
 [ MINVALUE long | NOMINVALUE | NO MINVALUE ]
 [ MAXVALUE long | NOMAXVALUE | NO MAXVALUE ]
-[ CYCLE long | NOCYCLE |  NO CYCLE ]
-[ CACHE long |  NOCACHE |  NO CACHE ]
+[ CYCLE long | NOCYCLE | NO CYCLE ]
+[ CACHE long | NOCACHE | NO CACHE ]
 ","
 Creates a new sequence.
 The data type of a sequence is BIGINT.
@@ -2129,7 +2129,7 @@ Long numbers are between -9223372036854775808 and 9223372036854775807.
 "
 
 "Other Grammar","Name","
-{ { A-Z|_  } [ { A-Z|_|0-9 } [...] ] } | quotedName
+{ { A-Z|_ } [ { A-Z|_|0-9 } [...] ] } | quotedName
 ","
 Names are not case sensitive. There is no maximum name length.
 ","
@@ -2515,7 +2515,7 @@ OTHER
 
 "Data Types","VARCHAR Type","
 { VARCHAR | LONGVARCHAR | VARCHAR2 | NVARCHAR
-    | NVARCHAR2 | VARCHAR_CASESENSITIVE}  [ ( precisionInt ) ]
+    | NVARCHAR2 | VARCHAR_CASESENSITIVE} [ ( precisionInt ) ]
 ","
 A Unicode String.
 Use two single quotes ('') to create a quote.
@@ -4240,7 +4240,7 @@ Returns the number of the current row.
 This method returns a long.
 It is supported for SELECT statements, as well as for DELETE and UPDATE.
 The first row has the row number 1, and is calculated before ordering and grouping the result set,
-but after evaluating index conditions (even when the  index conditions are specified in an outer query).
+but after evaluating index conditions (even when the index conditions are specified in an outer query).
 To get the row number after ordering and grouping, use a subquery.
 ","
 SELECT ROWNUM(), * FROM TEST;
@@ -4251,7 +4251,7 @@ SELECT ID FROM (SELECT T.*, ROWNUM AS R FROM TEST T) WHERE R BETWEEN 2 AND 3;
 "Functions (System)","SCHEMA","
 SCHEMA()
 ","
-Returns the name of the default  schema for this session.
+Returns the name of the default schema for this session.
 ","
 CALL SCHEMA()
 "

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3849,7 +3849,7 @@ WEEK(CREATED)
 "Functions (Time and Date)","ISO_WEEK","
 ISO_WEEK(timestamp)
 ","
-Returns the week (1-53) from a timestamp.
+Returns the ISO week (1-53) from a timestamp.
 This method uses the ISO definition when
 first week of year should have at least four days
 and week is started with Monday.

--- a/h2/src/tools/org/h2/build/doc/GenerateHelp.java
+++ b/h2/src/tools/org/h2/build/doc/GenerateHelp.java
@@ -41,10 +41,21 @@ public class GenerateHelp {
             for (int i = 0; i < columnCount; i++) {
                 String s = rs.getString(1 + i);
                 if (i == 3) {
-                    int dot = s.indexOf('.');
-                    if (dot >= 0) {
-                        s = s.substring(0, dot + 1);
+                    int len = s.length();
+                    int end = 0;
+                    for (; end < len; end++) {
+                        char ch = s.charAt(end);
+                        if (ch == '.') {
+                            end++;
+                            break;
+                        }
+                        if (ch == '"') {
+                            do {
+                                end++;
+                            } while (end < len && s.charAt(end) != '"');
+                        }
                     }
+                    s = s.substring(0, end);
                 }
                 row[i] = s;
             }

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -765,4 +765,4 @@ jacoco xdata invokes sourcefiles classfiles duplication crypto stacktraces prt d
 interpolated thead
 
 die weekdiff osx subprocess dow proleptic microsecond microseconds divisible cmp denormalized suppressed saturated mcs
-london dfs weekdays intermittent looked msec tstz africa monrovia
+london dfs weekdays intermittent looked msec tstz africa monrovia asia tokyo


### PR DESCRIPTION
1. `GenerateHelp` now truncates descriptions for `TEXT` columns in smarter way. Period used inside a quoted strings is not treated any more as an end of the first sentence. This fixes issue with truncated descriptions like `See also Java "Math.` in output of the `HELP` command.

2. First sentence in description of `ISO_WEEK` is changed for `HELP` command. First sentence in previous version was exactly the same as for `WEEK` so `HELP` command was not useful to distinguish between them.

3. Description of `SCOPE_IDENTITY` is slightly changed to avoid bad truncation for embedded help.

4. Outdated notice about generated keys is removed from description of `MERGE INTO`. Now this command returns generated keys for inserted rows in oblivious and correct way.

5. Double spaces between words are replaced with single space character, spaces before commas in normal sentences are removed.

6. `dictionary.txt` is also updated.