### PR TITLE
Implement INFORMATION_SCHEMA.KEY_COLUMN_USAGE from SQL standard

### DIFF
--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -568,7 +568,8 @@ public class MetaTable extends Table {
                     "TABLE_SCHEMA",
                     "TABLE_NAME",
                     "COLUMN_NAME",
-                    "ORDINAL_POSITION"
+                    "ORDINAL_POSITION",
+                    "POSITION_IN_UNIQUE_CONSTRAINT"
             );
             indexColumnName = "TABLE_NAME";
             break;
@@ -1948,6 +1949,7 @@ public class MetaTable extends Table {
                 }
                 for (int i = 0; i < indexColumns.length; i++) {
                     IndexColumn indexColumn = indexColumns[i];
+                    String ordinalPosition = Integer.toString(i + 1);
                     add(rows,
                             // CONSTRAINT_CATALOG
                             catalog,
@@ -1964,7 +1966,9 @@ public class MetaTable extends Table {
                             // COLUMN_NAME
                             indexColumn.columnName,
                             // ORDINAL_POSITION
-                            Integer.toString(i + 1)
+                            ordinalPosition,
+                            // POSITION_IN_UNIQUE_CONSTRAINT
+                            (constraintType == Constraint.Type.REFERENTIAL ? ordinalPosition : null)
                         );
                 }
             }

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -110,7 +110,8 @@ public class MetaTable extends Table {
     private static final int SESSION_STATE = 27;
     private static final int QUERY_STATISTICS = 28;
     private static final int SYNONYMS = 29;
-    private static final int META_TABLE_TYPE_COUNT = SYNONYMS + 1;
+    private static final int KEY_COLUMN_USAGE = 30;
+    private static final int META_TABLE_TYPE_COUNT = KEY_COLUMN_USAGE + 1;
 
     private final int type;
     private final int indexColumn;
@@ -542,20 +543,35 @@ public class MetaTable extends Table {
             break;
         }
         case SYNONYMS: {
-                setObjectName("SYNONYMS");
-                cols = createColumns(
-                        "SYNONYM_CATALOG",
-                        "SYNONYM_SCHEMA",
-                        "SYNONYM_NAME",
-                        "SYNONYM_FOR",
-                        "SYNONYM_FOR_SCHEMA",
-                        "TYPE_NAME",
-                        "STATUS",
-                        "REMARKS",
-                        "ID INT"
-                );
-                indexColumnName = "SYNONYM_NAME";
-                break;
+            setObjectName("SYNONYMS");
+            cols = createColumns(
+                    "SYNONYM_CATALOG",
+                    "SYNONYM_SCHEMA",
+                    "SYNONYM_NAME",
+                    "SYNONYM_FOR",
+                    "SYNONYM_FOR_SCHEMA",
+                    "TYPE_NAME",
+                    "STATUS",
+                    "REMARKS",
+                    "ID INT"
+            );
+            indexColumnName = "SYNONYM_NAME";
+            break;
+        }
+        case KEY_COLUMN_USAGE: {
+            setObjectName("KEY_COLUMN_USAGE");
+            cols = createColumns(
+                    "CONSTRAINT_CATALOG",
+                    "CONSTRAINT_SCHEMA",
+                    "CONSTRAINT_NAME",
+                    "TABLE_CATALOG",
+                    "TABLE_SCHEMA",
+                    "TABLE_NAME",
+                    "COLUMN_NAME",
+                    "ORDINAL_POSITION"
+            );
+            indexColumnName = "TABLE_NAME";
+            break;
         }
         default:
             throw DbException.throwInternalError("type="+type);
@@ -1883,30 +1899,77 @@ public class MetaTable extends Table {
             break;
         }
         case SYNONYMS: {
-                for (TableSynonym synonym : database.getAllSynonyms()) {
-                    add(rows,
-                            // SYNONYM_CATALOG
-                            catalog,
-                            // SYNONYM_SCHEMA
-                            identifier(synonym.getSchema().getName()),
-                            // SYNONYM_NAME
-                            identifier(synonym.getName()),
-                            // SYNONYM_FOR
-                            synonym.getSynonymForName(),
-                            // SYNONYM_FOR_SCHEMA
-                            synonym.getSynonymForSchema().getName(),
-                            // TYPE NAME
-                            "SYNONYM",
-                            // STATUS
-                            "VALID",
-                            // REMARKS
-                            replaceNullWithEmpty(synonym.getComment()),
-                            // ID
-                            "" + synonym.getId()
-                    );
-                }
-                break;
+            for (TableSynonym synonym : database.getAllSynonyms()) {
+                add(rows,
+                        // SYNONYM_CATALOG
+                        catalog,
+                        // SYNONYM_SCHEMA
+                        identifier(synonym.getSchema().getName()),
+                        // SYNONYM_NAME
+                        identifier(synonym.getName()),
+                        // SYNONYM_FOR
+                        synonym.getSynonymForName(),
+                        // SYNONYM_FOR_SCHEMA
+                        synonym.getSynonymForSchema().getName(),
+                        // TYPE NAME
+                        "SYNONYM",
+                        // STATUS
+                        "VALID",
+                        // REMARKS
+                        replaceNullWithEmpty(synonym.getComment()),
+                        // ID
+                        "" + synonym.getId()
+                );
             }
+            break;
+        }
+        case KEY_COLUMN_USAGE: {
+            for (SchemaObject obj : database.getAllSchemaObjects(
+                    DbObject.CONSTRAINT)) {
+                Constraint constraint = (Constraint) obj;
+                Constraint.Type constraintType = constraint.getConstraintType();
+                IndexColumn[] indexColumns = null;
+                Table table = constraint.getTable();
+                if (hideTable(table, session)) {
+                    continue;
+                }
+                String tableName = identifier(table.getName());
+                if (!checkIndex(session, tableName, indexFrom, indexTo)) {
+                    continue;
+                }
+                if (constraintType == Constraint.Type.UNIQUE ||
+                        constraintType == Constraint.Type.PRIMARY_KEY) {
+                    indexColumns = ((ConstraintUnique) constraint).getColumns();
+                } else if (constraintType == Constraint.Type.REFERENTIAL) {
+                    indexColumns = ((ConstraintReferential) constraint).getColumns();
+                }
+                if (indexColumns == null) {
+                    continue;
+                }
+                for (int i = 0; i < indexColumns.length; i++) {
+                    IndexColumn indexColumn = indexColumns[i];
+                    add(rows,
+                            // CONSTRAINT_CATALOG
+                            catalog,
+                            // CONSTRAINT_SCHEMA
+                            identifier(constraint.getSchema().getName()),
+                            // CONSTRAINT_NAME
+                            identifier(constraint.getName()),
+                            // TABLE_CATALOG
+                            catalog,
+                            // TABLE_SCHEMA
+                            identifier(table.getSchema().getName()),
+                            // TABLE_NAME
+                            tableName,
+                            // COLUMN_NAME
+                            indexColumn.columnName,
+                            // ORDINAL_POSITION
+                            Integer.toString(i + 1)
+                        );
+                }
+            }
+            break;
+        }
         default:
             DbException.throwInternalError("type="+type);
         }

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1084,6 +1084,8 @@ public class TestMetaData extends TestBase {
         rs.next();
         assertEquals("IN_DOUBT", rs.getString("TABLE_NAME"));
         rs.next();
+        assertEquals("KEY_COLUMN_USAGE", rs.getString("TABLE_NAME"));
+        rs.next();
         assertEquals("LOCKS", rs.getString("TABLE_NAME"));
         rs.next();
         assertEquals("QUERY_STATISTICS", rs.getString("TABLE_NAME"));

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -83,6 +83,7 @@ public class TestScript extends TestBase {
 
         testScript("testScript.sql");
         testScript("derived-column-names.sql");
+        testScript("information_schema.sql");
         testScript("joins.sql");
         testScript("altertable-index-reuse.sql");
         testScript("query-optimisations.sql");

--- a/h2/src/test/org/h2/test/scripts/information_schema.sql
+++ b/h2/src/test/org/h2/test/scripts/information_schema.sql
@@ -19,21 +19,21 @@ ALTER TABLE T2 ADD CONSTRAINT FK_1 FOREIGN KEY (C3, C4) REFERENCES T1(C1, C3);
 > ok
 
 SELECT * FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE LIMIT 0;
-> CONSTRAINT_CATALOG CONSTRAINT_SCHEMA CONSTRAINT_NAME TABLE_CATALOG TABLE_SCHEMA TABLE_NAME COLUMN_NAME ORDINAL_POSITION
-> ------------------ ----------------- --------------- ------------- ------------ ---------- ----------- ----------------
+> CONSTRAINT_CATALOG CONSTRAINT_SCHEMA CONSTRAINT_NAME TABLE_CATALOG TABLE_SCHEMA TABLE_NAME COLUMN_NAME ORDINAL_POSITION POSITION_IN_UNIQUE_CONSTRAINT
+> ------------------ ----------------- --------------- ------------- ------------ ---------- ----------- ---------------- -----------------------------
 > rows: 0
 
-SELECT CONSTRAINT_NAME, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+SELECT CONSTRAINT_NAME, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
     WHERE CONSTRAINT_CATALOG = DATABASE() AND CONSTRAINT_SCHEMA = SCHEMA() AND TABLE_CATALOG = DATABASE() AND TABLE_SCHEMA = SCHEMA()
     ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION;
-> CONSTRAINT_NAME TABLE_NAME COLUMN_NAME ORDINAL_POSITION
-> --------------- ---------- ----------- ----------------
-> PK_1            T1         C1          1
-> PK_1            T1         C2          2
-> U_1             T1         C3          1
-> U_1             T1         C4          2
-> FK_1            T2         C3          1
-> FK_1            T2         C4          2
+> CONSTRAINT_NAME TABLE_NAME COLUMN_NAME ORDINAL_POSITION POSITION_IN_UNIQUE_CONSTRAINT
+> --------------- ---------- ----------- ---------------- -----------------------------
+> PK_1            T1         C1          1                null
+> PK_1            T1         C2          2                null
+> U_1             T1         C3          1                null
+> U_1             T1         C4          2                null
+> FK_1            T2         C3          1                1
+> FK_1            T2         C4          2                2
 > rows (ordered): 6
 
 DROP TABLE T2;

--- a/h2/src/test/org/h2/test/scripts/information_schema.sql
+++ b/h2/src/test/org/h2/test/scripts/information_schema.sql
@@ -1,0 +1,43 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+CREATE TABLE T1(C1 INT NOT NULL, C2 INT NOT NULL, C3 INT, C4 INT);
+> ok
+
+ALTER TABLE T1 ADD CONSTRAINT PK_1 PRIMARY KEY(C1, C2);
+> ok
+
+ALTER TABLE T1 ADD CONSTRAINT U_1 UNIQUE(C3, C4);
+> ok
+
+CREATE TABLE T2(C1 INT, C2 INT, C3 INT, C4 INT);
+> ok
+
+ALTER TABLE T2 ADD CONSTRAINT FK_1 FOREIGN KEY (C3, C4) REFERENCES T1(C1, C3);
+> ok
+
+SELECT * FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE LIMIT 0;
+> CONSTRAINT_CATALOG CONSTRAINT_SCHEMA CONSTRAINT_NAME TABLE_CATALOG TABLE_SCHEMA TABLE_NAME COLUMN_NAME ORDINAL_POSITION
+> ------------------ ----------------- --------------- ------------- ------------ ---------- ----------- ----------------
+> rows: 0
+
+SELECT CONSTRAINT_NAME, TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+    WHERE CONSTRAINT_CATALOG = DATABASE() AND CONSTRAINT_SCHEMA = SCHEMA() AND TABLE_CATALOG = DATABASE() AND TABLE_SCHEMA = SCHEMA()
+    ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION;
+> CONSTRAINT_NAME TABLE_NAME COLUMN_NAME ORDINAL_POSITION
+> --------------- ---------- ----------- ----------------
+> PK_1            T1         C1          1
+> PK_1            T1         C2          2
+> U_1             T1         C3          1
+> U_1             T1         C4          2
+> FK_1            T2         C3          1
+> FK_1            T2         C4          2
+> rows (ordered): 6
+
+DROP TABLE T2;
+> ok
+
+DROP TABLE T1;
+> ok


### PR DESCRIPTION
This is a standard meta table with information about key columns used by constraints. It is also mentioned in H2's roadmap.

For `FOREIGN KEY` constraints referencing columns are listed, not the referenced ones. This is specified in standard.

I also fixed indentation of `SYNONYMS`.