### PR TITLE
Copy enumerators from table to view

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1012: NPE when querying INFORMATION_SCHEMA.COLUMNS on a view that references an ENUM column
+</li>
 <li>Issue #1010: MERGE USING table not found with qualified table
 </li>
 <li>PR #1009: Fix ARRAY_AGG with ORDER BY and refactor aggregates

--- a/h2/src/main/org/h2/expression/Operation.java
+++ b/h2/src/main/org/h2/expression/Operation.java
@@ -186,6 +186,8 @@ public class Operation extends Expression {
             dataType = left.getType();
             if (dataType == Value.UNKNOWN) {
                 dataType = Value.DECIMAL;
+            } else if (dataType == Value.ENUM) {
+                dataType = Value.INT;
             }
             break;
         case CONCAT:
@@ -315,7 +317,9 @@ public class Operation extends Expression {
                         DataType.getDataType(r).name);
             } else {
                 dataType = Value.getHigherOrder(l, r);
-                if (DataType.isStringType(dataType) &&
+                if (dataType == Value.ENUM) {
+                    dataType = Value.INT;
+                } else if (DataType.isStringType(dataType) &&
                         session.getDatabase().getMode().allowPlusForStringConcat) {
                     opType = OpType.CONCAT;
                 }

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -193,7 +193,13 @@ public class TableView extends Table {
                 long precision = expr.getPrecision();
                 int scale = expr.getScale();
                 int displaySize = expr.getDisplaySize();
-                Column col = new Column(name, type, precision, scale, displaySize);
+                String[] enumerators = null;
+                if (type == Value.ENUM) {
+                    if (expr instanceof ExpressionColumn) {
+                        enumerators = ((ExpressionColumn) expr).getColumn().getEnumerators();
+                    }
+                }
+                Column col = new Column(name, type, precision, scale, displaySize, enumerators);
                 col.setTable(this, i);
                 // Fetch check constraint from view column source
                 ExpressionColumn fromColumn = null;

--- a/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
@@ -185,3 +185,22 @@ SELECT * FROM TEST;
 
 DROP TABLE TEST;
 > ok
+
+CREATE TABLE TEST(E ENUM('A', 'B'));
+> ok
+
+CREATE VIEW V AS SELECT * FROM TEST;
+> ok
+
+SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE COLUMN_NAME = 'E' ORDER BY TABLE_NAME;
+> TABLE_CATALOG TABLE_SCHEMA TABLE_NAME COLUMN_NAME ORDINAL_POSITION COLUMN_DEFAULT IS_NULLABLE DATA_TYPE CHARACTER_MAXIMUM_LENGTH CHARACTER_OCTET_LENGTH NUMERIC_PRECISION NUMERIC_PRECISION_RADIX NUMERIC_SCALE CHARACTER_SET_NAME COLLATION_NAME TYPE_NAME NULLABLE IS_COMPUTED SELECTIVITY CHECK_CONSTRAINT SEQUENCE_NAME REMARKS SOURCE_DATA_TYPE COLUMN_TYPE   COLUMN_ON_UPDATE
+> ------------- ------------ ---------- ----------- ---------------- -------------- ----------- --------- ------------------------ ---------------------- ----------------- ----------------------- ------------- ------------------ -------------- --------- -------- ----------- ----------- ---------------- ------------- ------- ---------------- ------------- ----------------
+> SCRIPT        PUBLIC       TEST       E           1                null           YES         1111      2147483647               2147483647             2147483647        10                      0             Unicode            OFF            ENUM      1        FALSE       50                           null                  null             ENUM('A','B') null
+> SCRIPT        PUBLIC       V          E           1                null           YES         1111      2147483647               2147483647             2147483647        10                      0             Unicode            OFF            ENUM      1        FALSE       50                           null                  null             ENUM('A','B') null
+> rows (ordered): 2
+
+DROP VIEW V;
+> ok
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
@@ -189,17 +189,65 @@ DROP TABLE TEST;
 CREATE TABLE TEST(E ENUM('A', 'B'));
 > ok
 
+INSERT INTO TEST VALUES ('B');
+> update count: 1
+
 CREATE VIEW V AS SELECT * FROM TEST;
 > ok
+
+SELECT * FROM V;
+> E
+> -
+> B
+> rows: 1
+
+CREATE VIEW V1 AS SELECT E + 2 AS E FROM TEST;
+> ok
+
+SELECT * FROM V1;
+> E
+> -
+> 3
+> rows: 1
+
+CREATE VIEW V2 AS SELECT E + E AS E FROM TEST;
+> ok
+
+SELECT * FROM V2;
+> E
+> -
+> 2
+> rows: 1
+
+CREATE VIEW V3 AS SELECT -E AS E FROM TEST;
+> ok
+
+SELECT * FROM V3;
+> E
+> --
+> -1
+> rows: 1
 
 SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE COLUMN_NAME = 'E' ORDER BY TABLE_NAME;
 > TABLE_CATALOG TABLE_SCHEMA TABLE_NAME COLUMN_NAME ORDINAL_POSITION COLUMN_DEFAULT IS_NULLABLE DATA_TYPE CHARACTER_MAXIMUM_LENGTH CHARACTER_OCTET_LENGTH NUMERIC_PRECISION NUMERIC_PRECISION_RADIX NUMERIC_SCALE CHARACTER_SET_NAME COLLATION_NAME TYPE_NAME NULLABLE IS_COMPUTED SELECTIVITY CHECK_CONSTRAINT SEQUENCE_NAME REMARKS SOURCE_DATA_TYPE COLUMN_TYPE   COLUMN_ON_UPDATE
 > ------------- ------------ ---------- ----------- ---------------- -------------- ----------- --------- ------------------------ ---------------------- ----------------- ----------------------- ------------- ------------------ -------------- --------- -------- ----------- ----------- ---------------- ------------- ------- ---------------- ------------- ----------------
 > SCRIPT        PUBLIC       TEST       E           1                null           YES         1111      2147483647               2147483647             2147483647        10                      0             Unicode            OFF            ENUM      1        FALSE       50                           null                  null             ENUM('A','B') null
 > SCRIPT        PUBLIC       V          E           1                null           YES         1111      2147483647               2147483647             2147483647        10                      0             Unicode            OFF            ENUM      1        FALSE       50                           null                  null             ENUM('A','B') null
-> rows (ordered): 2
+> SCRIPT        PUBLIC       V1         E           1                null           YES         4         2147483647               2147483647             2147483647        10                      0             Unicode            OFF            INTEGER   1        FALSE       50                           null                  null             INTEGER       null
+> SCRIPT        PUBLIC       V2         E           1                null           YES         4         2147483647               2147483647             2147483647        10                      0             Unicode            OFF            INTEGER   1        FALSE       50                           null                  null             INTEGER       null
+> SCRIPT        PUBLIC       V3         E           1                null           YES         4         2147483647               2147483647             2147483647        10                      0             Unicode            OFF            INTEGER   1        FALSE       50                           null                  null             INTEGER       null
+> rows (ordered): 5
 
 DROP VIEW V;
+> ok
+
+DROP VIEW V1;
+> ok
+
+DROP VIEW V2;
+> ok
+
+DROP VIEW V3;
 > ok
 
 DROP TABLE TEST;


### PR DESCRIPTION
This fixes issue #1012.

View did not pass enumerators for `ENUM` columns that causes NPE on queries from `INFORMATION_SCHEMA.COLUMNS` and possibly other issues.

I fixed this issues only for cases where column in a view is based on `ExpressionColumn`, it is the most typical situation.

Arithmetic operators on enumerations are entirely broken anyway, I'll send a separate issue to discuss situation with them.