### PR TITLE
Remove unused parameters from readJoin() and readTableFilter()

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1369,7 +1369,7 @@ public class Parser {
             } else {
                 TableFilter top;
                 top = readTableFilter();
-                top = readJoin(top, false, false);
+                top = readJoin(top, false);
                 top = getNested(top);
                 read(")");
                 alias = readFromAlias(null);
@@ -1717,7 +1717,7 @@ public class Parser {
         return command;
     }
 
-    private TableFilter readJoin(TableFilter top, boolean nested, boolean fromOuter) {
+    private TableFilter readJoin(TableFilter top, boolean nested) {
         boolean joined = false;
         TableFilter last = top;
         while (true) {
@@ -1727,7 +1727,7 @@ public class Parser {
                 read("JOIN");
                 // the right hand side is the 'inner' table usually
                 join = readTableFilter();
-                join = readJoin(join, nested, true);
+                join = readJoin(join, nested);
                 Expression on = null;
                 if (readIf("ON")) {
                     on = readExpression();
@@ -1739,7 +1739,7 @@ public class Parser {
                 readIf("OUTER");
                 read("JOIN");
                 join = readTableFilter();
-                join = readJoin(join, true, true);
+                join = readJoin(join, true);
                 Expression on = null;
                 if (readIf("ON")) {
                     on = readExpression();
@@ -1750,7 +1750,7 @@ public class Parser {
             } else if (readIf("INNER")) {
                 read("JOIN");
                 join = readTableFilter();
-                top = readJoin(top, false, false);
+                top = readJoin(top, false);
                 Expression on = null;
                 if (readIf("ON")) {
                     on = readExpression();
@@ -1758,7 +1758,7 @@ public class Parser {
                 top.addJoin(join, false, false, on);
             } else if (readIf("JOIN")) {
                 join = readTableFilter();
-                top = readJoin(top, false, false);
+                top = readJoin(top, false);
                 Expression on = null;
                 if (readIf("ON")) {
                     on = readExpression();
@@ -2149,7 +2149,7 @@ public class Parser {
     }
 
     private void parseJoinTableFilter(TableFilter top, final Select command) {
-        top = readJoin(top, false, top.isJoinOuter());
+        top = readJoin(top, false);
         command.addTableFilter(top, true);
         boolean isOuter = false;
         while (true) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1369,7 +1369,7 @@ public class Parser {
             } else {
                 TableFilter top;
                 top = readTableFilter(false);
-                top = readJoin(top, currentSelect, false, false);
+                top = readJoin(top, false, false);
                 top = getNested(top);
                 read(")");
                 alias = readFromAlias(null);
@@ -1717,8 +1717,7 @@ public class Parser {
         return command;
     }
 
-    private TableFilter readJoin(TableFilter top, Select command,
-            boolean nested, boolean fromOuter) {
+    private TableFilter readJoin(TableFilter top, boolean nested, boolean fromOuter) {
         boolean joined = false;
         TableFilter last = top;
         while (true) {
@@ -1728,7 +1727,7 @@ public class Parser {
                 read("JOIN");
                 // the right hand side is the 'inner' table usually
                 join = readTableFilter(fromOuter);
-                join = readJoin(join, command, nested, true);
+                join = readJoin(join, nested, true);
                 Expression on = null;
                 if (readIf("ON")) {
                     on = readExpression();
@@ -1740,7 +1739,7 @@ public class Parser {
                 readIf("OUTER");
                 read("JOIN");
                 join = readTableFilter(true);
-                join = readJoin(join, command, true, true);
+                join = readJoin(join, true, true);
                 Expression on = null;
                 if (readIf("ON")) {
                     on = readExpression();
@@ -1751,7 +1750,7 @@ public class Parser {
             } else if (readIf("INNER")) {
                 read("JOIN");
                 join = readTableFilter(fromOuter);
-                top = readJoin(top, command, false, false);
+                top = readJoin(top, false, false);
                 Expression on = null;
                 if (readIf("ON")) {
                     on = readExpression();
@@ -1759,7 +1758,7 @@ public class Parser {
                 top.addJoin(join, false, false, on);
             } else if (readIf("JOIN")) {
                 join = readTableFilter(fromOuter);
-                top = readJoin(top, command, false, false);
+                top = readJoin(top, false, false);
                 Expression on = null;
                 if (readIf("ON")) {
                     on = readExpression();
@@ -2150,7 +2149,7 @@ public class Parser {
     }
 
     private void parseJoinTableFilter(TableFilter top, final Select command) {
-        top = readJoin(top, command, false, top.isJoinOuter());
+        top = readJoin(top, false, top.isJoinOuter());
         command.addTableFilter(top, true);
         boolean isOuter = false;
         while (true) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1348,7 +1348,7 @@ public class Parser {
         return command;
     }
 
-    private TableFilter readTableFilter(boolean fromOuter) {
+    private TableFilter readTableFilter() {
         Table table;
         String alias = null;
         if (readIf("(")) {
@@ -1368,7 +1368,7 @@ public class Parser {
                         query, currentSelect);
             } else {
                 TableFilter top;
-                top = readTableFilter(false);
+                top = readTableFilter();
                 top = readJoin(top, false, false);
                 top = getNested(top);
                 read(")");
@@ -1726,7 +1726,7 @@ public class Parser {
                 readIf("OUTER");
                 read("JOIN");
                 // the right hand side is the 'inner' table usually
-                join = readTableFilter(fromOuter);
+                join = readTableFilter();
                 join = readJoin(join, nested, true);
                 Expression on = null;
                 if (readIf("ON")) {
@@ -1738,7 +1738,7 @@ public class Parser {
             } else if (readIf("LEFT")) {
                 readIf("OUTER");
                 read("JOIN");
-                join = readTableFilter(true);
+                join = readTableFilter();
                 join = readJoin(join, true, true);
                 Expression on = null;
                 if (readIf("ON")) {
@@ -1749,7 +1749,7 @@ public class Parser {
                 throw getSyntaxError();
             } else if (readIf("INNER")) {
                 read("JOIN");
-                join = readTableFilter(fromOuter);
+                join = readTableFilter();
                 top = readJoin(top, false, false);
                 Expression on = null;
                 if (readIf("ON")) {
@@ -1757,7 +1757,7 @@ public class Parser {
                 }
                 top.addJoin(join, false, false, on);
             } else if (readIf("JOIN")) {
-                join = readTableFilter(fromOuter);
+                join = readTableFilter();
                 top = readJoin(top, false, false);
                 Expression on = null;
                 if (readIf("ON")) {
@@ -1766,11 +1766,11 @@ public class Parser {
                 top.addJoin(join, false, false, on);
             } else if (readIf("CROSS")) {
                 read("JOIN");
-                join = readTableFilter(fromOuter);
+                join = readTableFilter();
                 top.addJoin(join, false, false, null);
             } else if (readIf("NATURAL")) {
                 read("JOIN");
-                join = readTableFilter(fromOuter);
+                join = readTableFilter();
                 Column[] tableCols = last.getTable().getColumns();
                 Column[] joinCols = join.getTable().getColumns();
                 String tableSchema = last.getTable().getSchema().getName();
@@ -2104,7 +2104,7 @@ public class Parser {
 
     private void parseSelectSimpleFromPart(Select command) {
         do {
-            TableFilter filter = readTableFilter(false);
+            TableFilter filter = readTableFilter();
             parseJoinTableFilter(filter, command);
         } while (readIf(","));
 


### PR DESCRIPTION
1. `command` parameter in `readJoin()` was not used.

1. `fromOuter` parameter of `readTableFilter()` was not used and without it the same parameter of `readJoin() also is not needed.