### PR TITLE
Update ASM from 6.1-beta to 6.1

### DIFF
--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -163,15 +163,15 @@ public class Build extends BuildBase {
         downloadUsingMaven("ext/org.jacoco.report-0.8.0.jar",
                 "org.jacoco", "org.jacoco.report", "0.8.0",
                 "1bcab2a451f5a382bc674857c8f3f6d3fa52151d");
-        downloadUsingMaven("ext/asm-6.1-beta.jar",
-                "org.ow2.asm", "asm", "6.1-beta",
-                "bac2f84e42b7db902103a9ec8c4ca1293223e0ea");
-        downloadUsingMaven("ext/asm-commons-6.1-beta.jar",
-                "org.ow2.asm", "asm-commons", "6.1-beta",
-                "4ec77cde3be41559f92d25cdb39b9c55ee479253");
-        downloadUsingMaven("ext/asm-tree-6.1-beta.jar",
-                "org.ow2.asm", "asm-tree", "6.1-beta",
-                "539d3b0f5f7f5b04b1c286de8e76655b59ab2d43");
+        downloadUsingMaven("ext/asm-6.1.jar",
+                "org.ow2.asm", "asm", "6.1",
+                "94a0d17ba8eb24833cd54253ace9b053786a9571");
+        downloadUsingMaven("ext/asm-commons-6.1.jar",
+                "org.ow2.asm", "asm-commons", "6.1",
+                "8a8d242d7ce00fc937a245fae5b65763d13f7cd1");
+        downloadUsingMaven("ext/asm-tree-6.1.jar",
+                "org.ow2.asm", "asm-tree", "6.1",
+                "701262d4b9bcbdc2d4b80617e82db9a2b7f4f088");
         downloadUsingMaven("ext/args4j-2.33.jar",
                 "args4j", "args4j", "2.33",
                 "bd87a75374a6d6523de82fef51fc3cfe9baf9fc9");
@@ -209,9 +209,9 @@ public class Build extends BuildBase {
                 "ext/org.jacoco.cli-0.8.0.jar" + File.pathSeparator
                 + "ext/org.jacoco.core-0.8.0.jar" + File.pathSeparator
                 + "ext/org.jacoco.report-0.8.0.jar" + File.pathSeparator
-                + "ext/asm-6.1-beta.jar" + File.pathSeparator
-                + "ext/asm-commons-6.1-beta.jar" + File.pathSeparator
-                + "ext/asm-tree-6.1-beta.jar" + File.pathSeparator
+                + "ext/asm-6.1.jar" + File.pathSeparator
+                + "ext/asm-commons-6.1.jar" + File.pathSeparator
+                + "ext/asm-tree-6.1.jar" + File.pathSeparator
                 + "ext/args4j-2.33.jar",
                 "org.jacoco.cli.internal.Main", "report", "coverage/jacoco.exec",
                 "--classfiles", "coverage/bin",


### PR DESCRIPTION
Update ASM libraries used by `build coverage` to a stable version.