### PR TITLE
1.4.196 doesn't have actual support for synonyms

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -69,7 +69,7 @@ Change Log
 </li>
 <li>PR #1021: Update JdbcDatabaseMetaData to JDBC 4.1 (Java 7)
 </li>
-<li>Issue #992: 1.4.196+ client cannot use DatabaseMetaData with 1.4.195- server
+<li>Issue #992: 1.4.197 client cannot use DatabaseMetaData with 1.4.196 and older server
 </li>
 <li>Issue #1016: ResultSet.getObject() should return enum value, not ordinal
 </li>


### PR DESCRIPTION
My tests with different versions were messed up, looks like I used 1.4.195 for some tests where 1.4.196 should be used. Also support for synonyms have old and long history, so I didn't notice that only 1.4.197 have a real support that we can use from the client session. This pull request follows up PR #1020 and simply bumps required version to 1.4.197. With 1.4.196 and older servers client will not try to access unavailable `INFORMATION_SCHEMA.SYNONYMS` table any more. PR #1020 fixes this issue for 1.4.195 and older versions, but not for 1.4.196 due to my mistake.