### PR TITLE
Check parameters in JdbcPreparedStatement.addBatch()

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -1329,6 +1329,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
                 Value[] set = new Value[size];
                 for (int i = 0; i < size; i++) {
                     ParameterInterface param = parameters.get(i);
+                    param.checkSet();
                     Value value = param.getParamValue();
                     set[i] = value;
                 }

--- a/h2/src/test/org/h2/test/jdbc/TestBatchUpdates.java
+++ b/h2/src/test/org/h2/test/jdbc/TestBatchUpdates.java
@@ -13,6 +13,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
 
 /**
@@ -210,6 +212,7 @@ public class TestBatchUpdates extends TestBase {
         String s = COFFEE_UPDATE;
         trace("Prepared Statement String:" + s);
         prep = conn.prepareStatement(s);
+        assertThrows(ErrorCode.PARAMETER_NOT_SET_1, prep).addBatch();
         prep.setInt(1, 2);
         prep.addBatch();
         prep.setInt(1, 3);


### PR DESCRIPTION
`JdbcPreparedStatement.addBatch()` silently converts parameters that were not set to `NULL` values. This is not expected, an exception should be thrown to indicate a problem.