### PR TITLE
Fix issues with BUILTIN_ALIAS_OVERRIDE=1

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2707,7 +2707,7 @@ public class Parser {
         return orderList;
     }
 
-    private JavaFunction readJavaFunction(Schema schema, String functionName) {
+    private JavaFunction readJavaFunction(Schema schema, String functionName, boolean throwIfNotFound) {
         FunctionAlias functionAlias = null;
         if (schema != null) {
             functionAlias = schema.findFunction(functionName);
@@ -2716,7 +2716,11 @@ public class Parser {
                     functionName);
         }
         if (functionAlias == null) {
-            throw DbException.get(ErrorCode.FUNCTION_NOT_FOUND_1, functionName);
+            if (throwIfNotFound) {
+                throw DbException.get(ErrorCode.FUNCTION_NOT_FOUND_1, functionName);
+            } else {
+                return null;
+            }
         }
         Expression[] args;
         ArrayList<Expression> argList = New.arrayList();
@@ -2761,7 +2765,14 @@ public class Parser {
 
     private Expression readFunction(Schema schema, String name) {
         if (schema != null) {
-            return readJavaFunction(schema, name);
+            return readJavaFunction(schema, name, true);
+        }
+        boolean allowOverride = database.isAllowBuiltinAliasOverride();
+        if (allowOverride) {
+            JavaFunction jf = readJavaFunction(null, name, false);
+            if (jf != null) {
+                return jf;
+            }
         }
         AggregateType agg = getAggregateType(name);
         if (agg != null) {
@@ -2773,7 +2784,10 @@ public class Parser {
             if (aggregate != null) {
                 return readJavaAggregate(aggregate);
             }
-            return readJavaFunction(null, name);
+            if (allowOverride) {
+                throw DbException.get(ErrorCode.FUNCTION_NOT_FOUND_1, name);
+            }
+            return readJavaFunction(null, name, true);
         }
         switch (function.getFunctionType()) {
         case Function.CAST: {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -5114,19 +5114,12 @@ public class Parser {
 
     private CreateFunctionAlias parseCreateFunctionAlias(boolean force) {
         boolean ifNotExists = readIfNotExists();
-        final boolean newAliasSameNameAsBuiltin = Function.getFunction(database, currentToken) != null;
-        String aliasName;
-        if (database.isAllowBuiltinAliasOverride() && newAliasSameNameAsBuiltin) {
-            aliasName = currentToken;
-            schemaName = session.getCurrentSchemaName();
-            read();
-        } else {
-            aliasName = readIdentifierWithSchema();
-        }
+        String aliasName = readIdentifierWithSchema();
+        final boolean newAliasSameNameAsBuiltin = Function.getFunction(database, aliasName) != null;
         if (database.isAllowBuiltinAliasOverride() && newAliasSameNameAsBuiltin) {
             // fine
         } else if (isKeyword(aliasName) ||
-                Function.getFunction(database, aliasName) != null ||
+                newAliasSameNameAsBuiltin ||
                 getAggregateType(aliasName) != null) {
             throw DbException.get(ErrorCode.FUNCTION_ALIAS_ALREADY_EXISTS_1,
                     aliasName);

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -267,6 +267,8 @@ public class Database implements DataHandler {
                 ci.getProperty("JAVA_OBJECT_SERIALIZER", null);
         this.multiThreaded =
                 ci.getProperty("MULTI_THREADED", false);
+        this.allowBuiltinAliasOverride =
+                ci.getProperty("BUILTIN_ALIAS_OVERRIDE", false);
         boolean closeAtVmShutdown =
                 dbSettings.dbCloseOnExit;
         int traceLevelFile =

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -103,7 +103,8 @@ public class TestScript extends TestBase {
                 "uuid", "varchar", "varchar-ignorecase" }) {
             testScript("datatypes/" + s + ".sql");
         }
-        for (String s : new String[] { "alterTableAdd", "alterTableDropColumn", "createView", "createTable",
+        for (String s : new String[] { "alterTableAdd", "alterTableDropColumn",
+                "createAlias", "createView", "createTable",
                 "dropSchema" }) {
             testScript("ddl/" + s + ".sql");
         }

--- a/h2/src/test/org/h2/test/scripts/ddl/createAlias.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/createAlias.sql
@@ -1,0 +1,51 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+create alias "SYSDATE" for "java.lang.Integer.parseInt(java.lang.String)";
+> exception
+
+create alias "MIN" for "java.lang.Integer.parseInt(java.lang.String)";
+> exception
+
+create alias "CAST" for "java.lang.Integer.parseInt(java.lang.String)";
+> exception
+
+--- function alias ---------------------------------------------------------------------------------------------
+CREATE ALIAS MY_SQRT FOR "java.lang.Math.sqrt";
+> ok
+
+SELECT MY_SQRT(2.0) MS, SQRT(2.0);
+> MS                 1.4142135623730951
+> ------------------ ------------------
+> 1.4142135623730951 1.4142135623730951
+> rows: 1
+
+SELECT MY_SQRT(SUM(X)), SUM(X), MY_SQRT(55) FROM SYSTEM_RANGE(1, 10);
+> PUBLIC.MY_SQRT(SUM(X)) SUM(X) PUBLIC.MY_SQRT(55)
+> ---------------------- ------ ------------------
+> 7.416198487095663      55     7.416198487095663
+> rows: 1
+
+SELECT MY_SQRT(-1.0) MS, SQRT(NULL) S;
+> MS  S
+> --- ----
+> NaN null
+> rows: 1
+
+SCRIPT NOPASSWORDS NOSETTINGS;
+> SCRIPT
+> ------------------------------------------------------------
+> CREATE FORCE ALIAS PUBLIC.MY_SQRT FOR "java.lang.Math.sqrt";
+> CREATE USER IF NOT EXISTS SA PASSWORD '' ADMIN;
+> rows: 2
+
+SELECT ALIAS_NAME, JAVA_CLASS, JAVA_METHOD, DATA_TYPE, COLUMN_COUNT, RETURNS_RESULT, REMARKS FROM INFORMATION_SCHEMA.FUNCTION_ALIASES;
+> ALIAS_NAME JAVA_CLASS     JAVA_METHOD DATA_TYPE COLUMN_COUNT RETURNS_RESULT REMARKS
+> ---------- -------------- ----------- --------- ------------ -------------- -------
+> MY_SQRT    java.lang.Math sqrt        8         1            2
+> rows: 1
+
+DROP ALIAS MY_SQRT;
+> ok

--- a/h2/src/test/org/h2/test/scripts/ddl/createAlias.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/createAlias.sql
@@ -49,3 +49,54 @@ SELECT ALIAS_NAME, JAVA_CLASS, JAVA_METHOD, DATA_TYPE, COLUMN_COUNT, RETURNS_RES
 
 DROP ALIAS MY_SQRT;
 > ok
+
+CREATE SCHEMA TEST_SCHEMA;
+> ok
+
+CREATE ALIAS TRUNC FOR "java.lang.Math.floor(double)";
+> exception
+
+CREATE ALIAS PUBLIC.TRUNC FOR "java.lang.Math.floor(double)";
+> exception
+
+CREATE ALIAS TEST_SCHEMA.TRUNC FOR "java.lang.Math.round(double)";
+> exception
+
+SET BUILTIN_ALIAS_OVERRIDE=1;
+> ok
+
+CREATE ALIAS TRUNC FOR "java.lang.Math.floor(double)";
+> ok
+
+DROP ALIAS TRUNC;
+> ok
+
+CREATE ALIAS PUBLIC.TRUNC FOR "java.lang.Math.floor(double)";
+> ok
+
+CREATE ALIAS TEST_SCHEMA.TRUNC FOR "java.lang.Math.round(double)";
+> ok
+
+SELECT PUBLIC.TRUNC(1.5);
+>> 1.0
+
+SELECT PUBLIC.TRUNC(-1.5);
+>> -2.0
+
+SELECT TEST_SCHEMA.TRUNC(1.5);
+>> 2
+
+SELECT TEST_SCHEMA.TRUNC(-1.5);
+>> -1
+
+DROP ALIAS PUBLIC.TRUNC;
+> ok
+
+DROP ALIAS TEST_SCHEMA.TRUNC;
+> ok
+
+SET BUILTIN_ALIAS_OVERRIDE=0;
+> ok
+
+DROP SCHEMA TEST_SCHEMA RESTRICT;
+> ok

--- a/h2/src/test/org/h2/test/scripts/ddl/createAlias.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/createAlias.sql
@@ -68,6 +68,12 @@ SET BUILTIN_ALIAS_OVERRIDE=1;
 CREATE ALIAS TRUNC FOR "java.lang.Math.floor(double)";
 > ok
 
+SELECT TRUNC(1.5);
+>> 1.0
+
+SELECT TRUNC(-1.5);
+>> -2.0
+
 DROP ALIAS TRUNC;
 > ok
 

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -1689,15 +1689,6 @@ explain select * from test where id in(1, 2, null);
 drop table test;
 > ok
 
-create alias "SYSDATE" for "java.lang.Integer.parseInt(java.lang.String)";
-> exception
-
-create alias "MIN" for "java.lang.Integer.parseInt(java.lang.String)";
-> exception
-
-create alias "CAST" for "java.lang.Integer.parseInt(java.lang.String)";
-> exception
-
 CREATE TABLE PARENT(A INT, B INT, PRIMARY KEY(A, B));
 > ok
 
@@ -5097,44 +5088,6 @@ SELECT count(*) FROM test_null WHERE not ('X'=null and 1=0);
 > rows: 1
 
 drop table if exists test_null;
-> ok
-
---- function alias ---------------------------------------------------------------------------------------------
-CREATE ALIAS MY_SQRT FOR "java.lang.Math.sqrt";
-> ok
-
-SELECT MY_SQRT(2.0) MS, SQRT(2.0);
-> MS                 1.4142135623730951
-> ------------------ ------------------
-> 1.4142135623730951 1.4142135623730951
-> rows: 1
-
-SELECT MY_SQRT(SUM(X)), SUM(X), MY_SQRT(55) FROM SYSTEM_RANGE(1, 10);
-> PUBLIC.MY_SQRT(SUM(X)) SUM(X) PUBLIC.MY_SQRT(55)
-> ---------------------- ------ ------------------
-> 7.416198487095663      55     7.416198487095663
-> rows: 1
-
-SELECT MY_SQRT(-1.0) MS, SQRT(NULL) S;
-> MS  S
-> --- ----
-> NaN null
-> rows: 1
-
-SCRIPT NOPASSWORDS NOSETTINGS;
-> SCRIPT
-> ------------------------------------------------------------
-> CREATE FORCE ALIAS PUBLIC.MY_SQRT FOR "java.lang.Math.sqrt";
-> CREATE USER IF NOT EXISTS SA PASSWORD '' ADMIN;
-> rows: 2
-
-SELECT ALIAS_NAME, JAVA_CLASS, JAVA_METHOD, DATA_TYPE, COLUMN_COUNT, RETURNS_RESULT, REMARKS FROM INFORMATION_SCHEMA.FUNCTION_ALIASES;
-> ALIAS_NAME JAVA_CLASS     JAVA_METHOD DATA_TYPE COLUMN_COUNT RETURNS_RESULT REMARKS
-> ---------- -------------- ----------- --------- ------------ -------------- -------
-> MY_SQRT    java.lang.Math sqrt        8         1            2
-> rows: 1
-
-DROP ALIAS MY_SQRT;
 > ok
 
 --- schema ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request fixes issue with `BUILTIN_ALIAS_OVERRIDE` from the mailing list:
https://groups.google.com/forum/#!topic/h2-database/j-exKwwQftI

1. Logic in `parseCreateFunctionAlias()` was wrong and also more complicated than necessary. Overridden aliases with specified schema (database recreates them on initialization always with the schema name) were not checked correctly.

2. `Parser.readFunction()` had a problem with overridden aliases without a schema name.

3. `Database.allowBuiltinAliasOverride` was initialized after initialization of database metadata if parameter was specified in connection URL. If some overridden alias was persisted on database shutdown such database became not connectable any more. With these changes parameter is also initialized in constructor, so parameter in connection URL can be used to connect to such database.

4. Some old tests are moved from `testScript.sql` into new file `createAlias.sql`.