### PR TITLE
Fix ON DUPLICATE KEY UPDATE with ENUM

### DIFF
--- a/h2/src/main/org/h2/expression/Comparison.java
+++ b/h2/src/main/org/h2/expression/Comparison.java
@@ -272,7 +272,7 @@ public class Comparison extends Condition {
         }
         int dataType = Value.getHigherOrder(left.getType(), right.getType());
         if (dataType == Value.ENUM) {
-            String[] enumerators = getEnumerators(l, r);
+            String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(l, r);
             l = l.convertToEnum(enumerators);
             r = r.convertToEnum(enumerators);
         } else {
@@ -281,16 +281,6 @@ public class Comparison extends Condition {
         }
         boolean result = compareNotNull(database, l, r, compareType);
         return ValueBoolean.get(result);
-    }
-
-    private static String[] getEnumerators(Value left, Value right) {
-        if (left.getType() == Value.ENUM) {
-            return ((ValueEnum) left).getEnumerators();
-        } else if (right.getType() == Value.ENUM) {
-            return ((ValueEnum) right).getEnumerators();
-        } else {
-            return new String[0];
-        }
     }
 
     /**

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -40,6 +40,7 @@ import org.h2.schema.TriggerObject;
 import org.h2.util.Utils;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
+import org.h2.value.ValueEnum;
 import org.h2.value.ValueNull;
 
 /**
@@ -1192,8 +1193,14 @@ public abstract class Table extends SchemaObjectBase {
             return 0;
         }
         int dataType = Value.getHigherOrder(a.getType(), b.getType());
-        a = a.convertTo(dataType);
-        b = b.convertTo(dataType);
+        if (dataType == Value.ENUM) {
+            String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(a, b);
+            a = a.convertToEnum(enumerators);
+            b = b.convertToEnum(enumerators);
+        } else {
+            a = a.convertTo(dataType);
+            b = b.convertTo(dataType);
+        }
         return a.compareTypeSafe(b, compareMode);
     }
 

--- a/h2/src/main/org/h2/value/ValueEnum.java
+++ b/h2/src/main/org/h2/value/ValueEnum.java
@@ -81,6 +81,26 @@ public class ValueEnum extends ValueEnumBase {
         throw DbException.get(ErrorCode.GENERAL_ERROR_1, "Unexpected error");
     }
 
+    /**
+     * Returns enumerators for the two specified values for a binary operation.
+     *
+     * @param left
+     *                  left (first) operand
+     * @param right
+     *                  right (second) operand
+     * @return enumerators from the left or the right value, or an empty array if
+     *         both values do not have enumerators
+     */
+    public static String[] getEnumeratorsForBinaryOperation(Value left, Value right) {
+        if (left.getType() == Value.ENUM) {
+            return ((ValueEnum) left).getEnumerators();
+        } else if (right.getType() == Value.ENUM) {
+            return ((ValueEnum) right).getEnumerators();
+        } else {
+            return new String[0];
+        }
+    }
+
     public String[] getEnumerators() {
         return enumerators;
     }

--- a/h2/src/test/org/h2/test/db/TestDuplicateKeyUpdate.java
+++ b/h2/src/test/org/h2/test/db/TestDuplicateKeyUpdate.java
@@ -40,6 +40,7 @@ public class TestDuplicateKeyUpdate extends TestBase {
         testOnDuplicateKeyInsertMultiValue(conn);
         testPrimaryKeyAndUniqueKey(conn);
         testUpdateCountAndQualifiedNames(conn);
+        testEnum(conn);
         conn.close();
         deleteDb("duplicateKeyUpdate");
     }
@@ -298,6 +299,16 @@ public class TestDuplicateKeyUpdate extends TestBase {
                 .executeUpdate("insert into s2.test(id, name) values(2, 'd') " +
                         "on duplicate key update s3.test.name = values(name)");
         stat.execute("drop schema s2 cascade");
+    }
+
+    private void testEnum(Connection conn) throws SQLException {
+        Statement stat = conn.createStatement();
+        stat.execute("create table test(e enum('a', 'b') unique)");
+        PreparedStatement ps = conn.prepareStatement("insert into test(e) values (?) on duplicate key update e = e");
+        ps.setString(1, "a");
+        assertEquals(1, ps.executeUpdate());
+        assertEquals(0, ps.executeUpdate());
+        stat.execute("drop table test");
     }
 
 }


### PR DESCRIPTION
This fixes an additional test case from the issue #1006.

`Table.compareTypeSafe()` needs a fix for `ENUM` values too.