### PR TITLE
Optimize arguments for MVMap.init()

### DIFF
--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -125,8 +125,7 @@ public class CreateTable extends CommandWithColumns {
                 try {
                     session.setUndoLogEnabled(false);
                     session.startStatementWithinTransaction();
-                    Insert insert = null;
-                    insert = new Insert(session);
+                    Insert insert = new Insert(session);
                     insert.setSortedInsertMode(sortedInsertMode);
                     insert.setQuery(asQuery);
                     insert.setTable(table);

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -632,9 +632,7 @@ public final class DataUtils {
                     c = s.charAt(i++);
                     if (c == '\\') {
                         if (i == size) {
-                            throw DataUtils.newIllegalStateException(
-                                    DataUtils.ERROR_FILE_CORRUPT,
-                                    "Not a map: {0}", s);
+                            throw newIllegalStateException(ERROR_FILE_CORRUPT, "Not a map: {0}", s);
                         }
                         c = s.charAt(i++);
                     } else if (c == '\"') {
@@ -663,8 +661,7 @@ public final class DataUtils {
             int startKey = i;
             i = s.indexOf(':', i);
             if (i < 0) {
-                throw DataUtils.newIllegalStateException(
-                        DataUtils.ERROR_FILE_CORRUPT, "Not a map: {0}", s);
+                throw newIllegalStateException(ERROR_FILE_CORRUPT, "Not a map: {0}", s);
             }
             String key = s.substring(startKey, i++);
             i = parseMapValue(buff, s, i, size);
@@ -696,20 +693,19 @@ public final class DataUtils {
             int startKey = i;
             i = s.indexOf(':', i);
             if (i < 0) {
-                throw DataUtils.newIllegalStateException(
-                        DataUtils.ERROR_FILE_CORRUPT, "Not a map: {0}", s);
+                throw newIllegalStateException(ERROR_FILE_CORRUPT, "Not a map: {0}", s);
             }
             if (i - startKey == 8 && s.regionMatches(startKey, "fletcher", 0, 8)) {
-                DataUtils.parseMapValue(buff, s, i + 1, size);
+                parseMapValue(buff, s, i + 1, size);
                 int check = (int) Long.parseLong(buff.toString(), 16);
-                if (check == DataUtils.getFletcher32(bytes, start, startKey - 1)) {
+                if (check == getFletcher32(bytes, start, startKey - 1)) {
                     return map;
                 }
                 // Corrupted map
                 return null;
             }
             String key = s.substring(startKey, i++);
-            i = DataUtils.parseMapValue(buff, s, i, size);
+            i = parseMapValue(buff, s, i, size);
             map.put(key, buff.toString());
             buff.setLength(0);
         }
@@ -742,8 +738,7 @@ public final class DataUtils {
             int startKey = i;
             i = s.indexOf(':', i);
             if (i < 0) {
-                throw DataUtils.newIllegalStateException(
-                        DataUtils.ERROR_FILE_CORRUPT, "Not a map: {0}", s);
+                throw newIllegalStateException(ERROR_FILE_CORRUPT, "Not a map: {0}", s);
             }
             if (i++ - startKey == keyLength && s.regionMatches(startKey, key, 0, keyLength)) {
                 StringBuilder buff = new StringBuilder();
@@ -759,9 +754,7 @@ public final class DataUtils {
                             c = s.charAt(i++);
                             if (c == '\\') {
                                 if (i == size) {
-                                    throw DataUtils.newIllegalStateException(
-                                            DataUtils.ERROR_FILE_CORRUPT,
-                                            "Not a map: {0}", s);
+                                    throw newIllegalStateException(ERROR_FILE_CORRUPT, "Not a map: {0}", s);
                                 }
                                 c = s.charAt(i++);
                             } else if (c == '\"') {
@@ -1095,8 +1088,7 @@ public final class DataUtils {
 
         @Override
         public V setValue(V value) {
-            throw DataUtils.newUnsupportedOperationException(
-                    "Updating the value is not supported");
+            throw newUnsupportedOperationException("Updating the value is not supported");
         }
 
     }

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -747,7 +747,7 @@ public final class DataUtils {
             }
             if (i++ - startKey == keyLength && s.regionMatches(startKey, key, 0, keyLength)) {
                 StringBuilder buff = new StringBuilder();
-                i = parseMapValue(buff, s, i, size);
+                parseMapValue(buff, s, i, size);
                 return buff.toString();
             } else {
                 while (i < size) {

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -753,10 +753,9 @@ public final class DataUtils {
                         while (i < size) {
                             c = s.charAt(i++);
                             if (c == '\\') {
-                                if (i == size) {
+                                if (i++ == size) {
                                     throw newIllegalStateException(ERROR_FILE_CORRUPT, "Not a map: {0}", s);
                                 }
-                                c = s.charAt(i++);
                             } else if (c == '\"') {
                                 break;
                             }

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -725,6 +725,19 @@ public final class DataUtils {
      * @throws IllegalStateException if parsing failed
      */
     public static String getMapName(String s) {
+        return getFromMap(s, "name");
+    }
+
+    /**
+     * Parse a specified pair from key-value pair list.
+     *
+     * @param s the list
+     * @param key the name of the key
+     * @return value of the specified item, or {@code null}
+     * @throws IllegalStateException if parsing failed
+     */
+    public static String getFromMap(String s, String key) {
+        int keyLength = key.length();
         for (int i = 0, size = s.length(); i < size;) {
             int startKey = i;
             i = s.indexOf(':', i);
@@ -732,7 +745,7 @@ public final class DataUtils {
                 throw DataUtils.newIllegalStateException(
                         DataUtils.ERROR_FILE_CORRUPT, "Not a map: {0}", s);
             }
-            if (i++ - startKey == 4 && s.regionMatches(startKey, "name", 0, 4)) {
+            if (i++ - startKey == keyLength && s.regionMatches(startKey, key, 0, keyLength)) {
                 StringBuilder buff = new StringBuilder();
                 i = parseMapValue(buff, s, i, size);
                 return buff.toString();

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -8,7 +8,6 @@ package org.h2.mvstore;
 import java.util.AbstractList;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -96,12 +95,13 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * Open this map with the given store and configuration.
      *
      * @param store the store
-     * @param config the configuration
+     * @param id map id
+     * @param createVersion version in which this map was created
      */
-    protected void init(MVStore store, HashMap<String, Object> config) {
+    protected void init(MVStore store, int id, long createVersion) {
         this.store = store;
-        this.id = DataUtils.readHexInt(config, "id", 0);
-        this.createVersion = DataUtils.readHexLong(config, "createVersion", 0);
+        this.id = id;
+        this.createVersion = createVersion;
         this.writeVersion = store.getCurrentVersion();
         this.root = Page.createEmpty(this,  -1);
     }
@@ -1112,10 +1112,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
     MVMap<K, V> openReadOnly() {
         MVMap<K, V> m = new MVMap<>(keyType, valueType);
         m.readOnly = true;
-        HashMap<String, Object> config = new HashMap<>();
-        config.put("id", id);
-        config.put("createVersion", createVersion);
-        m.init(store, config);
+        m.init(store, id, createVersion);
         m.root = root;
         return m;
     }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -458,7 +458,8 @@ public final class MVStore {
             }
             map = builder.create();
             String config = meta.get(MVMap.getMapKey(id));
-            map.init(this, id, DataUtils.readHexLong(DataUtils.parseMap(config), "createVersion", 0));
+            String v = DataUtils.getFromMap(config, "createVersion");
+            map.init(this, id, v != null ? DataUtils.parseHexLong(v): 0);
             root = getRootPos(meta, id);
         } else {
             id = ++lastMapId;

--- a/h2/src/test/org/h2/test/store/SequenceMap.java
+++ b/h2/src/test/org/h2/test/store/SequenceMap.java
@@ -6,7 +6,6 @@
 package org.h2.test.store;
 
 import java.util.AbstractSet;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Set;
 import org.h2.mvstore.MVMap;
@@ -32,8 +31,8 @@ public class SequenceMap extends MVMap<Long, Long> {
     }
 
     @Override
-    public void init(MVStore store, HashMap<String, Object> config) {
-        super.init(store, config);
+    public void init(MVStore store, int id, long createVersion) {
+        super.init(store, id, createVersion);
     }
 
     @Override

--- a/h2/src/test/org/h2/test/store/SequenceMap.java
+++ b/h2/src/test/org/h2/test/store/SequenceMap.java
@@ -9,7 +9,6 @@ import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.Set;
 import org.h2.mvstore.MVMap;
-import org.h2.mvstore.MVStore;
 
 /**
  * A custom map returning the keys and values values 1 .. 10.
@@ -28,11 +27,6 @@ public class SequenceMap extends MVMap<Long, Long> {
 
     public SequenceMap() {
         super(null, null);
-    }
-
-    @Override
-    public void init(MVStore store, int id, long createVersion) {
-        super.init(store, id, createVersion);
     }
 
     @Override


### PR DESCRIPTION
1. This method got a `HashMap` with two mappings. The most callers created a new `HashMap` for invocation of this method. Now both values are passed directly for simplicity and to reduce amount of allocated garbage and improve speed.

2. `DataUtils.getFromMap()` is extracted from `DataUtils.getMapName()` and reused in the remaining place, because only one argument was parsed from map. This also reduces amount of garbage and works faster.