### PR TITLE
Preserve type names in more places especially for UUID

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,18 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1004: Preserve type names in more places especially for UUID
+</li>
+<li>Issue #1000: Regression in INFORMATION_SCHEMA.CONSTRAINTS.CONSTRAINT_TYPE content
+</li>
+<li>Issue #997: Can not delete from tables with enums
+</li>
+<li>Issue #994: Too much column in result set for GENERATED_KEYS on table with DEFAULT
+</li>
+<li>PR #993: Fix some compiler warnings and improve assert*() methods
+</li>
+<li>PR #991: Generate shorter queries in JdbcDatabaseMetaData.getTables() and remove some dead code
+</li>
 <li>PR #989: Fix more issues with range table and improve its documentation
 </li>
 </ul>

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3027,7 +3027,7 @@ public class Parser {
             int index = currentValue.getInt() - 1;
             if (index < 0 || index >= Constants.MAX_PARAMETER_INDEX) {
                 throw DbException.getInvalidValueException(
-                        "parameter index", index);
+                        "parameter index", index + 1);
             }
             if (indexedParameterList.size() <= index) {
                 indexedParameterList.ensureCapacity(index + 1);

--- a/h2/src/main/org/h2/expression/TableFunction.java
+++ b/h2/src/main/org/h2/expression/TableFunction.java
@@ -135,14 +135,12 @@ public class TableFunction extends Function {
         simple.setAutoClose(false);
         for (int i = 0; i < columnCount; i++) {
             String name = rs.getColumnName(i);
-            /*
-             * TODO Some types, such as Value.BYTES and Value.UUID are mapped to the same
-             * SQL type and we can lose real type here.
-             */
-            int sqlType = DataType.convertTypeToSQLType(rs.getColumnType(i));
+            DataType dataType = DataType.getDataType(rs.getColumnType(i));
+            int sqlType = dataType.sqlType;
+            String sqlTypeName = dataType.name;
             int precision = MathUtils.convertLongToInt(rs.getColumnPrecision(i));
             int scale = rs.getColumnScale(i);
-            simple.addColumn(name, sqlType, precision, scale);
+            simple.addColumn(name, sqlType, sqlTypeName, precision, scale);
         }
         rs.reset();
         for (int i = 0; i < maxrows && rs.next(); i++) {

--- a/h2/src/main/org/h2/tools/SimpleResultSet.java
+++ b/h2/src/main/org/h2/tools/SimpleResultSet.java
@@ -38,6 +38,7 @@ import org.h2.util.Bits;
 import org.h2.util.JdbcUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.New;
+import org.h2.util.SimpleColumnInfo;
 import org.h2.util.Utils;
 import org.h2.value.DataType;
 
@@ -67,7 +68,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
     private int rowId = -1;
     private boolean wasNull;
     private SimpleRowSource source;
-    private ArrayList<Column> columns = New.arrayList();
+    private ArrayList<SimpleColumnInfo> columns = New.arrayList();
     private boolean autoClose = true;
 
     /**
@@ -123,13 +124,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
         if (name == null) {
             name = "C" + (columns.size() + 1);
         }
-        Column column = new Column();
-        column.name = name;
-        column.sqlType = sqlType;
-        column.precision = precision;
-        column.scale = scale;
-        column.sqlTypeName = sqlTypeName;
-        columns.add(column);
+        columns.add(new SimpleColumnInfo(name, sqlType, sqlTypeName, precision, scale));
     }
 
     /**
@@ -1012,7 +1007,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
         if (o == null) {
             return null;
         }
-        switch (columns.get(columnIndex - 1).sqlType) {
+        switch (columns.get(columnIndex - 1).type) {
         case Types.CLOB:
             Clob c = (Clob) o;
             return c.getSubString(1, MathUtils.convertLongToInt(c.length()));
@@ -1868,7 +1863,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
      */
     @Override
     public int getColumnType(int columnIndex) throws SQLException {
-        return getColumn(columnIndex - 1).sqlType;
+        return getColumn(columnIndex - 1).type;
     }
 
     /**
@@ -2045,7 +2040,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
      */
     @Override
     public String getColumnTypeName(int columnIndex) throws SQLException {
-        return getColumn(columnIndex - 1).sqlTypeName;
+        return getColumn(columnIndex - 1).typeName;
     }
 
     /**
@@ -2295,7 +2290,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
         return o;
     }
 
-    private Column getColumn(int i) throws SQLException {
+    private SimpleColumnInfo getColumn(int i) throws SQLException {
         checkColumnIndex(i + 1);
         return columns.get(i);
     }
@@ -2353,37 +2348,6 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
      */
     public boolean getAutoClose() {
         return autoClose;
-    }
-
-    /**
-     * This class holds the data of a result column.
-     */
-    static class Column {
-
-        /**
-         * The column label.
-         */
-        String name;
-
-        /**
-         * The column type Name
-         */
-        String sqlTypeName;
-
-        /**
-         * The SQL type.
-         */
-        int sqlType;
-
-        /**
-         * The precision.
-         */
-        int precision;
-
-        /**
-         * The scale.
-         */
-        int scale;
     }
 
     /**

--- a/h2/src/main/org/h2/util/MergedResultSet.java
+++ b/h2/src/main/org/h2/util/MergedResultSet.java
@@ -24,64 +24,9 @@ import org.h2.tools.SimpleResultSet;
  * that have {@code NAME} column should also define it with the same type.
  */
 public final class MergedResultSet {
-    /**
-     * Metadata of a column.
-     */
-    private static final class ColumnInfo {
-        final String name;
+    private final ArrayList<Map<SimpleColumnInfo, Object>> data = New.arrayList();
 
-        final int type;
-
-        final String typeName;
-
-        final int precision;
-
-        final int scale;
-
-        /**
-         * Creates metadata.
-         *
-         * @param name
-         *            name of the column
-         * @param type
-         *            type of the column, see {@link java.sql.Types}
-         * @param typeName
-         *            type name of the column
-         * @param precision
-         *            precision of the column
-         * @param scale
-         *            scale of the column
-         */
-        ColumnInfo(String name, int type, String typeName, int precision, int scale) {
-            this.name = name;
-            this.type = type;
-            this.typeName = typeName;
-            this.precision = precision;
-            this.scale = scale;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            ColumnInfo other = (ColumnInfo) obj;
-            return name.equals(other.name);
-        }
-
-        @Override
-        public int hashCode() {
-            return name.hashCode();
-        }
-
-    }
-
-    private final ArrayList<Map<ColumnInfo, Object>> data = New.arrayList();
-
-    private final ArrayList<ColumnInfo> columns = New.arrayList();
+    private final ArrayList<SimpleColumnInfo> columns = New.arrayList();
 
     /**
      * Appends a result set.
@@ -97,9 +42,9 @@ public final class MergedResultSet {
         if (cols == 0) {
             return;
         }
-        ColumnInfo[] info = new ColumnInfo[cols];
+        SimpleColumnInfo[] info = new SimpleColumnInfo[cols];
         for (int i = 1; i <= cols; i++) {
-            ColumnInfo ci = new ColumnInfo(meta.getColumnName(i), meta.getColumnType(i), meta.getColumnTypeName(i),
+            SimpleColumnInfo ci = new SimpleColumnInfo(meta.getColumnName(i), meta.getColumnType(i), meta.getColumnTypeName(i),
                     meta.getPrecision(i), meta.getScale(i));
             info[i - 1] = ci;
             if (!columns.contains(ci)) {
@@ -110,9 +55,9 @@ public final class MergedResultSet {
             if (cols == 1) {
                 data.add(Collections.singletonMap(info[0], rs.getObject(1)));
             } else {
-                HashMap<ColumnInfo, Object> map = new HashMap<>();
+                HashMap<SimpleColumnInfo, Object> map = new HashMap<>();
                 for (int i = 1; i <= cols; i++) {
-                    ColumnInfo ci = info[i - 1];
+                    SimpleColumnInfo ci = info[i - 1];
                     map.put(ci, rs.getObject(i));
                 }
                 data.add(map);
@@ -127,12 +72,12 @@ public final class MergedResultSet {
      */
     public SimpleResultSet getResult() {
         SimpleResultSet rs = new SimpleResultSet();
-        for (ColumnInfo ci : columns) {
+        for (SimpleColumnInfo ci : columns) {
             rs.addColumn(ci.name, ci.type, ci.typeName, ci.precision, ci.scale);
         }
-        for (Map<ColumnInfo, Object> map : data) {
+        for (Map<SimpleColumnInfo, Object> map : data) {
             Object[] row = new Object[columns.size()];
-            for (Map.Entry<ColumnInfo, Object> entry : map.entrySet()) {
+            for (Map.Entry<SimpleColumnInfo, Object> entry : map.entrySet()) {
                 row[columns.indexOf(entry.getKey())] = entry.getValue();
             }
             rs.addRow(row);

--- a/h2/src/main/org/h2/util/MergedResultSet.java
+++ b/h2/src/main/org/h2/util/MergedResultSet.java
@@ -32,6 +32,8 @@ public final class MergedResultSet {
 
         final int type;
 
+        final String typeName;
+
         final int precision;
 
         final int scale;
@@ -43,14 +45,17 @@ public final class MergedResultSet {
          *            name of the column
          * @param type
          *            type of the column, see {@link java.sql.Types}
+         * @param typeName
+         *            type name of the column
          * @param precision
          *            precision of the column
          * @param scale
          *            scale of the column
          */
-        ColumnInfo(String name, int type, int precision, int scale) {
+        ColumnInfo(String name, int type, String typeName, int precision, int scale) {
             this.name = name;
             this.type = type;
+            this.typeName = typeName;
             this.precision = precision;
             this.scale = scale;
         }
@@ -94,8 +99,8 @@ public final class MergedResultSet {
         }
         ColumnInfo[] info = new ColumnInfo[cols];
         for (int i = 1; i <= cols; i++) {
-            ColumnInfo ci = new ColumnInfo(meta.getColumnName(i), meta.getColumnType(i), meta.getPrecision(i),
-                    meta.getScale(i));
+            ColumnInfo ci = new ColumnInfo(meta.getColumnName(i), meta.getColumnType(i), meta.getColumnTypeName(i),
+                    meta.getPrecision(i), meta.getScale(i));
             info[i - 1] = ci;
             if (!columns.contains(ci)) {
                 columns.add(ci);
@@ -123,7 +128,7 @@ public final class MergedResultSet {
     public SimpleResultSet getResult() {
         SimpleResultSet rs = new SimpleResultSet();
         for (ColumnInfo ci : columns) {
-            rs.addColumn(ci.name, ci.type, ci.precision, ci.scale);
+            rs.addColumn(ci.name, ci.type, ci.typeName, ci.precision, ci.scale);
         }
         for (Map<ColumnInfo, Object> map : data) {
             Object[] row = new Object[columns.size()];

--- a/h2/src/main/org/h2/util/MergedResultSet.java
+++ b/h2/src/main/org/h2/util/MergedResultSet.java
@@ -44,8 +44,8 @@ public final class MergedResultSet {
         }
         SimpleColumnInfo[] info = new SimpleColumnInfo[cols];
         for (int i = 1; i <= cols; i++) {
-            SimpleColumnInfo ci = new SimpleColumnInfo(meta.getColumnName(i), meta.getColumnType(i), meta.getColumnTypeName(i),
-                    meta.getPrecision(i), meta.getScale(i));
+            SimpleColumnInfo ci = new SimpleColumnInfo(meta.getColumnName(i), meta.getColumnType(i),
+                    meta.getColumnTypeName(i), meta.getPrecision(i), meta.getScale(i));
             info[i - 1] = ci;
             if (!columns.contains(ci)) {
                 columns.add(ci);

--- a/h2/src/main/org/h2/util/SimpleColumnInfo.java
+++ b/h2/src/main/org/h2/util/SimpleColumnInfo.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.util;
+
+/**
+ * Metadata of a column.
+ *
+ * <p>
+ * Notice: {@linkplain #equals(Object)} and {@linkplain #hashCode()} use only
+ * {@linkplain #name} field.
+ * </p>
+ */
+public final class SimpleColumnInfo {
+    /**
+     * Name of the column.
+     */
+    public final String name;
+
+    /**
+     * Type of the column, see {@link java.sql.Types}.
+     */
+    public final int type;
+
+    /**
+     * Type name of the column.
+     */
+    public final String typeName;
+
+    /**
+     * Precision of the column
+     */
+    public final int precision;
+
+    /**
+     * Scale of the column.
+     */
+    public final int scale;
+
+    /**
+     * Creates metadata.
+     *
+     * @param name
+     *            name of the column
+     * @param type
+     *            type of the column, see {@link java.sql.Types}
+     * @param typeName
+     *            type name of the column
+     * @param precision
+     *            precision of the column
+     * @param scale
+     *            scale of the column
+     */
+    public SimpleColumnInfo(String name, int type, String typeName, int precision, int scale) {
+        this.name = name;
+        this.type = type;
+        this.typeName = typeName;
+        this.precision = precision;
+        this.scale = scale;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SimpleColumnInfo other = (SimpleColumnInfo) obj;
+        return name.equals(other.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -856,6 +856,11 @@ public class DataType {
      */
     public static int convertSQLTypeToValueType(int sqlType, String sqlTypeName) {
         switch (sqlType) {
+            case Types.BINARY:
+                if (sqlTypeName.equalsIgnoreCase("UUID")) {
+                    return Value.UUID;
+                }
+                break;
             case Types.OTHER:
             case Types.JAVA_OBJECT:
                 if (sqlTypeName.equalsIgnoreCase("geometry")) {

--- a/h2/src/test/org/h2/test/jdbc/TestGetGeneratedKeys.java
+++ b/h2/src/test/org/h2/test/jdbc/TestGetGeneratedKeys.java
@@ -8,6 +8,7 @@ package org.h2.test.jdbc;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.UUID;
@@ -127,6 +128,9 @@ public class TestGetGeneratedKeys extends TestBase {
         prep.addBatch();
         prep.executeBatch();
         ResultSet rs = prep.getGeneratedKeys();
+        ResultSetMetaData meta = rs.getMetaData();
+        assertEquals("BIGINT", meta.getColumnTypeName(1));
+        assertEquals("UUID", meta.getColumnTypeName(2));
         rs.next();
         assertEquals(1L, rs.getLong(1));
         UUID u1 = (UUID) rs.getObject(2);

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -8,11 +8,14 @@ package org.h2.test.jdbc;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Driver;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.UUID;
+
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
@@ -135,6 +138,13 @@ public class TestMetaData extends TestBase {
         assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT, conn.getHoldability());
         assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT, rs.getHoldability());
         stat.executeUpdate("drop table test");
+
+        PreparedStatement prep = conn.prepareStatement("SELECT X FROM TABLE (X UUID = ?)");
+        prep.setObject(1, UUID.randomUUID());
+        rs = prep.executeQuery();
+        rsMeta = rs.getMetaData();
+        assertEquals("UUID", rsMeta.getColumnTypeName(1));
+
         conn.close();
     }
 

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -770,5 +770,5 @@ openoffice organize libre systemtables gmane sea borders announced millennium al
 
 opti excessively
 
-iterators tech enums incompatibilities loses reimplement readme reorganize milli subdirectory
+iterators tech enums incompatibilities loses reimplement readme reorganize milli subdirectory linkplain inspections
 


### PR DESCRIPTION
1. `UUID` data type name was converted to `BINARY` in different places. Now this type name is preserved by `TABLE` function and in generated keys for batch updates.

2. Off-by-one error is fixed in error message about illegal ?n parameter index in prepared statement.