### PR TITLE
don't allow null values in ConcurrentArrayList

### DIFF
--- a/h2/src/main/org/h2/mvstore/ConcurrentArrayList.java
+++ b/h2/src/main/org/h2/mvstore/ConcurrentArrayList.java
@@ -49,6 +49,10 @@ public class ConcurrentArrayList<K> {
      * @param obj the element
      */
     public synchronized void add(K obj) {
+        if (obj == null) {
+            throw DataUtils.newIllegalStateException(
+                    DataUtils.ERROR_INTERNAL, "adding null value to list");
+        }
         int len = array.length;
         array = Arrays.copyOf(array, len + 1);
         array[len] = obj;


### PR DESCRIPTION
because that can be the only reason for the CI failure I saw:

ERROR: FAIL java.lang.NullPointerException java.lang.NullPointerException ------------------------------
java.lang.NullPointerException
	at org.h2.mvstore.MVMap.openVersion(MVMap.java:1095)
	at org.h2.test.store.TestConcurrent.testConcurrentChangeAndGetVersion(TestConcurrent.java:346)
	at org.h2.test.store.TestConcurrent.test(TestConcurrent.java:56)
	at org.h2.test.TestBase.runTest(TestBase.java:142)
	at org.h2.test.TestAll.addTest(TestAll.java:990)
	at org.h2.test.TestAll.testUnit(TestAll.java:960)
	at org.h2.test.TestAll.runTests(TestAll.java:625)
	at org.h2.test.TestAll.testAll(TestAll.java:563)
	at org.h2.test.TestAll.run(TestAll.java:512)
	at org.h2.test.TestAll.main(TestAll.java:452)