### PR TITLE
Fix MVSecondaryIndex.convertToKey() for ENUM data type

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -323,7 +323,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
             int idx = c.getColumnId();
             Value v = r.getValue(idx);
             if (v != null) {
-                array[i] = v.convertTo(c.getType());
+                array[i] = v.convertTo(c.getType(), -1, null, null, c.getEnumerators());
             }
         }
         array[keyColumns - 1] = ValueLong.get(r.getKey());

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -6,6 +6,7 @@
 package org.h2.test.db;
 
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -99,6 +100,9 @@ public class TestIndex extends TestBase {
 
         conn.close();
         deleteDb("index");
+
+        // This test uses own connection
+        testEnumIndex();
     }
 
     private void testOrderIndex() throws SQLException {
@@ -748,6 +752,29 @@ public class TestIndex extends TestBase {
             stat.execute("DROP ALIAS TEST_INDEX");
         }
         assertEquals(1, testFunctionIndexCounter);
+    }
+
+    private void testEnumIndex() throws SQLException {
+        if (config.memory || config.networked) {
+            return;
+        }
+        deleteDb("index");
+        String url = "jdbc:h2:" + getBaseDir() + "/index;DB_CLOSE_DELAY=0";
+        Connection conn = DriverManager.getConnection(url);
+        Statement stat = conn.createStatement();
+
+        stat.execute("CREATE TABLE TEST(ID INT, V ENUM('A', 'B'), CONSTRAINT PK PRIMARY KEY(ID, V))");
+        stat.execute("INSERT INTO TEST VALUES (1, 'A'), (2, 'B')");
+
+        conn.close();
+        conn = DriverManager.getConnection(url);
+        stat = conn.createStatement();
+
+        stat.execute("DELETE FROM TEST WHERE V = 'A'");
+        stat.execute("DROP TABLE TEST");
+
+        conn.close();
+        deleteDb("index");
     }
 
 }


### PR DESCRIPTION
This fixes issue #997.

Enumeration values are read from disk as `INT` values and then casted to `ENUM`, but `MVSecondaryIndex` did not pass enumerators to `Value.convertTo()` that leads to validation exception.