### PR TITLE
Update database size information and links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@
 1. Very fast, open source, JDBC API
 2. Embedded and server modes; in-memory databases
 3. Browser based Console application
-4. Small footprint: around 1.5 MB jar file size
+4. Small footprint: around 2 MB jar file size
 
 More information: http://h2database.com
 
 ## Features
 
-| | [H2](http://www.h2database.com/) | [Derby](http://db.apache.org/derby) | [HSQLDB](http://hsqldb.org) | [MySQL](http://mysql.com) | [PostgreSQL](http://www.postgresql.org) |
-|---------------------------|-------|-------|-------|-------|-------|
-| Pure Java                 | Yes   | Yes   | Yes   | No    | No    |
-| Memory Mode               | Yes   | Yes   | Yes   | No    | No    |
-| Encrypted Database        | Yes   | Yes   | Yes   | No    | No    |
-| ODBC Driver               | Yes   | No    | No    | Yes   | Yes   |
-| Fulltext Search           | Yes   | No    | No    | Yes   | Yes   |
-| Multi Version Concurrency | Yes   | No    | Yes   | Yes   | Yes   |
-| Footprint (jar/dll size)  | ~1 MB | ~2 MB | ~1 MB | ~4 MB | ~6 MB |
+| | [H2](http://www.h2database.com/) | [Derby](http://db.apache.org/derby) | [HSQLDB](http://hsqldb.org) | [MySQL](https://www.mysql.com/) | [PostgreSQL](https://www.postgresql.org) |
+|--------------------------------|---------|---------|---------|-------|---------|
+| Pure Java                      | Yes     | Yes     | Yes     | No    | No      |
+| Memory Mode                    | Yes     | Yes     | Yes     | No    | No      |
+| Encrypted Database             | Yes     | Yes     | Yes     | No    | No      |
+| ODBC Driver                    | Yes     | No      | No      | Yes   | Yes     |
+| Fulltext Search                | Yes     | No      | No      | Yes   | Yes     |
+| Multi Version Concurrency      | Yes     | No      | Yes     | Yes   | Yes     |
+| Footprint (embedded database)  | ~2 MB   | ~3 MB   | ~1.5 MB | —     | —       |
+| Footprint (JDBC client driver) | ~500 KB | ~600 KB | ~1.5 MB | ~1 MB | ~700 KB |


### PR DESCRIPTION
1. Footprints are specified for embedded database (for Java databases) and for client drivers separately. I didn't find a separate client driver for HSQLDB, looks like there is no one. Derby and H2 have separate drivers, but looks like we should publish official client driver for a next release, because now it can be built only from sources.

2. All footprints are specified for a most recent stable versions of another databases or their JDBC drivers and for current development version of H2.

3. Links to websites of MySQL and PostgreSQL now use their canonical names with www and https.