### PR TITLE
Reduce allocation of ExpressionVisitor instances

### DIFF
--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -1435,20 +1435,18 @@ public class Select extends Query {
         default:
         }
         ExpressionVisitor v2 = visitor.incrementQueryLevel(1);
-        boolean result = true;
         for (Expression e : expressions) {
             if (!e.isEverything(v2)) {
-                result = false;
-                break;
+                return false;
             }
         }
-        if (result && condition != null && !condition.isEverything(v2)) {
-            result = false;
+        if (condition != null && !condition.isEverything(v2)) {
+            return false;
         }
-        if (result && having != null && !having.isEverything(v2)) {
-            result = false;
+        if (having != null && !having.isEverything(v2)) {
+            return false;
         }
-        return result;
+        return true;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -45,6 +45,7 @@ import org.h2.test.utils.ProxyCodeGenerator;
 import org.h2.test.utils.ResultVerifier;
 import org.h2.test.utils.SelfDestructor;
 import org.h2.tools.DeleteDbFiles;
+import org.h2.util.Utils;
 
 /**
  * The base class for all tests.
@@ -140,7 +141,14 @@ public abstract class TestBase {
             init(conf);
             start = System.nanoTime();
             test();
-            println("");
+            if (!config.mvStore) {
+                /*
+                 * This code is here to debug memory issues with PageStore testing on Travis.
+                 */
+                println("(" + (Utils.getMemoryUsed() >> 10) + " MiB used after)");
+            } else {
+                println("");
+            }
         } catch (Throwable e) {
             println("FAIL " + e.toString());
             logError("FAIL " + e.toString(), e);

--- a/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
+++ b/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
@@ -18,6 +18,7 @@ import java.util.Random;
 import org.h2.test.TestBase;
 import org.h2.test.db.Db;
 import org.h2.test.db.Db.Prepared;
+import org.h2.util.Utils;
 
 /**
  * This test executes random SQL statements to test if optimizations are working
@@ -115,6 +116,9 @@ public class TestFuzzOptimizations extends TestBase {
                     params.set(j, value);
                 }
                 executeAndCompare(condition, params, message);
+            }
+            if (!config.mvStore) {
+                println((Utils.getMemoryUsed() >> 10) + " MiB used");
             }
         }
         executeAndCompare("a >=0 and b in(?, 2) and a in(1, ?, null)", Arrays.asList("10", "2"),

--- a/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
+++ b/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
@@ -102,12 +102,12 @@ public class TestFuzzOptimizations extends TestBase {
         int size = getSize(100, 1000);
         for (int i = 0; i < size; i++) {
             long seed = seedGenerator.nextLong();
-            println("seed: " + seed);
+            println("testIn() seed: " + seed);
             Random random = new Random(seed);
             ArrayList<String> params = new ArrayList<>();
             String condition = getRandomCondition(random, params, columns,
                     compares, values);
-            String message = "seed: " + seed + " " + condition;
+            String message = "testIn() seed: " + seed + " " + condition;
             executeAndCompare(condition, params, message);
             if (params.size() > 0) {
                 for (int j = 0; j < params.size(); j++) {
@@ -118,7 +118,7 @@ public class TestFuzzOptimizations extends TestBase {
             }
         }
         executeAndCompare("a >=0 and b in(?, 2) and a in(1, ?, null)", Arrays.asList("10", "2"),
-                "seed=-6191135606105920350L");
+                "testIn() seed=-6191135606105920350L");
         db.execute("drop table test0, test1");
     }
 
@@ -192,7 +192,7 @@ public class TestFuzzOptimizations extends TestBase {
         db.execute("UPDATE TEST SET B = NULL WHERE B = 0");
         Random random = new Random();
         long seed = random.nextLong();
-        println("seed: " + seed);
+        println("testInSelect() seed: " + seed);
         for (int i = 0; i < 100; i++) {
             String column = random.nextBoolean() ? "A" : "B";
             String value = new String[] { "NULL", "0", "A", "B" }[random.nextInt(4)];
@@ -206,7 +206,7 @@ public class TestFuzzOptimizations extends TestBase {
                 " FROM TEST I WHERE I." + compare + "=?) ORDER BY 1, 2";
             List<Map<String, Object>> a = db.prepare(sql1).set(x).query();
             List<Map<String, Object>> b = db.prepare(sql2).set(x).query();
-            assertTrue("seed: " + seed + " sql: " + sql1 +
+            assertTrue("testInSelect() seed: " + seed + " sql: " + sql1 +
                     " a: " + a + " b: " + b, a.equals(b));
         }
         db.execute("DROP TABLE TEST");
@@ -217,7 +217,7 @@ public class TestFuzzOptimizations extends TestBase {
         db.execute("CREATE TABLE TEST(A INT, B INT, C INT)");
         Random random = new Random();
         long seed = random.nextLong();
-        println("seed: " + seed);
+        println("testGroupSorted() seed: " + seed);
         for (int i = 0; i < 100; i++) {
             Prepared p = db.prepare("INSERT INTO TEST VALUES(?, ?, ?)");
             p.set(new String[] { null, "0", "1", "2" }[random.nextInt(4)]);

--- a/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
+++ b/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
@@ -118,6 +118,10 @@ public class TestFuzzOptimizations extends TestBase {
                 executeAndCompare(condition, params, message);
             }
             if (!config.mvStore) {
+                /*
+                 * Travis tests have problems with automatic garbage collection, so request a GC
+                 * explicitly and print its results.
+                 */
                 println((Utils.getMemoryUsed() >> 10) + " MiB used");
             }
         }


### PR DESCRIPTION
This is a second attempt to reduce GC pressure in `TestFuzzOptimizations`.

Instances of `INDEPENDENT` and `EVALUATABLE` visitors are preallocated with query levels from 0 to 7. This should be enough for almost all cases. `TestFuzzOptimizations` sometimes uses deeper levels, so `ExpressionVisitor.incrementQueryLevel()` is covered by this test case.

With this change the most allocated class does not appear any more in allocation samples during this test.