### PR TITLE
Improve test scripts

### DIFF
--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -207,7 +207,37 @@ public class TestScript extends TestBase {
         while (true) {
             String s = in.readLine();
             if (s == null) {
-                return s;
+                return null;
+            }
+            if (s.startsWith("#")) {
+                int end = s.indexOf('#', 1);
+                if (end < 3) {
+                    fail("Bad line \"" + s + '\"');
+                }
+                boolean val;
+                switch (s.charAt(1)) {
+                case '+':
+                    val = true;
+                    break;
+                case '-':
+                    val = false;
+                    break;
+                default:
+                    fail("Bad line \"" + s + '\"');
+                    return null;
+                }
+                String flag = s.substring(2, end);
+                s = s.substring(end + 1);
+                switch (flag) {
+                case "mvStore":
+                    if (config.mvStore == val) {
+                        break;
+                    } else {
+                        continue;
+                    }
+                default:
+                    fail("Unknown flag \"" + flag + '\"');
+                }
             }
             s = s.trim();
             if (s.length() > 0) {

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -86,6 +86,7 @@ public class TestScript extends TestBase {
         reconnectOften = !config.memory && config.big;
 
         testScript("testScript.sql");
+        testScript("comments.sql");
         testScript("derived-column-names.sql");
         testScript("dual.sql");
         testScript("indexes.sql");

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -494,10 +494,7 @@ public class TestScript extends TestBase {
                 if (reconnectOften && sql.toUpperCase().startsWith("EXPLAIN")) {
                     return;
                 }
-                errors.append(fileName).append('\n');
-                errors.append("line: ").append(in.getLineNumber()).append('\n');
-                errors.append("exp: ").append(compare).append('\n');
-                errors.append("got: ").append(s).append('\n');
+                addWriteResultError(compare, s);
                 if (ex != null) {
                     TestBase.logError("script", ex);
                 }
@@ -508,9 +505,18 @@ public class TestScript extends TestBase {
                 }
             }
         } else {
+            addWriteResultError("<nothing>", s);
+            TestBase.logErrorMessage(errors.toString());
             putBack = compare;
         }
         write(s);
+    }
+
+    private void addWriteResultError(String expected, String got) {
+        errors.append(fileName).append('\n');
+        errors.append("line: ").append(in.getLineNumber()).append('\n');
+        errors.append("exp: ").append(expected).append('\n');
+        errors.append("got: ").append(got).append('\n');
     }
 
     private void write(String s) {

--- a/h2/src/test/org/h2/test/scripts/comments.sql
+++ b/h2/src/test/org/h2/test/scripts/comments.sql
@@ -1,0 +1,50 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+CALL 1 /* comment */ ;;
+> 1
+> -
+> 1
+> rows: 1
+
+CALL 1 /* comment */ ;
+> 1
+> -
+> 1
+> rows: 1
+
+call /* remark * / * /* ** // end */ 1;
+> 1
+> -
+> 1
+> rows: 1
+
+--- remarks/comments/syntax ----------------------------------------------------------------------------------------------
+CREATE TABLE TEST(
+ID INT PRIMARY KEY, -- this is the primary key, type {integer}
+NAME VARCHAR(255) -- this is a string
+);
+> ok
+
+INSERT INTO TEST VALUES(
+1 /* ID */,
+'Hello' // NAME
+);
+> update count: 1
+
+SELECT * FROM TEST;
+> ID NAME
+> -- -----
+> 1  Hello
+> rows: 1
+
+DROP_ TABLE_ TEST_T;
+> exception SYNTAX_ERROR_2
+
+DROP TABLE TEST /*;
+> exception SYNTAX_ERROR_1
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
@@ -24,6 +24,7 @@ select * from card;
 > 0    clubs
 > 3    hearts
 > 4    null
+> rows: 3
 
 select * from card order by suit;
 > RANK SUIT
@@ -31,6 +32,7 @@ select * from card order by suit;
 > 4    null
 > 3    hearts
 > 0    clubs
+> rows (ordered): 3
 
 insert into card (rank, suit) values (8, 'diamonds'), (10, 'clubs'), (7, 'hearts');
 > update count: 3
@@ -42,17 +44,13 @@ select suit, count(rank) from card group by suit order by suit, count(rank);
 > hearts   2
 > clubs    2
 > diamonds 1
+> rows (ordered): 4
 
 select rank from card where suit = 'diamonds';
-> RANK
-> ----
-> 8
+>> 8
 
 select column_type from information_schema.columns where COLUMN_NAME = 'SUIT';
-> COLUMN_TYPE
-> ------------------------------------------
-> ENUM('hearts','clubs','spades','diamonds')
-> rows: 1
+>> ENUM('hearts','clubs','spades','diamonds')
 
 --- ENUM integer-based operations
 
@@ -61,6 +59,7 @@ select rank from card where suit = 1;
 > ----
 > 0
 > 10
+> rows: 2
 
 insert into card (rank, suit) values(5, 2);
 > update count: 1
@@ -69,6 +68,7 @@ select * from card where rank = 5;
 > RANK SUIT
 > ---- ------
 > 5    spades
+> rows: 1
 
 --- ENUM edge cases
 
@@ -100,6 +100,7 @@ select * from card;
 > ---- ------
 > 0    clubs
 > 3    hearts
+> rows: 2
 
 drop table card;
 > ok
@@ -125,6 +126,7 @@ select rank from card where suit = 'clubs';
 > ----
 > 0
 > 1
+> rows: 2
 
 drop table card;
 > ok
@@ -143,18 +145,21 @@ insert into card (rank, suit) values (0, 'clubs'), (3, 'hearts'), (1, 'clubs');
 > update count: 3
 
 create index idx_card_suite on card(`suit`);
+> ok
 
 select rank from card where suit = 'clubs';
 > RANK
 > ----
 > 0
 > 1
+> rows: 2
 
 select rank from card where suit in ('clubs');
 > RANK
 > ----
 > 0
 > 1
+> rows: 2
 
 drop table card;
 > ok

--- a/h2/src/test/org/h2/test/scripts/datatypes/timestamp-with-timezone.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/timestamp-with-timezone.sql
@@ -10,9 +10,7 @@ INSERT INTO tab_with_timezone(x) VALUES ('2017-01-01');
 > update count: 1
 
 SELECT "Query".* FROM (select * from tab_with_timezone where x > '2016-01-01') AS "Query";
-> X
-> ----------------------
-> 2017-01-01 00:00:00+00
+>> 2017-01-01 00:00:00+00
 
 DELETE FROM tab_with_timezone;
 > update count: 1

--- a/h2/src/test/org/h2/test/scripts/dml/mergeUsing.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/mergeUsing.sql
@@ -19,6 +19,7 @@ SELECT * FROM PARENT;
 > -- -----
 > 1  Coco1
 > 2  Coco2
+> rows: 2
 
 EXPLAIN PLAN
     MERGE INTO PARENT AS P
@@ -28,9 +29,7 @@ EXPLAIN PLAN
             UPDATE SET P.NAME = S.NAME WHERE 2 = 2 WHEN NOT
         MATCHED THEN
             INSERT (ID, NAME) VALUES (S.ID, S.NAME);
-> PLAN
-> ---------------------------------------------------------------------------------------------------------------------------------
-> MERGE INTO PUBLIC.PARENT(ID, NAME) KEY(ID) SELECT X AS ID, ('Coco' || X) AS NAME FROM SYSTEM_RANGE(1, 2) /* PUBLIC.RANGE_INDEX */
+>> MERGE INTO PUBLIC.PARENT(ID, NAME) KEY(ID) SELECT X AS ID, ('Coco' || X) AS NAME FROM SYSTEM_RANGE(1, 2) /* PUBLIC.RANGE_INDEX */
 
 DROP TABLE PARENT;
 > ok

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/array-agg.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/array-agg.sql
@@ -20,6 +20,7 @@ select array_agg(v order by v asc),
 > rows (ordered): 1
 
 create index test_idx on test(v);
+> ok
 
 select ARRAY_AGG(v order by v asc),
     ARRAY_AGG(v order by v desc) filter (where v >= '4')

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/avg.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/avg.sql
@@ -18,6 +18,7 @@ select avg(v), avg(v) filter (where v >= 40) from test where v <= 100;
 > rows: 1
 
 create index test_idx on test(v);
+> ok
 
 select avg(v), avg(v) filter (where v >= 40) from test where v <= 100;
 > AVG(V) AVG(V) FILTER (WHERE (V >= 40))

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/bit-and.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/bit-and.sql
@@ -21,6 +21,7 @@ select bit_and(v), bit_and(v) filter (where v <= 0xffffffff0fff) from test where
 > rows: 1
 
 create index test_idx on test(v);
+> ok
 
 select bit_and(v), bit_and(v) filter (where v <= 0xffffffff0fff) from test where v >= 0xff0fffffffff;
 > BIT_AND(V)      BIT_AND(V) FILTER (WHERE (V <= 281474976649215))

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/bit-or.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/bit-or.sql
@@ -20,6 +20,7 @@ select bit_or(v), bit_or(v) filter (where v >= 8) from test where v <= 512;
 > rows: 1
 
 create index test_idx on test(v);
+> ok
 
 select bit_or(v), bit_or(v) filter (where v >= 8) from test where v <= 512;
 > BIT_OR(V) BIT_OR(V) FILTER (WHERE (V >= 8))

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/count.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/count.sql
@@ -18,6 +18,7 @@ select count(v), count(v) filter (where v >= 4) from test where v <= 10;
 > rows: 1
 
 create index test_idx on test(v);
+> ok
 
 select count(v), count(v) filter (where v >= 4) from test where v <= 10;
 > COUNT(V) COUNT(V) FILTER (WHERE (V >= 4))

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/group-concat.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/group-concat.sql
@@ -20,6 +20,7 @@ select group_concat(v order by v asc separator '-'),
 > rows (ordered): 1
 
 create index test_idx on test(v);
+> ok
 
 select group_concat(v order by v asc separator '-'),
     group_concat(v order by v desc separator '-') filter (where v >= '4')

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/max.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/max.sql
@@ -18,6 +18,7 @@ select max(v), max(v) filter (where v <= 8) from test where v <= 10;
 > rows: 1
 
 create index test_idx on test(v);
+> ok
 
 select max(v), max(v) filter (where v <= 8) from test where v <= 10;
 > MAX(V) MAX(V) FILTER (WHERE (V <= 8))

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/median.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/median.sql
@@ -598,6 +598,7 @@ select median(v), median(v) filter (where v >= 40) from test where v <= 100;
 > rows: 1
 
 create index test_idx on test(v);
+> ok
 
 select median(v), median(v) filter (where v >= 40) from test where v <= 100;
 > MEDIAN(V) MEDIAN(V) FILTER (WHERE (V >= 40))
@@ -623,6 +624,7 @@ insert into test values
     ('First', 10), ('First', 10), ('First', 20), ('First', 30), ('First', 30),
     ('Second', 5), ('Second', 4), ('Second', 20), ('Second', 22), ('Second', 300),
     ('Third', 3), ('Third', 100), ('Third', 150), ('Third', 170), ('Third', 400);
+> update count: 15
 
 select dept, median(amount) from test group by dept order by dept;
 > DEPT   MEDIAN(AMOUNT)

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/min.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/min.sql
@@ -18,6 +18,7 @@ select min(v), min(v) filter (where v >= 4) from test where v >= 2;
 > rows: 1
 
 create index test_idx on test(v);
+> ok
 
 select min(v), min(v) filter (where v >= 4) from test where v >= 2;
 > MIN(V) MIN(V) FILTER (WHERE (V >= 4))

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/sum.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/sum.sql
@@ -18,6 +18,7 @@ select sum(v), sum(v) filter (where v >= 4) from test where v <= 10;
 > rows: 1
 
 create index test_idx on test(v);
+> ok
 
 select sum(v), sum(v) filter (where v >= 4) from test where v <= 10;
 > SUM(V) SUM(V) FILTER (WHERE (V >= 4))

--- a/h2/src/test/org/h2/test/scripts/functions/string/char.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/char.sql
@@ -7,10 +7,10 @@ create memory table test(id int primary key, name varchar(255));
 > ok
 
 insert into test values(1, 'Hello');
+> update count: 1
 
 select char(null) en, char(65) ea from test;
 > EN   EA
 > ---- --
 > null A
 > rows: 1
-

--- a/h2/src/test/org/h2/test/scripts/functions/string/concat.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/concat.sql
@@ -6,6 +6,7 @@ create memory table test(id int primary key, name varchar(255));
 > ok
 
 insert into test values(1, 'Hello');
+> update count: 1
 
 select concat(null, null) en, concat(null, 'a') ea, concat('b', null) eb, concat('ab', 'c') abc from test;
 > EN   EA EB ABC

--- a/h2/src/test/org/h2/test/scripts/functions/string/difference.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/difference.sql
@@ -7,6 +7,7 @@ create memory table test(id int primary key, name varchar(255));
 > ok
 
 insert into test values(1, 'Hello');
+> update count: 1
 
 select difference(null, null) en, difference('a', null) en1, difference(null, 'a') en2 from test;
 > EN   EN1  EN2
@@ -19,5 +20,3 @@ select difference('abc', 'abc') e0, difference('Thomas', 'Tom') e1 from test;
 > -- --
 > 4  3
 > rows: 1
-
-

--- a/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
@@ -13,6 +13,7 @@ select regexp_replace('Sylvain', 'S..', 'TOTO', 'mni');
 >> TOTOvain
 
 set mode oracle;
+> ok
 
 select regexp_replace('first last', '(\w+) (\w+)', '\2 \1');
 >> last first
@@ -27,6 +28,7 @@ select regexp_replace('first last', '(\w+) (\w+)', '$2 $1');
 >> $2 $1
 
 set mode regular;
+> ok
 
 select regexp_replace('first last', '(\w+) (\w+)', '\2 \1');
 >> 2 1

--- a/h2/src/test/org/h2/test/scripts/functions/string/soundex.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/soundex.sql
@@ -7,6 +7,7 @@ create memory table test(id int primary key, name varchar(255));
 > ok
 
 insert into test values(1, 'Hello');
+> update count: 1
 
 select soundex(null) en, soundex('tom') et from test;
 > EN   ET
@@ -23,4 +24,3 @@ soundex('VanDeusen') V532, soundex('Ashcraft') A261 from test;
 > ---- ---- ---- ---- ---- ---- ---- ----
 > W252 L000 G362 P236 J250 T522 V532 A261
 > rows: 1
-

--- a/h2/src/test/org/h2/test/scripts/functions/system/rownum.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/rownum.sql
@@ -11,7 +11,7 @@ select row_number() over () as rnum, str from test where str = 'A';
 > RNUM STR
 > ---- ---
 > 1    A
+> rows: 1
 
 drop table test;
 > ok
-

--- a/h2/src/test/org/h2/test/scripts/functions/system/set.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/set.sql
@@ -24,6 +24,7 @@ SELECT 1 AS VERY_VERY_VERY_LONG_ID_VERY_VERY_VERY_LONG_ID, SUM(X)+1 AS _12345678
 > VERY_VERY_VERY_LONG_ID_VERY_VE _123456789012345 SUMX1 SUMX147 x noName6 noName7
 > ------------------------------ ---------------- ----- ------- - ------- -------
 > 1                              4                4     51      x !!!     !!!!
+> rows: 1
 
 SET COLUMN_NAME_RULES=EMULATE='Oracle';
 > ok
@@ -33,6 +34,7 @@ SELECT 1 AS VERY_VERY_VERY_LONG_ID, SUM(X)+1 AS _123456789012345, SUM(X)+1 , SUM
 > VERY_VERY_VERY_LONG_ID _123456789012345 SUMX1 SUMX147 x _UNNAMED_6 _UNNAMED_7
 > ---------------------- ---------------- ----- ------- - ---------- ----------
 > 1                      4                4     51      x !!!        !!!!
+> rows: 1
 
 SET COLUMN_NAME_RULES=EMULATE='Oracle';
 > ok
@@ -42,6 +44,7 @@ SELECT 1 AS VERY_VERY_VERY_LONG_ID, SUM(X)+1 AS _123456789012345, SUM(X)+1 , SUM
 > VERY_VERY_VERY_LONG_ID _123456789012345 SUMX1 SUMX147 x _UNNAMED_6 _UNNAMED_7 _23456789012345678901234567890XXX
 > ---------------------- ---------------- ----- ------- - ---------- ---------- ---------------------------------
 > 1                      4                4     51      x !!!        !!!!       Very Long
+> rows: 1
 
 SET COLUMN_NAME_RULES=EMULATE='PostgreSQL';
 > ok
@@ -51,6 +54,7 @@ SELECT 1 AS VERY_VERY_VERY_LONG_ID, SUM(X)+1 AS _123456789012345, SUM(X)+1 , SUM
 > VERY_VERY_VERY_LONG_ID _123456789012345 SUMX1 SUMX147 x _UNNAMED_6 _UNNAMED_7 QuotedColumnId
 > ---------------------- ---------------- ----- ------- - ---------- ---------- --------------
 > 1                      4                4     51      x !!!        !!!!       999
+> rows: 1
 
 SET COLUMN_NAME_RULES=DEFAULT;
 > ok

--- a/h2/src/test/org/h2/test/scripts/joins.sql
+++ b/h2/src/test/org/h2/test/scripts/joins.sql
@@ -764,21 +764,36 @@ DROP TABLE C;
 > ok
 
 CREATE TABLE T1(X1 INT);
+> ok
 CREATE TABLE T2(X2 INT);
+> ok
 CREATE TABLE T3(X3 INT);
+> ok
 CREATE TABLE T4(X4 INT);
+> ok
 CREATE TABLE T5(X5 INT);
+> ok
 
 INSERT INTO T1 VALUES (1);
+> update count: 1
 INSERT INTO T1 VALUES (NULL);
+> update count: 1
 INSERT INTO T2 VALUES (1);
+> update count: 1
 INSERT INTO T2 VALUES (NULL);
+> update count: 1
 INSERT INTO T3 VALUES (1);
+> update count: 1
 INSERT INTO T3 VALUES (NULL);
+> update count: 1
 INSERT INTO T4 VALUES (1);
+> update count: 1
 INSERT INTO T4 VALUES (NULL);
+> update count: 1
 INSERT INTO T5 VALUES (1);
+> update count: 1
 INSERT INTO T5 VALUES (NULL);
+> update count: 1
 
 SELECT T1.X1, T2.X2, T3.X3, T4.X4, T5.X5 FROM (
     T1 INNER JOIN (

--- a/h2/src/test/org/h2/test/scripts/joins.sql
+++ b/h2/src/test/org/h2/test/scripts/joins.sql
@@ -265,10 +265,8 @@ explain select * from test1
 inner join test2 on test1.id=test2.id left
 outer join test3 on test2.id=test3.id
 where test3.id is null;
-> PLAN
-> --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-> SELECT TEST1.ID, TEST2.ID, TEST3.ID FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ LEFT OUTER JOIN PUBLIC.TEST3 /* PUBLIC.PRIMARY_KEY_4C0: ID = TEST2.ID */ ON TEST2.ID = TEST3.ID INNER JOIN PUBLIC.TEST1 /* PUBLIC.PRIMARY_KEY_4: ID = TEST2.ID */ ON 1=1 WHERE (TEST3.ID IS NULL) AND (TEST1.ID = TEST2.ID)
-> rows: 1
+#+mvStore#>> SELECT TEST1.ID, TEST2.ID, TEST3.ID FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ LEFT OUTER JOIN PUBLIC.TEST3 /* PUBLIC.PRIMARY_KEY_4C0: ID = TEST2.ID */ ON TEST2.ID = TEST3.ID INNER JOIN PUBLIC.TEST1 /* PUBLIC.PRIMARY_KEY_4: ID = TEST2.ID */ ON 1=1 WHERE (TEST3.ID IS NULL) AND (TEST1.ID = TEST2.ID)
+#-mvStore#>> SELECT TEST1.ID, TEST2.ID, TEST3.ID FROM PUBLIC.TEST1 /* PUBLIC.TEST1.tableScan */ INNER JOIN PUBLIC.TEST2 /* PUBLIC.PRIMARY_KEY_4C: ID = TEST1.ID AND ID = TEST1.ID */ ON 1=1 /* WHERE TEST1.ID = TEST2.ID */ LEFT OUTER JOIN PUBLIC.TEST3 /* PUBLIC.PRIMARY_KEY_4C0: ID = TEST2.ID */ ON TEST2.ID = TEST3.ID WHERE (TEST3.ID IS NULL) AND (TEST1.ID = TEST2.ID)
 
 insert into test1 select x from system_range(2, 1000);
 > update count: 999
@@ -285,10 +283,7 @@ explain select * from test1
 inner join test2 on test1.id=test2.id
 left outer join test3 on test2.id=test3.id
 where test3.id is null;
-> PLAN
-> --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-> SELECT TEST1.ID, TEST2.ID, TEST3.ID FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ LEFT OUTER JOIN PUBLIC.TEST3 /* PUBLIC.PRIMARY_KEY_4C0: ID = TEST2.ID */ ON TEST2.ID = TEST3.ID INNER JOIN PUBLIC.TEST1 /* PUBLIC.PRIMARY_KEY_4: ID = TEST2.ID */ ON 1=1 WHERE (TEST3.ID IS NULL) AND (TEST1.ID = TEST2.ID)
-> rows: 1
+>> SELECT TEST1.ID, TEST2.ID, TEST3.ID FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ LEFT OUTER JOIN PUBLIC.TEST3 /* PUBLIC.PRIMARY_KEY_4C0: ID = TEST2.ID */ ON TEST2.ID = TEST3.ID INNER JOIN PUBLIC.TEST1 /* PUBLIC.PRIMARY_KEY_4: ID = TEST2.ID */ ON 1=1 WHERE (TEST3.ID IS NULL) AND (TEST1.ID = TEST2.ID)
 
 SELECT TEST1.ID, TEST2.ID, TEST3.ID
 FROM TEST2

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -3384,24 +3384,6 @@ call select 1.0/3.0*3.0, 100.0/2.0, -25.0/100.0, 0.0/3.0, 6.9/2.0, 0.72179425150
 > (0.999999999999999999999999990, 50, -0.25, 0, 3.45, 1.35822361752313607260107721120531135706133161972E-10)
 > rows: 1
 
-CALL 1 /* comment */ ;;
-> 1
-> -
-> 1
-> rows: 1
-
-CALL 1 /* comment */ ;
-> 1
-> -
-> 1
-> rows: 1
-
-call /* remark * / * /* ** // end */ 1;
-> 1
-> -
-> 1
-> rows: 1
-
 call (select x from dual where x is null);
 > SELECT X FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX: X IS NULL */ /* scanCount: 1 */ WHERE X IS NULL
 > -------------------------------------------------------------------------------------------------------
@@ -6380,34 +6362,6 @@ SELECT ID, MAX(NAME) FROM TEST GROUP BY ID HAVING MAX(NAME) LIKE 'World%';
 > -- ---------
 > 2  World
 > rows: 1
-
-DROP TABLE TEST;
-> ok
-
---- remarks/comments/syntax ----------------------------------------------------------------------------------------------
-CREATE TABLE TEST(
-ID INT PRIMARY KEY, -- this is the primary key, type {integer}
-NAME VARCHAR(255) -- this is a string
-);
-> ok
-
-INSERT INTO TEST VALUES(
-1 /* ID */,
-'Hello' // NAME
-);
-> update count: 1
-
-SELECT * FROM TEST;
-> ID NAME
-> -- -----
-> 1  Hello
-> rows: 1
-
-DROP_ TABLE_ TEST_T;
-> exception SYNTAX_ERROR_2
-
-DROP TABLE TEST /*;
-> exception SYNTAX_ERROR_1
 
 DROP TABLE TEST;
 > ok

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -8452,6 +8452,7 @@ select * from test where year in (select distinct year from test order by year d
 > ---- ---------
 > 2016 order
 > 2016 execution
+> rows (ordered): 2
 
 drop table test;
 > ok


### PR DESCRIPTION
1. `TestScript` now requires that all expected rows should be specified in test scripts. This allows to detect failures earlier. Some statements didn't have any expectations and bugs were not detected with them. Some statements had incomplete output listings and unexpected additional rows in output were not detected. Existing tests are fixed.

2. Now it's possible to specify MVStore-specific or PageStore-specific tests with `#+mvStore#` / `#-mvStore#` prefixes. Problem in `joins.sql` in PageStore mode is resolved in that way.

3. Tests for SQL comments are extracted from `testScript.sql` into own file `comments.sql` because they broke syntax highlighting of all following statements in `testScript.sql` in many editors.