### PR TITLE
Drop schema rights together with schema

### DIFF
--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -18,6 +18,7 @@ import org.h2.engine.DbObject;
 import org.h2.engine.DbObjectBase;
 import org.h2.engine.DbSettings;
 import org.h2.engine.FunctionAlias;
+import org.h2.engine.Right;
 import org.h2.engine.Session;
 import org.h2.engine.SysProperties;
 import org.h2.engine.User;
@@ -171,6 +172,11 @@ public class Schema extends DbObjectBase {
         while (functions != null && functions.size() > 0) {
             FunctionAlias obj = (FunctionAlias) functions.values().toArray()[0];
             database.removeSchemaObject(session, obj);
+        }
+        for (Right right : database.getAllRights()) {
+            if (right.getGrantedObject() == this) {
+                database.removeDatabaseObject(session, right);
+            }
         }
         database.removeMeta(session, getId());
         owner = null;

--- a/h2/src/test/org/h2/test/db/TestRights.java
+++ b/h2/src/test/org/h2/test/db/TestRights.java
@@ -48,6 +48,7 @@ public class TestRights extends TestBase {
         testSchemaRenameUser();
         testAccessRights();
         testSchemaAdminRole();
+        testSchemaDrop();
         deleteDb("rights");
     }
 
@@ -488,6 +489,24 @@ public class TestRights extends TestBase {
         execute("UPDATE SCHEMA_RIGHT_TEST_EXISTS.TEST_EXISTS Set NAME = 'Douglas'");
         assertThrows(ErrorCode.NOT_ENOUGH_RIGHTS_FOR_1, stat).
         execute("DELETE FROM SCHEMA_RIGHT_TEST_EXISTS.TEST_EXISTS");
+        conn.close();
+    }
+
+    private void testSchemaDrop() throws SQLException {
+        if (config.memory) {
+            return;
+        }
+        deleteDb("rights");
+        Connection conn = getConnection("rights");
+        stat = conn.createStatement();
+        stat.execute("create user test password '' admin");
+        stat.execute("create schema b");
+        stat.execute("grant select on schema b to test");
+        stat.execute("drop schema b cascade");
+        conn.close();
+        conn = getConnection("rights");
+        stat = conn.createStatement();
+        stat.execute("drop user test");
         conn.close();
     }
 


### PR DESCRIPTION
`DROP SCHEMA` statement did not drop rights that were granted directly to schema. Database was left in inconsistent state so reconnection was not possible.

This issue was reported in mailing list:
https://groups.google.com/forum/#!topic/h2-database/XfgDVU7NUmM