### PR TITLE
Support DISTINCT in Java aggregates

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,18 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1047: Support DISTINCT in custom aggregate functions
+</li>
+<li>PR #1046: Split off Transaction TransactionMap VersionedValue
+</li>
+<li>PR #1045: TransactionStore move into separate org.h2.mvstore.tx package
+</li>
+<li>PR #1044: Encapsulate TransactionStore.store field in preparation to a move
+</li>
+<li>PR #1040: generate less garbage for String substring+trim
+</li>
+<li>PR #1035: Minor free space accounting changes
+</li>
 <li>Issue #1034: MERGE USING should not require the same column count in tables
 </li>
 <li>PR #1033: Fix issues with BUILTIN_ALIAS_OVERRIDE=1

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2736,6 +2736,7 @@ public class Parser {
     }
 
     private JavaAggregate readJavaAggregate(UserAggregate aggregate) {
+        boolean distinct = readIf("DISTINCT");
         ArrayList<Expression> params = New.arrayList();
         do {
             params.add(readExpression());
@@ -2750,7 +2751,7 @@ public class Parser {
             filterCondition = null;
         }
         Expression[] list = params.toArray(new Expression[0]);
-        JavaAggregate agg = new JavaAggregate(aggregate, list, currentSelect, filterCondition);
+        JavaAggregate agg = new JavaAggregate(aggregate, list, currentSelect, distinct, filterCondition);
         currentSelect.setGroupQuery();
         return agg;
     }

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -32,6 +32,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Currency;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -694,6 +695,7 @@ public class TestFunctions extends TestBase implements AggregateFunction {
 
         @Override
         public Object getResult() {
+            Collections.sort(list);
             return list.get(list.size() / 2);
         }
 
@@ -793,6 +795,15 @@ public class TestFunctions extends TestBase implements AggregateFunction {
                 "SELECT SIMPLE_MEDIAN(X) FROM SYSTEM_RANGE(1, 9)");
         rs.next();
         assertEquals("5", rs.getString(1));
+
+        stat.execute("CREATE TABLE DATA(V INT)");
+        stat.execute("INSERT INTO DATA VALUES (1), (3), (2), (1), (1), (2), (1), (1), (1), (1), (1)");
+        rs = stat.executeQuery(
+                "SELECT SIMPLE_MEDIAN(V), SIMPLE_MEDIAN(DISTINCT V) FROM DATA");
+        rs.next();
+        assertEquals("1", rs.getString(1));
+        assertEquals("2", rs.getString(2));
+
         conn.close();
 
         if (config.memory) {


### PR DESCRIPTION
This fixes issue #1047.

This implementation reuses `AggregateDataCollecting` for Java aggregates with `DISTINCT` values. API for aggregate functions is not changed. Java aggregates without `DISTINCT` handled in the same way as before without buffering of values.