### PR TITLE
Update JdbcDatabaseMetaData.getSQLKeywords() and perform some minor optimizations

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3864,6 +3864,7 @@ public class Parser {
         parseIndex = i;
         String sub = sqlCommand.substring(start, i);
         checkLiterals(false);
+        BigDecimal bd;
         if (!containsE && sub.indexOf('.') < 0) {
             BigInteger bi = new BigInteger(sub);
             if (bi.compareTo(ValueLong.MAX_BI) <= 0) {
@@ -3875,12 +3876,13 @@ public class Parser {
                 currentTokenType = VALUE;
                 return;
             }
-        }
-        BigDecimal bd;
-        try {
-            bd = new BigDecimal(sub);
-        } catch (NumberFormatException e) {
-            throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, sub);
+            bd = new BigDecimal(bi);
+        } else {
+            try {
+                bd = new BigDecimal(sub);
+            } catch (NumberFormatException e) {
+                throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, sub);
+            }
         }
         currentValue = ValueDecimal.get(bd);
         currentTokenType = VALUE;

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -1535,19 +1535,19 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     }
 
     /**
-     * Gets the comma-separated list of all SQL keywords that are not supported
-     * as table/column/index name, in addition to the SQL-2003 keywords. The list
+     * Gets the comma-separated list of all SQL keywords that are not supported as
+     * table/column/index name, in addition to the SQL-2003 keywords. The list
      * returned is:
      * <pre>
-     * LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY
+     * INTERSECTS,LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY,TOP
      * </pre>
      * The complete list of keywords (including SQL-2003 keywords) is:
      * <pre>
-     * ALL, CHECK, CONSTRAINT, CROSS, CURRENT_DATE, CURRENT_TIME,
-     * CURRENT_TIMESTAMP, DISTINCT, EXCEPT, EXISTS, FALSE, FETCH, FOR, FOREIGN,
-     * FROM, FULL, GROUP, HAVING, INNER, INTERSECT, IS, JOIN, LIKE, LIMIT,
-     * MINUS, NATURAL, NOT, NULL, OFFSET, ON, ORDER, PRIMARY, ROWNUM, SELECT,
-     * SYSDATE, SYSTIME, SYSTIMESTAMP, TODAY, TRUE, UNION, UNIQUE, WHERE, WITH
+     * ALL, CHECK, CONSTRAINT, CROSS, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP,
+     * DISTINCT, EXCEPT, EXISTS, FALSE, FETCH, FOR, FOREIGN, FROM, FULL, GROUP,
+     * HAVING, INNER, INTERSECT, INTERSECTS, IS, JOIN, LIKE, LIMIT, MINUS, NATURAL,
+     * NOT, NULL, OFFSET, ON, ORDER, PRIMARY, ROWNUM, SELECT, SYSDATE, SYSTIME,
+     * SYSTIMESTAMP, TODAY, TOP, TRUE, UNION, UNIQUE, WHERE, WITH
      * </pre>
      *
      * @return a list of additional the keywords
@@ -1555,7 +1555,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     @Override
     public String getSQLKeywords() {
         debugCodeCall("getSQLKeywords");
-        return "LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY";
+        return "INTERSECTS,LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY,TOP";
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -1253,8 +1253,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
         try {
             debugCodeCall("executeBatch");
             if (batchParameters == null) {
-                // TODO batch: check what other database do if no parameters are
-                // set
+                // Empty batch is allowed, see JDK-4639504 and other issues
                 batchParameters = Utils.newSmallArrayList();
             }
             batchIdentities = new MergedResultSet();

--- a/h2/src/main/org/h2/jdbc/JdbcSQLException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLException.java
@@ -44,10 +44,10 @@ public class JdbcSQLException extends SQLException {
             int errorCode, Throwable cause, String stackTrace) {
         super(message, state, errorCode);
         this.originalMessage = message;
-        setSQL(sql);
         this.cause = cause;
         this.stackTrace = stackTrace;
-        buildMessage();
+        // setSQL() invokes buildBessage() by itself
+        setSQL(sql);
         initCause(cause);
     }
 

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -89,6 +89,10 @@ public class ParserUtil {
      * @return the token type
      */
     public static int getSaveTokenType(String s, boolean additionalKeywords) {
+        /*
+         * JdbcDatabaseMetaData.getSQLKeywords() and tests should be updated when new
+         * non-SQL:2003 keywords are introduced here.
+         */
         switch (s.charAt(0)) {
         case 'A':
             return getKeywordOrIdentifier(s, "ALL", KEYWORD);

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -464,7 +464,7 @@ public class TestMetaData extends TestBase {
 
         assertEquals("schema", meta.getSchemaTerm());
         assertEquals("\\", meta.getSearchStringEscape());
-        assertEquals("LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY",
+        assertEquals("INTERSECTS,LIMIT,MINUS,OFFSET,ROWNUM,SYSDATE,SYSTIME,SYSTIMESTAMP,TODAY,TOP",
                 meta.getSQLKeywords());
 
         assertTrue(meta.getURL().startsWith("jdbc:h2:"));


### PR DESCRIPTION
1. I fogrot to update `JdbcDatabaseMetaData.getSQLKeywords()` in #1096. This incompalibility is fixed now.

2. Empty batches are allowed, so replace TODO with an appropriate comment.

3. Do not invoke `buildMessage()` twice in `JdbcSQLException()`, use only one implicit invokation.

4. Do not parse large integer decimals twice in `Parser.readDecimal()`. `BigDecimal` has a fast consructor with `BigInteger` argument.