### PR TITLE
Fix TestFunctions.testToCharFromDateTime()

### DIFF
--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -1441,10 +1441,10 @@ public class TestFunctions extends TestBase implements AggregateFunction {
         Statement stat = conn.createStatement();
 
         TimeZone tz = TimeZone.getDefault();
-        boolean daylight = tz.inDaylightTime(new Date());
+        final Timestamp timestamp1979 = Timestamp.valueOf("1979-11-12 08:12:34.560");
+        boolean daylight = tz.inDaylightTime(timestamp1979);
         String tzShortName = tz.getDisplayName(daylight, TimeZone.SHORT);
         String tzLongName = tz.getID();
-        final Timestamp timestamp1979 = Timestamp.valueOf("1979-11-12 08:12:34.560");
 
         stat.executeUpdate("CREATE TABLE T (X TIMESTAMP(6))");
         stat.executeUpdate("INSERT INTO T VALUES " +


### PR DESCRIPTION
This fixes issue mentioned in https://github.com/h2database/h2database/pull/877#issuecomment-372160239

I fixed implementation for this time unit in f836f4c53df47631ae655f8a37e1894331707a90, but I didn't fix the old test that was also wrong, these compatibility functions had a lot of incorrect tests, but I didn't notice this problem before.