### PR TITLE
Copy also SRID in ValueGeometry.getGeometry()

### DIFF
--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -141,7 +141,20 @@ public class ValueGeometry extends Value {
      * @return a copy of the geometry object
      */
     public Geometry getGeometry() {
-        return getGeometryNoCopy().copy();
+        Geometry geometry = getGeometryNoCopy();
+        Geometry copy = geometry.copy();
+        /*
+         * Geometry factory is not preserved in WKB format, but SRID is preserved.
+         *
+         * We use a new factory to read geometries from WKB with default SRID value of
+         * 0.
+         *
+         * Geometry.copy() copies the geometry factory and copied value has SRID form
+         * the factory instead of original SRID value. So we need to copy SRID here with
+         * non-recommended (but not deprecated) setSRID() method.
+         */
+        copy.setSRID(geometry.getSRID());
+        return copy;
     }
 
     public Geometry getGeometryNoCopy() {

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import org.h2.engine.Mode;
 import org.h2.message.DbException;
 import org.h2.util.StringUtils;
+import org.h2.util.Utils;
 import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.CoordinateSequenceFilter;
 import org.locationtech.jts.geom.Envelope;
@@ -221,7 +222,7 @@ public class ValueGeometry extends Value {
 
     @Override
     public byte[] getBytes() {
-        return getWKB();
+        return Utils.cloneByteArray(getWKB());
     }
 
     @Override

--- a/h2/src/test/org/h2/test/db/TestSpatial.java
+++ b/h2/src/test/org/h2/test/db/TestSpatial.java
@@ -648,13 +648,14 @@ public class TestSpatial extends TestBase {
         GeometryFactory geometryFactory = new GeometryFactory();
         Geometry geometry = geometryFactory.createPoint(new Coordinate(0, 0));
         geometry.setSRID(27572);
-        ValueGeometry valueGeometry =
-                ValueGeometry.getFromGeometry(geometry);
+        ValueGeometry valueGeometry = ValueGeometry.getFromGeometry(geometry);
         Geometry geometry2 = geometryFactory.createPoint(new Coordinate(0, 0));
         geometry2.setSRID(5326);
-        ValueGeometry valueGeometry2 =
-                ValueGeometry.getFromGeometry(geometry2);
+        ValueGeometry valueGeometry2 = ValueGeometry.getFromGeometry(geometry2);
         assertFalse(valueGeometry.equals(valueGeometry2));
+        ValueGeometry valueGeometry3 = ValueGeometry.getFromGeometry(geometry);
+        assertEquals(valueGeometry, valueGeometry3);
+        assertEquals(geometry.getSRID(), valueGeometry3.getGeometry().getSRID());
         // Check illegal geometry (no WKB representation)
         try {
             ValueGeometry.get("POINT EMPTY");


### PR DESCRIPTION
JTS 1.15.0 does not copy SRID in `Geometry.copy()`, because SRID should be set by `GeometryFactory`.

H2 uses a new factory with SRID 0 to read values from WKB.

Values may have different factories so I think that there is no reason to set some factory for H2 from the user code.

WKB format preserves SRID anyway. The only problem is that deserialized geometries have correct SRID, but does hot have a geometry factory with such SRID. `Geometry.copy()` uses SRID from a factory, that's why copied values in our case always have SRID 0 that is not expected.

The only reasonable solution is to copy SRID by our code. Method for doing so is not deprecated.

WKBReader also uses the same method to set SRID values.

Also exposure of internal byte array by ValueGeometry.getBytes() is fixed.