### PR TITLE
Fix incorrect reads from the undo log

### DIFF
--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -118,6 +118,7 @@ public class Merge extends Prepared {
             }
         } else {
             // process select data for list
+            query.setNeverLazy(true);
             ResultInterface rows = query.query(0);
             count = 0;
             targetTable.fire(session, Trigger.UPDATE | Trigger.INSERT, true);

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -1286,7 +1286,12 @@ public class TransactionStore {
                     // transaction (possibly one with the same id)
                     data = map.get(key);
                 } else {
-                    data = (VersionedValue) d[2];
+                    if (map.getId() == (int) d[0]) {
+                        data = (VersionedValue) d[2];
+                    } else {
+                        // this entry does not belong to this map, try again
+                        data = map.get(key);
+                    }
                 }
             }
         }

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -1282,12 +1282,7 @@ public class TransactionStore {
                     // transaction (possibly one with the same id)
                     data = map.get(key);
                 } else {
-                    if (map.getId() == (int) d[0] && map.getKeyType().compare(key, d[1]) == 0) {
-                        data = (VersionedValue) d[2];
-                    } else {
-                        // this entry does not belong to this map, try again
-                        data = map.get(key);
-                    }
+                    data = (VersionedValue) d[2];
                 }
             }
         }
@@ -1534,7 +1529,8 @@ public class TransactionStore {
                             if (to != null && map.getKeyType().compare(k, to) > 0) {
                                 break;
                             }
-                            VersionedValue data = cursor.getValue();
+                            // cursor.getValue() returns outdated value
+                            VersionedValue data = map.get(key);
                             data = getValue(key, readLogId, data);
                             if (data != null && data.value != null) {
                                 @SuppressWarnings("unchecked")

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -966,9 +966,10 @@ public class TransactionStore {
                     long size = 0;
                     Cursor<K, VersionedValue> cursor = map.cursor(null);
                     while (cursor.hasNext()) {
-                        VersionedValue data;
                         K key = cursor.next();
-                        data = getValue(key, readLogId, cursor.getValue());
+                        // cursor.getValue() returns outdated value
+                        VersionedValue data = map.get(key);
+                        data = getValue(key, readLogId, data);
                         if (data != null && data.value != null) {
                             size++;
                         }

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -344,7 +344,7 @@ public class TransactionStore {
         }
         // TODO could synchronize on blocks (100 at a time or so)
         rwLock.writeLock().lock();
-        int oldStatus = t.status;
+        int oldStatus = t.getStatus();
         try {
             t.setStatus(Transaction.STATUS_COMMITTING);
             for (long logId = 0; logId < maxLogId; logId++) {

--- a/h2/src/main/org/h2/mvstore/db/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/db/TransactionStore.java
@@ -1282,7 +1282,7 @@ public class TransactionStore {
                     // transaction (possibly one with the same id)
                     data = map.get(key);
                 } else {
-                    if (map.getId() == (int) d[0]) {
+                    if (map.getId() == (int) d[0] && map.getKeyType().compare(key, d[1]) == 0) {
                         data = (VersionedValue) d[2];
                     } else {
                         // this entry does not belong to this map, try again

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
@@ -64,6 +64,9 @@ public class TestMvccMultiThreaded2 extends TestBase {
         ps.setInt(1, 1);
         ps.setInt(2, 100);
         ps.executeUpdate();
+        ps.setInt(1, 2);
+        ps.setInt(2, 200);
+        ps.executeUpdate();
         conn.commit();
 
         ArrayList<SelectForUpdate> threads = new ArrayList<>();
@@ -137,11 +140,20 @@ public class TestMvccMultiThreaded2 extends TestBase {
                     try {
                         PreparedStatement ps = conn.prepareStatement(
                                 "SELECT * FROM test WHERE entity_id = ? FOR UPDATE");
-                        ps.setString(1, "1");
+                        String id;
+                        int value;
+                        if ((iterationsProcessed & 1) == 0) {
+                            id = "1";
+                            value = 100;
+                        } else {
+                            id = "2";
+                            value = 200;
+                        }
+                        ps.setString(1, id);
                         ResultSet rs = ps.executeQuery();
 
                         assertTrue(rs.next());
-                        assertTrue(rs.getInt(2) == 100);
+                        assertTrue(rs.getInt(2) == value);
 
                         conn.commit();
                         iterationsProcessed++;

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import org.h2.jdbc.JdbcSQLException;
+import org.h2.message.DbException;
 import org.h2.test.TestBase;
 import org.h2.util.IOUtils;
 
@@ -80,9 +81,11 @@ public class TestMvccMultiThreaded2 extends TestBase {
         @SuppressWarnings("unused")
         int minProcessed = Integer.MAX_VALUE, maxProcessed = 0, totalProcessed = 0;
 
+        boolean allOk = true;
         for (SelectForUpdate sfu : threads) {
             // make sure all threads have stopped by joining with them
             sfu.join();
+            allOk &= sfu.ok;
             totalProcessed += sfu.iterationsProcessed;
             if (sfu.iterationsProcessed > maxProcessed) {
                 maxProcessed = sfu.iterationsProcessed;
@@ -102,6 +105,8 @@ public class TestMvccMultiThreaded2 extends TestBase {
 
         IOUtils.closeSilently(conn);
         deleteDb(getTestName());
+
+        assertTrue(allOk);
     }
 
     /**
@@ -110,6 +115,8 @@ public class TestMvccMultiThreaded2 extends TestBase {
     private class SelectForUpdate extends Thread {
 
         public int iterationsProcessed;
+
+        public boolean ok;
 
         SelectForUpdate() {
         }
@@ -149,11 +156,13 @@ public class TestMvccMultiThreaded2 extends TestBase {
                 }
             } catch (SQLException e) {
                 TestBase.logError("SQL error from thread "+getName(), e);
+                throw DbException.convert(e);
             } catch (Exception e) {
                 TestBase.logError("General error from thread "+getName(), e);
                 throw e;
             }
             IOUtils.closeSilently(conn);
+            ok = true;
         }
     }
 }


### PR DESCRIPTION
This issue is revealed by `TestMvccMultiThreaded2` and described in #953.

Counter of identities of operations for undo log is synchronized externally by session. And additional synchronization around operations with undo log does not help anyway.

So in looks more like reuse of transaction id or something similar. `getValue()` handles this situation when transaction log returns `null`, but does not handle the same situation if undo log returns a some record from it.

This pull request adds a check for map identity to prevent reading of records from another maps. If such record is read, the value discovery process is restarted like in other cases.

Failures in `TestMvccMultiThreaded2` are now treated as build error.

Please review this change. My analysis may be incorrect.