### PR TITLE
Disallow C++-style line comments in PostgreSQL mode

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3922,6 +3922,10 @@ public class Parser {
                     i++;
                 } else if (command[i + 1] == '/') {
                     // single line comment
+                    if (!database.getMode().allowCppStyleLineComments) {
+                        /* Database Mode does not support C-style line comments */
+                        throw getSyntaxError();
+                    }
                     changed = true;
                     startLoop = i;
                     while (true) {

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -198,6 +198,11 @@ public class Mode {
      */
     public HashMap<String, DataType> typeByNameMap = new HashMap<>();
 
+    /**
+     * Whether to allow C++-style //... line comments.
+     */
+    public boolean allowCppStyleLineComments;
+
     private final String name;
 
     private ModeEnum modeEnum;
@@ -205,6 +210,7 @@ public class Mode {
     static {
         Mode mode = new Mode(ModeEnum.REGULAR.name());
         mode.nullConcatIsNull = true;
+        mode.allowCppStyleLineComments = true;
         add(mode);
 
         mode = new Mode(ModeEnum.DB2.name());
@@ -241,6 +247,7 @@ public class Mode {
         //     org/hsqldb/jdbc/JDBCConnection.html#
         //     setClientInfo%28java.lang.String,%20java.lang.String%29
         mode.supportedClientInfoPropertiesRegEx = null;
+        mode.allowCppStyleLineComments = true;
         add(mode);
 
         mode = new Mode(ModeEnum.MSSQLServer.name());

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -288,6 +288,9 @@ public class TestCompatibility extends TestBase {
                 /* Expected! */
             }
         }
+
+        /* Test that C-style line comments //... are not allowed */
+        assertThrows(ErrorCode.SYNTAX_ERROR_1, stat, "// Don't do anything, actually");
     }
 
     private void testMySQL() throws SQLException {


### PR DESCRIPTION
We are using H2 in PostgreSQL mode, but some developers were using C-style line comments, which then failed to parse on a real PostgreSQL server instance, since PostgreSQL only supports C-style block comments, but not //... line comments.
This is to mitigate those kind of errors in the future.