### PR TITLE
Minor refactorings in Parser

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4154,40 +4154,39 @@ public class Parser {
                 break;
             }
         } else if (s.length() == 2) {
+            char c1 = s.charAt(1);
             switch (c0) {
             case ':':
-                if ("::".equals(s)) {
-                    return KEYWORD;
-                } else if (":=".equals(s)) {
+                if (c1 == ':' || c1 == '=') {
                     return KEYWORD;
                 }
                 break;
             case '>':
-                if (">=".equals(s)) {
+                if (c1 == '=') {
                     return BIGGER_EQUAL;
                 }
                 break;
             case '<':
-                if ("<=".equals(s)) {
+                if (c1 == '=') {
                     return SMALLER_EQUAL;
-                } else if ("<>".equals(s)) {
+                } else if (c1 == '>') {
                     return NOT_EQUAL;
                 }
                 break;
             case '!':
-                if ("!=".equals(s)) {
+                if (c1 == '=') {
                     return NOT_EQUAL;
-                } else if ("!~".equals(s)) {
+                } else if (c1 == '~') {
                     return KEYWORD;
                 }
                 break;
             case '|':
-                if ("||".equals(s)) {
+                if (c1 == '|') {
                     return STRING_CONCAT;
                 }
                 break;
             case '&':
-                if ("&&".equals(s)) {
+                if (c1 == '&') {
                     return SPATIAL_INTERSECTS;
                 }
                 break;

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3543,19 +3543,6 @@ public class Parser {
     }
 
     /*
-     * Reads passed token in list, in order and returns true on first match.
-     * If none of the token matches returns false
-     */
-    private boolean readIfOr(String... tokens) {
-        for (String token: tokens) {
-            if (readIf(token)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /*
      * Reads every token in list, in order - returns true if all are found.
      * If any are not found, returns false - AND resets parsing back to state when called.
      */
@@ -4490,7 +4477,9 @@ public class Parser {
                     }
                     original += "(" + p;
                     // Oracle syntax
-                    readIfOr("CHAR", "BYTE");
+                    if (!readIf("CHAR")) {
+                        readIf("BYTE");
+                    }
                     if (dataType.supportsScale) {
                         if (readIf(",")) {
                             scale = readInt();


### PR DESCRIPTION
1. `Parser.getSpecialType()` can simply check second character of two-char operators instead of string comparisons. This generates shorter and faster code.

2. `Parser.readIfOr()` was used only in one place and result of this method was ignored. This method is removed and the single invocation is replaced with simpler code.

3. `Parser.readIfMore()` got `strict` parameter and used in more places instead of `readIf(",")` / `read(")")` pairs. This makes code shorter and more consistent.