### PR TITLE
Generate shorter queries in JdbcDatabaseMetaData.getTables() and remove some dead code

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -143,18 +143,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
                         ", " + quoteArray(types) + ");");
             }
             checkClosed();
-            String tableType;
             int typesLength = types != null ? types.length : 0;
-            if (typesLength > 0) {
-                StatementBuilder buff = new StatementBuilder("TABLE_TYPE IN(");
-                for (int i = 0; i < typesLength; i++) {
-                    buff.appendExceptFirst(", ");
-                    buff.append('?');
-                }
-                tableType = buff.append(')').toString();
-            } else {
-                tableType = "TRUE";
-            }
 
             String tableSelect = "SELECT "
                     + "TABLE_CATALOG TABLE_CAT, "
@@ -171,8 +160,15 @@ public class JdbcDatabaseMetaData extends TraceObject implements
                     + "FROM INFORMATION_SCHEMA.TABLES "
                     + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
                     + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND TABLE_NAME LIKE ? ESCAPE ? "
-                    + "AND (" + tableType + ") ";
+                    + "AND TABLE_NAME LIKE ? ESCAPE ?";
+            if (typesLength > 0) {
+                StatementBuilder buff = new StatementBuilder(tableSelect).append(" AND TABLE_TYPE IN(");
+                for (int i = 0; i < typesLength; i++) {
+                    buff.appendExceptFirst(", ");
+                    buff.append('?');
+                }
+                tableSelect = buff.append(')').toString();
+            }
 
             boolean includeSynonyms = types == null || Arrays.asList(types).contains("SYNONYM");
             String synonymSelect = "SELECT "

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -144,9 +144,10 @@ public class JdbcDatabaseMetaData extends TraceObject implements
             }
             checkClosed();
             String tableType;
-            if (types != null && types.length > 0) {
+            int typesLength = types != null ? types.length : 0;
+            if (typesLength > 0) {
                 StatementBuilder buff = new StatementBuilder("TABLE_TYPE IN(");
-                for (String ignored : types) {
+                for (int i = 0; i < typesLength; i++) {
                     buff.appendExceptFirst(", ");
                     buff.append('?');
                 }
@@ -218,7 +219,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
             prep.setString(10, "\\");
             prep.setString(11, getPattern(tableNamePattern));
             prep.setString(12, "\\");
-            for (int i = 0; types != null && i < types.length; i++) {
+            for (int i = 0; i < typesLength; i++) {
                 prep.setString(13 + i, types[i]);
             }
             return prep.executeQuery();

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -158,14 +158,14 @@ public class JdbcDatabaseMetaData extends TraceObject implements
                     + "TYPE_NAME REF_GENERATION, "
                     + "SQL "
                     + "FROM INFORMATION_SCHEMA.TABLES "
-                    + "WHERE TABLE_CATALOG LIKE ? ESCAPE ? "
-                    + "AND TABLE_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND TABLE_NAME LIKE ? ESCAPE ?";
+                    + "WHERE TABLE_CATALOG LIKE ?1 ESCAPE ?4 "
+                    + "AND TABLE_SCHEMA LIKE ?2 ESCAPE ?4 "
+                    + "AND TABLE_NAME LIKE ?3 ESCAPE ?4";
             if (typesLength > 0) {
                 StatementBuilder buff = new StatementBuilder(tableSelect).append(" AND TABLE_TYPE IN(");
                 for (int i = 0; i < typesLength; i++) {
                     buff.appendExceptFirst(", ");
-                    buff.append('?');
+                    buff.append('?').append(i + 5);
                 }
                 tableSelect = buff.append(')').toString();
             }
@@ -184,9 +184,9 @@ public class JdbcDatabaseMetaData extends TraceObject implements
                     + "TYPE_NAME REF_GENERATION, "
                     + "NULL AS SQL "
                     + "FROM INFORMATION_SCHEMA.SYNONYMS "
-                    + "WHERE SYNONYM_CATALOG LIKE ? ESCAPE ? "
-                    + "AND SYNONYM_SCHEMA LIKE ? ESCAPE ? "
-                    + "AND SYNONYM_NAME LIKE ? ESCAPE ? "
+                    + "WHERE SYNONYM_CATALOG LIKE ?1 ESCAPE ?4 "
+                    + "AND SYNONYM_SCHEMA LIKE ?2 ESCAPE ?4 "
+                    + "AND SYNONYM_NAME LIKE ?3 ESCAPE ?4 "
                     + "AND (" + includeSynonyms + ") ";
 
             PreparedStatement prep = conn.prepareAutoCloseStatement("SELECT "
@@ -204,19 +204,11 @@ public class JdbcDatabaseMetaData extends TraceObject implements
                     + "FROM (" + synonymSelect  + " UNION " + tableSelect + ") "
                     + "ORDER BY TABLE_TYPE, TABLE_SCHEM, TABLE_NAME");
             prep.setString(1, getCatalogPattern(catalogPattern));
-            prep.setString(2, "\\");
-            prep.setString(3, getSchemaPattern(schemaPattern));
+            prep.setString(2, getSchemaPattern(schemaPattern));
+            prep.setString(3, getPattern(tableNamePattern));
             prep.setString(4, "\\");
-            prep.setString(5, getPattern(tableNamePattern));
-            prep.setString(6, "\\");
-            prep.setString(7, getCatalogPattern(catalogPattern));
-            prep.setString(8, "\\");
-            prep.setString(9, getSchemaPattern(schemaPattern));
-            prep.setString(10, "\\");
-            prep.setString(11, getPattern(tableNamePattern));
-            prep.setString(12, "\\");
             for (int i = 0; i < typesLength; i++) {
-                prep.setString(13 + i, types[i]);
+                prep.setString(5 + i, types[i]);
             }
             return prep.executeQuery();
         } catch (Exception e) {

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -1250,7 +1250,6 @@ public class JdbcPreparedStatement extends JdbcStatement implements
     @Override
     public int[] executeBatch() throws SQLException {
         try {
-            int id = getNextId(TraceObject.PREPARED_STATEMENT);
             debugCodeCall("executeBatch");
             if (batchParameters == null) {
                 // TODO batch: check what other database do if no parameters are


### PR DESCRIPTION
1. `JdbcDatabaseMetaData.getTables()` used inefficient logic to filer out synonyms if they are not requested. Now `UNION` is not used if synonyms are not needed.

2. The same method passed a lot of duplicated parameters. Now numbered parameters are used instead.

3. `JdbcPreparedStatement.executeBatch()` called `getNextId()` but result was not used anywhere after reimplementation of generated keys. This call is removed.

4. `SessionRemote.setAutoCommitSend()` had leftover code for unsupported TCP protocol versions below 8. This code is removed.