### PR TITLE
Fix an issue with code coverage and building of documentation

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,11 +21,35 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1123: Fix TCP version check
+</li>
+<li>PR #1122: Assorted changes
+</li>
+<li>PR #1121: Add some protection to ValueHashMap against hashes with the same less significant bits
+</li>
+<li>Issue #1097: H2 10x slower than HSQLDB and 6x than Apache Derby for specific query with GROUP BY and DISTINCT subquery
+</li>
+<li>Issue #1093: Use temporary files for ResultSet buffer tables in MVStore
+</li>
+<li>PR #1117: Fix sorting with distinct in ResultTempTable
+</li>
+<li>Issue #1095: Add support for INSERT IGNORE INTO &lt;table&gt; (&lt;columns&gt;) SELECT in MySQL Mode
+</li>
+<li>PR #1114: Minor cleanup and formatting fixes
+</li>
+<li>PR #1112: Improve test scripts
+</li>
+<li>PR #1111: Use a better fix for issue with SRID
+</li>
+<li>Issue #1107: Restore support of DATETIME2 with specified fractional seconds precision
+</li>
 <li>Issue #1106: Get rid of SwitchSource
 </li>
 <li>PR #1105: Assorted minor changes
 </li>
 <li>Issue #1102: CREATE SYNONYM rejects valid definition
+</li>
+<li>PR #1103: Remove redundant synchronization
 </li>
 <li>Issue #1048: 1.4.197 regression. org.h2.jdbc.JdbcSQLException: Timeout trying to lock table "SYS"
 </li>
@@ -43,7 +67,15 @@ Change Log
 </li>
 <li>PR #1087: improve performance of planning large queries
 </li>
+<li>PR #1085: Add tests for simple one-column index sorting
+</li>
+<li>PR #1084: re-enable some pagestore testing
+</li>
+<li>PR #1083: Assorted changes
+</li>
 <li>Issue #394: Recover tool places COLLATION and BINARY_COLLATION after temporary tables
+</li>
+<li>PR #1081: Session.getTransactionId should return a more distinguishing value
 </li>
 <li>Improve the script-based unit testing to check the error code of the exception thrown.
 </li>

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1126: Fix an issue with code coverage and building of documentation
+</li>
 <li>PR #1123: Fix TCP version check
 </li>
 <li>PR #1122: Assorted changes

--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -394,7 +394,7 @@ public class Insert extends Prepared implements ResultTarget {
 
         ArrayList<String> variableNames = new ArrayList<>(
                 duplicateKeyAssignmentMap.size());
-        Expression[] row = (currentRow == null) ? list.get(getCurrentRowNumber() - 1) 
+        Expression[] row = (currentRow == null) ? list.get(getCurrentRowNumber() - 1)
                 : new Expression[columns.length];
         for (int i = 0; i < columns.length; i++) {
             String key = table.getSchema().getName() + "." +

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -106,7 +106,8 @@ public class Select extends Query {
      */
     Object[] currentGroupByExprData;
     /**
-     * Maps an expression object to an index, to use in accessing the Object[] pointed to by groupByData.
+     * Maps an expression object to an index, to use in accessing the Object[]
+     * pointed to by groupByData.
      */
     final HashMap<Expression,Integer> exprToIndexInGroupByData = new HashMap<>();
     /**
@@ -117,7 +118,7 @@ public class Select extends Query {
      * Key into groupByData that produces currentGroupByExprData. Not used in lazy mode.
      */
     ValueArray currentGroupsKey;
-    
+
     private int havingIndex;
     private boolean isGroupQuery, isGroupSortedQuery;
     private boolean isForUpdate, isForUpdateMvcc;
@@ -1580,11 +1581,13 @@ public class Select extends Query {
                     Value[] row = null;
                     if (previousKeyValues == null) {
                         previousKeyValues = keyValues;
-                        currentGroupByExprData = new Object[Math.max(exprToIndexInGroupByData.size(), expressions.size())];
+                        currentGroupByExprData =new Object[Math.max(exprToIndexInGroupByData.size(),
+                                expressions.size())];
                     } else if (!Arrays.equals(previousKeyValues, keyValues)) {
                         row = createGroupSortedRow(previousKeyValues, columnCount);
                         previousKeyValues = keyValues;
-                        currentGroupByExprData = new Object[Math.max(exprToIndexInGroupByData.size(), expressions.size())];
+                        currentGroupByExprData = new Object[Math.max(exprToIndexInGroupByData.size(),
+                                expressions.size())];
                     }
                     currentGroupRowId++;
 

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -934,7 +934,8 @@ public class Database implements DataHandler {
         }
         if (SysProperties.CHECK2) {
             // If we are locking two different databases in the same stack, just ignore it.
-            // This only happens in TestLinkedTable where we connect to another h2 DB in the same process.
+            // This only happens in TestLinkedTable where we connect to another h2 DB in the
+            // same process.
             if (META_LOCK_DEBUGGING_DB.get() != null
                     && META_LOCK_DEBUGGING_DB.get() != this) {
                 final Session prev = META_LOCK_DEBUGGING.get();

--- a/h2/src/main/org/h2/expression/Aggregate.java
+++ b/h2/src/main/org/h2/expression/Aggregate.java
@@ -371,8 +371,8 @@ public class Aggregate extends Expression {
                 DbException.throwInternalError("type=" + type);
             }
         }
-        if (!select.isCurrentGroup()) {    
-            throw DbException.get(ErrorCode.INVALID_USE_OF_AGGREGATE_FUNCTION_1, getSQL());    
+        if (!select.isCurrentGroup()) {
+            throw DbException.get(ErrorCode.INVALID_USE_OF_AGGREGATE_FUNCTION_1, getSQL());
         }
         AggregateData data = (AggregateData)select.getCurrentGroupExprData(this);
         if (data == null) {

--- a/h2/src/main/org/h2/index/PageDataIndex.java
+++ b/h2/src/main/org/h2/index/PageDataIndex.java
@@ -312,9 +312,10 @@ public class PageDataIndex extends PageIndex {
     public double getCost(Session session, int[] masks,
             TableFilter[] filters, int filter, SortOrder sortOrder,
             AllColumnsForPlan allColumnsSet) {
-        // The +200 is so that indexes that can return the same data, but have less columns, will take precedence.
-        // This all works out easier in the MVStore case, because MVStore uses the same cost calculation
-        // code for the ScanIndex (i.e. the MVPrimaryIndex) and all other indices.
+        // The +200 is so that indexes that can return the same data, but have less
+        // columns, will take precedence. This all works out easier in the MVStore case,
+        // because MVStore uses the same cost calculation code for the ScanIndex (i.e.
+        // the MVPrimaryIndex) and all other indices.
         return 10 * (tableData.getRowCountApproximation() +
                 Constants.COST_ROW_OFFSET) + 200;
     }

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -459,8 +459,8 @@ public class RegularTable extends TableBase {
             return true;
         }
         if (!exclusive && lockSharedSessions.containsKey(session)) {
-          return true;
-      }
+            return true;
+        }
         synchronized (database) {
             if (!exclusive && lockSharedSessions.contains(session)) {
                 return true;

--- a/h2/src/main/org/h2/util/ValueHashMap.java
+++ b/h2/src/main/org/h2/util/ValueHashMap.java
@@ -228,7 +228,7 @@ public class ValueHashMap<V> extends HashBase {
                 keysIndex++;
                 Value key = keys[keysIndex];
                 if (key != null && key != ValueNull.DELETED)
-                    return new AbstractMap.SimpleImmutableEntry<Value, V>(key, values[keysIndex]);
+                    return new AbstractMap.SimpleImmutableEntry<>(key, values[keysIndex]);
             }
         }
         

--- a/h2/src/main/org/h2/util/ValueHashMap.java
+++ b/h2/src/main/org/h2/util/ValueHashMap.java
@@ -192,11 +192,11 @@ public class ValueHashMap<V> extends HashBase {
         }
         return list;
     }
-    
+
     public Iterable<Map.Entry<Value, V>> entries() {
         return new EntryIterable();
     }
-    
+
     private final class EntryIterable implements Iterable<Map.Entry<Value, V>> {
         EntryIterable() {
         }
@@ -231,7 +231,7 @@ public class ValueHashMap<V> extends HashBase {
                     return new AbstractMap.SimpleImmutableEntry<>(key, values[keysIndex]);
             }
         }
-        
+
         @Override
         public void remove() {
             throw new UnsupportedOperationException();

--- a/h2/src/test/org/h2/test/db/TestBigResult.java
+++ b/h2/src/test/org/h2/test/db/TestBigResult.java
@@ -85,9 +85,9 @@ public class TestBigResult extends TestBase {
             ps.executeUpdate();
         }
         // local result
-        testSortintAndDistinct1(stat, count, count);
+        testSortingAndDistinct1(stat, count, count);
         // external result
-        testSortintAndDistinct1(stat, 10, count);
+        testSortingAndDistinct1(stat, 10, count);
         stat.execute("DROP TABLE TEST");
         stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, VALUE1 INT NOT NULL, VALUE2 INT NOT NULL)");
         ps = conn.prepareStatement("INSERT INTO TEST VALUES (?, ?, ?)");
@@ -181,7 +181,7 @@ public class TestBigResult extends TestBase {
         conn.close();
     }
 
-    private void testSortintAndDistinct1(Statement stat, int maxRows, int count) throws SQLException {
+    private void testSortingAndDistinct1(Statement stat, int maxRows, int count) throws SQLException {
         stat.execute("SET MAX_MEMORY_ROWS " + maxRows);
         ResultSet rs = stat.executeQuery("SELECT VALUE FROM (SELECT DISTINCT ID, VALUE FROM TEST ORDER BY VALUE)");
         for (int i = 1; i <= count; i++) {

--- a/h2/src/test/org/h2/test/db/TestBigResult.java
+++ b/h2/src/test/org/h2/test/db/TestBigResult.java
@@ -28,7 +28,8 @@ public class TestBigResult extends TestBase {
     /**
      * Run just this test.
      *
-     * @param a ignored
+     * @param a
+     *              ignored
      */
     public static void main(String... a) throws Exception {
         TestBase.createCaller().init().test();
@@ -56,13 +57,11 @@ public class TestBigResult extends TestBase {
         int len = getSize(1000, 4000);
         stat.execute("SET MAX_MEMORY_ROWS " + (len / 10));
         stat.execute("CREATE TABLE RECOVERY(TRANSACTION_ID INT, SQL_STMT VARCHAR)");
-        stat.execute("INSERT INTO RECOVERY " +
-                "SELECT X, CASE MOD(X, 2) WHEN 0 THEN 'commit' ELSE 'begin' END " +
-                "FROM SYSTEM_RANGE(1, "+len+")");
-        ResultSet rs = stat.executeQuery("SELECT * FROM RECOVERY " +
-                "WHERE SQL_STMT LIKE 'begin%' AND " +
-                "TRANSACTION_ID NOT IN(SELECT TRANSACTION_ID FROM RECOVERY " +
-                "WHERE SQL_STMT='commit' OR SQL_STMT='rollback')");
+        stat.execute("INSERT INTO RECOVERY " + "SELECT X, CASE MOD(X, 2) WHEN 0 THEN 'commit' ELSE 'begin' END "
+                + "FROM SYSTEM_RANGE(1, " + len + ")");
+        ResultSet rs = stat.executeQuery("SELECT * FROM RECOVERY " + "WHERE SQL_STMT LIKE 'begin%' AND "
+                + "TRANSACTION_ID NOT IN(SELECT TRANSACTION_ID FROM RECOVERY "
+                + "WHERE SQL_STMT='commit' OR SQL_STMT='rollback')");
         int count = 0, last = 1;
         while (rs.next()) {
             assertEquals(last, rs.getInt(1));
@@ -209,7 +208,8 @@ public class TestBigResult extends TestBase {
         assertFalse(rs.next());
     }
 
-    private void testSortingAndDistinct2DistinctOnly(Statement stat, String sql, int maxRows, int partCount) throws SQLException {
+    private void testSortingAndDistinct2DistinctOnly(Statement stat, String sql, int maxRows, int partCount)
+            throws SQLException {
         ResultSet rs;
         stat.execute("SET MAX_MEMORY_ROWS " + maxRows);
         rs = stat.executeQuery(sql);
@@ -235,7 +235,8 @@ public class TestBigResult extends TestBase {
         assertFalse(rs.next());
     }
 
-    private void testSortingAndDistinct3DistinctOnly(Statement stat, String sql, int maxRows, int partCount) throws SQLException {
+    private void testSortingAndDistinct3DistinctOnly(Statement stat, String sql, int maxRows, int partCount)
+            throws SQLException {
         ResultSet rs;
         stat.execute("SET MAX_MEMORY_ROWS " + maxRows);
         rs = stat.executeQuery(sql);
@@ -261,7 +262,8 @@ public class TestBigResult extends TestBase {
         assertFalse(rs.next());
     }
 
-    private void testSortingAndDistinct4DistinctOnly(Statement stat, String sql, int maxRows, int count) throws SQLException {
+    private void testSortingAndDistinct4DistinctOnly(Statement stat, String sql, int maxRows, int count)
+            throws SQLException {
         stat.execute("SET MAX_MEMORY_ROWS " + maxRows);
         ResultSet rs = stat.executeQuery(sql);
         BitSet set = new BitSet();
@@ -278,7 +280,8 @@ public class TestBigResult extends TestBase {
         assertEquals(count, set.nextClearBit(0));
     }
 
-    private void testSortingAndDistinct4SortingOnly(Statement stat, String sql, int maxRows, int count) throws SQLException {
+    private void testSortingAndDistinct4SortingOnly(Statement stat, String sql, int maxRows, int count)
+            throws SQLException {
         stat.execute("SET MAX_MEMORY_ROWS " + maxRows);
         ResultSet rs = stat.executeQuery(sql);
         for (int i = 0; i < count; i++) {
@@ -377,8 +380,7 @@ public class TestBigResult extends TestBase {
         // rs.close();
         conn.close();
         deleteDb("bigResult");
-        ArrayList<String> files = FileLister.getDatabaseFiles(getBaseDir(),
-                "bigResult", true);
+        ArrayList<String> files = FileLister.getDatabaseFiles(getBaseDir(), "bigResult", true);
         if (files.size() > 0) {
             fail("file not deleted: " + files.get(0));
         }
@@ -415,15 +417,10 @@ public class TestBigResult extends TestBase {
         Connection conn = getConnection("bigResult");
         Statement stat = conn.createStatement();
         stat.execute("DROP TABLE IF EXISTS TEST");
-        stat.execute("CREATE TABLE TEST(" +
-                "ID INT PRIMARY KEY, " +
-                "Name VARCHAR(255), " +
-                "FirstName VARCHAR(255), " +
-                "Points INT," +
-                "LicenseID INT)");
+        stat.execute("CREATE TABLE TEST(" + "ID INT PRIMARY KEY, " + "Name VARCHAR(255), " + "FirstName VARCHAR(255), "
+                + "Points INT," + "LicenseID INT)");
         int len = getSize(10, 5000);
-        PreparedStatement prep = conn.prepareStatement(
-                "INSERT INTO TEST VALUES(?, ?, ?, ?, ?)");
+        PreparedStatement prep = conn.prepareStatement("INSERT INTO TEST VALUES(?, ?, ?, ?, ?)");
         for (int i = 0; i < len; i++) {
             prep.setInt(1, i);
             prep.setString(2, "Name " + i);
@@ -474,8 +471,7 @@ public class TestBigResult extends TestBase {
             prep.setString(2, "" + i / 200);
             prep.execute();
         }
-        Statement s2 = conn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
-                ResultSet.CONCUR_UPDATABLE);
+        Statement s2 = conn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
         rs = s2.executeQuery("SELECT NAME FROM DATA");
         rs.last();
         conn.setAutoCommit(true);

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -492,11 +492,11 @@ public class TestScript extends TestBase {
     }
 
     /** Convert the error code to a symbolic name from ErrorCode. */
-    private static final Map<Integer, String> ERROR_CODE_TO_NAME = new HashMap<>();
+    private static final Map<Integer, String> ERROR_CODE_TO_NAME = new HashMap<>(256);
     static {
         try {
             for (Field field : ErrorCode.class.getDeclaredFields()) {
-                if (Modifier.isStatic(field.getModifiers())) {
+                if (field.getModifiers() == (Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL)) {
                     ERROR_CODE_TO_NAME.put(field.getInt(null), field.getName());
                 }
             }

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -775,3 +775,4 @@ iterators tech enums incompatibilities loses reimplement readme reorganize milli
 geometries sourceschema destschema generatedcolumn alphanumerically usages
 
 sizable instantiates renders sdt txcommit unhelpful optimiser treats rejects referring untrusted computes vacate inverted
+reordered colliding evgenij archaic invocations apostrophe hypothetically testref ryazanov useless completes highlighting tends degrade


### PR DESCRIPTION
1. There was a problem with reflective access to constants in `ErrorCode` from the `TestScript` in code coverage mode. A more exact check for modifiers of fields is used to avoid access to fields from the instrumentation.

2. Long lines, bad indentation and similar issues are fixed.

3. A typo is fixed, `changelog.html` and `dictionary.txt` are updated.