### PR TITLE
Fix sorting with distinct in ResultTempTable

### DIFF
--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -289,6 +289,10 @@ public class LocalResult implements ResultInterface, ResultTarget {
         return ValueArray.get(values);
     }
 
+    private void createExternalResult() {
+        external = new ResultTempTable(session, expressions, distinct, sort);
+    }
+
     /**
      * Add a row to this object.
      *
@@ -303,7 +307,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
                 distinctRows.put(array, values);
                 rowCount = distinctRows.size();
                 if (rowCount > maxMemoryRows) {
-                    external = new ResultTempTable(session, expressions, true, sort);
+                    createExternalResult();
                     rowCount = external.addRows(distinctRows.values());
                     distinctRows = null;
                 }
@@ -316,7 +320,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
         rowCount++;
         if (rows.size() > maxMemoryRows) {
             if (external == null) {
-                external = new ResultTempTable(session, expressions, false, sort);
+                createExternalResult();
             }
             addRowsToDisk();
         }
@@ -353,7 +357,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
                             break;
                         }
                         if (external == null) {
-                            external = new ResultTempTable(session, expressions, true, sort);
+                            createExternalResult();
                         }
                         rows.add(list);
                         if (rows.size() > maxMemoryRows) {

--- a/h2/src/main/org/h2/result/ResultTempTable.java
+++ b/h2/src/main/org/h2/result/ResultTempTable.java
@@ -90,35 +90,32 @@ public class ResultTempTable implements ResultExternal {
     }
 
     private void createIndex() {
-        IndexColumn[] indexCols = null;
+        IndexColumn[] indexCols;
         if (sort != null) {
             int[] colIndex = sort.getQueryColumnIndexes();
             int len = colIndex.length;
-            int totalLen;
-            BitSet used;
             if (distinct) {
-                totalLen = columnCount;
-                used = new BitSet();
-            } else {
-                totalLen = len;
-                used = null;
-            }
-            indexCols = new IndexColumn[totalLen];
-            for (int i = 0; i < len; i++) {
-                int idx = colIndex[i];
-                if (used != null) {
+                BitSet used = new BitSet();
+                indexCols = new IndexColumn[columnCount];
+                for (int i = 0; i < len; i++) {
+                    int idx = colIndex[i];
                     used.set(idx);
+                    IndexColumn indexColumn = createIndexColumn(idx);
+                    indexColumn.sortType = sort.getSortTypes()[i];
+                    indexCols[i] = indexColumn;
                 }
-                IndexColumn indexColumn = createIndexColumn(idx);
-                indexColumn.sortType = sort.getSortTypes()[i];
-                indexCols[i] = indexColumn;
-            }
-            if (used != null) {
                 int idx = 0;
-                for (int i = len; i < totalLen; i++) {
+                for (int i = len; i < columnCount; i++) {
                     idx = used.nextClearBit(idx);
                     indexCols[i] = createIndexColumn(idx);
                     idx++;
+                }
+            } else {
+                indexCols = new IndexColumn[len];
+                for (int i = 0; i < len; i++) {
+                    IndexColumn indexColumn = createIndexColumn(colIndex[i]);
+                    indexColumn.sortType = sort.getSortTypes()[i];
+                    indexCols[i] = indexColumn;
                 }
             }
         } else {

--- a/h2/src/test/org/h2/test/db/TestBigResult.java
+++ b/h2/src/test/org/h2/test/db/TestBigResult.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.BitSet;
 
 import org.h2.store.FileLister;
 import org.h2.test.TestBase;
@@ -35,6 +36,7 @@ public class TestBigResult extends TestBase {
             return;
         }
         testLargeSubquery();
+        testSortingAndDistinct();
         testLargeUpdateDelete();
         testCloseConnectionDelete();
         testOrderGroup();
@@ -64,6 +66,104 @@ public class TestBigResult extends TestBase {
         }
         assertEquals(len / 2, count);
         conn.close();
+    }
+
+    private void testSortingAndDistinct() throws SQLException {
+        deleteDb("bigResult");
+        Connection conn = getConnection("bigResult");
+        Statement stat = conn.createStatement();
+        int count = getSize(1000, 4000);
+        stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, VALUE INT NOT NULL)");
+        PreparedStatement ps = conn.prepareStatement("INSERT INTO TEST VALUES (?, ?)");
+        for (int i = 0; i < count; i++) {
+            ps.setInt(1, i);
+            ps.setInt(2, count - i);
+            ps.executeUpdate();
+        }
+        // local result
+        testSortintAndDistinct1(stat, count, count);
+        // external result
+        testSortintAndDistinct1(stat, 10, count);
+        stat.execute("DROP TABLE TEST");
+        stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, VALUE1 INT NOT NULL, VALUE2 INT NOT NULL)");
+        ps = conn.prepareStatement("INSERT INTO TEST VALUES (?, ?, ?)");
+        int partCount = count / 10;
+        for (int i = 0; i < count; i++) {
+            ps.setInt(1, i);
+            int a = i / 10;
+            int b = i % 10;
+            ps.setInt(2, partCount - a);
+            ps.setInt(3, 10 - b);
+            ps.executeUpdate();
+        }
+        String sql;
+        /*
+         * Sorting only
+         */
+        sql = "SELECT VALUE2, VALUE1 FROM (SELECT ID, VALUE2, VALUE1 FROM TEST ORDER BY VALUE2)";
+        // local result
+        testSortingAndDistinct2(stat, sql, count, partCount);
+        // external result
+        testSortingAndDistinct2(stat, sql, 10, partCount);
+        /*
+         * Distinct only
+         */
+        sql = "SELECT VALUE2, VALUE1 FROM (SELECT DISTINCT ID, VALUE2, VALUE1 FROM TEST)";
+        // local result
+        testSortingAndDistinct2DistinctOnly(stat, sql, count, partCount);
+        // external result
+        testSortingAndDistinct2DistinctOnly(stat, sql, 10, partCount);
+        /*
+         * Sorting and distinct
+         */
+        sql = "SELECT VALUE2, VALUE1 FROM (SELECT DISTINCT ID, VALUE2, VALUE1 FROM TEST ORDER BY VALUE2)";
+        // local result
+        testSortingAndDistinct2(stat, sql, count, partCount);
+        // external result
+        testSortingAndDistinct2(stat, sql, 10, partCount);
+        conn.close();
+    }
+
+    private void testSortintAndDistinct1(Statement stat, int maxRows, int count) throws SQLException {
+        stat.execute("SET MAX_MEMORY_ROWS " + maxRows);
+        ResultSet rs = stat.executeQuery("SELECT VALUE FROM (SELECT DISTINCT ID, VALUE FROM TEST ORDER BY VALUE)");
+        for (int i = 1; i <= count; i++) {
+            assertTrue(rs.next());
+            assertEquals(rs.getInt(1), i);
+        }
+        assertFalse(rs.next());
+    }
+
+    private void testSortingAndDistinct2(Statement stat, String sql, int maxRows, int partCount) throws SQLException {
+        ResultSet rs;
+        stat.execute("SET MAX_MEMORY_ROWS " + maxRows);
+        rs = stat.executeQuery(sql);
+        BitSet set = new BitSet(partCount);
+        for (int i = 1; i <= 10; i++) {
+            set.clear();
+            for (int j = 1; j <= partCount; j++) {
+                assertTrue(rs.next());
+                assertEquals(i, rs.getInt(1));
+                set.set(rs.getInt(2));
+            }
+            assertEquals(partCount + 1, set.nextClearBit(1));
+        }
+        assertFalse(rs.next());
+    }
+
+    private void testSortingAndDistinct2DistinctOnly(Statement stat, String sql, int maxRows, int partCount) throws SQLException {
+        ResultSet rs;
+        stat.execute("SET MAX_MEMORY_ROWS " + maxRows);
+        rs = stat.executeQuery(sql);
+        BitSet set = new BitSet(partCount * 10);
+        for (int i = 1; i <= 10; i++) {
+            for (int j = 1; j <= partCount; j++) {
+                assertTrue(rs.next());
+                set.set(rs.getInt(1) * partCount + rs.getInt(2));
+            }
+        }
+        assertEquals(partCount * 11 + 1, set.nextClearBit(partCount + 1));
+        assertFalse(rs.next());
     }
 
     private void testLargeUpdateDelete() throws SQLException {


### PR DESCRIPTION
If both `DISTINCT` and `ORDER BY` were specified and result was large enough default sorting was used instead of specified in `ORDER BY` clause.

With this change the index is created in mixed mode. Columns from `ORDER BY` and all remaining columns are used together in the same index.