### PR TITLE
Fix TCP version check

### DIFF
--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -89,13 +89,17 @@ public class TcpServerThread implements Runnable {
                     throw DbException.get(ErrorCode.REMOTE_CONNECTION_NOT_ALLOWED);
                 }
                 int minClientVersion = transfer.readInt();
+                if (minClientVersion < 6) {
+                    throw DbException.get(ErrorCode.DRIVER_VERSION_ERROR_2,
+                            "" + minClientVersion, "" + Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED);
+                }
                 int maxClientVersion = transfer.readInt();
                 if (maxClientVersion < Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED) {
                     throw DbException.get(ErrorCode.DRIVER_VERSION_ERROR_2,
-                            "" + clientVersion, "" + Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED);
+                            "" + maxClientVersion, "" + Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED);
                 } else if (minClientVersion > Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED) {
                     throw DbException.get(ErrorCode.DRIVER_VERSION_ERROR_2,
-                            "" + clientVersion, "" + Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED);
+                            "" + minClientVersion, "" + Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED);
                 }
                 if (maxClientVersion >= Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED) {
                     clientVersion = Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED;

--- a/h2/src/test/org/h2/test/unit/TestOldVersion.java
+++ b/h2/src/test/org/h2/test/unit/TestOldVersion.java
@@ -141,7 +141,14 @@ public class TestOldVersion extends TestBase {
 
     private static ClassLoader getClassLoader(String jarFile) throws Exception {
         URL[] urls = { new URL(jarFile) };
-        return new URLClassLoader(urls, null);
+        return new URLClassLoader(urls, null) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name.startsWith("org.h2."))
+                    return super.loadClass(name, resolve);
+                return TestOldVersion.class.getClassLoader().loadClass(name);
+            }
+        };
     }
 
     private static Driver getDriver(ClassLoader cl) throws Exception {


### PR DESCRIPTION
1. Connection attempts from clients with TCP protocol version below 6 caused deadlock in communication. There is no `maxClientVersion` field in such archaic versions.

2. Custom classloader in `TestOldVersion` is fixed. I tested it with Java 9 only, so I'm not sure about older versions, but Travis will check 7 and 8.