### PR TITLE
Do not allocate a new ExpressionVisitor in incrementQueryLevel()

### DIFF
--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -1434,20 +1434,21 @@ public class Select extends Query {
         }
         default:
         }
-        ExpressionVisitor v2 = visitor.incrementQueryLevel(1);
+        visitor.incrementQueryLevel(1);
         boolean result = true;
         for (Expression e : expressions) {
-            if (!e.isEverything(v2)) {
+            if (!e.isEverything(visitor)) {
                 result = false;
                 break;
             }
         }
-        if (result && condition != null && !condition.isEverything(v2)) {
+        if (result && condition != null && !condition.isEverything(visitor)) {
             result = false;
         }
-        if (result && having != null && !having.isEverything(v2)) {
+        if (result && having != null && !having.isEverything(visitor)) {
             result = false;
         }
+        visitor.incrementQueryLevel(-1);
         return result;
     }
 

--- a/h2/src/main/org/h2/expression/ExpressionVisitor.java
+++ b/h2/src/main/org/h2/expression/ExpressionVisitor.java
@@ -113,7 +113,7 @@ public class ExpressionVisitor {
             new ExpressionVisitor(QUERY_COMPARABLE);
 
     private final int type;
-    private final int queryLevel;
+    private int queryLevel;
     private final HashSet<DbObject> dependencies;
     private final AllColumnsForPlan columns1;
     private final Table table;
@@ -245,11 +245,9 @@ public class ExpressionVisitor {
      * Increment or decrement the query level.
      *
      * @param offset 1 to increment, -1 to decrement
-     * @return a clone of this expression visitor, with the changed query level
      */
-    public ExpressionVisitor incrementQueryLevel(int offset) {
-        return new ExpressionVisitor(type, queryLevel + offset, dependencies,
-                columns1, table, resolver, maxDataModificationId, columns2);
+    public void incrementQueryLevel(int offset) {
+        queryLevel += offset;
     }
 
     /**


### PR DESCRIPTION
We can safely reuse current visitor in this place.

This change slightly reduces GC pressure in `TestFuzzOptimizations`.