### PR TITLE
Use a better fix for issue with SRID

### DIFF
--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -72,6 +72,10 @@ public class ValueGeometry extends Value {
      * @return the value
      */
     public static ValueGeometry getFromGeometry(Object o) {
+        /*
+         * Do not pass untrusted source geometry object to a cache, use only its WKB
+         * representation. Geometries are not fully immutable.
+         */
         return get(convertToWKB((Geometry) o));
     }
 

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import org.h2.engine.Mode;
 import org.h2.message.DbException;
+import org.h2.util.Bits;
 import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 import org.locationtech.jts.geom.CoordinateSequence;
@@ -143,24 +144,38 @@ public class ValueGeometry extends Value {
     public Geometry getGeometry() {
         Geometry geometry = getGeometryNoCopy();
         Geometry copy = geometry.copy();
-        /*
-         * Geometry factory is not preserved in WKB format, but SRID is preserved.
-         *
-         * We use a new factory to read geometries from WKB with default SRID value of
-         * 0.
-         *
-         * Geometry.copy() copies the geometry factory and copied value has SRID form
-         * the factory instead of original SRID value. So we need to copy SRID here with
-         * non-recommended (but not deprecated) setSRID() method.
-         */
-        copy.setSRID(geometry.getSRID());
         return copy;
     }
 
     public Geometry getGeometryNoCopy() {
         if (geometry == null) {
             try {
-                geometry = new WKBReader().read(bytes);
+                int srid = 0;
+                getSRID: if (bytes.length >= 5) {
+                    boolean bigEndian;
+                    switch (bytes[0]) {
+                    case 0:
+                        bigEndian = true;
+                        break;
+                    case 1:
+                        bigEndian = false;
+                        break;
+                    default:
+                        break getSRID;
+                    }
+                    int type = Bits.readInt(bytes, 1);
+                    if ((type & (bigEndian ? 0x2000_0000 : 0x20)) != 0 && bytes.length >= 9) {
+                        srid = Bits.readInt(bytes, 5);
+                        if (!bigEndian) {
+                            srid = Integer.reverseBytes(srid);
+                        }
+                    }
+                }
+                /*
+                 * No-arg WKBReader() constructor instantiates a new GeometryFactory and a new
+                 * PrecisionModel anyway, so special case for srid == 0 is not needed.
+                 */
+                geometry = new WKBReader(new GeometryFactory(new PrecisionModel(), srid)).read(bytes);
             } catch (ParseException ex) {
                 throw DbException.convert(ex);
             }

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -71,7 +71,7 @@ public class ValueGeometry extends Value {
      * @return the value
      */
     public static ValueGeometry getFromGeometry(Object o) {
-        return get((Geometry) o);
+        return get(convertToWKB((Geometry) o));
     }
 
     private static ValueGeometry get(Geometry g) {

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -167,8 +167,7 @@ public class ValueGeometry extends Value {
                     default:
                         break getSRID;
                     }
-                    int type = Bits.readInt(bytes, 1);
-                    if ((type & (bigEndian ? 0x2000_0000 : 0x20)) != 0 && bytes.length >= 9) {
+                    if ((bytes[bigEndian ? 1 : 4] & 0x20) != 0 && bytes.length >= 9) {
                         srid = Bits.readInt(bytes, 5);
                         if (!bigEndian) {
                             srid = Integer.reverseBytes(srid);

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -155,7 +155,7 @@ public class ValueGeometry extends Value {
         if (geometry == null) {
             try {
                 int srid = 0;
-                getSRID: if (bytes.length >= 5) {
+                getSRID: if (bytes.length >= 9) {
                     boolean bigEndian;
                     switch (bytes[0]) {
                     case 0:
@@ -167,7 +167,7 @@ public class ValueGeometry extends Value {
                     default:
                         break getSRID;
                     }
-                    if ((bytes[bigEndian ? 1 : 4] & 0x20) != 0 && bytes.length >= 9) {
+                    if ((bytes[bigEndian ? 1 : 4] & 0x20) != 0) {
                         srid = Bits.readInt(bytes, 5);
                         if (!bigEndian) {
                             srid = Integer.reverseBytes(srid);

--- a/h2/src/test/org/h2/test/db/TestSpatial.java
+++ b/h2/src/test/org/h2/test/db/TestSpatial.java
@@ -26,7 +26,9 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.util.AffineTransformation;
+import org.locationtech.jts.io.ByteOrderValues;
 import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBWriter;
 import org.locationtech.jts.io.WKTReader;
 
 /**
@@ -604,6 +606,26 @@ public class TestSpatial extends TestBase {
         // Test SRID
         copy = ValueGeometry.get(geom3d.getBytes());
         assertEquals(27572, copy.getGeometry().getSRID());
+        Point point = new GeometryFactory().createPoint((new Coordinate(1.1d, 1.2d)));
+        // SRID 0
+        checkSRID(ValueGeometry.getFromGeometry(point).getBytes(), 0);
+        checkSRID(new WKBWriter(2, ByteOrderValues.BIG_ENDIAN, false).write(point), 0);
+        checkSRID(new WKBWriter(2, ByteOrderValues.BIG_ENDIAN, true).write(point), 0);
+        checkSRID(new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN, false).write(point), 0);
+        checkSRID(new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN, true).write(point), 0);
+        // SRID 1,000,000,000
+        point.setSRID(1_000_000_000);
+        checkSRID(ValueGeometry.getFromGeometry(point).getBytes(), 1_000_000_000);
+        checkSRID(new WKBWriter(2, ByteOrderValues.BIG_ENDIAN, true).write(point), 1_000_000_000);
+        checkSRID(new WKBWriter(2, ByteOrderValues.LITTLE_ENDIAN, true).write(point), 1_000_000_000);
+    }
+
+    private void checkSRID(byte[] bytes, int srid) {
+        Point point = (Point) ValueGeometry.get(bytes).getGeometry();
+        assertEquals(1.1, point.getX());
+        assertEquals(1.2, point.getY());
+        assertEquals(srid, point.getSRID());
+        assertEquals(srid, point.getFactory().getSRID());
     }
 
     /**


### PR DESCRIPTION
1. User-supplied geometries should not be cached, because they are not immutable. SRID or user data can be changed. User data can also create a memory leak.

2. When decoding geometries from WKB pass pre-decoded value of SRID to its factory. This resolves issues with copying of SRID values in `Geometry.copy()` in better way. Moreover, `Geometry.setSRID()` method is not recommended. SRID values should be set via factories. With this change H2 will return values with both correct own SRID (`Geometry.getSRID()`) and correct SRID in a factory (`Geometry.getFactory().getSRID()`). This way should be safer. Old trick in `ValueGeomerty.getGeometry()` is removed.