### PR TITLE
Use Math.log10() and remove Mode.getOracle()

### DIFF
--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -345,10 +345,6 @@ public class Mode {
         return MODES.get(StringUtils.toUpperEnglish(name));
     }
 
-    public static Mode getOracle() {
-        return getInstance(ModeEnum.Oracle.name());
-    }
-
     public static Mode getRegular() {
         return getInstance(ModeEnum.REGULAR.name());
     }

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -620,10 +620,6 @@ public class Function extends Expression implements FunctionCall {
         }
     }
 
-    private static strictfp double log10(double value) {
-        return roundMagic(StrictMath.log(value) / StrictMath.log(10));
-    }
-
     @Override
     public Value getValue(Session session) {
         return getValueWithArgs(session, args);
@@ -682,7 +678,7 @@ public class Function extends Expression implements FunctionCall {
             }
             break;
         case LOG10:
-            result = ValueDouble.get(log10(v0.getDouble()));
+            result = ValueDouble.get(Math.log10(v0.getDouble()));
             break;
         case PI:
             result = ValueDouble.get(Math.PI);

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1315,7 +1315,7 @@ public class Function extends Expression implements FunctionCall {
         }
         case REPLACE: {
             if (v0 == ValueNull.INSTANCE || v1 == ValueNull.INSTANCE
-                    || v2 == ValueNull.INSTANCE && database.getMode() != Mode.getOracle()) {
+                    || v2 == ValueNull.INSTANCE && database.getMode().getEnum() != Mode.ModeEnum.Oracle) {
                 result = ValueNull.INSTANCE;
             } else {
                 String s0 = v0.getString();


### PR DESCRIPTION
1. Use `Math.log10()` directly for `LOG10`. Looks like slow custom implementation with two `Math.log()` calls, division, and tricky rounding was introduced before Java 5. Now it's better to use built-in function that returns more accurate result. This function is already used by `LOG` in some database modes.

2. There was only one caller of `Mode.getOracle()`. This call is slower than comparison with `Mode.getEnum()` because `Mode.getInstance()` performs case conversion and lookup in a table. So it makes more sense to use fast way and remove this function.