### PR TITLE
Show information about office configuration instead of fallback PDF generation mode

### DIFF
--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -456,17 +456,18 @@ public class Build extends BuildBase {
             exec("soffice", args("-invisible", "macro:///Standard.Module1.H2Pdf"));
             copy("docs", files("../h2web/h2.pdf"), "../h2web");
         } catch (Exception e) {
-            print("OpenOffice is not available: " + e);
-            try {
-                if (exec("soffice", args("--convert-to", "pdf", "--outdir", "docs/html",
-                        "docs/html/onePage.html")) == 0) {
-                    File f = new File("docs/html/onePage.pdf");
-                    if (f.exists()) {
-                        f.renameTo(new File("docs/h2.pdf"));
-                    }
-                }
-            } catch (Exception ex) {
-            }
+            println("OpenOffice / LibreOffice is not available or macros H2Pdf is not installed:");
+            println(e.toString());
+            println("********************************************************************************");
+            println("Install and run LibreOffice or OpenOffice.");
+            println("Open Tools - Macros - Organize Macros - LibreOffice Basic...");
+            println("Navigate to My Macros / Standard / Module1 and press Edit button.");
+            println("Put content of h2/src/installer/openoffice.txt here.");
+            println("Edit BaseDir variable value:");
+
+            println("    BaseDir = \"" + new File(System.getProperty("user.dir")).getParentFile().toURI() + '"');
+            println("Close office application and try to build installer again.");
+            println("********************************************************************************");
         }
         delete("docs/html/onePage.html");
         FileList files = files("../h2").keep("../h2/build.*");
@@ -480,7 +481,7 @@ public class Build extends BuildBase {
             exec("makensis", args("/v2", "src/installer/h2.nsi"));
             installer = true;
         } catch (Exception e) {
-            print("NSIS is not available: " + e);
+            println("NSIS is not available: " + e);
         }
         String buildDate = getStaticField("org.h2.engine.Constants", "BUILD_DATE");
         byte[] data = readFile(new File("../h2web/h2.zip"));

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -766,3 +766,4 @@ interpolated thead
 
 die weekdiff osx subprocess dow proleptic microsecond microseconds divisible cmp denormalized suppressed saturated mcs
 london dfs weekdays intermittent looked msec tstz africa monrovia asia tokyo weekday joi callers multipliers ucn
+openoffice organize libre


### PR DESCRIPTION
Fallback PDF generation mechanism that was introduced by me some time ago does not insert table of content, but its still was usable to test PDF after changes in `help.csv`. Now I found that old mechanism is still working on modern versions of LibreOffice. It just requires some manual operations that were not described. Actual problem was hidden by warnings that office suit prints on console.

This pull requests removes fallback mechanism, but prints information about office suit configuration for normal way, if this way fails. This code also generates and prints correct path to use in BASIC script.

There is one more problem that is not fixed in this full request. `-invisible` parameter is not supported of modern versions of LibreOffice (`--invisible` should be used instead), so office application will be shown on screen during PDF generation if LibreOffice is used.