### PR TITLE
Assorted minor changes

### DIFF
--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -329,10 +329,10 @@ public class DbSettings extends SettingsBase {
 
     /**
      * Database setting <code>MV_STORE</code>
-     * (default: false for version 1.3, true for version 1.4).<br />
+     * (default: true).<br />
      * Use the MVStore storage engine.
      */
-    public boolean mvStore = get("MV_STORE", Constants.VERSION_MINOR >= 4);
+    public boolean mvStore = get("MV_STORE", true);
 
     /**
      * Database setting <code>COMPRESS</code>

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -332,12 +332,11 @@ public class SysProperties {
 
     /**
      * System property <code>h2.oldStyleOuterJoin</code>
-     * (default: true for version 1.3, false for version 1.4).<br />
+     * (default: false).<br />
      * Limited support for the old-style Oracle outer join with "(+)".
      */
     public static final boolean OLD_STYLE_OUTER_JOIN =
-            Utils.getProperty("h2.oldStyleOuterJoin",
-                    Constants.VERSION_MINOR < 4);
+            Utils.getProperty("h2.oldStyleOuterJoin", false);
 
     /**
      * System property {@code h2.oldResultSetGetObject}, {@code true} by default.
@@ -439,13 +438,12 @@ public class SysProperties {
 
     /**
      * System property <code>h2.sortBinaryUnsigned</code>
-     * (default: false with version 1.3, true with version 1.4).<br />
+     * (default: true).<br />
      * Whether binary data should be sorted in unsigned mode
      * (0xff is larger than 0x00).
      */
     public static final boolean SORT_BINARY_UNSIGNED =
-            Utils.getProperty("h2.sortBinaryUnsigned",
-                    Constants.VERSION_MINOR >= 4);
+            Utils.getProperty("h2.sortBinaryUnsigned", true);
 
     /**
      * System property <code>h2.sortNullsHigh</code> (default: false).<br />
@@ -493,13 +491,12 @@ public class SysProperties {
 
     /**
      * System property <code>h2.implicitRelativePath</code>
-     * (default: true for version 1.3, false for version 1.4).<br />
+     * (default: false).<br />
      * If disabled, relative paths in database URLs need to be written as
      * jdbc:h2:./test instead of jdbc:h2:test.
      */
     public static final boolean IMPLICIT_RELATIVE_PATH =
-            Utils.getProperty("h2.implicitRelativePath",
-                    Constants.VERSION_MINOR < 4);
+            Utils.getProperty("h2.implicitRelativePath", false);
 
     /**
      * System property <code>h2.urlMap</code> (default: null).<br />

--- a/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
@@ -288,7 +288,7 @@ public class ObjectDataType implements DataType {
      * @return true if yes
      */
     static boolean isBigInteger(Object obj) {
-        return obj instanceof BigInteger && obj.getClass() == BigInteger.class;
+        return obj != null && obj.getClass() == BigInteger.class;
     }
 
     /**
@@ -298,7 +298,7 @@ public class ObjectDataType implements DataType {
      * @return true if yes
      */
     static boolean isBigDecimal(Object obj) {
-        return obj instanceof BigDecimal && obj.getClass() == BigDecimal.class;
+        return obj != null && obj.getClass() == BigDecimal.class;
     }
 
     /**
@@ -308,7 +308,7 @@ public class ObjectDataType implements DataType {
      * @return true if yes
      */
     static boolean isDate(Object obj) {
-        return obj instanceof Date && obj.getClass() == Date.class;
+        return obj != null && obj.getClass() == Date.class;
     }
 
     /**

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -1420,7 +1420,8 @@ public class WebApp {
     }
 
     private static boolean isBuiltIn(String sql, String builtIn) {
-        return StringUtils.startsWithIgnoreCase(sql, builtIn);
+        int len = builtIn.length();
+        return sql.length() >= len && sql.regionMatches(true, 0, builtIn, 0, len);
     }
 
     private String executeLoop(Connection conn, int count, String sql)

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -111,20 +111,6 @@ public class StringUtils {
     }
 
     /**
-     * Check is a string starts with another string, ignoring the case.
-     *
-     * @param s the string to check (must be longer than start)
-     * @param start the prefix of s
-     * @return true if start is a prefix of s
-     */
-    public static boolean startsWithIgnoreCase(String s, String start) {
-        if (s.length() < start.length()) {
-            return false;
-        }
-        return s.substring(0, start.length()).equalsIgnoreCase(start);
-    }
-
-    /**
      * Convert a string to a SQL literal. Null is converted to NULL. The text is
      * enclosed in single quotes. If there are any special characters, the
      * method STRINGDECODE is used.

--- a/h2/src/main/org/h2/value/ValueDecimal.java
+++ b/h2/src/main/org/h2/value/ValueDecimal.java
@@ -57,7 +57,7 @@ public class ValueDecimal extends Value {
     private ValueDecimal(BigDecimal value) {
         if (value == null) {
             throw new IllegalArgumentException("null");
-        } else if (!value.getClass().equals(BigDecimal.class)) {
+        } else if (value.getClass() != BigDecimal.class) {
             throw DbException.get(ErrorCode.INVALID_CLASS_2,
                     BigDecimal.class.getName(), value.getClass().getName());
         }

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -286,7 +286,7 @@ java org.h2.test.TestAll timer
     /**
      * Whether the MVStore storage is used.
      */
-    public boolean mvStore = Constants.VERSION_MINOR >= 4;
+    public boolean mvStore = true;
 
     /**
      * If the test should run with many rows.

--- a/h2/src/test/org/h2/test/db/TestSpaceReuse.java
+++ b/h2/src/test/org/h2/test/db/TestSpaceReuse.java
@@ -45,7 +45,7 @@ public class TestSpaceReuse extends TestBase {
             conn.createStatement().execute("delete from t");
             conn.close();
             String fileName = getBaseDir() + "/spaceReuse";
-            if (Constants.VERSION_MINOR >= 4) {
+            if (config.mvStore) {
                 fileName += Constants.SUFFIX_MV_FILE;
             } else {
                 fileName += Constants.SUFFIX_PAGE_FILE;


### PR DESCRIPTION
1. Conditions that check for 1.3/1.4 series of releases are replaced with boolean constants.

2. `TestCases.testBinaryCollation()` now tests both `UNSIGNED` and `SIGNED` collations.

3. `StringUtils.startsWithIgnoreCase()` was used only in one place. This method is inlined and reimplemented without allocation of a new object and in locale-independent way.

4. Checks like `obj instanceof Date && obj.getClass() == Date.class` are replaced with simpler and more readable `obj != null && obj.getClass() == Date.class`. `!value.getClass().equals(BigDecimal.class)` is replaced with `value.getClass() != BigDecimal.class`.