### PR TITLE
Add external storage of temporary results for MVStore mode

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.mvstore.db;
+
+import org.h2.engine.Database;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.message.DbException;
+import org.h2.mvstore.Cursor;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVMap.Builder;
+import org.h2.result.ResultExternal;
+import org.h2.value.Value;
+import org.h2.value.ValueArray;
+import org.h2.value.ValueLong;
+
+/**
+ * Plain temporary result.
+ */
+class MVPlainTempResult extends MVTempResult {
+
+    private final MVMap<ValueLong, ValueArray> map;
+    private long counter;
+
+    private Cursor<ValueLong, ValueArray> cursor;
+
+    private MVPlainTempResult(MVPlainTempResult parent) {
+        super(parent);
+        this.map = parent.map;
+    }
+
+    MVPlainTempResult(Session session, Expression[] expressions) {
+        super(session);
+        Database db = session.getDatabase();
+        ValueDataType keyType = new ValueDataType(null, null, null);
+        ValueDataType valueType = new ValueDataType(db.getCompareMode(), db, new int[expressions.length]);
+        Builder<ValueLong, ValueArray> builder = new MVMap.Builder<ValueLong, ValueArray>().keyType(keyType)
+                .valueType(valueType);
+        map = store.openMap("tmp", builder);
+    }
+
+    @Override
+    public int addRow(Value[] values) {
+        map.put(ValueLong.get(counter++), ValueArray.get(values));
+        return ++rowCount;
+    }
+
+    @Override
+    public boolean contains(Value[] values) {
+        throw DbException.getUnsupportedException("contains()");
+    }
+
+    @Override
+    public synchronized ResultExternal createShallowCopy() {
+        if (parent != null) {
+            return parent.createShallowCopy();
+        }
+        if (closed) {
+            return null;
+        }
+        childCount++;
+        return new MVPlainTempResult(this);
+    }
+
+    @Override
+    public Value[] next() {
+        if (cursor == null) {
+            cursor = map.cursor(null);
+        }
+        if (!cursor.hasNext()) {
+            return null;
+        }
+        cursor.next();
+        return cursor.getValue().getList();
+    }
+
+    @Override
+    public int removeRow(Value[] values) {
+        throw DbException.getUnsupportedException("removeRow()");
+    }
+
+    @Override
+    public void reset() {
+        cursor = null;
+    }
+
+}

--- a/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
@@ -6,7 +6,6 @@
 package org.h2.mvstore.db;
 
 import org.h2.engine.Database;
-import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.message.DbException;
 import org.h2.mvstore.Cursor;
@@ -65,16 +64,15 @@ class MVPlainTempResult extends MVTempResult {
     /**
      * Creates a new plain temporary result.
      *
-     * @param session
-     *                        database session.
+     * @param database
+     *                        database
      * @param expressions
      *                        column expressions
      */
-    MVPlainTempResult(Session session, Expression[] expressions) {
-        super(session);
-        Database db = session.getDatabase();
+    MVPlainTempResult(Database database, Expression[] expressions) {
+        super(database);
         ValueDataType keyType = new ValueDataType(null, null, null);
-        valueType = new ValueDataType(db.getCompareMode(), db, new int[expressions.length]);
+        valueType = new ValueDataType(database.getCompareMode(), database, new int[expressions.length]);
         Builder<ValueLong, ValueArray> builder = new MVMap.Builder<ValueLong, ValueArray>().keyType(keyType)
                 .valueType(valueType);
         map = store.openMap("tmp", builder);

--- a/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.mvstore.db;
+
+import java.util.BitSet;
+
+import org.h2.engine.Database;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.mvstore.Cursor;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVMap.Builder;
+import org.h2.result.ResultExternal;
+import org.h2.result.SortOrder;
+import org.h2.value.Value;
+import org.h2.value.ValueArray;
+
+/**
+ * Sorted temporary result.
+ */
+class MVSortedTempResult extends MVTempResult {
+
+    private final boolean distinct;
+    private final int[] indexes;
+    private final MVMap<ValueArray, Long> map;
+
+    private Cursor<ValueArray, Long> cursor;
+    private Value[] current;
+    private long valueCount;
+
+    private MVSortedTempResult(MVSortedTempResult parent) {
+        super(parent);
+        this.distinct = parent.distinct;
+        this.indexes = parent.indexes;
+        this.map = parent.map;
+        this.rowCount = parent.rowCount;
+    }
+
+    /**
+     * Creates a new sorted temporary result.
+     */
+    MVSortedTempResult(Session session, Expression[] expressions, boolean distinct, SortOrder sort) {
+        super(session);
+        this.distinct = distinct;
+        Database db = session.getDatabase();
+        int length = expressions.length;
+        int[] sortTypes = new int[length];
+        int[] indexes;
+        if (sort != null) {
+            indexes = new int[length];
+            int[] colIndex = sort.getQueryColumnIndexes();
+            int len = colIndex.length;
+            BitSet used = new BitSet();
+            for (int i = 0; i < len; i++) {
+                int idx = colIndex[i];
+                used.set(idx);
+                indexes[i] = idx;
+                sortTypes[i] = sort.getSortTypes()[i];
+            }
+            int idx = 0;
+            for (int i = len; i < length; i++) {
+                idx = used.nextClearBit(idx);
+                indexes[i] = idx;
+                idx++;
+            }
+            sameOrder: {
+                for (int i = 0; i < length; i++) {
+                    if (indexes[i] != i) {
+                        break sameOrder;
+                    }
+                }
+                indexes = null;
+            }
+        } else {
+            indexes = null;
+        }
+        this.indexes = indexes;
+        ValueDataType keyType = new ValueDataType(db.getCompareMode(), db, sortTypes);
+        Builder<ValueArray, Long> builder = new MVMap.Builder<ValueArray, Long>().keyType(keyType);
+        map = store.openMap("tmp", builder);
+    }
+
+    @Override
+    public int addRow(Value[] values) {
+        ValueArray key = getKey(values);
+        if (distinct) {
+            if (map.putIfAbsent(key, 1L) == null) {
+                rowCount++;
+            }
+        } else {
+            Long old = map.putIfAbsent(key, 1L);
+            if (old != null) {
+                map.put(key, old + 1);
+            }
+            rowCount++;
+        }
+        return rowCount;
+    }
+
+    @Override
+    public boolean contains(Value[] values) {
+        return map.containsKey(getKey(values));
+    }
+
+    @Override
+    public synchronized ResultExternal createShallowCopy() {
+        if (parent != null) {
+            return parent.createShallowCopy();
+        }
+        if (closed) {
+            return null;
+        }
+        childCount++;
+        return new MVSortedTempResult(this);
+    }
+
+    private ValueArray getKey(Value[] values) {
+        if (indexes != null) {
+            Value[] r = new Value[indexes.length];
+            for (int i = 0; i < indexes.length; i++) {
+                r[indexes[i]] = values[i];
+            }
+            values = r;
+        }
+        return ValueArray.get(values);
+    }
+
+    private Value[] getValue(Value[] key) {
+        if (indexes != null) {
+            Value[] r = new Value[indexes.length];
+            for (int i = 0; i < indexes.length; i++) {
+                r[i] = key[indexes[i]];
+            }
+            key = r;
+        }
+        return key;
+    }
+
+    @Override
+    public Value[] next() {
+        if (cursor == null) {
+            cursor = map.cursor(null);
+            current = null;
+            valueCount = 0L;
+        }
+        if (--valueCount > 0) {
+            return current;
+        }
+        current = null;
+        if (!cursor.hasNext()) {
+            return null;
+        }
+        current = getValue(cursor.next().getList());
+        valueCount = cursor.getValue();
+        return current;
+    }
+
+    @Override
+    public int removeRow(Value[] values) {
+        ValueArray key = getKey(values);
+        if (distinct) {
+            if (map.remove(key) != null) {
+                rowCount--;
+            }
+        } else {
+            Long old = map.remove(key);
+            if (old != null) {
+                long l = old;
+                if (l > 1) {
+                    map.put(key, l - 1);
+                }
+                rowCount--;
+            }
+        }
+        return rowCount;
+    }
+
+    @Override
+    public void reset() {
+        cursor = null;
+        current = null;
+        valueCount = 0L;
+    }
+
+}

--- a/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
@@ -20,17 +20,53 @@ import org.h2.value.ValueArray;
 
 /**
  * Sorted temporary result.
+ *
+ * <p>
+ * This result is used for distinct and/or sorted results.
+ * </p>
  */
 class MVSortedTempResult extends MVTempResult {
 
+    /**
+     * Whether this result is distinct.
+     */
     private final boolean distinct;
+
+    /**
+     * Mapping of indexes of columns to its positions in the store, or {@code null}
+     * if columns are not reordered.
+     */
     private final int[] indexes;
+
+    /**
+     * Map with rows as keys and counts of duplicate rows as values. If this map is
+     * distinct all values are 1.
+     */
     private final MVMap<ValueArray, Long> map;
 
+    /**
+     * Cursor for the {@link #next()} method.
+     */
     private Cursor<ValueArray, Long> cursor;
+
+    /**
+     * Current value for the {@link #next()} method. Used in non-distinct results
+     * with duplicate rows.
+     */
     private Value[] current;
+
+    /**
+     * Count of remaining duplicate rows for the {@link #next()} method. Used in
+     * non-distinct results.
+     */
     private long valueCount;
 
+    /**
+     * Creates a shallow copy of the result.
+     *
+     * @param parent
+     *                   parent result
+     */
     private MVSortedTempResult(MVSortedTempResult parent) {
         super(parent);
         this.distinct = parent.distinct;
@@ -41,6 +77,16 @@ class MVSortedTempResult extends MVTempResult {
 
     /**
      * Creates a new sorted temporary result.
+     *
+     * @param session
+     *                        database session
+     * @param expressions
+     *                        column expressions
+     * @param distinct
+     *                        whether this result should be distinct
+     * @param sort
+     *                        sort order, or {@code null} if this result does not
+     *                        need any sorting
      */
     MVSortedTempResult(Session session, Expression[] expressions, boolean distinct, SortOrder sort) {
         super(session);
@@ -50,31 +96,53 @@ class MVSortedTempResult extends MVTempResult {
         int[] sortTypes = new int[length];
         int[] indexes;
         if (sort != null) {
+            /*
+             * If sorting is specified we need to reorder columns in requested order and set
+             * sort types (ASC, DESC etc) for them properly.
+             */
             indexes = new int[length];
             int[] colIndex = sort.getQueryColumnIndexes();
             int len = colIndex.length;
+            // This set is used to remember columns that are already included
             BitSet used = new BitSet();
             for (int i = 0; i < len; i++) {
                 int idx = colIndex[i];
+                assert !used.get(idx);
                 used.set(idx);
                 indexes[i] = idx;
                 sortTypes[i] = sort.getSortTypes()[i];
             }
+            /*
+             * Because this result may have more columns than specified in sorting we need
+             * to add all remaining columns to the mapping of columns. A default sorting
+             * order (ASC / 0) will be used for them.
+             */
             int idx = 0;
             for (int i = len; i < length; i++) {
                 idx = used.nextClearBit(idx);
                 indexes[i] = idx;
                 idx++;
             }
+            /*
+             * Sometimes columns may be not reordered. Because reordering of columns
+             * slightly slows down other methods we check whether columns are really
+             * reordered or have the same order.
+             */
             sameOrder: {
                 for (int i = 0; i < length; i++) {
                     if (indexes[i] != i) {
+                        // Columns are reordered
                         break sameOrder;
                     }
                 }
+                /*
+                 * Columns are not reordered, set this field to null to disable reordering in
+                 * other methods.
+                 */
                 indexes = null;
             }
         } else {
+            // Columns are not reordered if sort order is not specified
             indexes = null;
         }
         this.indexes = indexes;
@@ -85,14 +153,18 @@ class MVSortedTempResult extends MVTempResult {
 
     @Override
     public int addRow(Value[] values) {
+        assert parent == null;
         ValueArray key = getKey(values);
         if (distinct) {
+            // Add a row and increment the counter only if row does not exist
             if (map.putIfAbsent(key, 1L) == null) {
                 rowCount++;
             }
         } else {
+            // Try to set counter to 1 first if such row does not exist yet
             Long old = map.putIfAbsent(key, 1L);
             if (old != null) {
+                // This rows is already in the map, increment its own counter
                 map.put(key, old + 1);
             }
             rowCount++;
@@ -117,6 +189,13 @@ class MVSortedTempResult extends MVTempResult {
         return new MVSortedTempResult(this);
     }
 
+    /**
+     * Reorder values if required and convert them into {@link ValueArray}.
+     *
+     * @param values
+     *                   values
+     * @return ValueArray for maps
+     */
     private ValueArray getKey(Value[] values) {
         if (indexes != null) {
             Value[] r = new Value[indexes.length];
@@ -128,6 +207,13 @@ class MVSortedTempResult extends MVTempResult {
         return ValueArray.get(values);
     }
 
+    /**
+     * Reorder values back if required.
+     *
+     * @param key
+     *                reordered values
+     * @return original values
+     */
     private Value[] getValue(Value[] key) {
         if (indexes != null) {
             Value[] r = new Value[indexes.length];
@@ -146,22 +232,35 @@ class MVSortedTempResult extends MVTempResult {
             current = null;
             valueCount = 0L;
         }
+        // If we have multiple rows with the same values return them all
         if (--valueCount > 0) {
+            /*
+             * Underflow in valueCount is hypothetically possible after a lot of invocations
+             * (not really possible in practice), but current will be null anyway.
+             */
             return current;
         }
-        current = null;
         if (!cursor.hasNext()) {
+            // Set current to null to be sure
+            current = null;
             return null;
         }
+        // Read the next row
         current = getValue(cursor.next().getList());
+        /*
+         * If valueCount is greater than 1 that is possible for non-distinct results the
+         * following invocations of next() will use this.current and this.valueCount.
+         */
         valueCount = cursor.getValue();
         return current;
     }
 
     @Override
     public int removeRow(Value[] values) {
+        assert parent == null;
         ValueArray key = getKey(values);
         if (distinct) {
+            // If an entry was removed decrement the counter
             if (map.remove(key) != null) {
                 rowCount--;
             }
@@ -170,6 +269,10 @@ class MVSortedTempResult extends MVTempResult {
             if (old != null) {
                 long l = old;
                 if (l > 1) {
+                    /*
+                     * We have more than one such row. Decrement its counter by 1 and put this row
+                     * back into map.
+                     */
                     map.put(key, l - 1);
                 }
                 rowCount--;

--- a/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
@@ -8,7 +8,6 @@ package org.h2.mvstore.db;
 import java.util.BitSet;
 
 import org.h2.engine.Database;
-import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.mvstore.Cursor;
 import org.h2.mvstore.MVMap;
@@ -78,8 +77,8 @@ class MVSortedTempResult extends MVTempResult {
     /**
      * Creates a new sorted temporary result.
      *
-     * @param session
-     *                        database session
+     * @param database
+     *                        database
      * @param expressions
      *                        column expressions
      * @param distinct
@@ -88,10 +87,9 @@ class MVSortedTempResult extends MVTempResult {
      *                        sort order, or {@code null} if this result does not
      *                        need any sorting
      */
-    MVSortedTempResult(Session session, Expression[] expressions, boolean distinct, SortOrder sort) {
-        super(session);
+    MVSortedTempResult(Database database, Expression[] expressions, boolean distinct, SortOrder sort) {
+        super(database);
         this.distinct = distinct;
-        Database db = session.getDatabase();
         int length = expressions.length;
         int[] sortTypes = new int[length];
         int[] indexes;
@@ -146,7 +144,7 @@ class MVSortedTempResult extends MVTempResult {
             indexes = null;
         }
         this.indexes = indexes;
-        ValueDataType keyType = new ValueDataType(db.getCompareMode(), db, sortTypes);
+        ValueDataType keyType = new ValueDataType(database.getCompareMode(), database, sortTypes);
         Builder<ValueArray, Long> builder = new MVMap.Builder<ValueArray, Long>().keyType(keyType);
         map = store.openMap("tmp", builder);
     }

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -75,12 +75,7 @@ public class MVTableEngine implements TableEngine {
             }
             if (key != null) {
                 encrypted = true;
-                char[] password = new char[key.length / 2];
-                for (int i = 0; i < password.length; i++) {
-                    password[i] = (char) (((key[i + i] & 255) << 16) |
-                            ((key[i + i + 1]) & 255));
-                }
-                builder.encryptionKey(password);
+                builder.encryptionKey(decodePassword(key));
             }
             if (db.getSettings().compressData) {
                 builder.compress();
@@ -99,6 +94,15 @@ public class MVTableEngine implements TableEngine {
         store.open(db, builder, encrypted);
         db.setMvStore(store);
         return store;
+    }
+
+    static char[] decodePassword(byte[] key) {
+        char[] password = new char[key.length / 2];
+        for (int i = 0; i < password.length; i++) {
+            password[i] = (char) (((key[i + i] & 255) << 16) |
+                    ((key[i + i + 1]) & 255));
+        }
+        return password;
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/MVTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTempResult.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.mvstore.db;
+
+import java.io.IOException;
+import java.lang.ref.Reference;
+import java.util.ArrayList;
+
+import org.h2.engine.Constants;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.message.DbException;
+import org.h2.mvstore.MVStore;
+import org.h2.mvstore.MVStore.Builder;
+import org.h2.result.ResultExternal;
+import org.h2.result.SortOrder;
+import org.h2.store.fs.FileUtils;
+import org.h2.util.TempFileDeleter;
+import org.h2.value.Value;
+
+/**
+ * Temporary result.
+ */
+public abstract class MVTempResult implements ResultExternal {
+
+    /**
+     * Creates MVStore-based temporary result.
+     *
+     * @param session
+     *                        session
+     * @param expressions
+     *                        expressions
+     * @param distinct
+     *                        is output distinct
+     * @param sort
+     *                        sort order, or {@code null}
+     * @return temporary result
+     */
+    public static ResultExternal of(Session session, Expression[] expressions, boolean distinct, SortOrder sort) {
+        return distinct || sort != null ? new MVSortedTempResult(session, expressions, distinct, sort)
+                : new MVPlainTempResult(session, expressions);
+    }
+
+    final MVStore store;
+
+    int rowCount;
+
+    final MVTempResult parent;
+
+    int childCount;
+
+    boolean closed;
+
+    private final TempFileDeleter tempFileDeleter;
+    private final String fileName;
+    private final Reference<?> fileRef;
+
+    MVTempResult(MVTempResult parent) {
+        this.parent = parent;
+        this.store = parent.store;
+        this.fileName = null;
+        this.tempFileDeleter = null;
+        this.fileRef = null;
+    }
+
+    MVTempResult(Session session) {
+        try {
+            fileName = FileUtils.createTempFile("h2tmp", Constants.SUFFIX_TEMP_FILE, false, true);
+            Builder builder = new MVStore.Builder().autoCommitDisabled().fileName(fileName);
+            byte[] key = session.getDatabase().getFileEncryptionKey();
+            if (key != null) {
+                builder.encryptionKey(MVTableEngine.decodePassword(key));
+            }
+            store = builder.open();
+            tempFileDeleter = session.getDatabase().getTempFileDeleter();
+            fileRef = tempFileDeleter.addFile(fileName, this);
+        } catch (IOException e) {
+            throw DbException.convert(e);
+        }
+        parent = null;
+    }
+
+    @Override
+    public int addRows(ArrayList<Value[]> rows) {
+        for (Value[] row : rows) {
+            addRow(row);
+        }
+        return rowCount;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (parent != null) {
+            parent.closeChild();
+        } else {
+            if (childCount == 0) {
+                delete();
+            }
+        }
+    }
+
+    private synchronized void closeChild() {
+        if (--childCount == 0 && closed) {
+            delete();
+        }
+    }
+
+    private void delete() {
+        store.closeImmediately();
+        tempFileDeleter.deleteFile(fileRef, fileName);
+    }
+
+    @Override
+    public void done() {
+        // Do nothing
+    }
+
+}

--- a/h2/src/main/org/h2/mvstore/db/MVTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTempResult.java
@@ -183,7 +183,6 @@ public abstract class MVTempResult implements ResultExternal {
     }
 
     private void delete() {
-        store.closeImmediately();
         tempFileDeleter.deleteFile(fileRef, closeable);
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTempResult.java
@@ -114,7 +114,7 @@ public abstract class MVTempResult implements ResultExternal {
     MVTempResult(Session session) {
         try {
             fileName = FileUtils.createTempFile("h2tmp", Constants.SUFFIX_TEMP_FILE, false, true);
-            Builder builder = new MVStore.Builder().autoCommitDisabled().fileName(fileName);
+            Builder builder = new MVStore.Builder().fileName(fileName);
             byte[] key = session.getDatabase().getFileEncryptionKey();
             if (key != null) {
                 builder.encryptionKey(MVTableEngine.decodePassword(key));

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -291,8 +291,9 @@ public class LocalResult implements ResultInterface, ResultTarget {
     }
 
     private void createExternalResult() {
-        external = session.getDatabase().getMvStore() != null
-                ? MVTempResult.of(session, expressions, distinct, sort)
+        Database database = session.getDatabase();
+        external = database.getMvStore() != null
+                ? MVTempResult.of(database, expressions, distinct, sort)
                         : new ResultTempTable(session, expressions, distinct, sort);
     }
 

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -15,6 +15,7 @@ import org.h2.engine.Session;
 import org.h2.engine.SessionInterface;
 import org.h2.expression.Expression;
 import org.h2.message.DbException;
+import org.h2.mvstore.db.MVTempResult;
 import org.h2.util.Utils;
 import org.h2.util.ValueHashMap;
 import org.h2.value.DataType;
@@ -290,7 +291,9 @@ public class LocalResult implements ResultInterface, ResultTarget {
     }
 
     private void createExternalResult() {
-        external = new ResultTempTable(session, expressions, distinct, sort);
+        external = session.getDatabase().getMvStore() != null
+                ? MVTempResult.of(session, expressions, distinct, sort)
+                        : new ResultTempTable(session, expressions, distinct, sort);
     }
 
     /**

--- a/h2/src/main/org/h2/result/ResultTempTable.java
+++ b/h2/src/main/org/h2/result/ResultTempTable.java
@@ -278,19 +278,7 @@ public class ResultTempTable implements ResultExternal {
             } else {
                 idx = table.getScanIndex(session);
             }
-            if (session.getDatabase().getMvStore() != null) {
-                // sometimes the transaction is already committed,
-                // in which case we can't use the session
-                if (idx.getRowCount(session) == 0 && rowCount > 0) {
-                    // this means querying is not transactional
-                    resultCursor = idx.find((Session) null, null, null);
-                } else {
-                    // the transaction is still open
-                    resultCursor = idx.find(session, null, null);
-                }
-            } else {
-                resultCursor = idx.find(session, null, null);
-            }
+            resultCursor = idx.find(session, null, null);
         }
         if (!resultCursor.next()) {
             return null;

--- a/h2/src/main/org/h2/util/TempFileDeleter.java
+++ b/h2/src/main/org/h2/util/TempFileDeleter.java
@@ -21,7 +21,7 @@ import org.h2.store.fs.FileUtils;
 public class TempFileDeleter {
 
     private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
-    private final HashMap<PhantomReference<?>, String> refMap = new HashMap<>();
+    private final HashMap<PhantomReference<?>, Object> refMap = new HashMap<>();
 
     private TempFileDeleter() {
         // utility class
@@ -32,43 +32,59 @@ public class TempFileDeleter {
     }
 
     /**
-     * Add a file to the list of temp files to delete. The file is deleted once
-     * the file object is garbage collected.
+     * Add a file or a closeable to the list of temporary objects to delete. The
+     * file is deleted once the file object is garbage collected.
      *
-     * @param fileName the file name
-     * @param file the object to monitor
-     * @return the reference that can be used to stop deleting the file
+     * @param resource the file name or the closeable
+     * @param monitor the object to monitor
+     * @return the reference that can be used to stop deleting the file or closing the closeable
      */
-    public synchronized Reference<?> addFile(String fileName, Object file) {
-        IOUtils.trace("TempFileDeleter.addFile", fileName, file);
-        PhantomReference<?> ref = new PhantomReference<>(file, queue);
-        refMap.put(ref, fileName);
+    public synchronized Reference<?> addFile(Object resource, Object monitor) {
+        if (!(resource instanceof String) && !(resource instanceof AutoCloseable)) {
+            throw DbException.getUnsupportedException("Unsupported resource " + resource);
+        }
+        IOUtils.trace("TempFileDeleter.addFile",
+                resource instanceof String ? (String) resource : "-", monitor);
+        PhantomReference<?> ref = new PhantomReference<>(monitor, queue);
+        refMap.put(ref, resource);
         deleteUnused();
         return ref;
     }
 
     /**
-     * Delete the given file now. This will remove the reference from the list.
+     * Delete the given file or close the closeable now. This will remove the
+     * reference from the list.
      *
      * @param ref the reference as returned by addFile
-     * @param fileName the file name
+     * @param resource the file name or closeable
      */
-    public synchronized void deleteFile(Reference<?> ref, String fileName) {
+    public synchronized void deleteFile(Reference<?> ref, Object resource) {
         if (ref != null) {
-            String f2 = refMap.remove(ref);
+            Object f2 = refMap.remove(ref);
             if (f2 != null) {
                 if (SysProperties.CHECK) {
-                    if (fileName != null && !f2.equals(fileName)) {
-                        DbException.throwInternalError("f2:" + f2 + " f:" + fileName);
+                    if (resource != null && !f2.equals(resource)) {
+                        DbException.throwInternalError("f2:" + f2 + " f:" + resource);
                     }
                 }
-                fileName = f2;
+                resource = f2;
             }
         }
-        if (fileName != null && FileUtils.exists(fileName)) {
+        if (resource instanceof String) {
+            String fileName = (String) resource;
+            if (FileUtils.exists(fileName)) {
+                try {
+                    IOUtils.trace("TempFileDeleter.deleteFile", fileName, null);
+                    FileUtils.tryDelete(fileName);
+                } catch (Exception e) {
+                    // TODO log such errors?
+                }
+            }
+        } else if (resource instanceof AutoCloseable) {
+            AutoCloseable closeable = (AutoCloseable) resource;
             try {
-                IOUtils.trace("TempFileDeleter.deleteFile", fileName, null);
-                FileUtils.tryDelete(fileName);
+                IOUtils.trace("TempFileDeleter.deleteCloseable", "-", null);
+                closeable.close();
             } catch (Exception e) {
                 // TODO log such errors?
             }
@@ -76,17 +92,17 @@ public class TempFileDeleter {
     }
 
     /**
-     * Delete all registered temp files.
+     * Delete all registered temp resources.
      */
     public void deleteAll() {
-        for (String tempFile : new ArrayList<>(refMap.values())) {
-            deleteFile(null, tempFile);
+        for (Object resource : new ArrayList<>(refMap.values())) {
+            deleteFile(null, resource);
         }
         deleteUnused();
     }
 
     /**
-     * Delete all unused files now.
+     * Delete all unused resources now.
      */
     public void deleteUnused() {
         while (queue != null) {
@@ -99,20 +115,21 @@ public class TempFileDeleter {
     }
 
     /**
-     * This method is called if a file should no longer be deleted if the object
-     * is garbage collected.
+     * This method is called if a file should no longer be deleted or a resource
+     * should no longer be closed if the object is garbage collected.
      *
      * @param ref the reference as returned by addFile
-     * @param fileName the file name
+     * @param resource file name or closeable
      */
-    public void stopAutoDelete(Reference<?> ref, String fileName) {
-        IOUtils.trace("TempFileDeleter.stopAutoDelete", fileName, ref);
+    public void stopAutoDelete(Reference<?> ref, Object resource) {
+        IOUtils.trace("TempFileDeleter.stopAutoDelete",
+                resource instanceof String ? (String) resource : "-", ref);
         if (ref != null) {
-            String f2 = refMap.remove(ref);
+            Object f2 = refMap.remove(ref);
             if (SysProperties.CHECK) {
-                if (f2 == null || !f2.equals(fileName)) {
+                if (f2 == null || !f2.equals(resource)) {
                     DbException.throwInternalError("f2:" + f2 +
-                            " " + (f2 == null ? "" : f2) + " f:" + fileName);
+                            " " + (f2 == null ? "" : f2) + " f:" + resource);
                 }
             }
         }


### PR DESCRIPTION
This is an initial implementation of external storage for huge temporary results for MVStore mode for discussion.

I did not test LOBs and I did not compare performance with `ResultTempTable` yet.