### PR TITLE
Assorted changes in documentation

### DIFF
--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -1065,7 +1065,6 @@ import java.sql.*;
 import java.util.*;
 public class Test {
     public static void main(String[] args) throws Exception {
-        Class.forName("org.h2.Driver");
         String url = "jdbc:h2:~/test";
         Properties prop = new Properties();
         prop.setProperty("user", "sa");
@@ -1083,7 +1082,6 @@ public class Test {
 }
 </pre>
 <p>
-This example requires Java 1.6.
 When using Swing, use <code>javax.swing.JPasswordField</code>.
 </p>
 

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -1780,13 +1780,6 @@ OR X = 2 OR X = 2 OR X = 2 OR X = 2 OR X = 2
         2617: HTTP Digest Access Authentication</a></td>
     </tr>
     <tr>
-        <td>GCJ</td>
-        <td>Compiler for Java. <a href="http://gcc.gnu.org/java">GNU
-        Compiler for the Java</a> and <a
-            href="http://www.dobysoft.com/products/nativej">NativeJ
-        (commercial)</a></td>
-    </tr>
-    <tr>
         <td>HTTPS</td>
         <td>A protocol to provide security to HTTP connections. See
         also: <a href="http://www.ietf.org/rfc/rfc2818.txt">RFC 2818:

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -45,7 +45,6 @@ Build
 <h2 id="portability">Portability</h2>
 <p>
 This database is written in Java and therefore works on many platforms.
-It can also be compiled to a native executable using GCJ.
 </p>
 
 <h2 id="environment">Environment</h2>

--- a/h2/src/docsrc/html/cheatSheet.html
+++ b/h2/src/docsrc/html/cheatSheet.html
@@ -169,7 +169,6 @@ Reference:
 
 <h2><a href="tutorial.html#connecting_using_jdbc">Using the JDBC API</a></h2>
 <pre>
-Class.forName("org.h2.Driver");
 Connection conn = DriverManager.
     getConnection("jdbc:h2:~/test");
 conn.close();

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -269,6 +269,7 @@ is equivalent to <code>DOUBLE</code>, and both are mapped to <code>java.lang.Dou
 See also
 <a href="http://java.sun.com/j2se/1.5.0/docs/guide/jdbc/getstart/mapping.html#1055162">
 Mapping SQL and Java Types - 8.3.10 FLOAT</a>.</p>
+<p>Use REAL or FLOAT(24) data type for <code>java.lang.Float</code> values.</p>
 
 <h3 id="gcj">Is the GCJ Version Stable? Faster?</h3>
 <p>

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -47,8 +47,6 @@ Frequently Asked Questions
     Column Names are Incorrect?</a><br />
 <a href="#float_is_double">
     Float is Double?</a><br />
-<a href="#gcj">
-    Is the GCJ Version Stable? Faster?</a><br />
 <a href="#how_to_translate">
     How to Translate this Project?</a><br />
 <a href="#how_to_contribute">
@@ -270,15 +268,6 @@ See also
 <a href="http://java.sun.com/j2se/1.5.0/docs/guide/jdbc/getstart/mapping.html#1055162">
 Mapping SQL and Java Types - 8.3.10 FLOAT</a>.</p>
 <p>Use REAL or FLOAT(24) data type for <code>java.lang.Float</code> values.</p>
-
-<h3 id="gcj">Is the GCJ Version Stable? Faster?</h3>
-<p>
-The GCJ version is not as stable as the Java version.
-When running the regression test with the GCJ version, sometimes the application just stops
-at what seems to be a random point without error message.
-Currently, the GCJ version is also slower than when using the Sun VM.
-However, the startup of the GCJ version is faster than when using a VM.
-</p>
 
 <h3 id="how_to_translate">How to Translate this Project?</h3>
 <p>

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -117,7 +117,6 @@ and the database URL starts with <code>jdbc:h2:</code>.
 To connect to a database using JDBC, use the following code:
 </p>
 <pre>
-Class.forName("org.h2.Driver");
 Connection conn = DriverManager.getConnection("jdbc:h2:~/test", "sa", "");
 </pre>
 

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -669,7 +669,6 @@ and user passwords are case sensitive. Here is an example to connect to a
 password-encrypted database:
 </p>
 <pre>
-Class.forName("org.h2.Driver");
 String url = "jdbc:h2:~/test;CIPHER=AES";
 String user = "sa";
 String pwds = "filepwd userpwd";

--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -108,10 +108,9 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Copy database: tool with config GUI and batch mode, extensible (example: compare).
 </li><li>Document, implement tool for long running transactions using user-defined compensation statements.
 </li><li>Support SET TABLE DUAL READONLY.
-</li><li>GCJ: what is the state now?
 </li><li>Events for: database Startup, Connections, Login attempts, Disconnections, Prepare (after parsing), Web Server. See http://docs.openlinksw.com/virtuoso/fn_dbev_startup.html
 </li><li>Optimization: simpler log compression.
-</li><li>Support standard INFORMATION_SCHEMA tables, as defined in http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt - specially KEY_COLUMN_USAGE: http://dev.mysql.com/doc/refman/5.0/en/information-schema.html, http://www.xcdsql.org/Misc/INFORMATION_SCHEMA%20With%20Rolenames.gif
+</li><li>Support more standard INFORMATION_SCHEMA tables, as defined in SQL standard.
 </li><li>Compatibility: in MySQL, HSQLDB, /0.0 is NULL; in PostgreSQL, Derby: division by zero. HSQLDB: 0.0e1 / 0.0e1 is NaN.
 </li><li>Functional tables should accept parameters from other tables (see FunctionMultiReturn) SELECT * FROM TEST T, P2C(T.A, T.R).
 </li><li>Custom class loader to reload functions on demand.
@@ -154,7 +153,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Java static code analysis: http://www.eclipse.org/tptp/
 </li><li>Compatibility for CREATE SCHEMA AUTHORIZATION.
 </li><li>Implement Clob / Blob truncate and the remaining functionality.
-</li><li>Add multiple columns at the same time with ALTER TABLE .. ADD .. ADD ...
 </li><li>File locking: writing a system property to detect concurrent access from the same VM (different classloaders).
 </li><li>Pure SQL triggers (example: update parent table if the child table is changed).
 </li><li>Add H2 to Gem (Ruby install system).
@@ -166,13 +164,11 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Compact databases without having to close the database (vacuum).
 </li><li>Implement more JDBC 4.0 features.
 </li><li>Support TRANSFORM / PIVOT as in MS Access.
-</li><li>SELECT * FROM (VALUES (...), (...), ....) AS alias(f1, ...).
 </li><li>Support updatable views with join on primary keys (to extend a table).
 </li><li>Public interface for functions (not public static).
 </li><li>Support reading the transaction log.
 </li><li>Feature matrix as in <a href="http://www.inetsoftware.de/products/jdbc/mssql/features/default.asp">i-net software</a>.
 </li><li>Updatable result set on table without primary key or unique index.
-</li><li>Compatibility with Derby and PostgreSQL: VALUES(1), (2); SELECT * FROM (VALUES (1), (2)) AS myTable(c1). Issue 221.
 </li><li>Allow execution time prepare for SELECT * FROM CSVREAD(?, 'columnNameString')
 </li><li>Support data type INTERVAL
 </li><li>Support nested transactions (possibly using savepoints internally).
@@ -231,7 +227,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Native search: support "phrase search", wildcard search (* and ?), case-insensitive search, boolean operators, and grouping
 </li><li>Improve documentation of access rights.
 </li><li>Support opening a database that is in the classpath, maybe using a new file system. Workaround: detect jar file using getClass().getProtectionDomain().getCodeSource().getLocation().
-</li><li>Support ENUM data type (see MySQL, PostgreSQL, MS SQL Server, maybe others).
 </li><li>Remember the user defined data type (domain) of a column.
 </li><li>MVCC: support multi-threaded kernel with multi-version concurrency.
 </li><li>Auto-server: add option to define the port range or list.
@@ -252,9 +247,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Translation: use ${.} in help.csv
 </li><li>Translated .pdf
 </li><li>Recovery tool: bad blocks should be converted to INSERT INTO SYSTEM_ERRORS(...), and things should go into the .trace.db file
-</li><li>Issue 357: support getGeneratedKeys to return multiple rows when used with batch updates.
-    This is supported by MySQL, but not Derby. Both PostgreSQL and HSQLDB don't support getGeneratedKeys.
-    Also support it when using INSERT ... SELECT.
 </li><li>RECOVER=2 to backup the database, run recovery, open the database
 </li><li>Recovery should work with encrypted databases
 </li><li>Corruption: new error code, add help
@@ -353,7 +345,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Support INTERVAL data type (see Oracle and others).
 </li><li>Combine Server and Console tool (only keep Server).
 </li><li>Store the Lucene index in the database itself.
-</li><li>Support standard MERGE statement: http://en.wikipedia.org/wiki/Merge_%28SQL%29
 </li><li>Oracle compatibility: support DECODE(x, ...).
 </li><li>MVCC: compare concurrent update behavior with PostgreSQL and Oracle.
 </li><li>HSQLDB compatibility: CREATE FUNCTION (maybe using a Function interface).
@@ -398,7 +389,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Pluggable access control mechanism.
 </li><li>Fulltext search (Lucene): support streaming CLOB data.
 </li><li>Document/example how to create and read an encrypted script file.
-</li><li>Check state of http://issues.apache.org/jira/browse/OPENJPA-1367 (H2 does support cross joins).
 </li><li>Fulltext search (Lucene): only prefix column names with _ if they already start with _. Instead of DATA / QUERY / modified use _DATA, _QUERY, _MODIFIED if possible.
 </li><li>Support a way to create or read compressed encrypted script files using an API.
 </li><li>Scripting language support (Javascript).
@@ -543,12 +533,9 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Issue 283: Improve performance of H2 on Android.
 </li><li>Support INSERT INTO / UPDATE / MERGE ... RETURNING to retrieve the generated key(s).
 </li><li>Column compression option - see http://groups.google.com/group/h2-database/browse_thread/thread/3e223504e52671fa/243da82244343f5d
-</li><li>PostgreSQL compatibility: ALTER TABLE ADD combined with adding a foreign key constraint, as in ALTER TABLE FOO ADD COLUMN PARENT BIGINT REFERENCES FOO(ID).
 </li><li>MS SQL Server compatibility: support @@ROWCOUNT.
-</li><li>PostgreSQL compatibility: LOG(x) is LOG10(x) and not LN(x).
 </li><li>Issue 311: Serialized lock mode: executeQuery of write operations fails.
 </li><li>PostgreSQL compatibility: support PgAdmin III (specially the function current_setting).
-</li><li>MySQL compatibility: support TIMESTAMPADD.
 </li><li>Support SELECT ... FOR UPDATE with joins (supported by PostgreSQL, MySQL, and HSQLDB; but not Derby).
 </li><li>Support SELECT ... FOR UPDATE OF [field-list] (supported by PostgreSQL, MySQL, and HSQLDB; but not Derby).
 </li><li>Support SELECT ... FOR UPDATE OF [table-list] (supported by PostgreSQL, HSQLDB, Sybase).

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -456,7 +456,6 @@ import java.sql.*;
 public class Test {
     public static void main(String[] a)
             throws Exception {
-        Class.forName("org.h2.Driver");
         Connection conn = DriverManager.
             getConnection("jdbc:h2:~/test", "sa", "");
         // add application code here
@@ -465,8 +464,7 @@ public class Test {
 }
 </pre>
 <p>
-This code first loads the driver (<code>Class.forName(...)</code>)
-and then opens a connection (using <code>DriverManager.getConnection()</code>).
+This code opens a connection (using <code>DriverManager.getConnection()</code>).
 The driver name is <code>"org.h2.Driver"</code>.
 The database URL always needs to start with <code>jdbc:h2:</code>
 to be recognized by this database. The second parameter in the <code>getConnection()</code> call
@@ -867,7 +865,6 @@ String url = "jdbc:h2:/data/data/" +
     ";FILE_LOCK=FS" +
     ";PAGE_SIZE=1024" +
     ";CACHE_SIZE=8192";
-Class.forName("org.h2.Driver");
 conn = DriverManager.getConnection(url);
 ...
 </pre>

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -1354,12 +1354,23 @@ CALL TIMESTAMP '2008-01-01 12:00:00+01:00';
 </pre>
 <p>
 If the time zone is not set, the value is parsed using the current time zone setting of the system.
-Date and time information is stored in H2 database files without time zone information.
-If the database is opened using another system time zone, the date and time will be the same.
+Date and time information is stored in H2 database files with or without time zone information depending on used data type.
+</p>
+<ul>
+<li>
+With TIMESTAMP data type if the database is opened using another system time zone, the date and time will be the same.
 That means if you store the value '2000-01-01 12:00:00' in one time zone, then close the database
 and open the database again in a different time zone, you will also get '2000-01-01 12:00:00'.
 Please note that changing the time zone after the H2 driver is loaded is not supported.
-</p>
+</li>
+<li>
+With TIMESTAMP WITH TIME ZONE data type time zone offset is stored and if you store the value
+'2008-01-01 12:00:00+01:00' it remains the same even if you close and reopen the database with a different time zone.
+If you store the value with specified time zone name like '2008-01-01 12:00:00 Europe/Berlin' this name will be
+converted to time zone offset.
+Names of time zones are not stored.
+</li>
+</ul>
 
 <h2 id="spring">Using Spring</h2>
 <h3>Using the TCP Server</h3>


### PR DESCRIPTION
1. H2 now supports `TIMESTAMP WITH TIME ZONE`, so mention it too in `tutorial.html` because old text says that time zone information is not stored in H2.

2. Java 7+ and Android load drivers automatically, so there is no reason to include `Class.forName()` call in examples in documentation.

3. I removed some implemented or otherwise resolved items from `roadmap.html`.

4. Documentation describes why `FLOAT` is `double`, but does not describe how to get data type for `float` values. I added a some valid type names.

5. H2 does not support GCJ any more and GCJ by itself is removed from GCC. So I removed references to it from documentation. There was a reference to commercial compiler, but looks like it's just a wrapper that requires some JRE to be installed, I removed this reference too.