### PR TITLE
Update schema rights on schema rename

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,18 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #456: H2 table privileges referring to old schema after schema rename
+</li>
+<li>Yet another fix to Page memory accounting
+</li>
+<li>Replace MVStore.ASSERT variable with assertions
+</li>
+<li>Issue #1063: Leftover comments about enhanced for loops
+</li>
+<li>PR #1059: Assorted minor changes
+</li>
+<li>PR #1058: Txcommit atomic
+</li>
 <li>Issue #1038: ora_hash function implementation off by one
 </li>
 <li>PR #1054: Introduce overflow bit in tx state

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -128,6 +128,18 @@ public class Schema extends DbObjectBase {
     }
 
     @Override
+    public ArrayList<DbObject> getChildren() {
+        ArrayList<DbObject> children = New.arrayList();
+        ArrayList<Right> rights = database.getAllRights();
+        for (Right right : rights) {
+            if (right.getGrantedObject() == this) {
+                children.add(right);
+            }
+        }
+        return children;
+    }
+
+    @Override
     public void removeChildrenAndResources(Session session) {
         while (triggers != null && triggers.size() > 0) {
             TriggerObject obj = (TriggerObject) triggers.values().toArray()[0];

--- a/h2/src/test/org/h2/test/db/TestRights.java
+++ b/h2/src/test/org/h2/test/db/TestRights.java
@@ -48,6 +48,8 @@ public class TestRights extends TestBase {
         testSchemaRenameUser();
         testAccessRights();
         testSchemaAdminRole();
+        testTableRename();
+        testSchemaRename();
         testSchemaDrop();
         deleteDb("rights");
     }
@@ -489,6 +491,43 @@ public class TestRights extends TestBase {
         execute("UPDATE SCHEMA_RIGHT_TEST_EXISTS.TEST_EXISTS Set NAME = 'Douglas'");
         assertThrows(ErrorCode.NOT_ENOUGH_RIGHTS_FOR_1, stat).
         execute("DELETE FROM SCHEMA_RIGHT_TEST_EXISTS.TEST_EXISTS");
+        conn.close();
+    }
+
+    private void testTableRename() throws SQLException {
+        if (config.memory) {
+            return;
+        }
+        deleteDb("rights");
+        Connection conn = getConnection("rights");
+        stat = conn.createStatement();
+        stat.execute("create user test password '' admin");
+        stat.execute("create schema b");
+        stat.execute("create table b.t1(id int)");
+        stat.execute("grant select on b.t1 to test");
+        stat.execute("alter table b.t1 rename to b.t2");
+        conn.close();
+        conn = getConnection("rights");
+        stat = conn.createStatement();
+        stat.execute("drop user test");
+        conn.close();
+    }
+
+    private void testSchemaRename() throws SQLException {
+        if (config.memory) {
+            return;
+        }
+        deleteDb("rights");
+        Connection conn = getConnection("rights");
+        stat = conn.createStatement();
+        stat.execute("create user test password '' admin");
+        stat.execute("create schema b");
+        stat.execute("grant select on schema b to test");
+        stat.execute("alter schema b rename to c");
+        conn.close();
+        conn = getConnection("rights");
+        stat = conn.createStatement();
+        stat.execute("drop user test");
         conn.close();
     }
 


### PR DESCRIPTION
Issue #456 is not reproducible with described steps, but if rights are granted directly to schema they are not updated that lead to such exception on reopening of database. This issue is fixed and a new tests are added for this operation and also for steps described in original issue #456.

There are some existing tests for different operations, but they do not test what happens when database is reopened.