### PR TITLE
Remove support of TCP protocol versions 6 and 7

### DIFF
--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -46,18 +46,6 @@ public class Constants {
     public static final String BUILD_VENDOR_AND_VERSION = null;
 
     /**
-     * The TCP protocol version number 6.
-     * @since 1.0.72 (2008-05-10)
-     */
-    public static final int TCP_PROTOCOL_VERSION_6 = 6;
-
-    /**
-     * The TCP protocol version number 7.
-     * @since 1.2.141 (2010-08-22)
-     */
-    public static final int TCP_PROTOCOL_VERSION_7 = 7;
-
-    /**
      * The TCP protocol version number 8.
      * @since 1.2.143 (2010-09-18)
      */
@@ -120,7 +108,7 @@ public class Constants {
     /**
      * Minimum supported version of TCP protocol.
      */
-    public static final int TCP_PROTOCOL_VERSION_MIN_SUPPORTED = TCP_PROTOCOL_VERSION_6;
+    public static final int TCP_PROTOCOL_VERSION_MIN_SUPPORTED = TCP_PROTOCOL_VERSION_8;
 
     /**
      * Maximum supported version of TCP protocol.

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -349,19 +349,15 @@ public class Transfer {
         case Value.TIME:
             if (version >= Constants.TCP_PROTOCOL_VERSION_9) {
                 writeLong(((ValueTime) v).getNanos());
-            } else if (version >= Constants.TCP_PROTOCOL_VERSION_7) {
-                writeLong(DateTimeUtils.getTimeLocalWithoutDst(v.getTime()));
             } else {
-                writeLong(v.getTime().getTime());
+                writeLong(DateTimeUtils.getTimeLocalWithoutDst(v.getTime()));
             }
             break;
         case Value.DATE:
             if (version >= Constants.TCP_PROTOCOL_VERSION_9) {
                 writeLong(((ValueDate) v).getDateValue());
-            } else if (version >= Constants.TCP_PROTOCOL_VERSION_7) {
-                writeLong(DateTimeUtils.getTimeLocalWithoutDst(v.getDate()));
             } else {
-                writeLong(v.getDate().getTime());
+                writeLong(DateTimeUtils.getTimeLocalWithoutDst(v.getDate()));
             }
             break;
         case Value.TIMESTAMP: {
@@ -369,13 +365,9 @@ public class Transfer {
                 ValueTimestamp ts = (ValueTimestamp) v;
                 writeLong(ts.getDateValue());
                 writeLong(ts.getTimeNanos());
-            } else if (version >= Constants.TCP_PROTOCOL_VERSION_7) {
-                Timestamp ts = v.getTimestamp();
-                writeLong(DateTimeUtils.getTimeLocalWithoutDst(ts));
-                writeInt(ts.getNanos() % 1_000_000);
             } else {
                 Timestamp ts = v.getTimestamp();
-                writeLong(ts.getTime());
+                writeLong(DateTimeUtils.getTimeLocalWithoutDst(ts));
                 writeInt(ts.getNanos() % 1_000_000);
             }
             break;
@@ -555,28 +547,24 @@ public class Transfer {
         case Value.DATE:
             if (version >= Constants.TCP_PROTOCOL_VERSION_9) {
                 return ValueDate.fromDateValue(readLong());
-            } else if (version >= Constants.TCP_PROTOCOL_VERSION_7) {
+            } else {
                 return ValueDate.fromMillis(DateTimeUtils.getTimeUTCWithoutDst(readLong()));
             }
-            return ValueDate.fromMillis(readLong());
         case Value.TIME:
             if (version >= Constants.TCP_PROTOCOL_VERSION_9) {
                 return ValueTime.fromNanos(readLong());
-            } else if (version >= Constants.TCP_PROTOCOL_VERSION_7) {
+            } else {
                 return ValueTime.fromMillis(DateTimeUtils.getTimeUTCWithoutDst(readLong()));
             }
-            return ValueTime.fromMillis(readLong());
         case Value.TIMESTAMP: {
             if (version >= Constants.TCP_PROTOCOL_VERSION_9) {
                 return ValueTimestamp.fromDateValueAndNanos(
                         readLong(), readLong());
-            } else if (version >= Constants.TCP_PROTOCOL_VERSION_7) {
+            } else {
                 return ValueTimestamp.fromMillisNanos(
                         DateTimeUtils.getTimeUTCWithoutDst(readLong()),
                         readInt() % 1_000_000);
             }
-            return ValueTimestamp.fromMillisNanos(readLong(),
-                    readInt() % 1_000_000);
         }
         case Value.TIMESTAMP_TZ: {
             return ValueTimestampTimeZone.fromDateValueAndNanos(readLong(),


### PR DESCRIPTION
After this change only 1.2.143 (2010-09-18) and later clients will be able to connect to a server from the next release (1.4.197?) and client from the next release will be able to connect only to servers with version 1.2.143 or later.