### PR TITLE
Add Parser.toString() method for improved debugging experience

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6918,4 +6918,9 @@ public class Parser {
         read();
         return readTableOrView();
     }
+
+    @Override
+    public String toString() {
+        return StringUtils.addAsterisk(sqlCommand, parseIndex);
+    }
 }


### PR DESCRIPTION
I'm currently debugging the parser to see if I can provide help with #918. I've found this little improvement here to be very helpful when stepping through the parser to know where exactly I'm at right now. The suggestion implements `toString()` by putting a `[*]` marker at the current parsing position.