### PR TITLE
Add database versions to javadoc of TCP protocol versions and update dictionary.txt

### DIFF
--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -47,61 +47,73 @@ public class Constants {
 
     /**
      * The TCP protocol version number 6.
+     * @since 1.0.72 (2008-05-10)
      */
     public static final int TCP_PROTOCOL_VERSION_6 = 6;
 
     /**
      * The TCP protocol version number 7.
+     * @since 1.2.141 (2010-08-22)
      */
     public static final int TCP_PROTOCOL_VERSION_7 = 7;
 
     /**
      * The TCP protocol version number 8.
+     * @since 1.2.143 (2010-09-18)
      */
     public static final int TCP_PROTOCOL_VERSION_8 = 8;
 
     /**
      * The TCP protocol version number 9.
+     * @since 1.3.158 (2011-07-17)
      */
     public static final int TCP_PROTOCOL_VERSION_9 = 9;
 
     /**
      * The TCP protocol version number 10.
+     * @since 1.3.162 (2011-11-26)
      */
     public static final int TCP_PROTOCOL_VERSION_10 = 10;
 
     /**
      * The TCP protocol version number 11.
+     * @since 1.3.163 (2011-12-30)
      */
     public static final int TCP_PROTOCOL_VERSION_11 = 11;
 
     /**
      * The TCP protocol version number 12.
+     * @since 1.3.168 (2012-07-13)
      */
     public static final int TCP_PROTOCOL_VERSION_12 = 12;
 
     /**
      * The TCP protocol version number 13.
+     * @since 1.3.174 (2013-10-19)
      */
     public static final int TCP_PROTOCOL_VERSION_13 = 13;
 
     /**
      * The TCP protocol version number 14.
+     * @since 1.3.176 (2014-04-05)
      */
     public static final int TCP_PROTOCOL_VERSION_14 = 14;
 
     /**
      * The TCP protocol version number 15.
+     * @since 1.4.178 Beta (2014-05-02)
      */
     public static final int TCP_PROTOCOL_VERSION_15 = 15;
 
     /**
      * The TCP protocol version number 16.
+     * @since 1.4.194 (2017-03-10)
      */
     public static final int TCP_PROTOCOL_VERSION_16 = 16;
 
     /**
      * The TCP protocol version number 17.
+     * @since 1.4.197 (TODO)
      */
     public static final int TCP_PROTOCOL_VERSION_17 = 17;
 

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -766,4 +766,4 @@ interpolated thead
 
 die weekdiff osx subprocess dow proleptic microsecond microseconds divisible cmp denormalized suppressed saturated mcs
 london dfs weekdays intermittent looked msec tstz africa monrovia asia tokyo weekday joi callers multipliers ucn
-openoffice organize libre systemtables gmane sea borders announced millennium
+openoffice organize libre systemtables gmane sea borders announced millennium alex nordlund rarely


### PR DESCRIPTION
1. Releases in which new TCP protocol versions were introduced now specified in their javadoc for future references.

2. `dictionary.txt` is updated.