### PR TITLE
Assorted changes in documentation

### DIFF
--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -529,7 +529,7 @@ H2 internally uses Unicode, and supports all character encoding systems and char
 <p>
 Using a native wrapper / adapter, Java applications can be run as a Windows Service.
 There are various tools available to do that. The Java Service Wrapper from
-<a href="http://wrapper.tanukisoftware.org">Tanuki Software, Inc.</a>
+<a href="https://wrapper.tanukisoftware.org">Tanuki Software, Inc.</a>
 is included in the installation. Batch files are provided to install, start, stop and uninstall the
 H2 Database Engine Service. This service contains the TCP Server and the H2 Console web application.
 The batch files are located in the directory <code>h2/service</code>.
@@ -538,7 +538,7 @@ The batch files are located in the directory <code>h2/service</code>.
 The service wrapper bundled with H2 is a 32-bit version.
 To use a 64-bit version of Windows (x64), you need to use a 64-bit version of the wrapper,
 for example the one from
-<a href="http://www.krenger.ch/blog/java-service-wrapper-3-5-14-for-windows-x64/">
+<a href="https://www.krenger.ch/blog/java-service-wrapper-3-5-14-for-windows-x64/">
 Simon Krenger</a>.
 </p>
 <p>
@@ -604,7 +604,7 @@ To use the PostgreSQL ODBC driver on 64 bit versions of Windows,
 first run <code>c:/windows/syswow64/odbcad32.exe</code>.
 At this point you set up your DSN just like you would on any other system.
 See also:
-<a href="http://archives.postgresql.org/pgsql-odbc/2005-09/msg00125.php">Re: ODBC Driver on Windows 64 bit</a>
+<a href="https://www.postgresql.org/message-id/dg76q0$khn$1@sea.gmane.org">Re: ODBC Driver on Windows 64 bit</a>
 </p>
 
 <h3>ODBC Installation</h3>
@@ -612,7 +612,7 @@ See also:
 First, the ODBC driver must be installed.
 Any recent PostgreSQL ODBC driver should work, however version 8.2 (<code>psqlodbc-08_02*</code>) or newer is recommended.
 The Windows version of the PostgreSQL ODBC driver is available at
-<a href="http://www.postgresql.org/ftp/odbc/versions/msi">http://www.postgresql.org/ftp/odbc/versions/msi</a>.
+<a href="https://www.postgresql.org/ftp/odbc/versions/msi/">https://www.postgresql.org/ftp/odbc/versions/msi/</a>.
 </p>
 
 <h3>Starting the Server</h3>
@@ -727,11 +727,11 @@ You can access a H2 database on .NET using the JDBC API, or using the ADO.NET in
 <h3>Using the ADO.NET API on .NET</h3>
 <p>
 An implementation of the ADO.NET interface is available in the open source project
-<a href="http://code.google.com/p/h2sharp">H2Sharp</a>.
+<a href="https://code.google.com/archive/p/h2sharp/">H2Sharp</a>.
 </p>
 
 <h3>Using the JDBC API on .NET</h3>
-<ul><li>Install the .NET Framework from <a href="http://www.microsoft.com">Microsoft</a>.
+<ul><li>Install the .NET Framework from <a href="https://www.microsoft.com">Microsoft</a>.
     Mono has not yet been tested.
 </li><li>Install <a href="http://www.ikvm.net">IKVM.NET</a>.
 </li><li>Copy the <code>h2*.jar</code> file to <code>ikvm/bin</code>
@@ -855,9 +855,9 @@ Unfortunately, even when calling <code>FileDescriptor.sync()</code> or
 <code>FileChannel.force()</code>,
 data is not always persisted to the hard drive, because most hard drives do not obey
 <code>fsync()</code>: see
-<a href="http://hardware.slashdot.org/article.pl?sid=05/05/13/0529252">Your Hard Drive Lies to You</a>.
+<a href="https://hardware.slashdot.org/story/05/05/13/0529252/your-hard-drive-lies-to-you">Your Hard Drive Lies to You</a>.
 In Mac OS X, <code>fsync</code> does not flush hard drive buffers. See
-<a href="http://lists.apple.com/archives/darwin-dev/2005/Feb/msg00072.html">Bad fsync?</a>.
+<a href="https://lists.apple.com/archives/darwin-dev/2005/Feb/msg00072.html">Bad fsync?</a>.
 So the situation is confusing, and tests prove there is a problem.
 </p>
 <p>
@@ -1764,53 +1764,53 @@ OR X = 2 OR X = 2 OR X = 2 OR X = 2 OR X = 2
     <tr>
         <td>AES-128</td>
         <td>A block encryption algorithm. See also: <a
-            href="http://en.wikipedia.org/wiki/Advanced_Encryption_Standard">Wikipedia:
-        AES</a></td>
+            href="https://en.wikipedia.org/wiki/Advanced_Encryption_Standard">Wikipedia:
+        Advanced Encryption Standard</a></td>
     </tr>
     <tr>
         <td>Birthday Paradox</td>
         <td>Describes the higher than expected probability that two
         persons in a room have the same birthday. Also valid for randomly
         generated UUIDs. See also: <a
-            href="http://en.wikipedia.org/wiki/Birthday_paradox">Wikipedia:
-        Birthday Paradox</a></td>
+            href="https://en.wikipedia.org/wiki/Birthday_problem">Wikipedia:
+        Birthday problem</a></td>
     </tr>
     <tr>
         <td>Digest</td>
         <td>Protocol to protect a password (but not to protect data).
-        See also: <a href="http://www.faqs.org/rfcs/rfc2617.html">RFC
+        See also: <a href="https://www.ietf.org/rfc/rfc2617.txt">RFC
         2617: HTTP Digest Access Authentication</a></td>
     </tr>
     <tr>
         <td>HTTPS</td>
         <td>A protocol to provide security to HTTP connections. See
-        also: <a href="http://www.ietf.org/rfc/rfc2818.txt">RFC 2818:
+        also: <a href="https://www.ietf.org/rfc/rfc2818.txt">RFC 2818:
         HTTP Over TLS</a></td>
     </tr>
     <tr>
         <td>Modes of Operation</td>
         <td><a
-            href="http://en.wikipedia.org/wiki/Block_cipher_modes_of_operation">Wikipedia:
-        Block cipher modes of operation</a></td>
+            href="https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation">Wikipedia:
+        Block cipher mode of operation</a></td>
     </tr>
     <tr>
         <td>Salt</td>
         <td>Random number to increase the security of passwords. See
-        also: <a href="http://en.wikipedia.org/wiki/Key_derivation_function">Wikipedia:
+        also: <a href="https://en.wikipedia.org/wiki/Key_derivation_function">Wikipedia:
         Key derivation function</a></td>
     </tr>
     <tr>
         <td>SHA-256</td>
         <td>A cryptographic one-way hash function. See also: <a
-            href="http://en.wikipedia.org/wiki/SHA_family">Wikipedia: SHA
-        hash functions</a></td>
+            href="https://en.wikipedia.org/wiki/Secure_Hash_Algorithms">Wikipedia:
+            Secure Hash Algorithms</a></td>
     </tr>
     <tr>
         <td>SQL Injection</td>
         <td>A security vulnerability where an application embeds SQL
         statements or expressions in user input. See also: <a
-            href="http://en.wikipedia.org/wiki/SQL_injection">Wikipedia:
-        SQL Injection</a></td>
+            href="https://en.wikipedia.org/wiki/SQL_injection">Wikipedia:
+        SQL injection</a></td>
     </tr>
     <tr>
         <td>Watermark Attack</td>

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -1563,7 +1563,7 @@ The current value of the settings can be read in the table
 </p>
 <p>
 For a complete list of settings, see
-<a href="../javadoc/org/h2/engine/SysProperties.html">SysProperties</a>.
+<a href="http://www.h2database.com/javadoc/org/h2/engine/SysProperties.html">SysProperties</a>.
 </p>
 
 <h2 id="server_bind_address">Setting the Server Bind Address</h2>
@@ -1675,7 +1675,8 @@ Java objects serialization is enabled by default for columns of type <code>OTHER
 To disable this feature set the system property <code>h2.serializeJavaObject=false</code> (default: true).
 </p>
 <p>
-Serialization and deserialization of java objects is customizable both at system level and at database level providing a <a href="../javadoc/org/h2/api/JavaObjectSerializer.html">JavaObjectSerializer</a> implementation:
+Serialization and deserialization of java objects is customizable both at system level and at database level providing a
+<a href="http://www.h2database.com/javadoc/org/h2/api/JavaObjectSerializer.html">JavaObjectSerializer</a> implementation:
 <ul>
 <li>
 At system level set the system property <code>h2.javaObjectSerializer</code> with the
@@ -1699,7 +1700,8 @@ It is possible to extend the type system of the database by providing your own i
 of minimal required API basically consisting of type identification and conversion routines.
 </p>
 <p>
-In order to enable this feature, set the system property <code>h2.customDataTypesHandler</code> (default: null) to the fully qualified name of the class providing <a href="../javadoc/org/h2/api/CustomDataTypesHandler.html">CustomDataTypesHandler</a> interface implementation. <br />
+In order to enable this feature, set the system property <code>h2.customDataTypesHandler</code> (default: null) to the fully qualified name of the class providing
+<a href="http://www.h2database.com/javadoc/org/h2/api/CustomDataTypesHandler.html">CustomDataTypesHandler</a> interface implementation. <br />
 The instance of that class will be created by H2 and used to:
 <ul>
 <li>resolve the names and identifiers of extrinsic data types.

--- a/h2/src/docsrc/html/architecture.html
+++ b/h2/src/docsrc/html/architecture.html
@@ -86,7 +86,7 @@ The primary classes of interest are:
 The parser lives in <code>org.h2.command.Parser</code>. It uses a straightforward recursive-descent design.
 </p>
 <p>
-See Wikipedia <a href="http://en.wikipedia.org/wiki/Recursive_descent_parser">Recursive-descent parser</a> page.
+See Wikipedia <a href="https://en.wikipedia.org/wiki/Recursive_descent_parser">Recursive descent parser</a> page.
 </p>
 
 
@@ -120,8 +120,8 @@ The primary packages of interest are:
 <h2 id="transaction">Undo log, redo log, and transactions layer</h2>
 <p>
 We have a transaction log, which is shared among all sessions. See also
-http://en.wikipedia.org/wiki/Transaction_log
-http://h2database.com/html/grammar.html#set_log
+<a href="https://en.wikipedia.org/wiki/Transaction_log">https://en.wikipedia.org/wiki/Transaction_log</a>
+<a href="http://h2database.com/html/grammar.html#set_log">http://h2database.com/html/grammar.html#set_log</a>
 </p>
 <p>
 We also have an undo log, which is per session, to undo an operation (an update that fails for example)

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -88,8 +88,11 @@ You will get a list of targets. If you want to build the <code>jar</code> file, 
 build jar
 </pre>
 <p>
-To run the build tool in shell mode, use the command line option <code>-</code> as in <code>./build.sh -</code>.
+To run the build tool in shell mode, use the command line option <code>-</code>:
 </p>
+<pre>
+./build.sh -
+</pre>
 
 <h3>Switching the Source Code</h3>
 <p>

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -272,8 +272,7 @@ or if  you have a feature request:
     please report the problem, including the complete error message and stack trace,
     and the root cause stack trace(s).
 </li><li>When sending source code, please use a public web clipboard such as
-    <a href="http://pastebin.com">Pastebin</a>,
-    <a href="http://cl1p.net">Cl1p</a>, or
+    <a href="http://pastebin.com/">Pastebin</a> or
     <a href="http://www.mysticpaste.com/new">Mystic Paste</a>
     to avoid formatting problems.
     Please keep test cases as simple and short as possible,

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -60,9 +60,9 @@ To use this database, it is not required to install this software however.
 </li><li><a href="http://www.eclipse.org">Eclipse</a>
 </li><li>Eclipse Plugins:
     <a href="http://subclipse.tigris.org">Subclipse</a>,
-    <a href="http://eclipse-cs.sourceforge.net">Eclipse Checkstyle Plug-in</a>,
+    <a href="https://checkstyle.github.io/eclipse-cs/">Eclipse Checkstyle Plug-in</a>,
     <a href="http://www.eclemma.org">EclEmma Java Code Coverage</a>
-</li><li><a href="http://www.mozilla.com/firefox">Mozilla Firefox</a>
+</li><li><a href="https://www.mozilla.com/firefox">Mozilla Firefox</a>
 </li><li><a href="http://www.openoffice.org">OpenOffice</a>
 </li><li><a href="http://nsis.sourceforge.net">NSIS</a> (Nullsoft Scriptable Install System)
 </li><li><a href="http://maven.apache.org">Maven</a>
@@ -148,7 +148,7 @@ however after a new release it may take a few hours before they are available th
 <h3>Maven Plugin to Start and Stop the TCP Server</h3>
 <p>
 A Maven plugin to start and stop the H2 TCP server is available from
-<a href="http://github.com/ljnelson/h2-maven-plugin">Laird Nelson at GitHub</a>.
+<a href="https://github.com/ljnelson/h2-maven-plugin">Laird Nelson at GitHub</a>.
 To start the H2 server, use:
 </p>
 <pre>
@@ -246,7 +246,7 @@ If you'd like to contribute bug fixes or new features, please consider the follo
 <p>
 For legal reasons, patches need to be public in the form of an
     <a href="https://github.com/h2database/h2database/issues">issue report or attachment</a> or in the form of an email
-    to the <a href="http://groups.google.com/group/h2-database">group</a>.
+    to the <a href="https://groups.google.com/group/h2-database">group</a>.
 Significant contributions need to include the following statement:
 </p>
 <p>
@@ -272,7 +272,7 @@ or if  you have a feature request:
     please report the problem, including the complete error message and stack trace,
     and the root cause stack trace(s).
 </li><li>When sending source code, please use a public web clipboard such as
-    <a href="http://pastebin.com/">Pastebin</a> or
+    <a href="https://pastebin.com/">Pastebin</a> or
     <a href="http://www.mysticpaste.com/new">Mystic Paste</a>
     to avoid formatting problems.
     Please keep test cases as simple and short as possible,

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -284,8 +284,8 @@ or if  you have a feature request:
     Please use the JDBC API and no external tools or libraries.
     The test should include all required initialization code, and
     should be started with the main method.
-</li><li>For large attachments, use a public temporary storage such as
-    <a href="http://rapidshare.com">Rapidshare</a>.
+</li><li>For large attachments, use a public storage such as
+    <a href="https://www.google.com/drive/">Google Drive</a>.
 </li><li>Google Group versus issue tracking:
     Use the
     <a href="http://groups.google.com/group/h2-database">Google Group</a>

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -69,7 +69,7 @@ Here is the list of known and confirmed issues:
     database to a SQL script using the old timezone, and create a new database in the new
     timezone.
 </li><li>Apache Harmony: there seems to be a bug in Harmony that affects H2.
-    See <a href="http://issues.apache.org/jira/browse/HARMONY-6505">HARMONY-6505</a>.
+    See <a href="https://issues.apache.org/jira/browse/HARMONY-6505">HARMONY-6505</a>.
 </li><li>Tomcat and Glassfish 3 set most static fields (final or non-final) to <code>null</code> when
     unloading a web application. This can cause a <code>NullPointerException</code> in H2 versions
     1.1.107 and older, and may still not work in newer versions. Please report it if you

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -172,7 +172,7 @@ When using one of the following features for production, please ensure your use 
 is well tested (if possible with automated test cases). The areas that are not well tested are:
 </p>
 <ul>
-<li>Platforms other than Windows, Linux, Mac OS X, or JVMs other than Oracle 1.6, 1.7, 1.8.
+<li>Platforms other than Windows, Linux, Mac OS X, or runtime environments other than Oracle / OpenJDK 7, 8, 9.
 </li><li>The features <code>AUTO_SERVER</code> and <code>AUTO_RECONNECT</code>.
 </li><li>Cluster mode, 2-phase commit, savepoints.
 </li><li>Fulltext search.

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -163,8 +163,8 @@ This comparison is based on
 H2 1.3,
 <a href="http://db.apache.org/derby">Apache Derby version 10.8</a>,
 <a href="http://hsqldb.org">HSQLDB 2.2</a>,
-<a href="http://mysql.com">MySQL 5.5</a>,
-<a href="http://www.postgresql.org">PostgreSQL 9.0</a>.
+<a href="https://www.mysql.com/">MySQL 5.5</a>,
+<a href="https://www.postgresql.org/">PostgreSQL 9.0</a>.
 </p>
 <table class="main">
 <tr>
@@ -370,7 +370,7 @@ H2 1.3,
 *8 Derby doesn't support standard compliant information schema tables.<br />
 *9 When using MVCC (multi version concurrency).<br />
 *10 Derby and HSQLDB
-    <a href="http://en.wikipedia.org/wiki/Block_cipher_modes_of_operation#Electronic_codebook_.28ECB.29">don't hide data patterns well</a>.<br />
+    <a href="https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Electronic_Codebook_(ECB)">don't hide data patterns well</a>.<br />
 *11 The MULTI_THREADED option is not enabled by default, and with version 1.3.x not supported when using MVCC.<br />
 *12 Derby doesn't support the <code>EXPLAIN</code> statement, but it supports runtime statistics and retrieving statement execution plans.<br />
 *13 Derby doesn't support the syntax <code>LIMIT .. [OFFSET ..]</code>, however it supports <code>FETCH FIRST .. ROW[S] ONLY</code>.<br />
@@ -1316,7 +1316,7 @@ In most cases, this is sufficient, however sometimes it is better to use the sam
 facility as the application, for example Log4j. To do that, this database support SLF4J.
 </p>
 <p>
-<a href="http://www.slf4j.org">SLF4J</a> is a simple facade for various logging APIs
+<a href="https://www.slf4j.org/">SLF4J</a> is a simple facade for various logging APIs
 and allows to plug in the desired implementation at deployment time.
 SLF4J supports implementations such as Logback, Log4j, Jakarta Commons Logging (JCL),
 Java logging, x4juli, and Simple Log.

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -809,7 +809,7 @@ other database settings can be passed in the database URL.
 Adding <code>;setting=value</code> at the end of a database URL is the
 same as executing the statement <code>SET setting value</code> just after
 connecting. For a list of supported settings, see <a href="grammar.html">SQL Grammar</a>
-or the <a href="../javadoc/org/h2/engine/DbSettings.html">DbSettings</a> javadoc.
+or the <a href="http://www.h2database.com/javadoc/org/h2/engine/DbSettings.html">DbSettings</a> javadoc.
 </p>
 
 <h2 id="custom_access_mode">Custom File Access Mode</h2>

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -378,16 +378,6 @@ H2 1.3,
 *15 Derby and H2 support <code>ROW_NUMBER() OVER()</code>.
 </p>
 
-<h3>DaffodilDb and One$Db</h3>
-<p>
-It looks like the development of this database has stopped. The last release was February 2006.
-</p>
-
-<h3>McKoi</h3>
-<p>
-It looks like the development of this database has stopped. The last release was August 2004.
-</p>
-
 <h2 id="products_work_with">H2 in Use</h2>
 <p>
 For a list of applications that work with or use H2, see:

--- a/h2/src/docsrc/html/fragments.html
+++ b/h2/src/docsrc/html/fragments.html
@@ -85,9 +85,9 @@ translate -->
 <b>Support</b><br />
 <a href="faq.html">FAQ</a><br />
 <a href="sourceError.html">Error Analyzer</a><br />
-<a href="http://groups.google.com/group/h2-database">Google Group (English)</a><br />
-<a href="http://groups.google.co.jp/group/h2-database-jp">Google Group (Japanese)</a><br />
-<a href="http://groups.google.com/group/h2-cn">Google Group (Chinese)</a><br />
+<a href="https://groups.google.com/group/h2-database">Google Group (English)</a><br />
+<a href="https://groups.google.co.jp/group/h2-database-jp">Google Group (Japanese)</a><br />
+<a href="https://groups.google.com/group/h2-cn">Google Group (Chinese)</a><br />
 <br />
 <b>Appendix</b><br />
 <a href="history.html">History &amp; Roadmap</a><br />

--- a/h2/src/docsrc/html/mainWeb.html
+++ b/h2/src/docsrc/html/mainWeb.html
@@ -154,7 +154,7 @@ Welcome to H2, the Java SQL database. The main features of H2 are:
             or <a href="http://www.h2database.com/html/newsfeed-rss.xml">Header only (RSS)</a>.
             </p><p>
                 <b>Email Newsletter:</b> Subscribe to
-                <a href="http://groups.google.com/group/h2database-news/subscribe">
+                <a href="https://groups.google.com/group/h2database-news/subscribe">
                 H2 Database News (Google account required)</a>
                 to get informed about new releases.
                 Your email address is only used in this context.

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -1387,46 +1387,6 @@ Use the following configuration to start and stop the H2 TCP server using the Sp
 The <code>destroy-method</code> will help prevent exceptions on hot-redeployment or when restarting the server.
 </p>
 
-<h3>Error Code Incompatibility</h3>
-<p>
-There is an incompatibility with the Spring JdbcTemplate and H2 version 1.3.154 and newer,
-because of a change in the error code. This will cause the JdbcTemplate to not detect
-a duplicate key condition, and so a <code>DataIntegrityViolationException</code> is thrown instead of
-<code>DuplicateKeyException</code>.
-See also <a href="http://jira.spring.io/browse/SPR-8235">the issue SPR-8235</a>.
-The workaround is to add the following XML file to the root of the classpath:
-</p>
-<pre>
-&lt;beans
-    xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation=
-        "http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd"
-    &gt;
-    &lt;import resource="classpath:org/springframework/jdbc/support/sql-error-codes.xml"/&gt;
-    &lt;bean id = "H2" class="org.springframework.jdbc.support.SQLErrorCodes"&gt;
-        &lt;property name="badSqlGrammarCodes"&gt;
-            &lt;value&gt;
-                42000,42001,42101,42102,42111,42112,42121,42122,42132
-            &lt;/value&gt;
-        &lt;/property&gt;
-        &lt;property name="duplicateKeyCodes"&gt;
-            &lt;value&gt;23001,23505&lt;/value&gt;
-        &lt;/property&gt;
-        &lt;property name="dataIntegrityViolationCodes"&gt;
-            &lt;value&gt;22003,22012,22025,23000&lt;/value&gt;
-        &lt;/property&gt;
-        &lt;property name="dataAccessResourceFailureCodes"&gt;
-            &lt;value&gt;90046,90100,90117,90121,90126&lt;/value&gt;
-        &lt;/property&gt;
-        &lt;property name="cannotAcquireLockCodes"&gt;
-            &lt;value&gt;50200&lt;/value&gt;
-        &lt;/property&gt;
-    &lt;/bean&gt;
-&lt;/beans&gt;
-</pre>
-
 <h2 id="osgi">OSGi</h2>
 <p>
 The standard H2 jar can be dropped in as a bundle in an OSGi container.

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -1146,9 +1146,9 @@ Example permission tags:
 For H2, opening a connection is fast if the database is already open.
 Still, using a connection pool improves performance if you open and close connections a lot.
 A simple connection pool is included in H2. It is based on the
-<a href="http://www.source-code.biz/snippets/java/8.htm">Mini Connection Pool Manager</a>
+<a href="http://www.source-code.biz/miniconnectionpoolmanager/">Mini Connection Pool Manager</a>
 from Christian d'Heureuse. There are other, more complex, open source connection pools available,
-for example the <a href="http://jakarta.apache.org/commons/dbcp/">Apache Commons DBCP</a>.
+for example the <a href="http://commons.apache.org/proper/commons-dbcp/">Apache Commons DBCP</a>.
 For H2, it is about twice as faster to get a connection from the built-in connection pool than to get
 one using <code>DriverManager.getConnection()</code>.The build-in connection pool is used as follows:
 </p>

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -564,11 +564,7 @@ Shutting down a TCP server can be protected using the option <code>-tcpPassword<
 <h2 id="using_hibernate">Using Hibernate</h2>
 <p>
 This database supports Hibernate version 3.1 and newer. You can use the HSQLDB Dialect,
-or the native H2 Dialect. Unfortunately the H2 Dialect included in some old versions of Hibernate was buggy.
-A <a href="http://opensource.atlassian.com/projects/hibernate/browse/HHH-3401">patch
-for Hibernate</a> has been submitted and is now applied.
-You can rename it to <code>H2Dialect.java</code> and include this as a patch in your application,
-or upgrade to a version of Hibernate where this is fixed.
+or the native H2 Dialect.
 </p>
 <p>
 When using Hibernate, try to use the <code>H2Dialect</code> if possible.

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -626,10 +626,6 @@ Another (more dangerous) solution is to set <code>useDatabaseLock</code> to fals
 
 <h2 id="using_netbeans">Using H2 within NetBeans</h2>
 <p>
-The project <a href="http://kenai.com/projects/nbh2">H2 Database Engine Support For NetBeans</a>
-allows you to start and stop the H2 server from within the IDE.
-</p>
-<p>
 There is a known issue when using the Netbeans SQL Execution Window:
 before executing a query, another query in the form <code>SELECT COUNT(*) FROM &lt;query&gt;</code> is run.
 This is a problem for queries that modify state, such as <code>SELECT SEQ.NEXTVAL</code>.

--- a/h2/src/test/org/h2/test/scripts/functions/timeanddate/current-time.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/timeanddate/current-time.sql
@@ -16,7 +16,7 @@ select length(curtime())>=8 c1, length(current_time())>=8 c2, substring(curtime(
 > rows: 1
 
 
-select length(now())>20 c1, length(current_timestamp())>18 c2, length(now(0))>18 c3, length(now(2))>18 c4 from test;
+select length(now())>18 c1, length(current_timestamp())>18 c2, length(now(0))>18 c3, length(now(2))>18 c4 from test;
 > C1   C2   C3   C4
 > ---- ---- ---- ----
 > TRUE TRUE TRUE TRUE

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -766,4 +766,4 @@ interpolated thead
 
 die weekdiff osx subprocess dow proleptic microsecond microseconds divisible cmp denormalized suppressed saturated mcs
 london dfs weekdays intermittent looked msec tstz africa monrovia asia tokyo weekday joi callers multipliers ucn
-openoffice organize libre systemtables
+openoffice organize libre systemtables gmane sea


### PR DESCRIPTION
1. Java 1.6 is not tested, information about it is removed.

2. There are two mentions of some unknown databases. They have more recent releases, but otherwise it seems like their development is not active. There is no reason to mention them at all.

3. Reference to one-time web clipboard service is removed. It allows to read pasted text only once.

4. Looks like mentioned web storage for larger data does not work any more, so mention Google Drive instead.

5. Some external links are updated to current locations or alternative sources when old sites are not available.