### PR TITLE
Fix ON DUPLICATE KEY UPDATE for inserts with multiple rows

### DIFF
--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -435,11 +435,12 @@ public class Insert extends Prepared implements ResultTarget {
             for (int i = 0; i < columns.length; i++) {
                 if (expr.getColumnName().equals(columns[i].getName())) {
                     if (condition == null) {
-                        condition = new Comparison(session, Comparison.EQUAL, expr, row[i++]);
+                        condition = new Comparison(session, Comparison.EQUAL, expr, row[i]);
                     } else {
                         condition = new ConditionAndOr(ConditionAndOr.AND, condition,
-                                new Comparison(session, Comparison.EQUAL, expr, row[i++]));
+                                new Comparison(session, Comparison.EQUAL, expr, row[i]));
                     }
+                    break;
                 }
             }
         }

--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -439,7 +439,7 @@ public class Insert extends Prepared implements ResultTarget {
                         condition = new ConditionAndOr(ConditionAndOr.AND,
                                 condition,
                                 new Comparison(session, Comparison.EQUAL, expr,
-                                        list.get(0)[i++]));
+                                        list.get(getCurrentRowNumber() - 1)[i++]));
                     }
                 }
             }

--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -375,12 +375,13 @@ public class Insert extends Prepared implements ResultTarget {
 
         ArrayList<String> variableNames = new ArrayList<>(
                 duplicateKeyAssignmentMap.size());
+        Expression[] row = list.get(getCurrentRowNumber() - 1);
         for (int i = 0; i < columns.length; i++) {
             String key = table.getSchema().getName() + "." +
                     table.getName() + "." + columns[i].getName();
             variableNames.add(key);
             session.setVariable(key,
-                    list.get(getCurrentRowNumber() - 1)[i].getValue(session));
+                    row[i].getValue(session));
         }
 
         StatementBuilder buff = new StatementBuilder("UPDATE ");
@@ -425,6 +426,7 @@ public class Insert extends Prepared implements ResultTarget {
             indexedColumns = foundIndex.getColumns();
         }
 
+        Expression[] row = list.get(getCurrentRowNumber() - 1);
         Expression condition = null;
         for (Column column : indexedColumns) {
             ExpressionColumn expr = new ExpressionColumn(session.getDatabase(),
@@ -433,13 +435,10 @@ public class Insert extends Prepared implements ResultTarget {
             for (int i = 0; i < columns.length; i++) {
                 if (expr.getColumnName().equals(columns[i].getName())) {
                     if (condition == null) {
-                        condition = new Comparison(session, Comparison.EQUAL,
-                                expr, list.get(getCurrentRowNumber() - 1)[i++]);
+                        condition = new Comparison(session, Comparison.EQUAL, expr, row[i++]);
                     } else {
-                        condition = new ConditionAndOr(ConditionAndOr.AND,
-                                condition,
-                                new Comparison(session, Comparison.EQUAL, expr,
-                                        list.get(getCurrentRowNumber() - 1)[i++]));
+                        condition = new ConditionAndOr(ConditionAndOr.AND, condition,
+                                new Comparison(session, Comparison.EQUAL, expr, row[i++]));
                     }
                 }
             }

--- a/h2/src/test/org/h2/test/db/TestDuplicateKeyUpdate.java
+++ b/h2/src/test/org/h2/test/db/TestDuplicateKeyUpdate.java
@@ -109,12 +109,14 @@ public class TestDuplicateKeyUpdate extends TestBase {
         assertEquals("UPDATE", rs.getNString(1));
 
         stat.execute("INSERT INTO table_test2 (a_text, some_text, updatable_text ) " +
-                "VALUES ('b', 'b', 'test') " +
+                "VALUES ('b', 'b', 'test'), ('c', 'c', 'test2') " +
                 "ON DUPLICATE KEY UPDATE updatable_text=values(updatable_text)");
         rs = stat.executeQuery("SELECT updatable_text " +
-                "FROM table_test2 where a_text = 'b'");
+                "FROM table_test2 where a_text in ('b', 'c') order by a_text");
         rs.next();
         assertEquals("test", rs.getNString(1));
+        rs.next();
+        assertEquals("test2", rs.getNString(1));
     }
 
     private void testDuplicateCache(Connection conn) throws SQLException {


### PR DESCRIPTION
This pull requests fixes issue from the mailing list:
https://groups.google.com/forum/#!topic/h2-database/mbT421k8-O4

1. Row 0 was used in one place instead of the current row.

2. Current row is extracted in a local variables for better readability.

3. Strange inner loop in `Insert.prepareUpdateCondition()`is fixed. If column is found it's time to stop the search. But inner loop for unknown reason skipped just the next column, not the all remaining columns.