### PR TITLE
Fix obscure error on non-standard SELECT * FROM A LEFT JOIN B NATURAL JOIN C

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1799,7 +1799,7 @@ public class Parser {
                         }
                     }
                 }
-                top.addJoin(join, false, nested, on);
+                top.addJoin(join, false, false, on);
             } else {
                 break;
             }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1733,7 +1733,7 @@ public class Parser {
                     on = readExpression();
                 }
                 top = getNested(top);
-                join.addJoin(top, true, false, on);
+                join.addJoin(top, true, on);
                 top = join;
             } else if (readIf("LEFT")) {
                 readIf("OUTER");
@@ -1744,7 +1744,7 @@ public class Parser {
                 if (readIf("ON")) {
                     on = readExpression();
                 }
-                top.addJoin(join, true, false, on);
+                top.addJoin(join, true, on);
             } else if (readIf("FULL")) {
                 throw getSyntaxError();
             } else if (readIf("INNER")) {
@@ -1755,7 +1755,7 @@ public class Parser {
                 if (readIf("ON")) {
                     on = readExpression();
                 }
-                top.addJoin(join, false, false, on);
+                top.addJoin(join, false, on);
             } else if (readIf("JOIN")) {
                 join = readTableFilter();
                 top = readJoin(top, false);
@@ -1763,11 +1763,11 @@ public class Parser {
                 if (readIf("ON")) {
                     on = readExpression();
                 }
-                top.addJoin(join, false, false, on);
+                top.addJoin(join, false, on);
             } else if (readIf("CROSS")) {
                 read("JOIN");
                 join = readTableFilter();
-                top.addJoin(join, false, false, null);
+                top.addJoin(join, false, null);
             } else if (readIf("NATURAL")) {
                 read("JOIN");
                 join = readTableFilter();
@@ -1799,7 +1799,7 @@ public class Parser {
                         }
                     }
                 }
-                top.addJoin(join, false, false, on);
+                top.addJoin(join, false, on);
             } else {
                 break;
             }
@@ -1817,7 +1817,7 @@ public class Parser {
         TableFilter top = new TableFilter(session, getDualTable(true),
                 joinTable, rightsChecked, currentSelect, n.getOrderInFrom(),
                 null);
-        top.addJoin(n, false, true, null);
+        top.addNestedJoin(n);
         return top;
     }
 
@@ -2490,7 +2490,7 @@ public class Parser {
                                 int idx = filters.indexOf(rightFilter);
                                 if (idx >= 0) {
                                     filters.remove(idx);
-                                    leftFilter.addJoin(rightFilter, true, false, r);
+                                    leftFilter.addJoin(rightFilter, true, r);
                                 } else {
                                     rightFilter.mapAndAddFilter(r);
                                 }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1817,7 +1817,7 @@ public class Parser {
         TableFilter top = new TableFilter(session, getDualTable(true),
                 joinTable, rightsChecked, currentSelect, n.getOrderInFrom(),
                 null);
-        top.addNestedJoin(n);
+        top.setNestedJoin(n);
         return top;
     }
 

--- a/h2/src/main/org/h2/command/dml/Optimizer.java
+++ b/h2/src/main/org/h2/command/dml/Optimizer.java
@@ -247,7 +247,7 @@ class Optimizer {
         TableFilter[] f2 = bestPlan.getFilters();
         topFilter = f2[0];
         for (int i = 0; i < f2.length - 1; i++) {
-            f2[i].addJoin(f2[i + 1], false, false, null);
+            f2[i].addJoin(f2[i + 1], false, null);
         }
         if (parse) {
             return;

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -661,11 +661,11 @@ public class TableFilter implements ColumnResolver {
     }
 
     /**
-     * Add a nested joined table.
+     * Set a nested joined table.
      *
      * @param filter the joined table filter
      */
-    public void addNestedJoin(TableFilter filter) {
+    public void setNestedJoin(TableFilter filter) {
         nestedJoin = filter;
     }
 

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -637,42 +637,37 @@ public class TableFilter implements ColumnResolver {
      *
      * @param filter the joined table filter
      * @param outer if this is an outer join
-     * @param nested if this is a nested join
      * @param on the join condition
      */
-    public void addJoin(TableFilter filter, boolean outer, boolean nested, Expression on) {
+    public void addJoin(TableFilter filter, boolean outer, Expression on) {
         if (on != null) {
             on.mapColumns(this, 0);
             TableFilterVisitor visitor = new MapColumnsVisitor(on);
             visit(visitor);
             filter.visit(visitor);
         }
-        if (nested) {
-            if (nestedJoin != null) {
-                throw DbException.throwInternalError();
-            }
-            nestedJoin = filter;
+        if (join == null) {
+            join = filter;
             filter.joinOuter = outer;
             if (outer) {
-                visit(new JOIVisitor());
+                filter.visit(new JOIVisitor());
             }
             if (on != null) {
                 filter.mapAndAddFilter(on);
             }
         } else {
-            if (join == null) {
-                join = filter;
-                filter.joinOuter = outer;
-                if (outer) {
-                    filter.visit(new JOIVisitor());
-                }
-                if (on != null) {
-                    filter.mapAndAddFilter(on);
-                }
-            } else {
-                join.addJoin(filter, outer, false, on);
-            }
+            join.addJoin(filter, outer, on);
         }
+    }
+
+    /**
+     * Add a nested joined table.
+     *
+     * @param filter the joined table filter
+     */
+    public void addNestedJoin(TableFilter filter) {
+        nestedJoin = filter;
+        filter.joinOuter = false;
     }
 
     /**

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -667,7 +667,6 @@ public class TableFilter implements ColumnResolver {
      */
     public void addNestedJoin(TableFilter filter) {
         nestedJoin = filter;
-        filter.joinOuter = false;
     }
 
     /**

--- a/h2/src/test/org/h2/test/scripts/joins.sql
+++ b/h2/src/test/org/h2/test/scripts/joins.sql
@@ -668,3 +668,56 @@ DROP TABLE PARENT;
 
 DROP TABLE CHILD;
 > ok
+
+CREATE TABLE A(A1 INT, A2 INT);
+> ok
+
+INSERT INTO A VALUES (1, 2);
+> update count: 1
+
+CREATE TABLE B(B1 INT, B2 INT);
+> ok
+
+INSERT INTO B VALUES (1, 2);
+> update count: 1
+
+CREATE TABLE C(B1 INT, C1 INT);
+> ok
+
+INSERT INTO C VALUES (1, 2);
+> update count: 1
+
+SELECT * FROM A LEFT JOIN B ON TRUE;
+> A1 A2 B1 B2
+> -- -- -- --
+> 1  2  1  2
+> rows: 1
+
+-- this syntax without ON or USING in not standard
+SELECT * FROM A LEFT JOIN B;
+> A1 A2 B1 B2
+> -- -- -- --
+> 1  2  1  2
+> rows: 1
+
+SELECT * FROM A LEFT JOIN B ON TRUE NATURAL JOIN C;
+> A1 A2 B1 B2 C1
+> -- -- -- -- --
+> 1  2  1  2  2
+> rows: 1
+
+-- this syntax without ON or USING in not standard
+SELECT * FROM A LEFT JOIN B NATURAL JOIN C;
+> A1 A2 B1 B2 C1
+> -- -- -- -- --
+> 1  2  1  2  2
+> rows: 1
+
+DROP TABLE A;
+> ok
+
+DROP TABLE B;
+> ok
+
+DROP TABLE C;
+> ok

--- a/h2/src/test/org/h2/test/scripts/joins.sql
+++ b/h2/src/test/org/h2/test/scripts/joins.sql
@@ -693,8 +693,21 @@ SELECT * FROM A LEFT JOIN B ON TRUE;
 > 1  2  1  2
 > rows: 1
 
+SELECT A.A1, A.A2, B.B1, B.B2 FROM A RIGHT JOIN B ON TRUE;
+> A1 A2 B1 B2
+> -- -- -- --
+> 1  2  1  2
+> rows: 1
+
 -- this syntax without ON or USING in not standard
 SELECT * FROM A LEFT JOIN B;
+> A1 A2 B1 B2
+> -- -- -- --
+> 1  2  1  2
+> rows: 1
+
+-- this syntax without ON or USING in not standard
+SELECT A.A1, A.A2, B.B1, B.B2 FROM A RIGHT JOIN B;
 > A1 A2 B1 B2
 > -- -- -- --
 > 1  2  1  2
@@ -706,8 +719,21 @@ SELECT * FROM A LEFT JOIN B ON TRUE NATURAL JOIN C;
 > 1  2  1  2  2
 > rows: 1
 
+SELECT A.A1, A.A2, B.B1, B.B2, C.C1 FROM A RIGHT JOIN B ON TRUE NATURAL JOIN C;
+> A1 A2 B1 B2 C1
+> -- -- -- -- --
+> 1  2  1  2  2
+> rows: 1
+
 -- this syntax without ON or USING in not standard
 SELECT * FROM A LEFT JOIN B NATURAL JOIN C;
+> A1 A2 B1 B2 C1
+> -- -- -- -- --
+> 1  2  1  2  2
+> rows: 1
+
+-- this syntax without ON or USING in not standard
+SELECT A.A1, A.A2, B.B1, B.B2, C.C1 FROM A RIGHT JOIN B NATURAL JOIN C;
 > A1 A2 B1 B2 C1
 > -- -- -- -- --
 > 1  2  1  2  2


### PR DESCRIPTION
`Parser.readJoin()` used `nested` argument in `NATURAL JOIN` parts. `true` value was not covered by tests, but I found a way to got such value with non-standard SQL query (I don't know why H2 allows outer joins without ON or USING). I found that this usage was incorrect and lead to obscure error like `Column "PUBLIC.B.B1" must be in the GROUP BY list`.

Only `LEFT` join without `ON` condition followed by `NATURAL` join was affected. May be chained `RIGHT` joins without `ON` conditions were affected too, but I didn't test them, all these cases are not normal and are not compatible with SQL standard.

If `ON` argument is used `readJoin()` got `nested = false` anyway, so this normal case was not affected. This difference caused by handling of `ON` condition in `readTableFilter()` that calls next `readJoin()` by itself and always passes `nested = false` to it. But without `ON` method `readJoin()` calls itself indirectly with `nested = true` and table filters were not constructed properly in this case.

I also added a test with `RIGHT` joins, they were not affected, but it's better to have such tests to avoid regressions in the future.