### PR TITLE
Remove Mode.supportOffsetFetch

### DIFF
--- a/h2/src/main/org/h2/bnf/context/DbContextRule.java
+++ b/h2/src/main/org/h2/bnf/context/DbContextRule.java
@@ -154,7 +154,7 @@ public class DbContextRule implements Rule {
                 break;
             }
             String alias = up.substring(0, i);
-            if (ParserUtil.isKeyword(alias, true)) {
+            if (ParserUtil.isKeyword(alias)) {
                 break;
             }
             s = s.substring(alias.length());
@@ -301,7 +301,7 @@ public class DbContextRule implements Rule {
             return s;
         }
         String alias = up.substring(0, i);
-        if ("SET".equals(alias) || ParserUtil.isKeyword(alias, true)) {
+        if ("SET".equals(alias) || ParserUtil.isKeyword(alias)) {
             return s;
         }
         if (newAlias) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2022,38 +2022,34 @@ public class Parser {
             command.setOrder(orderList);
             currentSelect = oldSelect;
         }
-        if (database.getMode().supportOffsetFetch) {
-            // make sure aggregate functions will not work here
-            Select temp = currentSelect;
-            currentSelect = null;
-
-            // http://sqlpro.developpez.com/SQL2008/
-            if (readIf("OFFSET")) {
-                command.setOffset(readExpression().optimize(session));
-                if (!readIf("ROW")) {
-                    readIf("ROWS");
-                }
+        // make sure aggregate functions will not work here
+        Select temp = currentSelect;
+        currentSelect = null;
+        // http://sqlpro.developpez.com/SQL2008/
+        if (readIf("OFFSET")) {
+            command.setOffset(readExpression().optimize(session));
+            if (!readIf("ROW")) {
+                readIf("ROWS");
             }
-            if (readIf("FETCH")) {
-                if (!readIf("FIRST")) {
-                    read("NEXT");
-                }
-                if (readIf("ROW")) {
-                    command.setLimit(ValueExpression.get(ValueInt.get(1)));
-                } else {
-                    Expression limit = readExpression().optimize(session);
-                    command.setLimit(limit);
-                    if (!readIf("ROW")) {
-                        read("ROWS");
-                    }
-                }
-                read("ONLY");
-            }
-
-            currentSelect = temp;
         }
+        if (readIf("FETCH")) {
+            if (!readIf("FIRST")) {
+                read("NEXT");
+            }
+            if (readIf("ROW")) {
+                command.setLimit(ValueExpression.get(ValueInt.get(1)));
+            } else {
+                Expression limit = readExpression().optimize(session);
+                command.setLimit(limit);
+                if (!readIf("ROW")) {
+                    read("ROWS");
+                }
+            }
+            read("ONLY");
+        }
+        currentSelect = temp;
         if (readIf("LIMIT")) {
-            Select temp = currentSelect;
+            temp = currentSelect;
             // make sure aggregate functions will not work here
             currentSelect = null;
             Expression limit = readExpression().optimize(session);
@@ -4195,7 +4191,7 @@ public class Parser {
             // if not yet converted to uppercase, do it now
             s = StringUtils.toUpperEnglish(s);
         }
-        return getSaveTokenType(s, database.getMode().supportOffsetFetch, false);
+        return getSaveTokenType(s, false);
     }
 
     private boolean isKeyword(String s) {
@@ -4203,11 +4199,11 @@ public class Parser {
             // if not yet converted to uppercase, do it now
             s = StringUtils.toUpperEnglish(s);
         }
-        return ParserUtil.isKeyword(s, false);
+        return ParserUtil.isKeyword(s);
     }
 
-    private static int getSaveTokenType(String s, boolean supportOffsetFetch, boolean functionsAsKeywords) {
-        return ParserUtil.getSaveTokenType(s, supportOffsetFetch, functionsAsKeywords);
+    private static int getSaveTokenType(String s, boolean functionsAsKeywords) {
+        return ParserUtil.getSaveTokenType(s, functionsAsKeywords);
     }
 
     private Column parseColumnForTable(String columnName,

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -100,13 +100,6 @@ public class Mode {
     public boolean squareBracketQuotedNames;
 
     /**
-     * Support for the syntax
-     * [OFFSET .. ROW|ROWS] [FETCH FIRST .. ROW|ROWS ONLY]
-     * as an alternative for LIMIT .. OFFSET.
-     */
-    public boolean supportOffsetFetch = Constants.VERSION_MINOR >= 4;
-
-    /**
      * The system columns 'CTID' and 'OID' are supported.
      */
     public boolean systemColumns;
@@ -216,7 +209,6 @@ public class Mode {
 
         mode = new Mode(ModeEnum.DB2.name());
         mode.aliasColumnName = true;
-        mode.supportOffsetFetch = true;
         mode.sysDummy1 = true;
         mode.isolationLevelInSelectOrInsertStatement = true;
         // See
@@ -232,7 +224,6 @@ public class Mode {
         mode = new Mode(ModeEnum.Derby.name());
         mode.aliasColumnName = true;
         mode.uniqueIndexNullsHandling = UniqueIndexNullsHandling.FORBID_ANY_DUPLICATES;
-        mode.supportOffsetFetch = true;
         mode.sysDummy1 = true;
         mode.isolationLevelInSelectOrInsertStatement = true;
         // Derby does not support client info properties as of version 10.12.1.1
@@ -298,7 +289,6 @@ public class Mode {
         mode = new Mode(ModeEnum.PostgreSQL.name());
         mode.aliasColumnName = true;
         mode.nullConcatIsNull = true;
-        mode.supportOffsetFetch = true;
         mode.systemColumns = true;
         mode.logIsLogBase10 = true;
         mode.regexpReplaceBackslashReferences = true;

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -45,14 +45,13 @@ public class ParserUtil {
      * Checks if this string is a SQL keyword.
      *
      * @param s the token to check
-     * @param supportOffsetFetch if OFFSET and FETCH are keywords
      * @return true if it is a keyword
      */
-    public static boolean isKeyword(String s, boolean supportOffsetFetch) {
+    public static boolean isKeyword(String s) {
         if (s == null || s.length() == 0) {
             return false;
         }
-        return getSaveTokenType(s, supportOffsetFetch, false) != IDENTIFIER;
+        return getSaveTokenType(s, false) != IDENTIFIER;
     }
 
     /**
@@ -79,18 +78,17 @@ public class ParserUtil {
                 return false;
             }
         }
-        return getSaveTokenType(s, true, functionsAsKeywords) == IDENTIFIER;
+        return getSaveTokenType(s, functionsAsKeywords) == IDENTIFIER;
     }
 
     /**
      * Get the token type.
      *
      * @param s the token
-     * @param supportOffsetFetch whether offset / fetch are supported
      * @param functionsAsKeywords whether "current data / time" functions are keywords
      * @return the token type
      */
-    public static int getSaveTokenType(String s, boolean supportOffsetFetch, boolean functionsAsKeywords) {
+    public static int getSaveTokenType(String s, boolean functionsAsKeywords) {
         switch (s.charAt(0)) {
         case 'A':
             return getKeywordOrIdentifier(s, "ALL", KEYWORD);
@@ -116,15 +114,15 @@ public class ParserUtil {
             }
             return getKeywordOrIdentifier(s, "EXISTS", KEYWORD);
         case 'F':
-            if ("FROM".equals(s)) {
+            if ("FETCH".equals(s)) {
+                return KEYWORD;
+            } else if ("FROM".equals(s)) {
                 return KEYWORD;
             } else if ("FOR".equals(s)) {
                 return KEYWORD;
             } else if ("FOREIGN".equals(s)) {
                 return KEYWORD;
             } else if ("FULL".equals(s)) {
-                return KEYWORD;
-            } else if (supportOffsetFetch && "FETCH".equals(s)) {
                 return KEYWORD;
             }
             return getKeywordOrIdentifier(s, "FALSE", FALSE);
@@ -156,9 +154,9 @@ public class ParserUtil {
             }
             return getKeywordOrIdentifier(s, "NULL", NULL);
         case 'O':
-            if ("ON".equals(s)) {
+            if ("OFFSET".equals(s)) {
                 return KEYWORD;
-            } else if (supportOffsetFetch && "OFFSET".equals(s)) {
+            } else if ("ON".equals(s)) {
                 return KEYWORD;
             }
             return getKeywordOrIdentifier(s, "ORDER", KEYWORD);


### PR DESCRIPTION
This flag was always set to `true` as described in issue #927.

In this pull request this flag and all parameters in which it was passed to different methods are removed.

There are one minor difference: `Parser.isKeyword()` now treats `OFFSET` and `FETCH` as keywords unlike it was before, but this method in only called from methods that parse `CREATE AGGREGATE`, `CREATE CONSTANT` (not `CONSTRAINT`), and `CREATE ALIAS`. This commands are not used too often and such names are not expected to be here.

Parsing of column names etc., where probability of such names are much higher is not changed.