### PR TITLE
Session.getTransactionId should return a more distinguishing value

### DIFF
--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1634,7 +1634,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
             if (transaction == null) {
                 return ValueNull.INSTANCE;
             }
-            return ValueString.get(Long.toString(getTransaction().getId()));
+            return ValueString.get(Long.toString(getTransaction().getSequenceNum()));
         }
         if (!database.isPersistent()) {
             return ValueNull.INSTANCE;

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -126,6 +126,10 @@ public class Transaction {
         return transactionId;
     }
 
+    public long getSequenceNum() {
+        return sequenceNum;
+    }
+
     public int getStatus() {
         return getStatus(statusAndLogId.get());
     }


### PR DESCRIPTION
The newly introduced Transaction.sequenceNum is a better choice than Transaction.transactionId