### PR TITLE
Move some tests in better place and add an additional test for 2PC

### DIFF
--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -35,7 +35,6 @@ public class TestCompatibility extends TestBase {
     public void test() throws SQLException {
         deleteDb("compatibility");
 
-        testOnDuplicateKey();
         testCaseSensitiveIdentifiers();
         testKeyAsColumnInMySQLMode();
 
@@ -54,42 +53,6 @@ public class TestCompatibility extends TestBase {
 
         conn.close();
         deleteDb("compatibility");
-    }
-
-    private void testOnDuplicateKey() throws SQLException {
-        Connection c = getConnection("compatibility;MODE=MYSQL");
-        Statement stat = c.createStatement();
-        stat.execute("set mode mysql");
-        stat.execute("create schema s2");
-        stat.execute("create table s2.test(id int primary key, name varchar(255))");
-        stat.execute("insert into s2.test(id, name) values(1, 'a')");
-        assertEquals(2, stat.executeUpdate("insert into s2.test(id, name) values(1, 'b') " +
-                "on duplicate key update name = values(name)"));
-        assertEquals(0, stat.executeUpdate("insert into s2.test(id, name) values(1, 'b') " +
-                "on duplicate key update name = values(name)"));
-        assertEquals(1, stat.executeUpdate("insert into s2.test(id, name) values(2, 'c') " +
-                "on duplicate key update name = values(name)"));
-        ResultSet rs = stat.executeQuery("select id, name from s2.test order by id");
-        assertTrue(rs.next());
-        assertEquals(1, rs.getInt(1));
-        assertEquals("b", rs.getString(2));
-        assertTrue(rs.next());
-        assertEquals(2, rs.getInt(1));
-        assertEquals("c", rs.getString(2));
-        assertFalse(rs.next());
-        // Check qualified names in ON UPDATE case
-        assertEquals(2, stat.executeUpdate("insert into s2.test(id, name) values(2, 'd') " +
-                "on duplicate key update test.name = values(name)"));
-        assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, stat)
-                .executeUpdate("insert into s2.test(id, name) values(2, 'd') " +
-                        "on duplicate key update test2.name = values(name)");
-        assertEquals(2, stat.executeUpdate("insert into s2.test(id, name) values(2, 'e') " +
-                "on duplicate key update s2.test.name = values(name)"));
-        assertThrows(ErrorCode.SCHEMA_NAME_MUST_MATCH, stat)
-                .executeUpdate("insert into s2.test(id, name) values(2, 'd') " +
-                        "on duplicate key update s3.test.name = values(name)");
-        stat.execute("drop schema s2 cascade");
-        c.close();
     }
 
     private void testKeyAsColumnInMySQLMode() throws SQLException {

--- a/h2/src/test/org/h2/test/db/TestTransaction.java
+++ b/h2/src/test/org/h2/test/db/TestTransaction.java
@@ -35,6 +35,7 @@ public class TestTransaction extends TestBase {
 
     @Override
     public void test() throws SQLException {
+        config.mvStore = false;
         testClosingConnectionWithSessionTempTable();
         testClosingConnectionWithLockedTable();
         testConstraintCreationRollback();
@@ -48,7 +49,6 @@ public class TestTransaction extends TestBase {
         testReferential();
         testSavepoint();
         testIsolation();
-        testTwoPhaseCommit();
         deleteDb("transaction");
     }
 
@@ -542,44 +542,6 @@ public class TestTransaction extends TestBase {
     private void test(Statement stat, String sql) throws SQLException {
         trace(sql);
         stat.execute(sql);
-    }
-
-    private void testTwoPhaseCommit() throws SQLException {
-        if (config.memory) {
-            return;
-        }
-        deleteDb("transaction2pc");
-        Connection conn = getConnection("transaction2pc");
-        Statement stat = conn.createStatement();
-        stat.execute("CREATE TABLE TEST (ID INT PRIMARY KEY)");
-        conn.setAutoCommit(false);
-        stat.execute("INSERT INTO TEST VALUES (1)");
-        stat.execute("PREPARE COMMIT \"#1\"");
-        conn.commit();
-        stat.execute("SHUTDOWN IMMEDIATELY");
-        conn = getConnection("transaction2pc");
-        stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("SELECT TRANSACTION, STATE FROM INFORMATION_SCHEMA.IN_DOUBT");
-        assertFalse(rs.next());
-        rs = stat.executeQuery("SELECT ID FROM TEST");
-        assertTrue(rs.next());
-        assertEquals(1, rs.getInt(1));
-        assertFalse(rs.next());
-        conn.setAutoCommit(false);
-        stat.execute("INSERT INTO TEST VALUES (2)");
-        stat.execute("PREPARE COMMIT \"#2\"");
-        conn.rollback();
-        stat.execute("SHUTDOWN IMMEDIATELY");
-        conn = getConnection("transaction2pc");
-        stat = conn.createStatement();
-        rs = stat.executeQuery("SELECT TRANSACTION, STATE FROM INFORMATION_SCHEMA.IN_DOUBT");
-        assertFalse(rs.next());
-        rs = stat.executeQuery("SELECT ID FROM TEST");
-        assertTrue(rs.next());
-        assertEquals(1, rs.getInt(1));
-        assertFalse(rs.next());
-        conn.close();
-        deleteDb("transaction2pc");
     }
 
 }

--- a/h2/src/test/org/h2/test/db/TestTransaction.java
+++ b/h2/src/test/org/h2/test/db/TestTransaction.java
@@ -35,7 +35,6 @@ public class TestTransaction extends TestBase {
 
     @Override
     public void test() throws SQLException {
-        config.mvStore = false;
         testClosingConnectionWithSessionTempTable();
         testClosingConnectionWithLockedTable();
         testConstraintCreationRollback();

--- a/h2/src/test/org/h2/test/db/TestTwoPhaseCommit.java
+++ b/h2/src/test/org/h2/test/db/TestTwoPhaseCommit.java
@@ -43,6 +43,8 @@ public class TestTwoPhaseCommit extends TestBase {
         openWith(false);
         test(false);
 
+        testInDoubtAfterShutdown();
+
         if (!config.mvStore) {
             testLargeTransactionName();
         }
@@ -115,4 +117,43 @@ public class TestTwoPhaseCommit extends TestBase {
         stat.execute("PREPARE COMMIT XID_TEST_TRANSACTION_WITH_LONG_NAME");
         crash(conn);
     }
+
+    private void testInDoubtAfterShutdown() throws SQLException {
+        if (config.memory) {
+            return;
+        }
+        deleteDb("twoPhaseCommit");
+        Connection conn = getConnection("twoPhaseCommit");
+        Statement stat = conn.createStatement();
+        stat.execute("CREATE TABLE TEST (ID INT PRIMARY KEY)");
+        conn.setAutoCommit(false);
+        stat.execute("INSERT INTO TEST VALUES (1)");
+        stat.execute("PREPARE COMMIT \"#1\"");
+        conn.commit();
+        stat.execute("SHUTDOWN IMMEDIATELY");
+        conn = getConnection("twoPhaseCommit");
+        stat = conn.createStatement();
+        ResultSet rs = stat.executeQuery("SELECT TRANSACTION, STATE FROM INFORMATION_SCHEMA.IN_DOUBT");
+        assertFalse(rs.next());
+        rs = stat.executeQuery("SELECT ID FROM TEST");
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+        assertFalse(rs.next());
+        conn.setAutoCommit(false);
+        stat.execute("INSERT INTO TEST VALUES (2)");
+        stat.execute("PREPARE COMMIT \"#2\"");
+        conn.rollback();
+        stat.execute("SHUTDOWN IMMEDIATELY");
+        conn = getConnection("twoPhaseCommit");
+        stat = conn.createStatement();
+        rs = stat.executeQuery("SELECT TRANSACTION, STATE FROM INFORMATION_SCHEMA.IN_DOUBT");
+        assertFalse(rs.next());
+        rs = stat.executeQuery("SELECT ID FROM TEST");
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+        assertFalse(rs.next());
+        conn.close();
+        deleteDb("twoPhaseCommit");
+    }
+
 }

--- a/h2/src/test/org/h2/test/db/TestTwoPhaseCommit.java
+++ b/h2/src/test/org/h2/test/db/TestTwoPhaseCommit.java
@@ -152,6 +152,20 @@ public class TestTwoPhaseCommit extends TestBase {
         assertTrue(rs.next());
         assertEquals(1, rs.getInt(1));
         assertFalse(rs.next());
+        conn.setAutoCommit(false);
+        stat.execute("INSERT INTO TEST VALUES (3)");
+        stat.execute("PREPARE COMMIT \"#3\"");
+        stat.execute("SHUTDOWN IMMEDIATELY");
+        conn = getConnection("twoPhaseCommit");
+        stat = conn.createStatement();
+        rs = stat.executeQuery("SELECT TRANSACTION, STATE FROM INFORMATION_SCHEMA.IN_DOUBT");
+        assertTrue(rs.next());
+        assertEquals("#3", rs.getString("TRANSACTION"));
+        assertEquals("IN_DOUBT", rs.getString("STATE"));
+        rs = stat.executeQuery("SELECT ID FROM TEST");
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+        assertFalse(rs.next());
         conn.close();
         deleteDb("twoPhaseCommit");
     }


### PR DESCRIPTION
1. A test for `ON DUPLICATE KEY UPDATE` is moved from `TestCompatibility` to `TestDuplicateKeyUpdate` to group such tests together.

2. A test for 2PC is moved from `TestTransaction` to `TestTwoPhaseCommit` for the same purpose.

3. The moved 2PC test is extended to check what happens if transaction was not committed or rolled back.