### PR TITLE
Do not include mvstore.DataUtils in client jar and other changes

### DIFF
--- a/h2/src/main/org/h2/compress/LZFInputStream.java
+++ b/h2/src/main/org/h2/compress/LZFInputStream.java
@@ -8,7 +8,7 @@ package org.h2.compress;
 import java.io.IOException;
 import java.io.InputStream;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
+import org.h2.util.Utils;
 
 /**
  * An input stream to read from an LZF stream.
@@ -31,7 +31,7 @@ public class LZFInputStream extends InputStream {
     }
 
     private static byte[] ensureSize(byte[] buff, int len) {
-        return buff == null || buff.length < len ? DataUtils.newBytes(len) : buff;
+        return buff == null || buff.length < len ? Utils.newBytes(len) : buff;
     }
 
     private void fillBuffer() throws IOException {

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -31,7 +31,6 @@ import org.h2.engine.Database;
 import org.h2.engine.Mode;
 import org.h2.engine.Session;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.schema.Schema;
 import org.h2.schema.Sequence;
 import org.h2.security.BlockCipher;
@@ -1819,7 +1818,7 @@ public class Function extends Expression implements FunctionCall {
 
     private static byte[] getPaddedArrayCopy(byte[] data, int blockSize) {
         int size = MathUtils.roundUpInt(data.length, blockSize);
-        return DataUtils.copyBytes(data, size);
+        return Utils.copyBytes(data, size);
     }
 
     private static byte[] decrypt(String algorithm, byte[] key, byte[] data) {

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -228,7 +228,7 @@ public class Chunk {
      * @return the string
      */
     public String asString() {
-        StringBuilder buff = new StringBuilder();
+        StringBuilder buff = new StringBuilder(240);
         DataUtils.appendMap(buff, "chunk", id);
         DataUtils.appendMap(buff, "block", block);
         DataUtils.appendMap(buff, "len", len);
@@ -254,17 +254,17 @@ public class Chunk {
     }
 
     byte[] getFooterBytes() {
-        StringBuilder buff = new StringBuilder();
+        StringBuilder buff = new StringBuilder(FOOTER_LENGTH);
         DataUtils.appendMap(buff, "chunk", id);
         DataUtils.appendMap(buff, "block", block);
         DataUtils.appendMap(buff, "version", version);
         byte[] bytes = buff.toString().getBytes(StandardCharsets.ISO_8859_1);
         int checksum = DataUtils.getFletcher32(bytes, 0, bytes.length);
         DataUtils.appendMap(buff, "fletcher", checksum);
-        while (buff.length() < Chunk.FOOTER_LENGTH - 1) {
+        while (buff.length() < FOOTER_LENGTH - 1) {
             buff.append(' ');
         }
-        buff.append("\n");
+        buff.append('\n');
         return buff.toString().getBytes(StandardCharsets.ISO_8859_1);
     }
 

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -154,11 +154,6 @@ public final class DataUtils {
     public static final int PAGE_LARGE = 2 * 1024 * 1024;
 
     /**
-     * An 0-size byte array.
-     */
-    private static final byte[] EMPTY_BYTES = {};
-
-    /**
      * Get the length of the variable size int.
      *
      * @param x the value
@@ -935,62 +930,6 @@ public final class DataUtils {
             }
         }
         return 0;
-    }
-
-    /**
-     * Create an array of bytes with the given size. If this is not possible
-     * because not enough memory is available, an OutOfMemoryError with the
-     * requested size in the message is thrown.
-     * <p>
-     * This method should be used if the size of the array is user defined, or
-     * stored in a file, so wrong size data can be distinguished from regular
-     * out-of-memory.
-     * </p>
-     *
-     * @param len the number of bytes requested
-     * @return the byte array
-     * @throws OutOfMemoryError if the allocation was too large
-     */
-    public static byte[] newBytes(int len) {
-        if (len == 0) {
-            return EMPTY_BYTES;
-        }
-        try {
-            return new byte[len];
-        } catch (OutOfMemoryError e) {
-            Error e2 = new OutOfMemoryError("Requested memory: " + len);
-            e2.initCause(e);
-            throw e2;
-        }
-    }
-
-    /**
-     * Creates a copy of array of bytes with the new size. If this is not possible
-     * because not enough memory is available, an OutOfMemoryError with the
-     * requested size in the message is thrown.
-     * <p>
-     * This method should be used if the size of the array is user defined, or
-     * stored in a file, so wrong size data can be distinguished from regular
-     * out-of-memory.
-     * </p>
-     *
-     * @param bytes source array
-     * @param len the number of bytes in the new array
-     * @return the byte array
-     * @throws OutOfMemoryError if the allocation was too large
-     * @see Arrays#copyOf(byte[], int)
-     */
-    public static byte[] copyBytes(byte[] bytes, int len) {
-        if (len == 0) {
-            return EMPTY_BYTES;
-        }
-        try {
-            return Arrays.copyOf(bytes, len);
-        } catch (OutOfMemoryError e) {
-            Error e2 = new OutOfMemoryError("Requested memory: " + len);
-            e2.initCause(e);
-            throw e2;
-        }
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -12,9 +12,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -570,10 +568,10 @@ public final class DataUtils {
      */
     public static StringBuilder appendMap(StringBuilder buff,
             HashMap<String, ?> map) {
-        ArrayList<String> list = new ArrayList<>(map.keySet());
-        Collections.sort(list);
-        for (String k : list) {
-            appendMap(buff, k, map.get(k));
+        Object[] keys = map.keySet().toArray();
+        Arrays.sort(keys);
+        for (Object k : keys) {
+            appendMap(buff, (String) k, map.get(k));
         }
         return buff;
     }

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -566,14 +566,28 @@ public final class DataUtils {
      * @param map the map
      * @return the string builder
      */
-    public static StringBuilder appendMap(StringBuilder buff,
-            HashMap<String, ?> map) {
+    public static StringBuilder appendMap(StringBuilder buff, HashMap<String, ?> map) {
         Object[] keys = map.keySet().toArray();
         Arrays.sort(keys);
         for (Object k : keys) {
-            appendMap(buff, (String) k, map.get(k));
+            String key = (String) k;
+            Object value = map.get(key);
+            if (value instanceof Long) {
+                appendMap(buff, key, (long) value);
+            } else if (value instanceof Integer) {
+                appendMap(buff, key, (int) value);
+            } else {
+                appendMap(buff, key, value.toString());
+            }
         }
         return buff;
+    }
+
+    private static StringBuilder appendMapKey(StringBuilder buff, String key) {
+        if (buff.length() > 0) {
+            buff.append(',');
+        }
+        return buff.append(key).append(':');
     }
 
     /**
@@ -585,25 +599,14 @@ public final class DataUtils {
      * @param key the key
      * @param value the value
      */
-    public static void appendMap(StringBuilder buff, String key, Object value) {
-        if (buff.length() > 0) {
-            buff.append(',');
-        }
-        buff.append(key).append(':');
-        String v;
-        if (value instanceof Long) {
-            v = Long.toHexString((Long) value);
-        } else if (value instanceof Integer) {
-            v = Integer.toHexString((Integer) value);
-        } else {
-            v = value.toString();
-        }
-        if (v.indexOf(',') < 0 && v.indexOf('\"') < 0) {
-            buff.append(v);
+    public static void appendMap(StringBuilder buff, String key, String value) {
+        appendMapKey(buff, key);
+        if (value.indexOf(',') < 0 && value.indexOf('\"') < 0) {
+            buff.append(value);
         } else {
             buff.append('\"');
-            for (int i = 0, size = v.length(); i < size; i++) {
-                char c = v.charAt(i);
+            for (int i = 0, size = value.length(); i < size; i++) {
+                char c = value.charAt(i);
                 if (c == '\"') {
                     buff.append('\\');
                 }
@@ -611,6 +614,30 @@ public final class DataUtils {
             }
             buff.append('\"');
         }
+    }
+
+    /**
+     * Append a key-value pair to the string builder. Keys may not contain a
+     * colon.
+     *
+     * @param buff the target buffer
+     * @param key the key
+     * @param value the value
+     */
+    public static void appendMap(StringBuilder buff, String key, long value) {
+        appendMapKey(buff, key).append(Long.toHexString(value));
+    }
+
+    /**
+     * Append a key-value pair to the string builder. Keys may not contain a
+     * colon.
+     *
+     * @param buff the target buffer
+     * @param key the key
+     * @param value the value
+     */
+    public static void appendMap(StringBuilder buff, String key, int value) {
+        appendMapKey(buff, key).append(Integer.toHexString(value));
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -801,7 +801,7 @@ public final class MVStore {
     }
 
     private void writeStoreHeader() {
-        StringBuilder buff = new StringBuilder();
+        StringBuilder buff = new StringBuilder(112);
         if (lastChunk != null) {
             storeHeader.put("block", lastChunk.block);
             storeHeader.put("chunk", lastChunk.id);
@@ -811,7 +811,7 @@ public final class MVStore {
         byte[] bytes = buff.toString().getBytes(StandardCharsets.ISO_8859_1);
         int checksum = DataUtils.getFletcher32(bytes, 0, bytes.length);
         DataUtils.appendMap(buff, "fletcher", checksum);
-        buff.append("\n");
+        buff.append('\n');
         bytes = buff.toString().getBytes(StandardCharsets.ISO_8859_1);
         ByteBuffer header = ByteBuffer.allocate(2 * BLOCK_SIZE);
         header.put(bytes);

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -26,6 +26,7 @@ import org.h2.mvstore.type.DataType;
 import org.h2.mvstore.type.StringDataType;
 import org.h2.store.fs.FilePath;
 import org.h2.store.fs.FileUtils;
+import org.h2.util.Utils;
 
 /**
  * Utility methods used in combination with the MVStore.
@@ -226,7 +227,7 @@ public class MVStoreTool {
                             Compressor compressor = getCompressor(fast);
                             int lenAdd = DataUtils.readVarInt(chunk);
                             int compLen = pageSize + start - chunk.position();
-                            byte[] comp = DataUtils.newBytes(compLen);
+                            byte[] comp = Utils.newBytes(compLen);
                             chunk.get(comp);
                             int l = compLen + lenAdd;
                             data = ByteBuffer.allocate(l);

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import org.h2.compress.Compressor;
 import org.h2.mvstore.type.DataType;
+import org.h2.util.Utils;
 
 /**
  * A page (a node or a leaf).
@@ -702,7 +703,7 @@ public class Page {
             }
             int lenAdd = DataUtils.readVarInt(buff);
             int compLen = pageLength + start - buff.position();
-            byte[] comp = DataUtils.newBytes(compLen);
+            byte[] comp = Utils.newBytes(compLen);
             buff.get(comp);
             int l = compLen + lenAdd;
             buff = ByteBuffer.allocate(l);

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -23,6 +23,7 @@ import org.h2.result.SortOrder;
 import org.h2.store.DataHandler;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.JdbcUtils;
+import org.h2.util.Utils;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
@@ -489,7 +490,7 @@ public class ValueDataType implements DataType {
         case Value.DECIMAL: {
             int scale = readVarInt(buff);
             int len = readVarInt(buff);
-            byte[] buff2 = DataUtils.newBytes(len);
+            byte[] buff2 = Utils.newBytes(len);
             buff.get(buff2, 0, len);
             BigInteger b = new BigInteger(buff2);
             return ValueDecimal.get(new BigDecimal(b, scale));
@@ -514,13 +515,13 @@ public class ValueDataType implements DataType {
         }
         case Value.BYTES: {
             int len = readVarInt(buff);
-            byte[] b = DataUtils.newBytes(len);
+            byte[] b = Utils.newBytes(len);
             buff.get(b, 0, len);
             return ValueBytes.getNoCopy(b);
         }
         case Value.JAVA_OBJECT: {
             int len = readVarInt(buff);
-            byte[] b = DataUtils.newBytes(len);
+            byte[] b = Utils.newBytes(len);
             buff.get(b, 0, len);
             return ValueJavaObject.getNoCopy(null, b, handler);
         }
@@ -550,7 +551,7 @@ public class ValueDataType implements DataType {
         case Value.CLOB: {
             int smallLen = readVarInt(buff);
             if (smallLen >= 0) {
-                byte[] small = DataUtils.newBytes(smallLen);
+                byte[] small = Utils.newBytes(smallLen);
                 buff.get(small, 0, smallLen);
                 return ValueLobDb.createSmallLob(type, small);
             } else if (smallLen == -3) {
@@ -597,7 +598,7 @@ public class ValueDataType implements DataType {
         }
         case Value.GEOMETRY: {
             int len = readVarInt(buff);
-            byte[] b = DataUtils.newBytes(len);
+            byte[] b = Utils.newBytes(len);
             buff.get(b, 0, len);
             return ValueGeometry.get(b);
         }
@@ -607,7 +608,7 @@ public class ValueDataType implements DataType {
             if (JdbcUtils.customDataTypesHandler != null) {
                 int customType = readVarInt(buff);
                 int len = readVarInt(buff);
-                byte[] b = DataUtils.newBytes(len);
+                byte[] b = Utils.newBytes(len);
                 buff.get(b, 0, len);
                 return JdbcUtils.customDataTypesHandler.convert(
                         ValueBytes.getNoCopy(b), customType);
@@ -622,7 +623,7 @@ public class ValueDataType implements DataType {
                 return ValueLong.get(type - LONG_0_7);
             } else if (type >= BYTES_0_31 && type < BYTES_0_31 + 32) {
                 int len = type - BYTES_0_31;
-                byte[] b = DataUtils.newBytes(len);
+                byte[] b = Utils.newBytes(len);
                 buff.get(b, 0, len);
                 return ValueBytes.getNoCopy(b);
             } else if (type >= STRING_0_31 && type < STRING_0_31 + 32) {

--- a/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.UUID;
 import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.WriteBuffer;
+import org.h2.util.Utils;
 
 /**
  * A data type implementation for the most common data types, including
@@ -1000,7 +1001,7 @@ public class ObjectDataType implements DataType {
                 return BigInteger.valueOf(DataUtils.readVarLong(buff));
             }
             int len = DataUtils.readVarInt(buff);
-            byte[] bytes = DataUtils.newBytes(len);
+            byte[] bytes = Utils.newBytes(len);
             buff.get(bytes);
             return new BigInteger(bytes);
         }
@@ -1077,7 +1078,7 @@ public class ObjectDataType implements DataType {
             }
             int scale = DataUtils.readVarInt(buff);
             int len = DataUtils.readVarInt(buff);
-            byte[] bytes = DataUtils.newBytes(len);
+            byte[] bytes = Utils.newBytes(len);
             buff.get(bytes);
             BigInteger b = new BigInteger(bytes);
             return new BigDecimal(b, scale);
@@ -1414,7 +1415,7 @@ public class ObjectDataType implements DataType {
             if (tag != TYPE_ARRAY) {
                 byte[] data;
                 int len = tag - TAG_BYTE_ARRAY_0_15;
-                data = DataUtils.newBytes(len);
+                data = Utils.newBytes(len);
                 buff.get(data);
                 return data;
             }
@@ -1545,7 +1546,7 @@ public class ObjectDataType implements DataType {
         @Override
         public Object read(ByteBuffer buff, int tag) {
             int len = DataUtils.readVarInt(buff);
-            byte[] data = DataUtils.newBytes(len);
+            byte[] data = Utils.newBytes(len);
             int size = data.length * 2;
             // adjust the average size
             // using an exponential moving average

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -40,7 +40,6 @@ import org.h2.jdbc.JdbcPreparedStatement;
 import org.h2.jdbc.JdbcResultSet;
 import org.h2.jdbc.JdbcStatement;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.util.DateTimeUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
@@ -152,7 +151,7 @@ public class PgServerThread implements Runnable {
         }
         int len = dataInRaw.readInt();
         len -= 4;
-        byte[] data = DataUtils.newBytes(len);
+        byte[] data = Utils.newBytes(len);
         dataInRaw.readFully(data, 0, len);
         dataIn = new DataInputStream(new ByteArrayInputStream(data, 0, len));
         switch (x) {
@@ -639,7 +638,7 @@ public class PgServerThread implements Runnable {
             prep.setNull(col, Types.NULL);
         } else if (text) {
             // plain text
-            byte[] data = DataUtils.newBytes(paramLen);
+            byte[] data = Utils.newBytes(paramLen);
             readFully(data);
             String str = new String(data, getEncoding());
             switch (pgType) {
@@ -687,13 +686,13 @@ public class PgServerThread implements Runnable {
                 prep.setDouble(col, dataIn.readDouble());
                 break;
             case PgServer.PG_TYPE_BYTEA:
-                byte[] d1 = DataUtils.newBytes(paramLen);
+                byte[] d1 = Utils.newBytes(paramLen);
                 readFully(d1);
                 prep.setBytes(col, d1);
                 break;
             default:
                 server.trace("Binary format for type: "+pgType+" is unsupported");
-                byte[] d2 = DataUtils.newBytes(paramLen);
+                byte[] d2 = Utils.newBytes(paramLen);
                 readFully(d2);
                 prep.setString(col, new String(d2, getEncoding()));
             }

--- a/h2/src/main/org/h2/server/web/WebThread.java
+++ b/h2/src/main/org/h2/server/web/WebThread.java
@@ -20,10 +20,10 @@ import java.util.StringTokenizer;
 
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.util.IOUtils;
 import org.h2.util.NetUtils;
 import org.h2.util.StringUtils;
+import org.h2.util.Utils;
 
 /**
  * For each connection to a session, an object of this class is created.
@@ -317,7 +317,7 @@ class WebThread extends WebApp implements Runnable {
         if (multipart) {
             // not supported
         } else if (session != null && len > 0) {
-            byte[] bytes = DataUtils.newBytes(len);
+            byte[] bytes = Utils.newBytes(len);
             for (int pos = 0; pos < len;) {
                 pos += input.read(bytes, pos, len - pos);
             }

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -23,11 +23,11 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.Bits;
 import org.h2.util.DateTimeUtils;
 import org.h2.util.MathUtils;
+import org.h2.util.Utils;
 import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
@@ -745,7 +745,7 @@ public class Data {
         case Value.DECIMAL: {
             int scale = readVarInt();
             int len = readVarInt();
-            byte[] buff = DataUtils.newBytes(len);
+            byte[] buff = Utils.newBytes(len);
             read(buff, 0, len);
             BigInteger b = new BigInteger(buff);
             return ValueDecimal.get(new BigDecimal(b, scale));
@@ -783,19 +783,19 @@ public class Data {
         }
         case Value.BYTES: {
             int len = readVarInt();
-            byte[] b = DataUtils.newBytes(len);
+            byte[] b = Utils.newBytes(len);
             read(b, 0, len);
             return ValueBytes.getNoCopy(b);
         }
         case Value.GEOMETRY: {
             int len = readVarInt();
-            byte[] b = DataUtils.newBytes(len);
+            byte[] b = Utils.newBytes(len);
             read(b, 0, len);
             return ValueGeometry.get(b);
         }
         case Value.JAVA_OBJECT: {
             int len = readVarInt();
-            byte[] b = DataUtils.newBytes(len);
+            byte[] b = Utils.newBytes(len);
             read(b, 0, len);
             return ValueJavaObject.getNoCopy(null, b, handler);
         }
@@ -825,7 +825,7 @@ public class Data {
         case Value.CLOB: {
             int smallLen = readVarInt();
             if (smallLen >= 0) {
-                byte[] small = DataUtils.newBytes(smallLen);
+                byte[] small = Utils.newBytes(smallLen);
                 read(small, 0, smallLen);
                 return ValueLobDb.createSmallLob(type, small);
             } else if (smallLen == -3) {
@@ -889,7 +889,7 @@ public class Data {
                 return ValueLong.get(type - LONG_0_7);
             } else if (type >= BYTES_0_31 && type < BYTES_0_31 + 32) {
                 int len = type - BYTES_0_31;
-                byte[] b = DataUtils.newBytes(len);
+                byte[] b = Utils.newBytes(len);
                 read(b, 0, len);
                 return ValueBytes.getNoCopy(b);
             } else if (type >= STRING_0_31 && type < STRING_0_31 + 32) {
@@ -1316,7 +1316,7 @@ public class Data {
     private void expand(int plus) {
         // must copy everything, because pos could be 0 and data may be
         // still required
-        data = DataUtils.copyBytes(data, (data.length + plus) * 2);
+        data = Utils.copyBytes(data, (data.length + plus) * 2);
     }
 
     /**

--- a/h2/src/main/org/h2/store/FileStoreInputStream.java
+++ b/h2/src/main/org/h2/store/FileStoreInputStream.java
@@ -9,8 +9,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.h2.engine.Constants;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.tools.CompressTool;
+import org.h2.util.Utils;
 
 /**
  * An input stream that is backed by a file store.
@@ -117,7 +117,7 @@ public class FileStoreInputStream extends InputStream {
         page.readInt();
         if (compress != null) {
             int uncompressed = page.readInt();
-            byte[] buff = DataUtils.newBytes(remainingInBuffer);
+            byte[] buff = Utils.newBytes(remainingInBuffer);
             page.read(buff, 0, remainingInBuffer);
             page.reset();
             page.checkCapacity(uncompressed);

--- a/h2/src/main/org/h2/store/fs/FilePathEncrypt.java
+++ b/h2/src/main/org/h2/store/fs/FilePathEncrypt.java
@@ -15,7 +15,6 @@ import java.nio.channels.FileLock;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import org.h2.mvstore.DataUtils;
 import org.h2.security.AES;
 import org.h2.security.BlockCipher;
 import org.h2.security.SHA256;
@@ -194,11 +193,11 @@ public class FilePathEncrypt extends FilePathWrapper {
                 byte[] header = Arrays.copyOf(HEADER, BLOCK_SIZE);
                 salt = MathUtils.secureRandomBytes(SALT_LENGTH);
                 System.arraycopy(salt, 0, header, SALT_POS, salt.length);
-                DataUtils.writeFully(base, 0, ByteBuffer.wrap(header));
+                writeFully(base, 0, ByteBuffer.wrap(header));
                 size = 0;
             } else {
                 salt = new byte[SALT_LENGTH];
-                DataUtils.readFully(base, SALT_POS, ByteBuffer.wrap(salt));
+                readFully(base, SALT_POS, ByteBuffer.wrap(salt));
                 if ((size & BLOCK_SIZE_MASK) != 0) {
                     size -= BLOCK_SIZE;
                 }
@@ -319,7 +318,7 @@ public class FilePathEncrypt extends FilePathWrapper {
                 int plus = (int) (size & BLOCK_SIZE_MASK);
                 if (plus > 0) {
                     temp = ByteBuffer.allocate(plus);
-                    DataUtils.writeFully(base, p + HEADER_LENGTH + l, temp);
+                    writeFully(base, p + HEADER_LENGTH + l, temp);
                 }
                 return len;
             }

--- a/h2/src/main/org/h2/tools/CompressTool.java
+++ b/h2/src/main/org/h2/tools/CompressTool.java
@@ -25,9 +25,9 @@ import org.h2.compress.LZFInputStream;
 import org.h2.compress.LZFOutputStream;
 import org.h2.engine.Constants;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.util.Bits;
 import org.h2.util.StringUtils;
+import org.h2.util.Utils;
 
 /**
  * A tool to losslessly compress data, and expand the compressed data again.
@@ -44,10 +44,10 @@ public class CompressTool {
 
     private byte[] getBuffer(int min) {
         if (min > MAX_BUFFER_SIZE) {
-            return DataUtils.newBytes(min);
+            return Utils.newBytes(min);
         }
         if (cachedBuffer == null || cachedBuffer.length < min) {
-            cachedBuffer = DataUtils.newBytes(min);
+            cachedBuffer = Utils.newBytes(min);
         }
         return cachedBuffer;
     }
@@ -79,7 +79,7 @@ public class CompressTool {
         Compressor compress = getCompressor(algorithm);
         byte[] buff = getBuffer((len < 100 ? len + 100 : len) * 2);
         int newLen = compress(in, in.length, compress, buff);
-        return DataUtils.copyBytes(buff, newLen);
+        return Utils.copyBytes(buff, newLen);
     }
 
     private static int compress(byte[] in, int len, Compressor compress,
@@ -108,7 +108,7 @@ public class CompressTool {
         try {
             int len = readVariableInt(in, 1);
             int start = 1 + getVariableIntLength(len);
-            byte[] buff = DataUtils.newBytes(len);
+            byte[] buff = Utils.newBytes(len);
             compress.expand(in, start, in.length - start, buff, 0, len);
             return buff;
         } catch (Exception e) {

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -210,6 +210,62 @@ public class Utils {
     }
 
     /**
+     * Create an array of bytes with the given size. If this is not possible
+     * because not enough memory is available, an OutOfMemoryError with the
+     * requested size in the message is thrown.
+     * <p>
+     * This method should be used if the size of the array is user defined, or
+     * stored in a file, so wrong size data can be distinguished from regular
+     * out-of-memory.
+     * </p>
+     *
+     * @param len the number of bytes requested
+     * @return the byte array
+     * @throws OutOfMemoryError if the allocation was too large
+     */
+    public static byte[] newBytes(int len) {
+        if (len == 0) {
+            return EMPTY_BYTES;
+        }
+        try {
+            return new byte[len];
+        } catch (OutOfMemoryError e) {
+            Error e2 = new OutOfMemoryError("Requested memory: " + len);
+            e2.initCause(e);
+            throw e2;
+        }
+    }
+
+    /**
+     * Creates a copy of array of bytes with the new size. If this is not possible
+     * because not enough memory is available, an OutOfMemoryError with the
+     * requested size in the message is thrown.
+     * <p>
+     * This method should be used if the size of the array is user defined, or
+     * stored in a file, so wrong size data can be distinguished from regular
+     * out-of-memory.
+     * </p>
+     *
+     * @param bytes source array
+     * @param len the number of bytes in the new array
+     * @return the byte array
+     * @throws OutOfMemoryError if the allocation was too large
+     * @see Arrays#copyOf(byte[], int)
+     */
+    public static byte[] copyBytes(byte[] bytes, int len) {
+        if (len == 0) {
+            return EMPTY_BYTES;
+        }
+        try {
+            return Arrays.copyOf(bytes, len);
+        } catch (OutOfMemoryError e) {
+            Error e2 = new OutOfMemoryError("Requested memory: " + len);
+            e2.initCause(e);
+            throw e2;
+        }
+    }
+
+    /**
      * Create a new byte array and copy all the data. If the size of the byte
      * array is zero, the same array is returned.
      *

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -22,7 +22,6 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.SessionInterface;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.security.SHA256;
 import org.h2.store.Data;
 import org.h2.store.DataReader;
@@ -284,7 +283,7 @@ public class Transfer {
         if (len == -1) {
             return null;
         }
-        byte[] b = DataUtils.newBytes(len);
+        byte[] b = Utils.newBytes(len);
         in.readFully(b);
         return b;
     }

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -19,7 +19,6 @@ import org.h2.engine.Constants;
 import org.h2.engine.Mode;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.store.DataHandler;
 import org.h2.store.FileStore;
 import org.h2.store.FileStoreInputStream;
@@ -430,11 +429,11 @@ public class ValueLob extends Value {
                 buff = IOUtils.readBytesAndClose(in, -1);
                 len = buff.length;
             } else {
-                buff = DataUtils.newBytes(len);
+                buff = Utils.newBytes(len);
                 len = IOUtils.readFully(in, buff, len);
             }
             if (len <= handler.getMaxLengthInplaceLob()) {
-                byte[] small = DataUtils.copyBytes(buff, len);
+                byte[] small = Utils.copyBytes(buff, len);
                 return ValueLob.createSmallLob(Value.BLOB, small);
             }
             ValueLob lob = new ValueLob(Value.BLOB, null);
@@ -796,7 +795,7 @@ public class ValueLob extends Value {
                 int tabId = tableId;
                 if (type == Value.BLOB) {
                     createFromStream(
-                            DataUtils.newBytes(len), 0, getInputStream(), Long.MAX_VALUE, h);
+                            Utils.newBytes(len), 0, getInputStream(), Long.MAX_VALUE, h);
                 } else {
                     createFromReader(
                             new char[len], 0, getReader(), Long.MAX_VALUE, h);

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -19,7 +19,6 @@ import org.h2.engine.Constants;
 import org.h2.engine.Mode;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.store.DataHandler;
 import org.h2.store.FileStore;
 import org.h2.store.FileStoreInputStream;
@@ -611,11 +610,11 @@ public class ValueLobDb extends Value implements Value.ValueClob,
                 buff = IOUtils.readBytesAndClose(in, -1);
                 len = buff.length;
             } else {
-                buff = DataUtils.newBytes(len);
+                buff = Utils.newBytes(len);
                 len = IOUtils.readFully(in, buff, len);
             }
             if (len <= handler.getMaxLengthInplaceLob()) {
-                byte[] small = DataUtils.copyBytes(buff, len);
+                byte[] small = Utils.copyBytes(buff, len);
                 return ValueLobDb.createSmallLob(Value.BLOB, small, small.length);
             }
             ValueLobDb lob = new ValueLobDb(handler, buff, len, in, remaining);


### PR DESCRIPTION
This class is large enough and mostly MVStore-specific. It's strange to see `mvstore` package in client library.

I moved two very common methods to `Utils` that removes most references to `DataUtils` from client code.

`FilePathEncrypt` already have own simplified copies of some methods from `DataUtils`, but these methods were not used in all places, I replaced the remaining references to `DataUtils` with these local methods.

Also I slightly reorganized `DataUtils.appendMap()` methods. They mostly used with `int` and `long` values, but these values were handled in slow way. Wrapping and unwrapping of value is not so slow, but double scanning of resulting string for special characters that cannot be in the sting and additional if-else conditions slows these methods noticeably. I also specified initial capacity of some string builders for these maps because default initial capacity of 16 was too small and causes a lot of reallocations. This improves their speed and reduces amount of allocated garbage that is slightly noticeable in standalone MVStore, but is not noticeable in H2 itself.

These changes together reduce the size of client jar by almost 8 KB, and also reduce the size of the main jar, but only by 60+ bytes.