### PR TITLE
Atomic change of transaction state

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -277,7 +277,7 @@ public class TransactionMap<K, V> {
             }
         }
         VersionedValue newValue = new VersionedValue(
-                TransactionStore.getOperationId(transaction.transactionId, transaction.logId),
+                TransactionStore.getOperationId(transaction.transactionId, transaction.getLogId()),
                 value);
         if (current == null) {
             // a new value

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -345,16 +345,15 @@ public class TransactionStore {
      *
      * @param t the transaction
      * @param maxLogId the last log id
+     * @param oldStatus last status
      */
-    void commit(Transaction t, long maxLogId) {
+    void commit(Transaction t, long maxLogId, int oldStatus) {
         if (store.isClosed()) {
             return;
         }
         // TODO could synchronize on blocks (100 at a time or so)
         rwLock.writeLock().lock();
-        int oldStatus = t.getStatus();
         try {
-            t.setStatus(Transaction.STATUS_COMMITTING);
             for (long logId = 0; logId < maxLogId; logId++) {
                 Long undoKey = getOperationId(t.getId(), logId);
                 Object[] op = undoLog.get(undoKey);


### PR DESCRIPTION
Transaction status and log id are combined into AtomicLong.
Those two are the only mutable transaction's fields intended to be shared between threads. 
