### PR TITLE
Use >> syntax in median.sql and move out more tests from testScript.sql

### DIFF
--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/median.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/median.sql
@@ -14,30 +14,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -53,30 +45,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -92,30 +76,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -131,30 +107,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -170,30 +138,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -209,30 +169,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -244,30 +196,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -279,30 +223,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -314,30 +250,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -349,30 +277,22 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15
+>> 15
 
 insert into test values (10);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 drop table test;
 > ok
@@ -384,30 +304,22 @@ insert into test values (2), (2), (1);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 2.0
+>> 2.0
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 2.0
+>> 2.0
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 1.5
+>> 1.5
 
 insert into test values (1);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 1.5
+>> 1.5
 
 drop table test;
 > ok
@@ -419,30 +331,22 @@ insert into test values (2), (2), (1);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 2.0
+>> 2.0
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 2.0
+>> 2.0
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 1.5
+>> 1.5
 
 insert into test values (1);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 1.5
+>> 1.5
 
 drop table test;
 > ok
@@ -454,30 +358,22 @@ insert into test values (2), (2), (1);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 2
+>> 2
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 2
+>> 2
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 1.5
+>> 1.5
 
 insert into test values (1);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 1.5
+>> 1.5
 
 drop table test;
 > ok
@@ -489,30 +385,22 @@ insert into test values ('20:00:00'), ('20:00:00'), ('10:00:00');
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20:00:00
+>> 20:00:00
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20:00:00
+>> 20:00:00
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 15:00:00
+>> 15:00:00
 
 insert into test values ('10:00:00');
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15:00:00
+>> 15:00:00
 
 drop table test;
 > ok
@@ -524,30 +412,22 @@ insert into test values ('2000-01-20'), ('2000-01-20'), ('2000-01-10');
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ----------
-> 2000-01-20
+>> 2000-01-20
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ----------
-> 2000-01-20
+>> 2000-01-20
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ------------------
-> 2000-01-15
+>> 2000-01-15
 
 insert into test values ('2000-01-10');
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ----------
-> 2000-01-15
+>> 2000-01-15
 
 drop table test;
 > ok
@@ -559,30 +439,22 @@ insert into test values ('2000-01-20 20:00:00'), ('2000-01-20 20:00:00'), ('2000
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> -------------------
-> 2000-01-20 20:00:00
+>> 2000-01-20 20:00:00
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> -------------------
-> 2000-01-20 20:00:00
+>> 2000-01-20 20:00:00
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> -------------------
-> 2000-01-15 15:00:00
+>> 2000-01-15 15:00:00
 
 insert into test values ('2000-01-10 10:00:00');
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> -------------------
-> 2000-01-15 15:00:00
+>> 2000-01-15 15:00:00
 
 delete from test;
 > update count: 5
@@ -591,9 +463,7 @@ insert into test values ('2000-01-20 20:00:00'), ('2000-01-21 20:00:00');
 > update count: 2
 
 select median(v) from test;
-> MEDIAN(V)
-> -------------------
-> 2000-01-21 08:00:00
+>> 2000-01-21 08:00:00
 
 drop table test;
 > ok
@@ -605,30 +475,22 @@ insert into test values ('2000-01-20 20:00:00+04'), ('2000-01-20 20:00:00+04'), 
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ----------------------
-> 2000-01-20 20:00:00+04
+>> 2000-01-20 20:00:00+04
 
 insert into test values (null);
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ----------------------
-> 2000-01-20 20:00:00+04
+>> 2000-01-20 20:00:00+04
 
 select median(distinct v) from test;
-> MEDIAN(DISTINCT V)
-> ----------------------
-> 2000-01-15 15:00:00+03
+>> 2000-01-15 15:00:00+03
 
 insert into test values ('2000-01-10 10:00:00+02');
 > update count: 1
 
 select median(v) from test;
-> MEDIAN(V)
-> ----------------------
-> 2000-01-15 15:00:00+03
+>> 2000-01-15 15:00:00+03
 
 delete from test;
 > update count: 5
@@ -637,9 +499,7 @@ insert into test values ('2000-01-20 20:00:00+10:15'), ('2000-01-21 20:00:00-09'
 > update count: 2
 
 select median(v) from test;
-> MEDIAN(V)
-> -------------------------
-> 2000-01-21 08:00:30+00:37
+>> 2000-01-21 08:00:30+00:37
 
 drop table test;
 > ok
@@ -671,17 +531,13 @@ insert into test values (20), (20), (10);
 > update count: 3
 
 select median(v) from test where v <> 20;
-> MEDIAN(V)
-> ---------
-> 10
+>> 10
 
 create index test_idx on test(v asc);
 > ok
 
 select median(v) from test where v <> 20;
-> MEDIAN(V)
-> ---------
-> 10
+>> 10
 
 drop table test;
 > ok
@@ -697,9 +553,7 @@ insert into test values (20, 1), (10, 2), (20, 3);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 drop table test;
 > ok
@@ -712,25 +566,19 @@ create index test_idx on test(v desc);
 > ok
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> null
+>> null
 
 insert into test values (10), (20);
 > update count: 2
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 15
+>> 15
 
 insert into test values (20), (10), (20);
 > update count: 3
 
 select median(v) from test;
-> MEDIAN(V)
-> ---------
-> 20
+>> 20
 
 drop table test;
 > ok

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/abs.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/abs.sql
@@ -24,3 +24,9 @@ select abs(null) vn, abs(-1) r1, abs(1) r2, abs(0) r3, abs(-0.1) r4, abs(0.1) r5
 > null 1  1  0  0.1 0.1
 > rows: 1
 
+select * from table(id int=(1, 2), name varchar=('Hello', 'World')) x order by id;
+> ID NAME
+> -- -----
+> 1  Hello
+> 2  World
+> rows (ordered): 2

--- a/h2/src/test/org/h2/test/scripts/functions/system/cast.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/cast.sql
@@ -87,3 +87,15 @@ select cast(cast(95605327.73 as float) as decimal);
 
 select cast(cast('01020304-0506-0708-090a-0b0c0d0e0f00' as uuid) as binary);
 >> 0102030405060708090a0b0c0d0e0f00
+
+call cast('null' as uuid);
+> exception
+
+select cast('12345678123456781234567812345678' as uuid);
+>> 12345678-1234-5678-1234-567812345678
+
+select cast('000102030405060708090a0b0c0d0e0f' as uuid);
+>> 00010203-0405-0607-0809-0a0b0c0d0e0f
+
+select -cast(0 as double);
+>> 0.0

--- a/h2/src/test/org/h2/test/scripts/functions/system/decode.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/decode.sql
@@ -26,3 +26,6 @@ select decode('3', 2.0, 2.0, 3, 3.0);
 
 select decode(4.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 9.0);
 >> 4.0
+
+select decode(1, 1, '1', 1, '11') from dual;
+>> 1

--- a/h2/src/test/org/h2/test/scripts/functions/system/table.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/table.sql
@@ -2,3 +2,44 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+select * from table(a int=(1)), table(b int=(2));
+> A B
+> - -
+> 1 2
+> rows: 1
+
+create table test as select * from table(id int=(1, 2, 3));
+> ok
+
+SELECT * FROM (SELECT * FROM TEST) ORDER BY id;
+> ID
+> --
+> 1
+> 2
+> 3
+> rows (ordered): 3
+
+SELECT * FROM (SELECT * FROM TEST) x ORDER BY id;
+> ID
+> --
+> 1
+> 2
+> 3
+> rows (ordered): 3
+
+drop table test;
+> ok
+
+explain select * from table(id int = (1, 2), name varchar=('Hello', 'World'));
+> PLAN
+> -----------------------------------------------------------------------------------------------------
+> SELECT TABLE.ID, TABLE.NAME FROM TABLE(ID INT=(1, 2), NAME VARCHAR=('Hello', 'World')) /* function */
+> rows: 1
+
+select * from table(id int=(1, 2), name varchar=('Hello', 'World')) x order by id;
+> ID NAME
+> -- -----
+> 1  Hello
+> 2  World
+> rows (ordered): 2

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -15,18 +15,6 @@ select * from test where id in (select id from test order by 'x');
 drop table test;
 > ok
 
-select abs(cast(0.0 as double)) x;
-> X
-> ---
-> 0.0
-> rows: 1
-
-select * from table(a int=(1)), table(b int=(2));
-> A B
-> - -
-> 1 2
-> rows: 1
-
 select x, x in(2, 3) i from system_range(1, 2) group by x;
 > X I
 > - -----
@@ -144,12 +132,6 @@ select case seq.nextval when 2 then 'two' when 3 then 'three' when 1 then 'one' 
 drop sequence seq;
 > ok
 
-select decode(1, 1, '1', 1, '11') r from dual;
-> R
-> -
-> 1
-> rows: 1
-
 create table test(x int);
 > ok
 
@@ -235,9 +217,6 @@ update test set pid = 1 where id = 2;
 
 drop table test;
 > ok
-
-call cast('null' as uuid);
-> exception
 
 create table test(name varchar(255));
 > ok
@@ -418,12 +397,6 @@ explain select -cast(0 as real), -cast(0 as double);
 > PLAN
 > ----------------------------------------------------------------
 > SELECT 0.0, 0.0 FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX */
-> rows: 1
-
-select -cast(0 as double) nz;
-> NZ
-> ---
-> 0.0
 > rows: 1
 
 select () empty;
@@ -1400,28 +1373,6 @@ DROP ROLE Y;
 DROP ROLE X;
 > ok
 
-create table test as select * from table(id int=(1, 2, 3));
-> ok
-
-SELECT * FROM (SELECT * FROM TEST) ORDER BY id;
-> ID
-> --
-> 1
-> 2
-> 3
-> rows (ordered): 3
-
-SELECT * FROM (SELECT * FROM TEST) x ORDER BY id;
-> ID
-> --
-> 1
-> 2
-> 3
-> rows (ordered): 3
-
-drop table test;
-> ok
-
 select top sum(1) 0 from dual;
 > exception
 
@@ -2064,12 +2015,6 @@ select * from V, C where V.V  = C.C;
 drop table A, B, C, V cascade;
 > ok
 
-explain select * from table(id int = (1, 2), name varchar=('Hello', 'World'));
-> PLAN
-> -----------------------------------------------------------------------------------------------------
-> SELECT TABLE.ID, TABLE.NAME FROM TABLE(ID INT=(1, 2), NAME VARCHAR=('Hello', 'World')) /* function */
-> rows: 1
-
 CREATE TABLE TEST(ID INT PRIMARY KEY, FLAG BOOLEAN, NAME VARCHAR);
 > ok
 
@@ -2274,13 +2219,6 @@ select (1, 2);
 > ------
 > (1, 2)
 > rows: 1
-
-select * from table(id int=(1, 2), name varchar=('Hello', 'World')) x order by id;
-> ID NAME
-> -- -----
-> 1  Hello
-> 2  World
-> rows (ordered): 2
 
 create table array_test(x array);
 > ok
@@ -2789,18 +2727,6 @@ drop view address_view;
 
 drop table address;
 > ok
-
-select cast('12345678123456781234567812345678' as uuid);
-> '12345678-1234-5678-1234-567812345678'
-> --------------------------------------
-> 12345678-1234-5678-1234-567812345678
-> rows: 1
-
-select cast('000102030405060708090a0b0c0d0e0f' as uuid);
-> '00010203-0405-0607-0809-0a0b0c0d0e0f'
-> --------------------------------------
-> 00010203-0405-0607-0809-0a0b0c0d0e0f
-> rows: 1
 
 CREATE ALIAS PARSE_INT2 FOR "java.lang.Integer.parseInt(java.lang.String, int)";
 > ok


### PR DESCRIPTION
1. I forgot to check unit tests fro aggregates, `>>` syntax is useful in `median.sql`.

2. Some more tests are moved  from `testScript.sql` into separate scripts.