### PR TITLE
Do not include help and images in client jar

### DIFF
--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -979,6 +979,8 @@ public class Build extends BuildBase {
             files = files.keep("src/main/org/h2/res/_messages_en.*");
         }
         if (clientOnly) {
+            files = files.exclude("src/main/org/h2/res/help.csv");
+            files = files.exclude("src/main/org/h2/res/h2*");
             files = files.exclude("src/main/org/h2/res/javadoc.properties");
             files = files.exclude("src/main/org/h2/server/*");
         }


### PR DESCRIPTION
`help.csv` is used only by `HELP` meta table and by BNF, this code in not included in client library. Images are only used by `Console` that is not included in client jar too. This change reduces the size of h2-client by 32 KB.