### PR TITLE
Add META-INF/versions to all non-Android jars that use Bits

### DIFF
--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -525,15 +525,21 @@ public class Build extends BuildBase {
     }
 
     /**
+     * Add META-INF/versions for Java 9+.
+     */
+    private void addVersions() {
+        copy("temp/META-INF/versions/9", files("src/java9/precompiled"), "src/java9/precompiled");
+    }
+
+    /**
      * Create the regular h2.jar file.
      */
     @Description(summary = "Create the regular h2.jar file.")
     public void jar() {
         compile();
-        FileList files = files("src/java9/precompiled");
-        copy("temp/META-INF/versions/9", files, "src/java9/precompiled");
+        addVersions();
         manifest("H2 Database Engine", "org.h2.tools.Console");
-        files = files("temp").
+        FileList files = files("temp").
             exclude("temp/android/*").
             exclude("temp/org/h2/android/*").
             exclude("temp/org/h2/build/*").
@@ -596,6 +602,7 @@ public class Build extends BuildBase {
     @Description(summary = "Create h2client.jar with only the remote JDBC implementation.")
     public void jarClient() {
         compile(true, true, false);
+        addVersions();
         FileList files = files("temp").
             exclude("temp/org/h2/build/*").
             exclude("temp/org/h2/dev/*").
@@ -622,6 +629,7 @@ public class Build extends BuildBase {
     @Description(summary = "Create h2mvstore.jar containing only the MVStore.")
     public void jarMVStore() {
         compileMVStore(true);
+        addVersions();
         manifestMVStore();
         FileList files = files("temp");
         files.exclude("*.DS_Store");
@@ -636,6 +644,7 @@ public class Build extends BuildBase {
     @Description(summary = "Create h2small.jar containing only the embedded database.")
     public void jarSmall() {
         compile(false, false, true);
+        addVersions();
         FileList files = files("temp").
             exclude("temp/android/*").
             exclude("temp/org/h2/android/*").


### PR DESCRIPTION
`org.h2.utlis.Bits` contains Java 7/8 and separate Java 9+ implementations of some methods that work with byte arrays. Java 9 implementations are much faster. Multi-release jar is used to switch between implementations. These optimized implementations were included only in main jar.

This pull requests includes them in other non-Android jars that uses `Bits` class:
* h2-client (JDBC client driver)
* h2small (only embedded database)
* h2-mvstore (MVStore, `Bits` used by encryption code)

JaQu does not use `Bits`. Multi-release jars are also not supported on Android, and Android does not have recent new features from Java.