### PR TITLE
Fix more issues with ON DUPLICATE KEY UPDATE in MySQL mode

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1027: Add support for fully qualified names in MySQL compatibility mode
+</li>
+<li>Issue #178: INSERT ON DUPLICATE KEY UPDATE returns wrong generated key
+</li>
+<li>PR #1025: Remove BitField and replace its usages with BitSet
+</li>
 <li>Issue #1019: Console incorrectly sorts BigDecimal columns alphanumerically
 </li>
 <li>PR #1021: Update JdbcDatabaseMetaData to JDBC 4.1 (Java 7)

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1232,7 +1232,24 @@ public class Parser {
                 read("KEY");
                 read("UPDATE");
                 do {
-                    Column column = parseColumn(table);
+                    String columnName = readColumnIdentifier();
+                    if (readIf(".")) {
+                        String schemaOrTableName = columnName;
+                        String tableOrColumnName = readColumnIdentifier();
+                        if (readIf(".")) {
+                            if (!table.getSchema().getName().equals(schemaOrTableName)) {
+                                throw DbException.get(ErrorCode.SCHEMA_NAME_MUST_MATCH);
+                            }
+                            columnName = readColumnIdentifier();
+                        } else {
+                            columnName = tableOrColumnName;
+                            tableOrColumnName = schemaOrTableName;
+                        }
+                        if (!table.getName().equals(tableOrColumnName)) {
+                            throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, tableOrColumnName);
+                        }
+                    }
+                    Column column = table.getColumn(columnName);
                     read("=");
                     Expression expression;
                     if (readIf("DEFAULT")) {

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -49,6 +49,8 @@ public class Update extends Prepared {
     /** The limit expression as specified in the LIMIT clause. */
     private Expression limitExpr;
 
+    private boolean updateToCurrentValuesReturnsZero;
+
     private final ArrayList<Column> columns = New.arrayList();
     private final HashMap<Column, Expression> expressionMap  = new HashMap<>();
 
@@ -134,7 +136,7 @@ public class Update extends Prepared {
                         }
                         newRow.setValue(i, newValue);
                     }
-                    if (setOnUpdate) {
+                    if (setOnUpdate || updateToCurrentValuesReturnsZero) {
                         setOnUpdate = false;
                         for (int i = 0; i < columnCount; i++) {
                             // Use equals here to detect changes from numeric 0 to 0.0 and similar
@@ -152,6 +154,8 @@ public class Update extends Prepared {
                                     }
                                 }
                             }
+                        } else if (updateToCurrentValuesReturnsZero) {
+                            count--;
                         }
                     }
                     table.validateConvertUpdateSequence(session, newRow);
@@ -267,5 +271,15 @@ public class Update extends Prepared {
 
     public void setSourceTableFilter(TableFilter sourceTableFilter) {
         this.sourceTableFilter = sourceTableFilter;
+    }
+
+    /**
+     * Sets expected update count for update to current values case.
+     *
+     * @param updateToCurrentValuesReturnsZero if zero should be returned as update
+     *        count if update set row to current values
+     */
+    public void setUpdateToCurrentValuesReturnsZero(boolean updateToCurrentValuesReturnsZero) {
+        this.updateToCurrentValuesReturnsZero = updateToCurrentValuesReturnsZero;
     }
 }

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -77,6 +77,17 @@ public class TestCompatibility extends TestBase {
         assertEquals(2, rs.getInt(1));
         assertEquals("c", rs.getString(2));
         assertFalse(rs.next());
+        // Check qualified names in ON UPDATE case
+        assertEquals(2, stat.executeUpdate("insert into s2.test(id, name) values(2, 'd') " +
+                "on duplicate key update test.name = values(name)"));
+        assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, stat)
+                .executeUpdate("insert into s2.test(id, name) values(2, 'd') " +
+                        "on duplicate key update test2.name = values(name)");
+        assertEquals(2, stat.executeUpdate("insert into s2.test(id, name) values(2, 'e') " +
+                "on duplicate key update s2.test.name = values(name)"));
+        assertThrows(ErrorCode.SCHEMA_NAME_MUST_MATCH, stat)
+                .executeUpdate("insert into s2.test(id, name) values(2, 'd') " +
+                        "on duplicate key update s3.test.name = values(name)");
         stat.execute("drop schema s2 cascade");
         c.close();
     }

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -63,8 +63,20 @@ public class TestCompatibility extends TestBase {
         stat.execute("create schema s2");
         stat.execute("create table s2.test(id int primary key, name varchar(255))");
         stat.execute("insert into s2.test(id, name) values(1, 'a')");
-        stat.execute("insert into s2.test(id, name) values(1, 'b') " +
-                "on duplicate key update name = values(name)");
+        assertEquals(2, stat.executeUpdate("insert into s2.test(id, name) values(1, 'b') " +
+                "on duplicate key update name = values(name)"));
+        assertEquals(0, stat.executeUpdate("insert into s2.test(id, name) values(1, 'b') " +
+                "on duplicate key update name = values(name)"));
+        assertEquals(1, stat.executeUpdate("insert into s2.test(id, name) values(2, 'c') " +
+                "on duplicate key update name = values(name)"));
+        ResultSet rs = stat.executeQuery("select id, name from s2.test order by id");
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+        assertEquals("b", rs.getString(2));
+        assertTrue(rs.next());
+        assertEquals(2, rs.getInt(1));
+        assertEquals("c", rs.getString(2));
+        assertFalse(rs.next());
         stat.execute("drop schema s2 cascade");
         c.close();
     }

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -771,4 +771,4 @@ openoffice organize libre systemtables gmane sea borders announced millennium al
 opti excessively
 
 iterators tech enums incompatibilities loses reimplement readme reorganize milli subdirectory linkplain inspections
-geometries sourceschema destschema generatedcolumn alphanumerically
+geometries sourceschema destschema generatedcolumn alphanumerically usages


### PR DESCRIPTION
1. Issue #178 is fixed for provided test case. Insert statement returned wrong count of updated rows in case of update that was not compatible with results from MySQL.

2. Issue #1027 is fixed for both `table_name.column_name` (that is definitely supported by MySQL) and requested `schema_name.table_name.column_name` case (I didn't test it in MySQL, but let it be for consistency).

Both changes are relevant only for MySQL mode.