### PR TITLE
Fix RangeTable.getRowCount() for non-default step

### DIFF
--- a/h2/src/main/org/h2/table/RangeTable.java
+++ b/h2/src/main/org/h2/table/RangeTable.java
@@ -139,7 +139,19 @@ public class RangeTable extends Table {
 
     @Override
     public long getRowCount(Session session) {
-        return Math.max(0, getMax(session) - getMin(session) + 1);
+        long step = getStep(session);
+        if (step == 0L) {
+            throw DbException.get(ErrorCode.STEP_SIZE_MUST_NOT_BE_ZERO);
+        }
+        long delta = getMax(session) - getMin(session);
+        if (step > 0) {
+            if (delta < 0) {
+                return 0;
+            }
+        } else if (delta > 0) {
+            return 0;
+        }
+        return delta / step + 1;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -85,6 +85,7 @@ public class TestScript extends TestBase {
         testScript("derived-column-names.sql");
         testScript("information_schema.sql");
         testScript("joins.sql");
+        testScript("range_table.sql");
         testScript("altertable-index-reuse.sql");
         testScript("default-and-on_update.sql");
         testScript("query-optimisations.sql");

--- a/h2/src/test/org/h2/test/scripts/range_table.sql
+++ b/h2/src/test/org/h2/test/scripts/range_table.sql
@@ -1,0 +1,120 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+SELECT * FROM SYSTEM_RANGE(1, 10) ORDER BY 1;
+> X
+> --
+> 1
+> 2
+> 3
+> 4
+> 5
+> 6
+> 7
+> 8
+> 9
+> 10
+> rows (ordered): 10
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(1, 10);
+>> 10
+
+SELECT * FROM SYSTEM_RANGE(1, 10, 2) ORDER BY 1;
+> X
+> -
+> 1
+> 3
+> 5
+> 7
+> 9
+> rows (ordered): 5
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(1, 10, 2);
+>> 5
+
+SELECT * FROM SYSTEM_RANGE(1, 9, 2) ORDER BY 1;
+> X
+> -
+> 1
+> 3
+> 5
+> 7
+> 9
+> rows (ordered): 5
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(1, 9, 2);
+>> 5
+
+SELECT * FROM SYSTEM_RANGE(10, 1, -2) ORDER BY 1 DESC;
+> X
+> --
+> 10
+> 8
+> 6
+> 4
+> 2
+> rows (ordered): 5
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(10, 1, -2);
+>> 5
+
+SELECT * FROM SYSTEM_RANGE(10, 2, -2) ORDER BY 1 DESC;
+> X
+> --
+> 10
+> 8
+> 6
+> 4
+> 2
+> rows (ordered): 5
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(10, 2, -2);
+>> 5
+
+SELECT * FROM SYSTEM_RANGE(1, 1);
+> X
+> -
+> 1
+> rows: 1
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(1, 1);
+>> 1
+
+SELECT * FROM SYSTEM_RANGE(1, 1, -1);
+> X
+> -
+> 1
+> rows: 1
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(1, 1, -1);
+>> 1
+
+SELECT * FROM SYSTEM_RANGE(2, 1);
+> X
+> -
+> rows: 0
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(2, 1);
+>> 0
+
+SELECT * FROM SYSTEM_RANGE(2, 1, 2);
+> X
+> -
+> rows: 0
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(2, 1, 2);
+>> 0
+
+SELECT * FROM SYSTEM_RANGE(1, 2, 0);
+> exception
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(1, 2, 0);
+> exception
+
+SELECT * FROM SYSTEM_RANGE(2, 1, 0);
+> exception
+
+SELECT COUNT(*) FROM SYSTEM_RANGE(2, 1, 0);
+> exception


### PR DESCRIPTION
If third parameter of `SYSTEM_RANGE` is specified and the specified value is not `1` some aggregates return the wrong values due to problem in `RangeTable.getRowCount()` that ignored `step` value.

This method is fixed and tests are added for different values including negative steps.

`COUNT(*)` is used in tests because expected value is more oblivious for this aggregate.