### PR TITLE
Update changelog and add release date to TCP_PROTOCOL_VERSION_17

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,13 +21,23 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
-<li>-
+<li>PR #989: Fix more issues with range table and improve its documentation
 </li>
 </ul>
 
 <h2>Version 1.4.197 (2018-03-18)</h2>
 <ul>
+<li>PR #988: Fix RangeTable.getRowCount() for non-default step
+</li>
+<li>PR #987: ValueBoolean constants are not cleared and may be used directly
+</li>
+<li>PR #986: Check parameters in JdbcPreparedStatement.addBatch()
+</li>
 <li>PR #984: Minor refactorings in Parser
+</li>
+<li>PR #983: Code cleanups via IntelliJ IDEA inspections
+</li>
+<li>Issue #960: Implement remaining time unit in "date_trunc" function
 </li>
 <li>Issue #933: MVStore background writer endless loop
 </li>

--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -101,7 +101,7 @@ public class Constants {
 
     /**
      * The TCP protocol version number 17.
-     * @since 1.4.197 (TODO)
+     * @since 1.4.197 (2018-03-18)
      */
     public static final int TCP_PROTOCOL_VERSION_17 = 17;
 


### PR DESCRIPTION
Missing entries are added to `changelog.html`.

`Constants.TCP_PROTOCOL_VERSION_17` how have release date in Javadoc.