### PR TITLE
Fix font size, line length, TOC, and many broken links in PDF

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -6,8 +6,11 @@
 SELECT [ TOP term ] [ DISTINCT | ALL ] selectExpression [,...]
 FROM tableExpression [,...] [ WHERE expression ]
 [ GROUP BY expression [,...] ] [ HAVING expression ]
-[ { UNION [ ALL ] | MINUS | EXCEPT | INTERSECT } select ] [ ORDER BY order [,...] ]
-[ { LIMIT expression [ OFFSET expression ] [ SAMPLE_SIZE rowCountInt ] } | { [ OFFSET expression { ROW | ROWS } ] [ { FETCH { FIRST | NEXT } expression { ROW | ROWS } ONLY } ] } ]
+[ { UNION [ ALL ] | MINUS | EXCEPT | INTERSECT } select ]
+[ ORDER BY order [,...] ]
+[ { LIMIT expression [ OFFSET expression ] [ SAMPLE_SIZE rowCountInt ] }
+    | { [ OFFSET expression { ROW | ROWS } ]
+    [ { FETCH { FIRST | NEXT } expression { ROW | ROWS } ONLY } ] } ]
 [ FOR UPDATE ]
 ","
 Selects data from a table or multiple tables.
@@ -44,7 +47,8 @@ SELECT * FROM (SELECT ID, COUNT(*) FROM TEST
 "Commands (DML)","INSERT","
 INSERT INTO tableName
 { [ ( columnName [,...] ) ]
-    { VALUES { ( { DEFAULT | expression } [,...] ) } [,...] | [ DIRECT ] [ SORTED ] select } } |
+    { VALUES { ( { DEFAULT | expression } [,...] ) } [,...]
+        | [ DIRECT ] [ SORTED ] select } } |
     { SET { columnName = { DEFAULT | expression } } [,...] }
 ","
 Inserts a new row / new rows into a table.
@@ -99,7 +103,8 @@ CALL 15*25
 "
 
 "Commands (DML)","EXPLAIN","
-EXPLAIN { [ PLAN FOR ] | ANALYZE } { select | insert | update | delete | merge }
+EXPLAIN { [ PLAN FOR ] | ANALYZE }
+{ select | insert | update | delete | merge }
 ","
 Shows the execution plan for a statement.
 When using EXPLAIN ANALYZE, the statement is actually executed, and the query plan
@@ -269,7 +274,9 @@ ALTER SCHEMA TEST RENAME TO PRODUCTION
 "
 
 "Commands (DDL)","ALTER SEQUENCE","
-ALTER SEQUENCE [ IF EXISTS ] sequenceName [ RESTART WITH long ] [ INCREMENT BY long ]
+ALTER SEQUENCE [ IF EXISTS ] sequenceName
+[ RESTART WITH long ]
+[ INCREMENT BY long ]
 [ MINVALUE long | NOMINVALUE | NO MINVALUE ]
 [ MAXVALUE long | NOMAXVALUE | NO MAXVALUE ]
 [ CYCLE long | NOCYCLE | NO CYCLE ]
@@ -307,7 +314,8 @@ ALTER TABLE TEST ADD CONSTRAINT NAME_UNIQUE UNIQUE(NAME)
 "
 
 "Commands (DDL)","ALTER TABLE RENAME CONSTRAINT","
-ALTER TABLE [ IF EXISTS ] tableName RENAME oldConstraintName TO newConstraintName
+ALTER TABLE [ IF EXISTS ] tableName RENAME oldConstraintName
+TO newConstraintName
 ","
 Renames a constraint.
 This command commits an open transaction in this connection.
@@ -364,7 +372,8 @@ ALTER TABLE TEST ALTER COLUMN NAME SET INVISIBLE;
 "
 
 "Commands (DDL)","ALTER TABLE DROP COLUMN","
-ALTER TABLE [ IF EXISTS ] tableName DROP COLUMN [ IF EXISTS ] ( columnName [,...] )
+ALTER TABLE [ IF EXISTS ] tableName DROP COLUMN [ IF EXISTS ]
+( columnName [,...] )
 ","
 Removes column(s) from a table.
 This command commits an open transaction in this connection.
@@ -374,7 +383,8 @@ ALTER TABLE TEST DROP COLUMN NAME1, NAME2
 "
 
 "Commands (DDL)","ALTER TABLE DROP CONSTRAINT","
-ALTER TABLE [ IF EXISTS ] tableName DROP { CONSTRAINT [ IF EXISTS ] constraintName | PRIMARY KEY }
+ALTER TABLE [ IF EXISTS ] tableName DROP
+{ CONSTRAINT [ IF EXISTS ] constraintName | PRIMARY KEY }
 ","
 Removes a constraint or a primary key from a table.
 This command commits an open transaction in this connection.
@@ -626,11 +636,13 @@ be the resource name (for example ""java:comp/env/jdbc/Test"").
 Admin rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
-CREATE LINKED TABLE LINK('org.h2.Driver', 'jdbc:h2:test2', 'sa', 'sa', 'TEST');
+CREATE LINKED TABLE LINK('org.h2.Driver', 'jdbc:h2:test2',
+    'sa', 'sa', 'TEST');
 CREATE LINKED TABLE LINK('', 'jdbc:h2:test2', 'sa', 'sa',
     '(SELECT * FROM TEST WHERE ID>0)');
 CREATE LINKED TABLE LINK('javax.naming.InitialContext',
-    'java:comp/env/jdbc/Test', NULL, NULL, '(SELECT * FROM TEST WHERE ID>0)');
+    'java:comp/env/jdbc/Test', NULL, NULL,
+    '(SELECT * FROM TEST WHERE ID>0)');
 "
 
 "Commands (DDL)","CREATE ROLE","
@@ -643,7 +655,8 @@ CREATE ROLE READONLY
 "
 
 "Commands (DDL)","CREATE SCHEMA","
-CREATE SCHEMA [ IF NOT EXISTS ] name [ AUTHORIZATION ownerUserName ]
+CREATE SCHEMA [ IF NOT EXISTS ] name
+[ AUTHORIZATION ownerUserName ]
 [ WITH tableEngineParamName [,...] ]
 ","
 Creates a new schema. If no owner is specified, the current user is used. The
@@ -658,7 +671,8 @@ CREATE SCHEMA TEST_SCHEMA AUTHORIZATION SA
 "
 
 "Commands (DDL)","CREATE SEQUENCE","
-CREATE SEQUENCE [ IF NOT EXISTS ] newSequenceName [ START WITH long ]
+CREATE SEQUENCE [ IF NOT EXISTS ] newSequenceName
+[ START WITH long ]
 [ INCREMENT BY long ]
 [ MINVALUE long | NOMINVALUE | NO MINVALUE ]
 [ MAXVALUE long | NOMAXVALUE | NO MAXVALUE ]
@@ -722,9 +736,12 @@ CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR(255))
 "
 
 "Commands (DDL)","CREATE TRIGGER","
-CREATE TRIGGER [ IF NOT EXISTS ] newTriggerName { BEFORE | AFTER | INSTEAD OF }
-{ INSERT | UPDATE | DELETE | SELECT | ROLLBACK } [,...] ON tableName [ FOR EACH ROW ]
-[ QUEUE int ] [ NOWAIT ] { CALL triggeredClassName | AS sourceCodeString }
+CREATE TRIGGER [ IF NOT EXISTS ] newTriggerName
+{ BEFORE | AFTER | INSTEAD OF }
+{ INSERT | UPDATE | DELETE | SELECT | ROLLBACK }
+[,...] ON tableName [ FOR EACH ROW ]
+[ QUEUE int ] [ NOWAIT ]
+{ CALL triggeredClassName | AS sourceCodeString }
 ","
 Creates a new trigger.
 The trigger class must be public and implement ""org.h2.api.Trigger"".
@@ -1219,7 +1236,8 @@ SET BUILTIN_ALIAS_OVERRIDE TRUE
 
 "Commands (Other)","SET COLLATION","
 SET [ DATABASE ] COLLATION
-{ OFF | collationName [ STRENGTH { PRIMARY | SECONDARY | TERTIARY | IDENTICAL } ] }
+{ OFF | collationName
+    [ STRENGTH { PRIMARY | SECONDARY | TERTIARY | IDENTICAL } ] }
 ","
 Sets the collation used for comparing strings.
 This command can only be executed if there are no tables defined.
@@ -2206,7 +2224,8 @@ DATE '2004-12-31'
 "
 
 "Other Grammar","Decimal","
-[ + | - ] { { number [ . number ] } | { . number } } [ E [ + | - ] expNumber [...] ] ]
+[ + | - ] { { number [ . number ] } | { . number } }
+[ E [ + | - ] expNumber [...] ] ]
 ","
 A decimal number with fixed precision and scale.
 Internally, ""java.lang.BigDecimal"" is used.
@@ -2388,7 +2407,8 @@ FOREIGN KEY(ID) REFERENCES TEST(ID) ON UPDATE CASCADE
 "
 
 "Other Grammar","Script Compression Encryption","
-[ COMPRESSION { DEFLATE | LZF | ZIP | GZIP } ] [ CIPHER cipher PASSWORD string ]
+[ COMPRESSION { DEFLATE | LZF | ZIP | GZIP } ]
+[ CIPHER cipher PASSWORD string ]
 ","
 The compression and encryption algorithm to use for script files.
 When using encryption, only DEFLATE and LZF are supported.
@@ -2638,7 +2658,8 @@ DATE
 "
 
 "Data Types","TIMESTAMP Type","
-{ TIMESTAMP [ ( precisionInt ) ] [ WITHOUT TIME ZONE ] | DATETIME | SMALLDATETIME }
+{ TIMESTAMP [ ( precisionInt ) ] [ WITHOUT TIME ZONE ]
+    | DATETIME | SMALLDATETIME }
 ","
 The timestamp data type. The format is yyyy-MM-dd hh:mm:ss[.nnnnnnnnn].
 Stored internally as a BCD-encoded date, and nanoseconds since midnight.
@@ -2669,7 +2690,8 @@ TIMESTAMP WITH TIME ZONE
 "
 
 "Data Types","BINARY Type","
-{ BINARY | VARBINARY | LONGVARBINARY | RAW | BYTEA } [ ( precisionInt ) ]
+{ BINARY | VARBINARY | LONGVARBINARY | RAW | BYTEA }
+[ ( precisionInt ) ]
 ","
 Represents a byte array. For very long arrays, use BLOB.
 The maximum size is 2 GB, but the whole object is kept in
@@ -2750,7 +2772,8 @@ CHAR(10)
 "
 
 "Data Types","BLOB Type","
-{ BLOB | TINYBLOB | MEDIUMBLOB | LONGBLOB | IMAGE | OID } [ ( precisionInt ) ]
+{ BLOB | TINYBLOB | MEDIUMBLOB | LONGBLOB | IMAGE | OID }
+[ ( precisionInt ) ]
 ","
 Like BINARY, but intended for very large values such as files or images. Unlike
 when using BINARY, large objects are not kept fully in-memory. Use
@@ -2763,7 +2786,8 @@ BLOB
 "
 
 "Data Types","CLOB Type","
-{ CLOB | TINYTEXT | TEXT | MEDIUMTEXT | LONGTEXT | NTEXT | NCLOB } [ ( precisionInt ) ]
+{ CLOB | TINYTEXT | TEXT | MEDIUMTEXT | LONGTEXT | NTEXT | NCLOB }
+[ ( precisionInt ) ]
 ","
 CLOB is like VARCHAR, but intended for very large values. Unlike when using
 VARCHAR, large CLOB objects are not kept fully in-memory; instead, they are streamed.

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -1380,7 +1380,7 @@ Remote TLS connections are supported using the Java Secure Socket Extension
 <p>
 To use your own keystore, set the system properties <code>javax.net.ssl.keyStore</code> and
 <code>javax.net.ssl.keyStorePassword</code> before starting the H2 server and client.
-See also <a href="http://java.sun.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CustomizingStores">
+See also <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/JSSERefGuide.html#CustomizingStores">
 Customizing the Default Key and Trust Stores, Store Types, and Store Passwords</a>
 for more information.
 </p>
@@ -1822,7 +1822,7 @@ OR X = 2 OR X = 2 OR X = 2 OR X = 2 OR X = 2
     <tr>
         <td>SSL/TLS</td>
         <td>Secure Sockets Layer / Transport Layer Security. See also:
-        <a href="http://java.sun.com/products/jsse/">Java Secure Socket
+        <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/JSSERefGuide.html">Java Secure Socket
         Extension (JSSE)</a></td>
     </tr>
 </table>

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -324,6 +324,7 @@ It is not possible to enable or disable this setting while the database is alrea
 <p>
 If MVCC is enabled, changing the lock mode (<code>LOCK_MODE</code>) has no effect.
 </p>
+<p>
 The MVCC mode is enabled by default in version 1.4.x,
 with the default MVStore storage engine.
 MVCC is disabled by default when using the PageStore storage engine
@@ -335,6 +336,7 @@ with the PageStore storage engine, it can not be used at the same time as
 <code>MULTI_THREADED=TRUE</code>;
 the complete undo log (the list of uncommitted changes) must fit in memory when using multi-version concurrency.
 The setting <code>MAX_MEMORY_UNDO</code> has no effect.
+</p>
 
 <h2 id="clustering">Clustering / High Availability</h2>
 <p>

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -268,7 +268,7 @@ or if  you have a feature request:
 </li><li>Before posting problems, check the
     <a href="faq.html">FAQ</a> and do a <a href="http://google.com">Google search</a>.
 </li><li>When got an unexpected exception, please try the
-    <a href="sourceError.html">Error Analyzer tool</a>. If this doesn't help,
+    <a href="http://www.h2database.com/html/sourceError.html">Error Analyzer tool</a>. If this doesn't help,
     please report the problem, including the complete error message and stack trace,
     and the root cause stack trace(s).
 </li><li>When sending source code, please use a public web clipboard such as

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -18,7 +18,7 @@ Build
 <table class="content"><tr class="content"><td class="content"><div class="contentDiv">
 <!-- } -->
 
-<h1>Build</h1>
+<h1 id="build_index">Build</h1>
 <a href="#portability">
     Portability</a><br />
 <a href="#environment">
@@ -263,7 +263,7 @@ or if  you have a feature request:
 <ul><li>For bug reports, please provide a
     <a href="http://sscce.org/">short, self contained, correct (compilable), example</a> of the problem.
 </li><li>Feature requests are always welcome, even if the feature is already on the
-    <a href="roadmap.html">roadmap</a>. Your mail will help prioritize feature requests.
+    <a href="http://www.h2database.com/html/roadmap.html">roadmap</a>. Your mail will help prioritize feature requests.
     If you urgently need a feature, consider <a href="#providing_patches">providing a patch</a>.
 </li><li>Before posting problems, check the
     <a href="faq.html">FAQ</a> and do a <a href="http://google.com">Google search</a>.

--- a/h2/src/docsrc/html/datatypes.html
+++ b/h2/src/docsrc/html/datatypes.html
@@ -18,7 +18,7 @@ Data Types
 <!-- } -->
 
 <h1>Data Types</h1>
-<h2>Index</h2>
+<h2 id="datatypes_index">Index</h2>
 <!-- syntax-start
 <p class="notranslate">
 <c:forEach var="item" items="dataTypes">

--- a/h2/src/docsrc/html/datatypes.html
+++ b/h2/src/docsrc/html/datatypes.html
@@ -52,7 +52,7 @@ syntax-end -->
 <!-- railroad-end -->
 
 <c:forEach var="item" items="dataTypes">
-<h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
+<h2 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h2>
 <!-- railroad-start -->
 <pre name="bnf" style="display: none">
 ${item.syntax}

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -17,7 +17,7 @@ Frequently Asked Questions
 <table class="content"><tr class="content"><td class="content"><div class="contentDiv">
 <!-- } -->
 
-<h1>Frequently Asked Questions</h1>
+<h1 id="faq_index">Frequently Asked Questions</h1>
 
 <a href="#support">
     I Have a Problem or Feature Request</a><br />
@@ -248,7 +248,7 @@ and not the alias name. If you need the alias name, use
 <a href="http://java.sun.com/javase/6/docs/api/java/sql/ResultSetMetaData.html#getColumnLabel(int)"><code>ResultSetMetaData.getColumnLabel()</code></a>.
 Some other database don't work like this yet (they don't follow the JDBC specification).
 If you need compatibility with those databases, use the <a href="features.html#compatibility">Compatibility Mode</a>,
-or append <a href="../javadoc/org/h2/engine/DbSettings.html#ALIAS_COLUMN_NAME"><code>;ALIAS_COLUMN_NAME=TRUE</code></a> to the database URL.
+or append <a href="http://www.h2database.com/javadoc/org/h2/engine/DbSettings.html#ALIAS_COLUMN_NAME"><code>;ALIAS_COLUMN_NAME=TRUE</code></a> to the database URL.
 </p>
 <p>
 This also applies to DatabaseMetaData calls that return a result set.
@@ -285,7 +285,7 @@ Please start with small patches. That could be adding a test case to improve the
 <a href="build.html#automated">code coverage</a> (the target code coverage for this project is 90%, higher is better).
 You will have to <a href="build.html">develop, build and run the tests</a>.
 Once you are familiar with the code, you could implement missing features from the
-<a href="roadmap.html">feature request list</a>.
+<a href="http://www.h2database.com/html/roadmap.html">feature request list</a>.
 I suggest to start with very small features that are easy to implement.
 Keep in mind to provide test cases as well.
 </p>

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -245,7 +245,7 @@ return <code>X</code>. What's wrong?
 This is not a bug. According the the JDBC specification, the method
 <code>ResultSetMetaData.getColumnName()</code> should return the name of the column
 and not the alias name. If you need the alias name, use
-<a href="http://java.sun.com/javase/6/docs/api/java/sql/ResultSetMetaData.html#getColumnLabel(int)"><code>ResultSetMetaData.getColumnLabel()</code></a>.
+<a href="https://docs.oracle.com/javase/7/docs/api/java/sql/ResultSetMetaData.html#getColumnLabel(int)"><code>ResultSetMetaData.getColumnLabel()</code></a>.
 Some other database don't work like this yet (they don't follow the JDBC specification).
 If you need compatibility with those databases, use the <a href="features.html#compatibility">Compatibility Mode</a>,
 or append <a href="http://www.h2database.com/javadoc/org/h2/engine/DbSettings.html#ALIAS_COLUMN_NAME"><code>;ALIAS_COLUMN_NAME=TRUE</code></a> to the database URL.
@@ -265,7 +265,7 @@ return a <code>java.lang.Float</code>. What's wrong?
 This is not a bug. According the the JDBC specification, the JDBC data type <code>FLOAT</code>
 is equivalent to <code>DOUBLE</code>, and both are mapped to <code>java.lang.Double</code>.
 See also
-<a href="http://java.sun.com/j2se/1.5.0/docs/guide/jdbc/getstart/mapping.html#1055162">
+<a href="https://docs.oracle.com/javase/1.5.0/docs/guide/jdbc/getstart/mapping.html#1055162">
 Mapping SQL and Java Types - 8.3.10 FLOAT</a>.</p>
 <p>Use REAL or FLOAT(24) data type for <code>java.lang.Float</code> values.</p>
 

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -391,7 +391,7 @@ It looks like the development of this database has stopped. The last release was
 <h2 id="products_work_with">H2 in Use</h2>
 <p>
 For a list of applications that work with or use H2, see:
-<a href="links.html">Links</a>.
+<a href="http://www.h2database.com/html/links.html">Links</a>.
 </p>
 
 <h2 id="connection_modes">Connection Modes</h2>

--- a/h2/src/docsrc/html/functions.html
+++ b/h2/src/docsrc/html/functions.html
@@ -164,7 +164,92 @@ syntax-end -->
 <p>Click on the header to switch between railroad diagram and BNF.</p>
 <!-- railroad-end -->
 
-<c:forEach var="item" items="functionsAll">
+<h2>Aggregate Functions</h2>
+<c:forEach var="item" items="functionsAggregate">
+<h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
+<!-- railroad-start -->
+<pre name="bnf" style="display: none">
+${item.syntax}
+</pre>
+<div name="railroad">
+${item.railroad}
+</div>
+<!-- railroad-end -->
+<!-- syntax-start
+<pre>
+${item.syntax}
+</pre>
+syntax-end -->
+<p>${item.text}</p>
+<p>Example:</p>
+<p class="notranslate">${item.example}</p>
+</c:forEach>
+
+<h2>Numeric Functions</h2>
+<c:forEach var="item" items="functionsNumeric">
+<h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
+<!-- railroad-start -->
+<pre name="bnf" style="display: none">
+${item.syntax}
+</pre>
+<div name="railroad">
+${item.railroad}
+</div>
+<!-- railroad-end -->
+<!-- syntax-start
+<pre>
+${item.syntax}
+</pre>
+syntax-end -->
+<p>${item.text}</p>
+<p>Example:</p>
+<p class="notranslate">${item.example}</p>
+</c:forEach>
+
+<h2>String Functions</h2>
+<c:forEach var="item" items="functionsString">
+<h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
+<!-- railroad-start -->
+<pre name="bnf" style="display: none">
+${item.syntax}
+</pre>
+<div name="railroad">
+${item.railroad}
+</div>
+<!-- railroad-end -->
+<!-- syntax-start
+<pre>
+${item.syntax}
+</pre>
+syntax-end -->
+<p>${item.text}</p>
+<p>Example:</p>
+<p class="notranslate">${item.example}</p>
+</c:forEach>
+
+<h2>Time and Date Functions</h2>
+<c:forEach var="item" items="functionsTimeDate">
+<h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
+<!-- railroad-start -->
+<pre name="bnf" style="display: none">
+${item.syntax}
+</pre>
+<div name="railroad">
+${item.railroad}
+</div>
+<!-- railroad-end -->
+<!-- syntax-start
+<pre>
+${item.syntax}
+</pre>
+syntax-end -->
+<p>${item.text}</p>
+<p>Example:</p>
+<p class="notranslate">${item.example}</p>
+</c:forEach>
+
+<h2>System Functions</h2>
+<c:forEach var="item" items="functionsSystem">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
 <pre name="bnf" style="display: none">

--- a/h2/src/docsrc/html/grammar.html
+++ b/h2/src/docsrc/html/grammar.html
@@ -170,7 +170,8 @@ syntax-end -->
 <p>Click on the header to switch between railroad diagram and BNF.</p>
 <!-- railroad-end -->
 
-<c:forEach var="item" items="commands">
+<h2>Commands (Data Manipulation)</h2>
+<c:forEach var="item" items="commandsDML">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
 <pre name="bnf" style="display: none">
@@ -191,6 +192,51 @@ syntax-end -->
 ${item.example}</p>
 </c:forEach>
 
+<h2>Commands (Data Definition)</h2>
+<c:forEach var="item" items="commandsDDL">
+<h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
+<!-- railroad-start -->
+<pre name="bnf" style="display: none">
+${item.syntax}
+</pre>
+<div name="railroad">
+${item.railroad}
+</div>
+<!-- railroad-end -->
+<!-- syntax-start
+<pre>
+${item.syntax}
+</pre>
+syntax-end -->
+<p>${item.text}</p>
+<p>Example:</p>
+<p class="notranslate">
+${item.example}</p>
+</c:forEach>
+
+<h2>Commands (Other)</h2>
+<c:forEach var="item" items="commandsOther">
+<h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
+<!-- railroad-start -->
+<pre name="bnf" style="display: none">
+${item.syntax}
+</pre>
+<div name="railroad">
+${item.railroad}
+</div>
+<!-- railroad-end -->
+<!-- syntax-start
+<pre>
+${item.syntax}
+</pre>
+syntax-end -->
+<p>${item.text}</p>
+<p>Example:</p>
+<p class="notranslate">
+${item.example}</p>
+</c:forEach>
+
+<h2>Datetime fields</h2>
 <c:forEach var="item" items="datetimeFields">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
@@ -212,6 +258,7 @@ syntax-end -->
 ${item.example}</p>
 </c:forEach>
 
+<h2>Other Grammar</h2>
 <c:forEach var="item" items="otherGrammar">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
@@ -226,6 +273,8 @@ syntax-end -->
 <p>Example:</p>
 <p class="notranslate">${item.example}</p>
 </c:forEach>
+
+<h2>System Tables</h2>
 
 <h3 id="information_schema" class="notranslate">Information Schema</h3>
 <p>

--- a/h2/src/docsrc/html/grammar.html
+++ b/h2/src/docsrc/html/grammar.html
@@ -18,7 +18,7 @@ SQL Grammar
 <!-- } -->
 
 <h1>SQL Grammar</h1>
-<h2>Index</h2>
+<h2 id="grammar_index">Index</h2>
 <h3>Commands (Data Manipulation)</h3>
 <!-- syntax-start
 <p class="notranslate">

--- a/h2/src/docsrc/html/stylesheetPdf.css
+++ b/h2/src/docsrc/html/stylesheetPdf.css
@@ -32,11 +32,12 @@ body {
     margin: 0px;
 }
 
-h1 {
+h1, p.title {
     background-color: #0000bb;
     padding: 2px 4px 2px 4px;
     color: #fff;
     font-size: 24pt;
+    font-weight: bold;
     line-height: normal;
 }
 

--- a/h2/src/docsrc/html/stylesheetPdf.css
+++ b/h2/src/docsrc/html/stylesheetPdf.css
@@ -5,17 +5,17 @@
  */
 
 td, input, select, textarea, body, code, pre, td, th {
-    font: 9pt Tahoma, Arial, Helvetica, sans-serif;
+    font: 14pt Tahoma, Arial, Helvetica, sans-serif;
     font-weight: normal;
 }
 
 h1, h2, h3, h4, h5 {
-    font: 9pt Arial, Helvetica, sans-serif;
+    font: 14pt Arial, Helvetica, sans-serif;
     font-weight: bold;
 }
 
 td, input, select, textarea, body, code, pre {
-    font-size: 9pt;
+    font-size: 14pt;
 }
 
 pre {
@@ -36,22 +36,22 @@ h1 {
     background-color: #0000bb;
     padding: 2px 4px 2px 4px;
     color: #fff;
-    font-size: 15pt;
+    font-size: 24pt;
     line-height: normal;
 }
 
 h2 {
-    font-size: 13pt;
+    font-size: 18pt;
     margin-top: 1.5em;
 }
 
 h3 {
-    font-size: 11pt;
+    font-size: 16pt;
     margin-top: 1.5em;
 }
 
 h4 {
-    font-size: 9pt;
+    font-size: 14pt;
     margin-top: 1.5em;
 }
 
@@ -69,7 +69,7 @@ table {
 }
 
 th {
-    font-size: 9pt;
+    font-size: 14pt;
     font-weight: normal;
     text-align: left;
     background-color: #ece9d8;
@@ -79,7 +79,7 @@ th {
 
 td {
     background-color: #ffffff;
-    font-size: 9pt;
+    font-size: 14pt;
     text-align: left;
     vertical-align: top;
     border: 1px solid #aca899;

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -18,7 +18,7 @@ Tutorial
 <table class="content"><tr class="content"><td class="content"><div class="contentDiv">
 <!-- } -->
 
-<h1>Tutorial</h1>
+<h1 id="tutorial_index">Tutorial</h1>
 <a href="#tutorial_starting_h2_console">
     Starting and Using the H2 Console</a><br />
 <a href="#console_syntax">

--- a/h2/src/installer/openoffice.txt
+++ b/h2/src/installer/openoffice.txt
@@ -29,6 +29,10 @@ sub H2Pdf
     HeadingStyle.BreakType = 3 ' Insert Page Break Before
     HeadingStyle.ParaKeepTogether = false
 
+    For i = 1 to 4
+        ParagraphStyles.getByName("Heading " + i).OutlineLevel = i
+    Next
+
     images = document.GraphicObjects
     For i = 0 to images.getCount() - 1
         image = images.getByIndex(i)

--- a/h2/src/tools/org/h2/build/doc/GenerateDoc.java
+++ b/h2/src/tools/org/h2/build/doc/GenerateDoc.java
@@ -70,30 +70,26 @@ public class GenerateDoc {
         // String help = "SELECT * FROM INFORMATION_SCHEMA.HELP WHERE SECTION";
         String help = "SELECT ROWNUM ID, * FROM CSVREAD('" +
                 IN_HELP + "', NULL, 'lineComment=#') WHERE SECTION ";
-        map("commands",
-                help + "LIKE 'Commands%' ORDER BY ID", true);
         map("commandsDML",
-                help + "= 'Commands (DML)' ORDER BY ID", false);
+                help + "= 'Commands (DML)' ORDER BY ID", true);
         map("commandsDDL",
-                help + "= 'Commands (DDL)' ORDER BY ID", false);
+                help + "= 'Commands (DDL)' ORDER BY ID", true);
         map("commandsOther",
-                help + "= 'Commands (Other)' ORDER BY ID", false);
+                help + "= 'Commands (Other)' ORDER BY ID", true);
         map("datetimeFields",
                 help + "= 'Datetime fields' ORDER BY ID", true);
         map("otherGrammar",
                 help + "= 'Other Grammar' ORDER BY ID", true);
         map("functionsAggregate",
-                help + "= 'Functions (Aggregate)' ORDER BY ID", false);
+                help + "= 'Functions (Aggregate)' ORDER BY ID", true);
         map("functionsNumeric",
-                help + "= 'Functions (Numeric)' ORDER BY ID", false);
+                help + "= 'Functions (Numeric)' ORDER BY ID", true);
         map("functionsString",
-                help + "= 'Functions (String)' ORDER BY ID", false);
+                help + "= 'Functions (String)' ORDER BY ID", true);
         map("functionsTimeDate",
-                help + "= 'Functions (Time and Date)' ORDER BY ID", false);
+                help + "= 'Functions (Time and Date)' ORDER BY ID", true);
         map("functionsSystem",
-                help + "= 'Functions (System)' ORDER BY ID", false);
-        map("functionsAll",
-                help + "LIKE 'Functions%' ORDER BY SECTION, ID", true);
+                help + "= 'Functions (System)' ORDER BY ID", true);
         map("dataTypes",
                 help + "LIKE 'Data Types%' ORDER BY SECTION, ID", true);
         map("informationSchema", "SELECT TABLE_NAME TOPIC, " +

--- a/h2/src/tools/org/h2/build/doc/LinkChecker.java
+++ b/h2/src/tools/org/h2/build/doc/LinkChecker.java
@@ -27,7 +27,13 @@ public class LinkChecker {
     private static final boolean TEST_EXTERNAL_LINKS = false;
     private static final boolean OPEN_EXTERNAL_LINKS = false;
     private static final String[] IGNORE_MISSING_LINKS_TO = {
-        "SysProperties", "ErrorCode"
+        "SysProperties", "ErrorCode",
+        // TODO check these replacement link too
+        "#build_index",
+        "#datatypes_index",
+        "#faq_index",
+        "#grammar_index",
+        "#tutorial_index"
     };
 
     private final HashMap<String, String> targets = new HashMap<>();

--- a/h2/src/tools/org/h2/build/doc/MergeDocs.java
+++ b/h2/src/tools/org/h2/build/doc/MergeDocs.java
@@ -51,7 +51,7 @@ public class MergeDocs {
         writer.println("H2 Documentation");
         writer.println("</title><link rel=\"stylesheet\" type=\"text/css\" " +
                 "href=\"stylesheetPdf.css\" /></head><body>");
-        writer.println("<h1>H2 Database Engine</h1>");
+        writer.println("<p class=\"title\">H2 Database Engine</p>");
         writer.println("<p>Version " + Constants.getFullVersion() + "</p>");
         writer.println(finalText);
         writer.println("</body></html>");

--- a/h2/src/tools/org/h2/build/doc/MergeDocs.java
+++ b/h2/src/tools/org/h2/build/doc/MergeDocs.java
@@ -41,6 +41,7 @@ public class MergeDocs {
             }
             text = disableRailroads(text);
             text = removeHeaderFooter(fileName, text);
+            text = fixLinks(text);
             buff.append(text);
         }
         String finalText = buff.toString();
@@ -90,6 +91,15 @@ public class MergeDocs {
         idx = text.indexOf(start) + start.length();
         text = text.substring(idx + 1);
         return text;
+    }
+
+    private static String fixLinks(String text) {
+        return text
+                .replaceAll("href=\"build.html\"", "href=\"#build_index\"")
+                .replaceAll("href=\"datatypes.html\"", "href=\"#datatypes_index\"")
+                .replaceAll("href=\"faq.html\"", "href=\"#faq_index\"")
+                .replaceAll("href=\"grammar.html\"", "href=\"#grammar_index\"")
+                .replaceAll("href=\"tutorial.html\"", "href=\"#tutorial_index\"");
     }
 
     private static String getContent(String fileName) throws Exception {


### PR DESCRIPTION
1. Font size in PDF is increased to 14 pt (common font size for A4 documents). Lines are still longer than lines in normal books, but it's better than it was before.

2. Table of contents embedded in PDF now contains proper hierarchy of headers. Many headers were misplaced before or not listed at all. Some code duplication in page generators are introduced because H2 processes JSP EL by itself and some functionality for more advanced loops is not implemented.

3. Many (but not all) relative links are fixed to point to anchors in PDF itself or to correct pages on H2 website.

4. Some links are changed from Sun website to Oracle website.