### PR TITLE
Fix table borders in PDF and other changes

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3895,7 +3895,7 @@ CURRENT_TIMESTAMP()
 "Functions (Time and Date)","DATEADD","
 { DATEADD| TIMESTAMPADD } (datetimeField, addIntLong, dateAndTime)
 ","
-Adds units to a date-time value. The string indicates the unit.
+Adds units to a date-time value. The datetimeField indicates the unit.
 Use negative values to subtract units.
 addIntLong may be a long value when manipulating milliseconds,
 microseconds, or nanoseconds otherwise its range is restricted to int.
@@ -3912,7 +3912,7 @@ DATEADD('MONTH', 1, DATE '2001-01-31')
 ","
 Returns the the number of crossed unit boundaries between two date/time values.
 This method returns a long.
-The string indicates the unit.
+The datetimeField indicates the unit.
 Only TIMEZONE_HOUR and TIMEZONE_MINUTE fields use the time zone offset component.
 With all other fields if date/time values have time zone offset component it is ignored.
 ","

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -79,11 +79,6 @@ Here is the list of known and confirmed issues:
 </li><li>Some problems have been found with right outer join. Internally, it is converted
     to left outer join, which does not always produce the same results as other databases
     when used in combination with other joins. This problem is fixed in H2 version 1.3.
-</li><li>When using Install4j before 4.1.4 on Linux and enabling <code>pack200</code>,
-    the <code>h2*.jar</code> becomes corrupted by the install process, causing application failure.
-    A workaround is to add an empty file <code>h2*.jar.nopack</code>
-    next to the <code>h2*.jar</code> file.
-    This problem is solved in Install4j 4.1.4.
 </li></ul>
 <p>
 For a complete list, see <a href="https://github.com/h2database/h2database/issues">Open Issues</a>.

--- a/h2/src/docsrc/html/faq.html
+++ b/h2/src/docsrc/html/faq.html
@@ -68,8 +68,6 @@ Here is the list of known and confirmed issues:
     USA, or within Europe), even if the timezone itself is different. As a workaround, export the
     database to a SQL script using the old timezone, and create a new database in the new
     timezone.
-</li><li>Apache Harmony: there seems to be a bug in Harmony that affects H2.
-    See <a href="https://issues.apache.org/jira/browse/HARMONY-6505">HARMONY-6505</a>.
 </li><li>Tomcat and Glassfish 3 set most static fields (final or non-final) to <code>null</code> when
     unloading a web application. This can cause a <code>NullPointerException</code> in H2 versions
     1.1.107 and older, and may still not work in newer versions. Please report it if you

--- a/h2/src/docsrc/html/stylesheetPdf.css
+++ b/h2/src/docsrc/html/stylesheetPdf.css
@@ -71,9 +71,8 @@ table {
 
 th {
     font-size: 14pt;
-    font-weight: normal;
+    font-weight: bold;
     text-align: left;
-    background-color: #ece9d8;
     border: 1px solid #aca899;
     padding: 2px;
 }

--- a/h2/src/tools/org/h2/build/doc/MergeDocs.java
+++ b/h2/src/tools/org/h2/build/doc/MergeDocs.java
@@ -43,6 +43,7 @@ public class MergeDocs {
             text = disableRailroads(text);
             text = removeHeaderFooter(fileName, text);
             text = fixLinks(text);
+            text = fixTableBorders(text);
             buff.append(text);
         }
         String finalText = buff.toString();
@@ -101,6 +102,12 @@ public class MergeDocs {
                 .replaceAll("href=\"faq.html\"", "href=\"#faq_index\"")
                 .replaceAll("href=\"grammar.html\"", "href=\"#grammar_index\"")
                 .replaceAll("href=\"tutorial.html\"", "href=\"#tutorial_index\"");
+    }
+
+    private static String fixTableBorders(String text) {
+        return text
+                .replaceAll("<table class=\"main\">",
+                        "<table class=\"main\" border=\"1\" cellpadding=\"5\" cellspacing=\"0\">");
     }
 
     private static String getContent(String fileName) throws Exception {

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -766,4 +766,4 @@ interpolated thead
 
 die weekdiff osx subprocess dow proleptic microsecond microseconds divisible cmp denormalized suppressed saturated mcs
 london dfs weekdays intermittent looked msec tstz africa monrovia asia tokyo weekday joi callers multipliers ucn
-openoffice organize libre systemtables gmane sea
+openoffice organize libre systemtables gmane sea borders


### PR DESCRIPTION
1. OpenOffice and LibreOffice can write CSS borders on export, but cannot read them on import. So write additional non-CSS borders to `onePage.html`. I also removed the background from table headers and add bold style instead for PDF only, because office suits do not fill the whole cell with this CSS background, there is a distance between table border and background that looks weird. Now tables are readable, there were some tables where it was not possible to see where one row is separated from another.

2. First argument of `DATEADD` and `DATEDIFF` now referenced by its name in description, it is not declared as string any more.

3. Apache Harmony cannot run current version of H2 and is not developed for a long time, no need to mention outdated issues with it at all.

4. I also removed information about a bug that was present in very old versions of Install4j, it was fixed a long time ago.