### PR TITLE
Fix building of documentation and use modern names of Java versions

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3260,7 +3260,7 @@ LOG(A)
 "Functions (Numeric)","LOG10","
 LOG10(numeric)
 ","
-See also Java ""Math.log10"" (in Java 5).
+See also Java ""Math.log10"".
 This method returns a double.
 ","
 LOG10(A)

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -49,14 +49,15 @@ This database is written in Java and therefore works on many platforms.
 
 <h2 id="environment">Environment</h2>
 <p>
-To run this database, a Java Runtime Environment (JRE) version 1.7 or higher is required.
+To run this database, a Java Runtime Environment (JRE) version 7 or higher is required.
 </p>
 <p>
 To create the database executables, the following software stack was used.
 To use this database, it is not required to install this software however.
 </p>
 <ul><li>Mac OS X and Windows
-</li><li><a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">Oracle JDK Version 1.7</a>
+</li><li><a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">Oracle JDK Version 7</a>
+(version 7 is not available for free download any more)
 </li><li><a href="http://www.eclipse.org">Eclipse</a>
 </li><li>Eclipse Plugins:
     <a href="http://subclipse.tigris.org">Subclipse</a>,
@@ -70,7 +71,7 @@ To use this database, it is not required to install this software however.
 
 <h2 id="building">Building the Software</h2>
 <p>
-You need to install a JDK, for example the Oracle JDK version 1.7 or 1.8.
+You need to install a JDK, for example the Oracle JDK version 7 or 8.
 Ensure that Java binary directory is included in the <code>PATH</code> environment variable, and that
 the environment variable <code>JAVA_HOME</code> points to your Java installation.
 On the command line, go to the directory <code>h2</code> and execute the following command:
@@ -96,7 +97,7 @@ To run the build tool in shell mode, use the command line option <code>-</code>:
 
 <h3>Switching the Source Code</h3>
 <p>
-The source code uses Java 1.7 features.
+The source code uses Java 7 features.
 To switch the source code to the installed version of Java, run:
 </p>
 <pre>

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1626,8 +1626,8 @@ public class Parser {
             ifExists = readIfExists(ifExists);
             command.setIfExists(ifExists);
             //Support for MySQL: DROP INDEX index_name ON tbl_name
-            if(readIf("ON")) {
-               	readIdentifierWithSchema();
+            if (readIf("ON")) {
+                readIdentifierWithSchema();
             }
             return command;
         } else if (readIf("USER")) {


### PR DESCRIPTION
1. Bad indentation in fixed.

2. Reference to Java 5 is removed.

3. All recent versions of JDK are named without `1.` prefix on download pages, use the same naming.

4. Mention that Oracle JDK 7 is not available for free download any more just to avoid possible confusion why download link does not provide access to this version.