### PR TITLE
Handle first and last arguments of FunctionIndex.find()

### DIFF
--- a/h2/src/main/org/h2/index/AbstractFunctionCursor.java
+++ b/h2/src/main/org/h2/index/AbstractFunctionCursor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.index;
+
+import org.h2.engine.Session;
+import org.h2.message.DbException;
+import org.h2.result.Row;
+import org.h2.result.SearchRow;
+import org.h2.value.Value;
+
+/**
+ * Abstract function cursor.
+ */
+abstract class AbstractFunctionCursor implements Cursor {
+    private final FunctionIndex index;
+
+    private final SearchRow first;
+
+    private final SearchRow last;
+
+    final Session session;
+
+    Value[] values;
+
+    Row row;
+
+    /**
+     * @param index
+     *            index
+     * @param first
+     *            first row
+     * @param last
+     *            last row
+     * @param session
+     *            session
+     */
+    AbstractFunctionCursor(FunctionIndex index, SearchRow first, SearchRow last, Session session) {
+        this.index = index;
+        this.first = first;
+        this.last = last;
+        this.session = session;
+    }
+
+    @Override
+    public Row get() {
+        if (values == null) {
+            return null;
+        }
+        if (row == null) {
+            row = session.createRow(values, 1);
+        }
+        return row;
+    }
+
+    @Override
+    public SearchRow getSearchRow() {
+        return get();
+    }
+
+    @Override
+    public boolean next() {
+        while (nextImpl()) {
+            Row current = get();
+            if (first != null) {
+                int comp = index.compareRows(current, first);
+                if (comp < 0) {
+                    continue;
+                }
+            }
+            if (last != null) {
+                int comp = index.compareRows(current, last);
+                if (comp > 0) {
+                    continue;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    abstract boolean nextImpl();
+
+    @Override
+    public boolean previous() {
+        throw DbException.throwInternalError(toString());
+    }
+
+}

--- a/h2/src/main/org/h2/index/AbstractFunctionCursor.java
+++ b/h2/src/main/org/h2/index/AbstractFunctionCursor.java
@@ -62,6 +62,10 @@ abstract class AbstractFunctionCursor implements Cursor {
 
     @Override
     public boolean next() {
+        final SearchRow first = this.first, last = this.last;
+        if (first == null && last == null) {
+            return nextImpl();
+        }
         while (nextImpl()) {
             Row current = get();
             if (first != null) {

--- a/h2/src/main/org/h2/index/BaseIndex.java
+++ b/h2/src/main/org/h2/index/BaseIndex.java
@@ -121,7 +121,7 @@ public abstract class BaseIndex extends SchemaObjectBase implements Index {
     }
 
     @Override
-    public boolean isFindSlow() {
+    public boolean isFindUsingFullTableScan() {
         return false;
     }
 

--- a/h2/src/main/org/h2/index/BaseIndex.java
+++ b/h2/src/main/org/h2/index/BaseIndex.java
@@ -120,6 +120,10 @@ public abstract class BaseIndex extends SchemaObjectBase implements Index {
         return false;
     }
 
+    @Override
+    public boolean isFindSlow() {
+        return false;
+    }
 
     @Override
     public Cursor find(TableFilter filter, SearchRow first, SearchRow last) {

--- a/h2/src/main/org/h2/index/FunctionCursor.java
+++ b/h2/src/main/org/h2/index/FunctionCursor.java
@@ -6,45 +6,23 @@
 package org.h2.index;
 
 import org.h2.engine.Session;
-import org.h2.message.DbException;
 import org.h2.result.ResultInterface;
-import org.h2.result.Row;
 import org.h2.result.SearchRow;
-import org.h2.value.Value;
 
 /**
  * A cursor for a function that returns a result.
  */
-public class FunctionCursor implements Cursor {
+public class FunctionCursor extends AbstractFunctionCursor {
 
-    private final Session session;
     private final ResultInterface result;
-    private Value[] values;
-    private Row row;
 
-    FunctionCursor(Session session, ResultInterface result) {
-        this.session = session;
+    FunctionCursor(FunctionIndex index, SearchRow first, SearchRow last, Session session, ResultInterface result) {
+        super(index, first, last, session);
         this.result = result;
     }
 
     @Override
-    public Row get() {
-        if (values == null) {
-            return null;
-        }
-        if (row == null) {
-            row = session.createRow(values, 1);
-        }
-        return row;
-    }
-
-    @Override
-    public SearchRow getSearchRow() {
-        return get();
-    }
-
-    @Override
-    public boolean next() {
+    boolean nextImpl() {
         row = null;
         if (result != null && result.next()) {
             values = result.currentRow();
@@ -52,11 +30,6 @@ public class FunctionCursor implements Cursor {
             values = null;
         }
         return values != null;
-    }
-
-    @Override
-    public boolean previous() {
-        throw DbException.throwInternalError(toString());
     }
 
 }

--- a/h2/src/main/org/h2/index/FunctionCursorResultSet.java
+++ b/h2/src/main/org/h2/index/FunctionCursorResultSet.java
@@ -10,7 +10,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import org.h2.engine.Session;
 import org.h2.message.DbException;
-import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.value.DataType;
 import org.h2.value.Value;
@@ -18,16 +17,13 @@ import org.h2.value.Value;
 /**
  * A cursor for a function that returns a JDBC result set.
  */
-public class FunctionCursorResultSet implements Cursor {
+public class FunctionCursorResultSet extends AbstractFunctionCursor {
 
-    private final Session session;
     private final ResultSet result;
     private final ResultSetMetaData meta;
-    private Value[] values;
-    private Row row;
 
-    FunctionCursorResultSet(Session session, ResultSet result) {
-        this.session = session;
+    FunctionCursorResultSet(FunctionIndex index, SearchRow first, SearchRow last, Session session, ResultSet result) {
+        super(index, first, last, session);
         this.result = result;
         try {
             this.meta = result.getMetaData();
@@ -37,23 +33,7 @@ public class FunctionCursorResultSet implements Cursor {
     }
 
     @Override
-    public Row get() {
-        if (values == null) {
-            return null;
-        }
-        if (row == null) {
-            row = session.createRow(values, 1);
-        }
-        return row;
-    }
-
-    @Override
-    public SearchRow getSearchRow() {
-        return get();
-    }
-
-    @Override
-    public boolean next() {
+    boolean nextImpl() {
         row = null;
         try {
             if (result != null && result.next()) {
@@ -70,11 +50,6 @@ public class FunctionCursorResultSet implements Cursor {
             throw DbException.convert(e);
         }
         return values != null;
-    }
-
-    @Override
-    public boolean previous() {
-        throw DbException.throwInternalError(toString());
     }
 
 }

--- a/h2/src/main/org/h2/index/FunctionIndex.java
+++ b/h2/src/main/org/h2/index/FunctionIndex.java
@@ -47,9 +47,9 @@ public class FunctionIndex extends BaseIndex {
     @Override
     public Cursor find(Session session, SearchRow first, SearchRow last) {
         if (functionTable.isBufferResultSetToLocalTemp()) {
-            return new FunctionCursor(session, functionTable.getResult(session));
+            return new FunctionCursor(this, first, last, session, functionTable.getResult(session));
         }
-        return new FunctionCursorResultSet(session,
+        return new FunctionCursorResultSet(this, first, last, session,
                 functionTable.getResultSet(session));
     }
 

--- a/h2/src/main/org/h2/index/FunctionIndex.java
+++ b/h2/src/main/org/h2/index/FunctionIndex.java
@@ -45,6 +45,11 @@ public class FunctionIndex extends BaseIndex {
     }
 
     @Override
+    public boolean isFindSlow() {
+        return true;
+    }
+
+    @Override
     public Cursor find(Session session, SearchRow first, SearchRow last) {
         if (functionTable.isBufferResultSetToLocalTemp()) {
             return new FunctionCursor(this, first, last, session, functionTable.getResult(session));

--- a/h2/src/main/org/h2/index/FunctionIndex.java
+++ b/h2/src/main/org/h2/index/FunctionIndex.java
@@ -17,7 +17,7 @@ import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
 
 /**
- * An index for a function that returns a result set. Search is this index
+ * An index for a function that returns a result set. Search in this index
  * performs scan over all rows and should be avoided.
  */
 public class FunctionIndex extends BaseIndex {
@@ -45,7 +45,7 @@ public class FunctionIndex extends BaseIndex {
     }
 
     @Override
-    public boolean isFindSlow() {
+    public boolean isFindUsingFullTableScan() {
         return true;
     }
 

--- a/h2/src/main/org/h2/index/FunctionIndex.java
+++ b/h2/src/main/org/h2/index/FunctionIndex.java
@@ -17,8 +17,8 @@ import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
 
 /**
- * An index for a function that returns a result set. This index can only scan
- * through all rows, search is not supported.
+ * An index for a function that returns a result set. Search is this index
+ * performs scan over all rows and should be avoided.
  */
 public class FunctionIndex extends BaseIndex {
 

--- a/h2/src/main/org/h2/index/Index.java
+++ b/h2/src/main/org/h2/index/Index.java
@@ -58,7 +58,7 @@ public interface Index extends SchemaObject {
      * @return {@code true} if {@code find()} implementation performs scan over all
      *         index, {@code false} if {@code find()} performs the fast lookup
      */
-    boolean isFindSlow();
+    boolean isFindUsingFullTableScan();
 
     /**
      * Find a row or a list of rows and create a cursor to iterate over the

--- a/h2/src/main/org/h2/index/Index.java
+++ b/h2/src/main/org/h2/index/Index.java
@@ -52,6 +52,15 @@ public interface Index extends SchemaObject {
     void remove(Session session, Row row);
 
     /**
+     * Returns {@code true} if {@code find()} implementation performs scan over all
+     * index, {@code false} if {@code find()} performs the fast lookup.
+     *
+     * @return {@code true} if {@code find()} implementation performs scan over all
+     *         index, {@code false} if {@code find()} performs the fast lookup
+     */
+    boolean isFindSlow();
+
+    /**
      * Find a row or a list of rows and create a cursor to iterate over the
      * result.
      *

--- a/h2/src/main/org/h2/index/IndexCursor.java
+++ b/h2/src/main/org/h2/index/IndexCursor.java
@@ -89,6 +89,9 @@ public class IndexCursor implements Cursor {
                 alwaysFalse = true;
                 break;
             }
+            if (index.isFindSlow()) {
+                continue;
+            }
             Column column = condition.getColumn();
             if (condition.getCompareType() == Comparison.IN_LIST) {
                 if (start == null && end == null) {

--- a/h2/src/main/org/h2/index/IndexCursor.java
+++ b/h2/src/main/org/h2/index/IndexCursor.java
@@ -89,7 +89,7 @@ public class IndexCursor implements Cursor {
                 alwaysFalse = true;
                 break;
             }
-            if (index.isFindSlow()) {
+            if (index.isFindUsingFullTableScan()) {
                 continue;
             }
             Column column = condition.getColumn();

--- a/h2/src/main/org/h2/index/IndexCursor.java
+++ b/h2/src/main/org/h2/index/IndexCursor.java
@@ -89,6 +89,8 @@ public class IndexCursor implements Cursor {
                 alwaysFalse = true;
                 break;
             }
+            // If index can perform only full table scan do not try to use it for regular
+            // lookups, each such lookup will perform an own table scan.
             if (index.isFindUsingFullTableScan()) {
                 continue;
             }

--- a/h2/src/main/org/h2/index/MultiVersionIndex.java
+++ b/h2/src/main/org/h2/index/MultiVersionIndex.java
@@ -73,6 +73,11 @@ public class MultiVersionIndex implements Index {
     }
 
     @Override
+    public boolean isFindSlow() {
+        return base.isFindSlow();
+    }
+
+    @Override
     public Cursor find(TableFilter filter, SearchRow first, SearchRow last) {
         synchronized (sync) {
             Cursor baseCursor = base.find(filter, first, last);

--- a/h2/src/main/org/h2/index/MultiVersionIndex.java
+++ b/h2/src/main/org/h2/index/MultiVersionIndex.java
@@ -73,8 +73,8 @@ public class MultiVersionIndex implements Index {
     }
 
     @Override
-    public boolean isFindSlow() {
-        return base.isFindSlow();
+    public boolean isFindUsingFullTableScan() {
+        return base.isFindUsingFullTableScan();
     }
 
     @Override

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -714,7 +714,7 @@ public class TestIndex extends TestBase {
         // There are additional callers like JdbcConnection.prepareCommand() and
         // CommandContainer.recompileIfReqired()
         for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
-            if (element.getClassName() == Select.class.getName()) {
+            if (element.getClassName().startsWith(Select.class.getName())) {
                 testFunctionIndexCounter++;
                 break;
             }


### PR DESCRIPTION
This fixes issue #322.

`FunctionIndex.find()` ignored the `first` and `last` arguments. Returned index cursor read all rows instead of specified range of rows.

A new `AbstractFunctionCursor` used as a base for `FunctionCursor` and `FunctionCursorResultSet`. This class performs filtration of results. Also common fields and methods were moved from subclasses to this class.

This pull request does not fix strange query plan that is generated for such selects from results of functions. Instead of table scan index lookups are generated, but each such lookup actually performs an own table scan.