### PR TITLE
Return name from ValueEnumBase.getObject()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1016: ResultSet.getObject() should return enum value, not ordinal
+</li>
 <li>Issue #1012: NPE when querying INFORMATION_SCHEMA.COLUMNS on a view that references an ENUM column
 </li>
 <li>Issue #1010: MERGE USING table not found with qualified table

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -982,7 +982,16 @@ public abstract class Value {
                     case STRING_IGNORECASE:
                     case STRING_FIXED:
                         return ValueEnum.get(enumerators, getString());
-                    default:
+                    case JAVA_OBJECT:
+                        Object object = JdbcUtils.deserialize(getBytesNoCopy(),
+                                getDataHandler());
+                        if (object instanceof String) {
+                            return ValueEnum.get(enumerators, (String) object);
+                        } else if (object instanceof Integer) {
+                            return ValueEnum.get(enumerators, (int) object);
+                        }
+                    //$FALL-THROUGH$
+                default:
                         throw DbException.get(
                                 ErrorCode.DATA_CONVERSION_ERROR_1, getString());
                 }

--- a/h2/src/main/org/h2/value/ValueEnumBase.java
+++ b/h2/src/main/org/h2/value/ValueEnumBase.java
@@ -77,7 +77,7 @@ public class ValueEnumBase extends Value {
 
     @Override
     public Object getObject() {
-        return ordinal;
+        return label;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -476,7 +476,7 @@ public class TestPreparedStatement extends TestBase {
             assertEquals(goodSizes[i], rs.getString(1));
             assertEquals(i, rs.getInt(1));
             Object o = rs.getObject(1);
-            assertEquals(Integer.class, o.getClass());
+            assertEquals(String.class, o.getClass());
         }
 
         for (int i = 0; i < goodSizes.length; i++) {

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1802,7 +1802,7 @@ public class TestResultSet extends TestBase {
     private void testEnum() throws SQLException {
         trace("Test ENUM");
 
-        stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, VALUE ENUM('A', 'B', 'C'))");
+        stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, VALUE ENUM('A', 'B', 'C', 'D', 'E', 'F', 'G'))");
         PreparedStatement prep = conn.prepareStatement("INSERT INTO TEST VALUES(?, ?)");
         prep.setInt(1, 1);
         prep.setString(2, "A");
@@ -1811,13 +1811,29 @@ public class TestResultSet extends TestBase {
         prep.setObject(2, "B");
         prep.executeUpdate();
         prep.setInt(1, 3);
-        prep.setObject(2, "C");
+        prep.setInt(2, 2);
+        prep.executeUpdate();
+        prep.setInt(1, 4);
+        prep.setObject(2, "D", Types.VARCHAR);
+        prep.executeUpdate();
+        prep.setInt(1, 5);
+        prep.setObject(2, "E", Types.OTHER);
+        prep.executeUpdate();
+        prep.setInt(1, 6);
+        prep.setObject(2, 5, Types.OTHER);
+        prep.executeUpdate();
+        prep.setInt(1, 7);
+        prep.setObject(2, 6, Types.INTEGER);
         prep.executeUpdate();
 
         ResultSet rs = stat.executeQuery("SELECT * FROM TEST ORDER BY ID");
         testEnumResult(rs, 1, "A", 0);
         testEnumResult(rs, 2, "B", 1);
         testEnumResult(rs, 3, "C", 2);
+        testEnumResult(rs, 4, "D", 3);
+        testEnumResult(rs, 5, "E", 4);
+        testEnumResult(rs, 6, "F", 5);
+        testEnumResult(rs, 7, "G", 6);
         assertFalse(rs.next());
 
         stat.execute("DROP TABLE TEST");

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -87,6 +87,7 @@ public class TestResultSet extends TestBase {
         testFindColumn();
         testColumnLength();
         testArray();
+        testEnum();
         testLimitMaxRows();
 
         trace("max rows=" + stat.getMaxRows());
@@ -1796,6 +1797,40 @@ public class TestResultSet extends TestBase {
 
         assertFalse(rs.next());
         stat.execute("DROP TABLE TEST");
+    }
+
+    private void testEnum() throws SQLException {
+        trace("Test ENUM");
+
+        stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, VALUE ENUM('A', 'B', 'C'))");
+        PreparedStatement prep = conn.prepareStatement("INSERT INTO TEST VALUES(?, ?)");
+        prep.setInt(1, 1);
+        prep.setString(2, "A");
+        prep.executeUpdate();
+        prep.setInt(1, 2);
+        prep.setObject(2, "B");
+        prep.executeUpdate();
+        prep.setInt(1, 3);
+        prep.setObject(2, "C");
+        prep.executeUpdate();
+
+        ResultSet rs = stat.executeQuery("SELECT * FROM TEST ORDER BY ID");
+        testEnumResult(rs, 1, "A", 0);
+        testEnumResult(rs, 2, "B", 1);
+        testEnumResult(rs, 3, "C", 2);
+        assertFalse(rs.next());
+
+        stat.execute("DROP TABLE TEST");
+    }
+
+    private void testEnumResult(ResultSet rs, int id, String name, int ordinal) throws SQLException {
+        assertTrue(rs.next());
+        assertEquals(id, rs.getInt(1));
+        assertEquals(name, rs.getString(2));
+        assertEquals(name, rs.getObject(2));
+        assertEquals(name, rs.getObject(2, String.class));
+        assertEquals(ordinal, rs.getInt(2));
+        assertEquals((Integer) ordinal, rs.getObject(2, Integer.class));
     }
 
     private byte[] readAllBytes(InputStream in) {


### PR DESCRIPTION
This fixes issue #1016.

`PreparedStatement.setObject(int, Object, int)` is also fixed. H2 maps `ENUM` to `Types.OTHER`, but this method did not work if such JDBC SQL type was specified.