### PR TITLE
ValueBoolean constants are not cleared and may be used directly

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2443,7 +2443,7 @@ public class Parser {
                     if (database.getMode().prohibitEmptyInPredicate) {
                         throw getSyntaxError();
                     }
-                    r = ValueExpression.get(ValueBoolean.get(false));
+                    r = ValueExpression.get(ValueBoolean.FALSE);
                 } else {
                     if (isSelect()) {
                         Query query = parseSelect();
@@ -2533,7 +2533,7 @@ public class Parser {
                                 } else {
                                     rightFilter.mapAndAddFilter(r);
                                 }
-                                r = ValueExpression.get(ValueBoolean.get(true));
+                                r = ValueExpression.get(ValueBoolean.TRUE);
                             }
                         }
                     } else {
@@ -3280,11 +3280,11 @@ public class Parser {
             break;
         case TRUE:
             read();
-            r = ValueExpression.get(ValueBoolean.get(true));
+            r = ValueExpression.get(ValueBoolean.TRUE);
             break;
         case FALSE:
             read();
-            r = ValueExpression.get(ValueBoolean.get(false));
+            r = ValueExpression.get(ValueBoolean.FALSE);
             break;
         case ROWNUM:
             read();

--- a/h2/src/main/org/h2/expression/ConditionAndOr.java
+++ b/h2/src/main/org/h2/expression/ConditionAndOr.java
@@ -100,7 +100,7 @@ public class ConditionAndOr extends Condition {
             if (r == ValueNull.INSTANCE) {
                 return r;
             }
-            return ValueBoolean.get(true);
+            return ValueBoolean.TRUE;
         }
         case OR: {
             if (l.getBoolean()) {
@@ -116,7 +116,7 @@ public class ConditionAndOr extends Condition {
             if (r == ValueNull.INSTANCE) {
                 return r;
             }
-            return ValueBoolean.get(false);
+            return ValueBoolean.FALSE;
         }
         default:
             throw DbException.throwInternalError("type=" + andOrType);

--- a/h2/src/main/org/h2/expression/ConditionInSelect.java
+++ b/h2/src/main/org/h2/expression/ConditionInSelect.java
@@ -62,16 +62,16 @@ public class ConditionInSelect extends Condition {
         }
         int dataType = rows.getColumnType(0);
         if (dataType == Value.NULL) {
-            return ValueBoolean.get(false);
+            return ValueBoolean.FALSE;
         }
         l = l.convertTo(dataType);
         if (rows.containsDistinct(new Value[] { l })) {
-            return ValueBoolean.get(true);
+            return ValueBoolean.TRUE;
         }
         if (rows.containsDistinct(new Value[] { ValueNull.INSTANCE })) {
             return ValueNull.INSTANCE;
         }
-        return ValueBoolean.get(false);
+        return ValueBoolean.FALSE;
     }
 
     private Value getValueSlow(ResultInterface rows, Value l) {

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -330,7 +330,7 @@ public class ExpressionColumn extends Expression {
         if (filter == tf && column.getType() == Value.BOOLEAN) {
             IndexCondition cond = IndexCondition.get(
                     Comparison.EQUAL, this, ValueExpression.get(
-                            ValueBoolean.get(true)));
+                            ValueBoolean.TRUE));
             filter.addIndexCondition(cond);
         }
     }
@@ -338,7 +338,7 @@ public class ExpressionColumn extends Expression {
     @Override
     public Expression getNotIfPossible(Session session) {
         return new Comparison(session, Comparison.EQUAL, this,
-                ValueExpression.get(ValueBoolean.get(false)));
+                ValueExpression.get(ValueBoolean.FALSE));
     }
 
 }

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1048,13 +1048,13 @@ public class Function extends Expression implements FunctionCall {
             break;
         }
         case ARRAY_CONTAINS: {
-            result = ValueBoolean.get(false);
+            result = ValueBoolean.FALSE;
             if (v0.getType() == Value.ARRAY) {
                 Value v1 = getNullOrValue(session, args, values, 1);
                 Value[] list = ((ValueArray) v0).getList();
                 for (Value v : list) {
                     if (v.equals(v1)) {
-                        result = ValueBoolean.get(true);
+                        result = ValueBoolean.TRUE;
                         break;
                     }
                 }

--- a/h2/src/main/org/h2/expression/Parameter.java
+++ b/h2/src/main/org/h2/expression/Parameter.java
@@ -176,7 +176,7 @@ public class Parameter extends Expression implements ParameterInterface {
     @Override
     public Expression getNotIfPossible(Session session) {
         return new Comparison(session, Comparison.EQUAL, this,
-                ValueExpression.get(ValueBoolean.get(false)));
+                ValueExpression.get(ValueBoolean.FALSE));
     }
 
     public void setColumn(Column column) {

--- a/h2/src/main/org/h2/expression/ValueExpression.java
+++ b/h2/src/main/org/h2/expression/ValueExpression.java
@@ -91,7 +91,7 @@ public class ValueExpression extends Expression {
     @Override
     public Expression getNotIfPossible(Session session) {
         return new Comparison(session, Comparison.EQUAL, this,
-                ValueExpression.get(ValueBoolean.get(false)));
+                ValueExpression.get(ValueBoolean.FALSE));
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -459,9 +459,9 @@ public class ValueDataType implements DataType {
         case Value.NULL:
             return ValueNull.INSTANCE;
         case BOOLEAN_TRUE:
-            return ValueBoolean.get(true);
+            return ValueBoolean.TRUE;
         case BOOLEAN_FALSE:
-            return ValueBoolean.get(false);
+            return ValueBoolean.FALSE;
         case INT_NEG:
             return ValueInt.get(-readVarInt(buff));
         case Value.ENUM:

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -716,9 +716,9 @@ public class Data {
         case Value.NULL:
             return ValueNull.INSTANCE;
         case BOOLEAN_TRUE:
-            return ValueBoolean.get(true);
+            return ValueBoolean.TRUE;
         case BOOLEAN_FALSE:
-            return ValueBoolean.get(false);
+            return ValueBoolean.FALSE;
         case INT_NEG:
             return ValueInt.get(-readVarInt());
         case Value.ENUM:

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -1042,12 +1042,12 @@ public abstract class Value {
                         s.equalsIgnoreCase("t") ||
                         s.equalsIgnoreCase("yes") ||
                         s.equalsIgnoreCase("y")) {
-                    return ValueBoolean.get(true);
+                    return ValueBoolean.TRUE;
                 } else if (s.equalsIgnoreCase("false") ||
                         s.equalsIgnoreCase("f") ||
                         s.equalsIgnoreCase("no") ||
                         s.equalsIgnoreCase("n")) {
-                    return ValueBoolean.get(false);
+                    return ValueBoolean.FALSE;
                 } else {
                     // convert to a number, and if it is not 0 then it is true
                     return ValueBoolean.get(new BigDecimal(s).signum() != 0);

--- a/h2/src/main/org/h2/value/ValueBoolean.java
+++ b/h2/src/main/org/h2/value/ValueBoolean.java
@@ -25,10 +25,14 @@ public class ValueBoolean extends Value {
     public static final int DISPLAY_SIZE = 5;
 
     /**
-     * Of type Object so that Tomcat doesn't set it to null.
+     * TRUE value.
      */
-    private static final Object TRUE = new ValueBoolean(true);
-    private static final Object FALSE = new ValueBoolean(false);
+    public static final ValueBoolean TRUE = new ValueBoolean(true);
+
+    /**
+     * FALSE value.
+     */
+    public static final ValueBoolean FALSE = new ValueBoolean(false);
 
     private final boolean value;
 
@@ -53,7 +57,7 @@ public class ValueBoolean extends Value {
 
     @Override
     public Value negate() {
-        return (ValueBoolean) (value ? FALSE : TRUE);
+        return value ? FALSE : TRUE;
     }
 
     @Override
@@ -95,7 +99,7 @@ public class ValueBoolean extends Value {
      * @return the value
      */
     public static ValueBoolean get(boolean b) {
-        return (ValueBoolean) (b ? TRUE : FALSE);
+        return b ? TRUE : FALSE;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/unit/TestClearReferences.java
+++ b/h2/src/test/org/h2/test/unit/TestClearReferences.java
@@ -50,6 +50,13 @@ public class TestClearReferences extends TestBase {
         "org.h2.value.Value.softCache",
     };
 
+    /**
+     * Path to main sources. In IDE project may be located either in the root
+     * directory of repository or in the h2 subdirectory.
+     */
+    private final String SOURCE_PATH = new File("h2/src/main/org/h2/Driver.java").exists()
+            ? "h2/src/main/" : "src/main/";
+
     private boolean hasError;
 
     /**
@@ -113,7 +120,7 @@ public class TestClearReferences extends TestBase {
             String className = file.getAbsolutePath().replace('\\', '/');
             className = className.substring(className.lastIndexOf("org/h2"));
             String packageName = className.substring(0, className.lastIndexOf('/'));
-            if (!new File("src/main/" + packageName).exists()) {
+            if (!new File(SOURCE_PATH + packageName).exists()) {
                 return;
             }
             className = className.replace('/', '.');

--- a/h2/src/test/org/h2/test/unit/TestDataPage.java
+++ b/h2/src/test/org/h2/test/unit/TestDataPage.java
@@ -126,8 +126,8 @@ public class TestDataPage extends TestBase implements DataHandler {
 
     private void testValues() {
         testValue(ValueNull.INSTANCE);
-        testValue(ValueBoolean.get(false));
-        testValue(ValueBoolean.get(true));
+        testValue(ValueBoolean.FALSE);
+        testValue(ValueBoolean.TRUE);
         for (int i = 0; i < 256; i++) {
             testValue(ValueByte.get((byte) i));
         }
@@ -205,7 +205,7 @@ public class TestDataPage extends TestBase implements DataHandler {
             }
         }
         testValue(ValueArray.get(new Value[0]));
-        testValue(ValueArray.get(new Value[] { ValueBoolean.get(true),
+        testValue(ValueArray.get(new Value[] { ValueBoolean.TRUE,
                 ValueInt.get(10) }));
 
         SimpleResultSet rs = new SimpleResultSet();

--- a/h2/src/test/org/h2/test/unit/TestValueMemory.java
+++ b/h2/src/test/org/h2/test/unit/TestValueMemory.java
@@ -151,7 +151,7 @@ public class TestValueMemory extends TestBase implements DataHandler {
         case Value.NULL:
             return ValueNull.INSTANCE;
         case Value.BOOLEAN:
-            return ValueBoolean.get(false);
+            return ValueBoolean.FALSE;
         case Value.BYTE:
             return ValueByte.get((byte) random.nextInt());
         case Value.SHORT:


### PR DESCRIPTION
1. `TestClearReferences` in slightly changed so now it also works if project directory is a root directory of a repository. Before this change it worked only from `h2` subdirectory.

2. `ValueBoolean.TRUE` and `FALSE` may be declared as `ValueBoolean` and not as `Object`, they are not cleared anyway. This allows to remove some casts and to make them public to use them directly for simplicity.

BTW, `ValueNull.NULL`, `ValueDecimal.ZERO` and others were declared in normal way before and all worked as expected. So there is no sense to use this trick for `ValueBoolean`. These instances do not have external references and they are not subjects of clearing.