### PR TITLE
More fixes for PgServer

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -992,7 +992,7 @@ public class Parser {
             buff.append("'ISO' AS DATESTYLE FROM DUAL");
         } else if (readIf("SERVER_VERSION")) {
             // for PostgreSQL compatibility
-            buff.append("'8.2.23' AS SERVER_VERSION FROM DUAL");
+            buff.append("'" + Constants.PG_VERSION + "' AS SERVER_VERSION FROM DUAL");
         } else if (readIf("SERVER_ENCODING")) {
             // for PostgreSQL compatibility
             buff.append("'UTF8' AS SERVER_ENCODING FROM DUAL");

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -992,7 +992,7 @@ public class Parser {
             buff.append("'ISO' AS DATESTYLE FROM DUAL");
         } else if (readIf("SERVER_VERSION")) {
             // for PostgreSQL compatibility
-            buff.append("'8.1.4' AS SERVER_VERSION FROM DUAL");
+            buff.append("'8.2.23' AS SERVER_VERSION FROM DUAL");
         } else if (readIf("SERVER_ENCODING")) {
             // for PostgreSQL compatibility
             buff.append("'UTF8' AS SERVER_ENCODING FROM DUAL");

--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -525,6 +525,11 @@ public class Constants {
      */
     public static final int QUERY_STATISTICS_MAX_ENTRIES = 100;
 
+    /**
+     * Announced version for PgServer.
+     */
+    public static final String PG_VERSION = "8.2.23";
+
     private Constants() {
         // utility class
     }

--- a/h2/src/main/org/h2/server/pg/PgServer.java
+++ b/h2/src/main/org/h2/server/pg/PgServer.java
@@ -392,7 +392,7 @@ public class PgServer implements Service {
      * @return the server name and version
      */
     public static String getVersion() {
-        return "PostgreSQL 8.1.4  server protocol using H2 " +
+        return "PostgreSQL 8.2.23  server protocol using H2 " +
                 Constants.getFullVersion();
     }
 

--- a/h2/src/main/org/h2/server/pg/PgServer.java
+++ b/h2/src/main/org/h2/server/pg/PgServer.java
@@ -392,7 +392,7 @@ public class PgServer implements Service {
      * @return the server name and version
      */
     public static String getVersion() {
-        return "PostgreSQL 8.2.23  server protocol using H2 " +
+        return "PostgreSQL " + Constants.PG_VERSION + " server protocol using H2 " +
                 Constants.getFullVersion();
     }
 

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -949,7 +949,7 @@ public class PgServerThread implements Runnable {
         sendParameterStatus("integer_datetimes", "off");
         sendParameterStatus("is_superuser", "off");
         sendParameterStatus("server_encoding", "SQL_ASCII");
-        sendParameterStatus("server_version", "8.1.4");
+        sendParameterStatus("server_version", "8.2.23");
         sendParameterStatus("session_authorization", userName);
         sendParameterStatus("standard_conforming_strings", "off");
         // TODO PostgreSQL TimeZone

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 
 import org.h2.command.CommandInterface;
 import org.h2.engine.ConnectionInfo;
+import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.jdbc.JdbcPreparedStatement;
@@ -949,7 +950,7 @@ public class PgServerThread implements Runnable {
         sendParameterStatus("integer_datetimes", "off");
         sendParameterStatus("is_superuser", "off");
         sendParameterStatus("server_encoding", "SQL_ASCII");
-        sendParameterStatus("server_version", "8.2.23");
+        sendParameterStatus("server_version", Constants.PG_VERSION);
         sendParameterStatus("session_authorization", userName);
         sendParameterStatus("standard_conforming_strings", "off");
         // TODO PostgreSQL TimeZone

--- a/h2/src/main/org/h2/server/pg/pg_catalog.sql
+++ b/h2/src/main/org/h2/server/pg/pg_catalog.sql
@@ -4,7 +4,7 @@
  * Initial Developer: H2 Group
  */
 ;
-drop schema if exists pg_catalog;
+drop schema if exists pg_catalog cascade;
 create schema pg_catalog;
 
 drop alias if exists pg_convertType;

--- a/h2/src/test/org/h2/test/db/TestShow.java
+++ b/h2/src/test/org/h2/test/db/TestShow.java
@@ -40,7 +40,7 @@ public class TestShow extends TestBase {
             assertResult("read committed", stat, "SHOW DEFAULT_TRANSACTION_ISOLATION");
             assertResult("read committed", stat, "SHOW TRANSACTION ISOLATION LEVEL");
             assertResult("ISO", stat, "SHOW DATESTYLE");
-            assertResult("8.1.4", stat, "SHOW SERVER_VERSION");
+            assertResult("8.2.23", stat, "SHOW SERVER_VERSION");
             assertResult("UTF8", stat, "SHOW SERVER_ENCODING");
         }
     }

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -59,9 +59,9 @@ public class Build extends BuildBase {
         downloadUsingMaven("ext/derbynet-10.10.1.1.jar",
                 "org/apache/derby", "derbynet", "10.10.1.1",
                 "912b08dca73663d4665e09cd317be1218412d93e");
-        downloadUsingMaven("ext/postgresql-9.4.1209.jre6.jar",
-                "org.postgresql", "postgresql", "9.4.1209.jre6",
-                "2ed7a5a8c952d9ea18af92efea7e56ef854abfea");
+        downloadUsingMaven("ext/postgresql-42.2.1.jre7",
+                "org.postgresql", "postgresql", "42.2.1.jre7",
+                "d06eb133d573240718fe4c24577ef086f7daad6c");
         downloadUsingMaven("ext/mysql-connector-java-5.1.6.jar",
                 "mysql", "mysql-connector-java", "5.1.6",
                 "380ef5226de2c85ff3b38cbfefeea881c5fce09d");
@@ -74,7 +74,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/derby-10.10.1.1.jar" +
                 File.pathSeparator + "ext/derbyclient-10.10.1.1.jar" +
                 File.pathSeparator + "ext/derbynet-10.10.1.1.jar" +
-                File.pathSeparator + "ext/postgresql-9.4.1209.jre6.jar" +
+                File.pathSeparator + "ext/postgresql-42.2.1.jre7" +
                 File.pathSeparator + "ext/mysql-connector-java-5.1.6.jar";
         StringList args = args("-Xmx128m",
                 "-cp", cp, "org.h2.test.bench.TestPerformance");
@@ -182,7 +182,7 @@ public class Build extends BuildBase {
         // JaCoCo does not support multiple versions of the same classes
         delete(files("coverage/bin/META-INF/versions"));
         String cp = "coverage/bin" +
-            File.pathSeparator + "ext/postgresql-9.4.1209.jre6.jar" +
+            File.pathSeparator + "ext/postgresql-42.2.1.jre7" +
             File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
             File.pathSeparator + "ext/lucene-core-3.6.2.jar" +
             File.pathSeparator + "ext/h2mig_pagestore_addon.jar" +
@@ -427,9 +427,9 @@ public class Build extends BuildBase {
                 "com/h2database", "h2", "1.2.127",
                 "056e784c7cf009483366ab9cd8d21d02fe47031a");
         // for TestPgServer
-        downloadUsingMaven("ext/postgresql-9.4.1209.jre6.jar",
-                "org.postgresql", "postgresql", "9.4.1209.jre6",
-                "2ed7a5a8c952d9ea18af92efea7e56ef854abfea");
+        downloadUsingMaven("ext/postgresql-42.2.1.jre7.jar",
+                "org.postgresql", "postgresql", "42.2.1.jre7",
+                "d06eb133d573240718fe4c24577ef086f7daad6c");
         // for TestTraceSystem
         downloadUsingMaven("ext/slf4j-nop-1.6.0.jar",
                 "org/slf4j", "slf4j-nop", "1.6.0",
@@ -1012,7 +1012,7 @@ public class Build extends BuildBase {
     private void test(boolean travis) {
         downloadTest();
         String cp = "temp" + File.pathSeparator + "bin" +
-                File.pathSeparator + "ext/postgresql-9.4.1209.jre6.jar" +
+                File.pathSeparator + "ext/postgresql-42.2.1.jre7.jar" +
                 File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
                 File.pathSeparator + "ext/lucene-core-3.6.2.jar" +
                 File.pathSeparator + "ext/h2mig_pagestore_addon.jar" +


### PR DESCRIPTION
1. `DROP SCHEMA` statement in H2 now assumes `RESTRICT` by default, so add `CASCADE` to `pg_catalog.sql` to avoid failure on reinitialization.

2. Use Java 7 version of PostgreSQL JDBC driver for testing, because outdated Java 6 version have problems on Java 9 and later.

3. Update announced version of PostgreSQL from 8.1.4 to 8.2.23 (latest version from 8.2 series). Version 8.1 is not supported by modern client drivers, to it's better to announce something 8.2-based to avoid noisy warnings. It looks like there is no significant for us changes in 8.2 (H2 do not provide many `pg_catalog` meta tables anyway so changes in unimplemented functionality does not matter), so this update should be safe. But we cannot announce more recent versions, because 8.3 have changes that should be reflected before.