### PR TITLE
Add and use incrementDateValue() and decrementDateValue()

### DIFF
--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -1221,12 +1221,10 @@ public class DateTimeUtils {
             timeNanos -= correction;
             if (timeNanos < 0) {
                 timeNanos += NANOS_PER_DAY;
-                dateValue = DateTimeUtils
-                        .dateValueFromAbsoluteDay(absoluteDayFromDateValue(dateValue) - 1);
+                dateValue = decrementDateValue(dateValue);
             } else if (timeNanos >= NANOS_PER_DAY) {
                 timeNanos -= NANOS_PER_DAY;
-                dateValue = DateTimeUtils
-                        .dateValueFromAbsoluteDay(absoluteDayFromDateValue(dateValue) + 1);
+                dateValue = incrementDateValue(dateValue);
             }
         }
         return ValueTimestampTimeZone.fromDateValueAndNanos(dateValue, timeNanos, (short) offsetMins);
@@ -1318,6 +1316,63 @@ public class DateTimeUtils {
             m -= 12;
         }
         return dateValue(y, m + 3, (int) d);
+    }
+
+    /**
+     * Return the next date value.
+     *
+     * @param dateValue
+     *            the date value
+     * @return the next date value
+     */
+    public static long incrementDateValue(long dateValue) {
+        int year = yearFromDateValue(dateValue);
+        if (year == 1582) {
+            // Use slow way instead of rarely needed large custom code.
+            return dateValueFromAbsoluteDay(absoluteDayFromDateValue(dateValue) + 1);
+        }
+        int day = dayFromDateValue(dateValue);
+        if (day < 28) {
+            return dateValue + 1;
+        }
+        int month = monthFromDateValue(dateValue);
+        if (day < getDaysInMonth(year, month)) {
+            return dateValue + 1;
+        }
+        day = 1;
+        if (month < 12) {
+            month++;
+        } else {
+            month = 1;
+            year++;
+        }
+        return dateValue(year, month, day);
+    }
+
+    /**
+     * Return the previous date value.
+     *
+     * @param dateValue
+     *            the date value
+     * @return the previous date value
+     */
+    public static long decrementDateValue(long dateValue) {
+        int year = yearFromDateValue(dateValue);
+        if (year == 1582) {
+            // Use slow way instead of rarely needed large custom code.
+            return dateValueFromAbsoluteDay(absoluteDayFromDateValue(dateValue) - 1);
+        }
+        if (dayFromDateValue(dateValue) > 1) {
+            return dateValue - 1;
+        }
+        int month = monthFromDateValue(dateValue);
+        if (month > 1) {
+            month--;
+        } else {
+            month = 12;
+            year--;
+        }
+        return dateValue(year, month, getDaysInMonth(year, month));
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -62,7 +62,7 @@ public class ValueTimestamp extends Value {
 
     private ValueTimestamp(long dateValue, long timeNanos) {
         this.dateValue = dateValue;
-        if (timeNanos < 0 || timeNanos >= 24L * 60 * 60 * 1000 * 1000 * 1000) {
+        if (timeNanos < 0 || timeNanos >= DateTimeUtils.NANOS_PER_DAY) {
             throw new IllegalArgumentException("timeNanos out of range " + timeNanos);
         }
         this.timeNanos = timeNanos;
@@ -229,7 +229,7 @@ public class ValueTimestamp extends Value {
         long dv = dateValue;
         if (n2 >= DateTimeUtils.NANOS_PER_DAY) {
             n2 -= DateTimeUtils.NANOS_PER_DAY;
-            dv = DateTimeUtils.dateValueFromAbsoluteDay(DateTimeUtils.absoluteDayFromDateValue(dateValue) + 1);
+            dv = DateTimeUtils.incrementDateValue(dv);
         }
         return fromDateValueAndNanos(dv, n2);
     }

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -70,7 +70,7 @@ public class ValueTimestampTimeZone extends Value {
 
     private ValueTimestampTimeZone(long dateValue, long timeNanos,
             short timeZoneOffsetMins) {
-        if (timeNanos < 0 || timeNanos >= 24L * 60 * 60 * 1000 * 1000 * 1000) {
+        if (timeNanos < 0 || timeNanos >= DateTimeUtils.NANOS_PER_DAY) {
             throw new IllegalArgumentException(
                     "timeNanos out of range " + timeNanos);
         }
@@ -218,7 +218,7 @@ public class ValueTimestampTimeZone extends Value {
         long dv = dateValue;
         if (n2 >= DateTimeUtils.NANOS_PER_DAY) {
             n2 -= DateTimeUtils.NANOS_PER_DAY;
-            dv = DateTimeUtils.dateValueFromAbsoluteDay(DateTimeUtils.absoluteDayFromDateValue(dateValue) + 1);
+            dv = DateTimeUtils.incrementDateValue(dv);
         }
         return fromDateValueAndNanos(dv, n2, timeZoneOffsetMins);
     }
@@ -228,25 +228,25 @@ public class ValueTimestampTimeZone extends Value {
         ValueTimestampTimeZone t = (ValueTimestampTimeZone) o;
         // Maximum time zone offset is +/-18 hours so difference in days between local
         // and UTC cannot be more than one day
-        long daysA = DateTimeUtils.absoluteDayFromDateValue(dateValue);
+        long dateValueA = dateValue;
         long timeA = timeNanos - timeZoneOffsetMins * 60_000_000_000L;
         if (timeA < 0) {
             timeA += DateTimeUtils.NANOS_PER_DAY;
-            daysA--;
+            dateValueA = DateTimeUtils.decrementDateValue(dateValueA);
         } else if (timeA >= DateTimeUtils.NANOS_PER_DAY) {
             timeA -= DateTimeUtils.NANOS_PER_DAY;
-            daysA++;
+            dateValueA = DateTimeUtils.incrementDateValue(dateValueA);
         }
-        long daysB = DateTimeUtils.absoluteDayFromDateValue(t.dateValue);
+        long dateValueB = t.dateValue;
         long timeB = t.timeNanos - t.timeZoneOffsetMins * 60_000_000_000L;
         if (timeB < 0) {
             timeB += DateTimeUtils.NANOS_PER_DAY;
-            daysB--;
+            dateValueB = DateTimeUtils.decrementDateValue(dateValueB);
         } else if (timeB >= DateTimeUtils.NANOS_PER_DAY) {
             timeB -= DateTimeUtils.NANOS_PER_DAY;
-            daysB++;
+            dateValueB = DateTimeUtils.incrementDateValue(dateValueB);
         }
-        int cmp = Long.compare(daysA, daysB);
+        int cmp = Long.compare(dateValueA, dateValueB);
         if (cmp != 0) {
             return cmp;
         }

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -377,6 +377,9 @@ public class TestDate extends TestBase {
                     assertEquals(y, DateTimeUtils.yearFromDateValue(date));
                     assertEquals(m, DateTimeUtils.monthFromDateValue(date));
                     assertEquals(d, DateTimeUtils.dayFromDateValue(date));
+                    long nextDateValue = DateTimeUtils.dateValueFromAbsoluteDay(next);
+                    assertEquals(nextDateValue, DateTimeUtils.incrementDateValue(date));
+                    assertEquals(date, DateTimeUtils.decrementDateValue(nextDateValue));
                 }
             }
         }


### PR DESCRIPTION
`ValueTimestampTimeZone.compareSecure()` was significantly slower than similar method of `ValueTimestamp` due to slow conversion of date values to absolute days. This is not always required because nanos of day are not always overflows or underflows after subtraction of time zone offset and even when normalization is needed in can be performed without conversion to absolute day. After these changes comparison of such values about two or three times faster depending on values (but is still slower than for plain `ValueTimestamp`, of course).

New helper methods are also used in other places where date value was incremented or decremented by one day. I didn't measure performance changes in these places, but it also should be better.