### PR TITLE
Fix time overflow in DATEADD

### DIFF
--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1942,9 +1942,9 @@ public class Function extends Expression implements FunctionCall {
             forceTimestamp = true;
         }
         timeNanos += count;
-        if (timeNanos > DateTimeUtils.NANOS_PER_DAY || timeNanos < 0) {
+        if (timeNanos >= DateTimeUtils.NANOS_PER_DAY || timeNanos < 0) {
             long d;
-            if (timeNanos > DateTimeUtils.NANOS_PER_DAY) {
+            if (timeNanos >= DateTimeUtils.NANOS_PER_DAY) {
                 d = timeNanos / DateTimeUtils.NANOS_PER_DAY;
             } else {
                 d = (timeNanos - DateTimeUtils.NANOS_PER_DAY + 1) / DateTimeUtils.NANOS_PER_DAY;

--- a/h2/src/test/org/h2/test/scripts/functions/timeanddate/dateadd.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/timeanddate/dateadd.sql
@@ -161,3 +161,9 @@ SELECT TIMESTAMPADD('TIMEZONE_MINUTE', -45, TIMESTAMP WITH TIME ZONE '2010-01-01
 > ---------------------------
 > 2010-01-01 10:00:00.0+06:45
 > rows: 1
+
+SELECT DATEADD(HOUR, 1, TIME '23:00:00') AS T;
+> T
+> --------
+> 00:00:00
+> rows: 1


### PR DESCRIPTION
New implementation of `DATEADD` had a wrong check for nanos of day overflow that was revealed by random failure in `TestOptimizations`.