### PR TITLE
Added support for ENUM in prepared statement where clause

### DIFF
--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -593,6 +593,17 @@ public abstract class Value {
     }
 
     /**
+     * Convert value to ENUM value
+     * @param enumerators allowed values for the ENUM to which the value is converted
+     * @return value represented as ENUM
+     */
+    public Value convertToEnum(String[] enumerators) {
+        // Use -1 to indicate "default behaviour" where value conversion should not
+        // depend on any datatype precision.
+        return convertTo(ENUM, -1, null, null, enumerators);
+    }
+
+    /**
      * Compare a value to the specified type.
      *
      * @param targetType the type of the returned value

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -479,6 +479,22 @@ public class TestPreparedStatement extends TestBase {
             assertEquals(Integer.class, o.getClass());
         }
 
+        for (int i = 0; i < goodSizes.length; i++) {
+            PreparedStatement prep = conn.prepareStatement("SELECT * FROM test_enum WHERE size = ?");
+            prep.setObject(1, goodSizes[i]);
+            ResultSet rs = prep.executeQuery();
+            rs.next();
+            String s = rs.getString(1);
+            assertTrue(s.equals(goodSizes[i]));
+            assertFalse(rs.next());
+        }
+
+        for (int i = 0; i < badSizes.length; i++) {
+            PreparedStatement prep = conn.prepareStatement("SELECT * FROM test_enum WHERE size = ?");
+            prep.setObject(1, badSizes[i]);
+            assertThrows(ErrorCode.ENUM_VALUE_NOT_PERMITTED, prep).executeQuery();
+        }
+
         stat.execute("DROP TABLE test_enum");
     }
 

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -492,7 +492,12 @@ public class TestPreparedStatement extends TestBase {
         for (int i = 0; i < badSizes.length; i++) {
             PreparedStatement prep = conn.prepareStatement("SELECT * FROM test_enum WHERE size = ?");
             prep.setObject(1, badSizes[i]);
-            assertThrows(ErrorCode.ENUM_VALUE_NOT_PERMITTED, prep).executeQuery();
+            if (config.lazy) {
+                ResultSet resultSet = prep.executeQuery();
+                assertThrows(ErrorCode.ENUM_VALUE_NOT_PERMITTED, resultSet).next();
+            } else {
+                assertThrows(ErrorCode.ENUM_VALUE_NOT_PERMITTED, prep).executeQuery();
+            }
         }
 
         stat.execute("DROP TABLE test_enum");


### PR DESCRIPTION
JDBC Prepared Statement does not support ENUM values, exception upon thrown upon execution of prepared statement like:

`PreparedStatement prep = conn.prepareStatement("SELECT * FROM test_enum WHERE size = ?");
prep.setObject(1, "small");
ResultSet rs = prep.executeQuery();`

Added code which handles case of ENUM column in where clause.
Added assertions in UT which check if prepared statement with ENUM used in where clause is working correctly.
