### PR TITLE
Implement Comparable<Value> in CompareMode and optimize ValueHashMap.keys()

### DIFF
--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -318,12 +318,7 @@ public class ScriptCommand extends ScriptBase {
             // Generate CREATE CONSTRAINT ...
             final ArrayList<SchemaObject> constraints = db.getAllSchemaObjects(
                     DbObject.CONSTRAINT);
-            Collections.sort(constraints, new Comparator<SchemaObject>() {
-                @Override
-                public int compare(SchemaObject c1, SchemaObject c2) {
-                    return ((Constraint) c1).compareTo((Constraint) c2);
-                }
-            });
+            Collections.sort(constraints, null);
             for (SchemaObject obj : constraints) {
                 if (excludeSchema(obj.getSchema())) {
                     continue;

--- a/h2/src/main/org/h2/engine/QueryStatisticsData.java
+++ b/h2/src/main/org/h2/engine/QueryStatisticsData.java
@@ -23,7 +23,7 @@ public class QueryStatisticsData {
             new Comparator<QueryEntry>() {
         @Override
         public int compare(QueryEntry o1, QueryEntry o2) {
-            return (int) Math.signum(o1.lastUpdateTime - o2.lastUpdateTime);
+            return Long.signum(o1.lastUpdateTime - o2.lastUpdateTime);
         }
     };
 

--- a/h2/src/main/org/h2/expression/Aggregate.java
+++ b/h2/src/main/org/h2/expression/Aggregate.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import org.h2.api.ErrorCode;
 import org.h2.command.dml.Select;
 import org.h2.command.dml.SelectOrderBy;
-import org.h2.engine.Database;
 import org.h2.engine.Session;
 import org.h2.index.Cursor;
 import org.h2.index.Index;

--- a/h2/src/main/org/h2/expression/Aggregate.java
+++ b/h2/src/main/org/h2/expression/Aggregate.java
@@ -267,13 +267,7 @@ public class Aggregate extends Expression {
                 }
             });
         } else {
-            final Database database = select.getSession().getDatabase();
-            Arrays.sort(array, new Comparator<Value> () {
-                @Override
-                public int compare(Value v1, Value v2) {
-                    return database.compare(v1, v2);
-                }
-            });
+            Arrays.sort(array, select.getSession().getDatabase().getCompareMode());
         }
     }
 

--- a/h2/src/main/org/h2/expression/AggregateDataMedian.java
+++ b/h2/src/main/org/h2/expression/AggregateDataMedian.java
@@ -8,7 +8,6 @@ package org.h2.expression;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 
 import org.h2.engine.Database;
 import org.h2.engine.Session;
@@ -173,12 +172,7 @@ class AggregateDataMedian extends AggregateDataCollecting {
             return ValueNull.INSTANCE;
         }
         final CompareMode mode = database.getCompareMode();
-        Arrays.sort(a, new Comparator<Value>() {
-            @Override
-            public int compare(Value o1, Value o2) {
-                return o1.compareTo(o2, mode);
-            }
-        });
+        Arrays.sort(a, mode);
         int len = a.length;
         int idx = len / 2;
         Value v1 = a[idx];

--- a/h2/src/main/org/h2/expression/ConditionInConstantSet.java
+++ b/h2/src/main/org/h2/expression/ConditionInConstantSet.java
@@ -6,7 +6,6 @@
 package org.h2.expression;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.TreeSet;
 import org.h2.engine.Session;
 import org.h2.index.IndexCondition;
@@ -43,12 +42,7 @@ public class ConditionInConstantSet extends Condition {
             ArrayList<Expression> valueList) {
         this.left = left;
         this.valueList = valueList;
-        this.valueSet = new TreeSet<>(new Comparator<Value>() {
-            @Override
-            public int compare(Value o1, Value o2) {
-                return session.getDatabase().compare(o1, o2);
-            }
-        });
+        this.valueSet = new TreeSet<>(session.getDatabase().getCompareMode());
         int type = left.getType();
         for (Expression expression : valueList) {
             valueSet.add(expression.getValue(session).convertTo(type));

--- a/h2/src/main/org/h2/index/IndexCondition.java
+++ b/h2/src/main/org/h2/index/IndexCondition.java
@@ -7,7 +7,6 @@ package org.h2.index;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import org.h2.command.dml.Query;
@@ -21,7 +20,6 @@ import org.h2.result.ResultInterface;
 import org.h2.table.Column;
 import org.h2.table.TableType;
 import org.h2.util.StatementBuilder;
-import org.h2.value.CompareMode;
 import org.h2.value.Value;
 
 /**
@@ -156,13 +154,7 @@ public class IndexCondition {
             valueSet.add(v);
         }
         Value[] array = valueSet.toArray(new Value[valueSet.size()]);
-        final CompareMode mode = session.getDatabase().getCompareMode();
-        Arrays.sort(array, new Comparator<Value>() {
-            @Override
-            public int compare(Value o1, Value o2) {
-                return o1.compareTo(o2, mode);
-            }
-        });
+        Arrays.sort(array, session.getDatabase().getCompareMode());
         return array;
     }
 

--- a/h2/src/main/org/h2/value/CompareMode.java
+++ b/h2/src/main/org/h2/value/CompareMode.java
@@ -7,6 +7,7 @@ package org.h2.value;
 
 import java.nio.charset.Charset;
 import java.text.Collator;
+import java.util.Comparator;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -17,7 +18,7 @@ import org.h2.util.StringUtils;
  * Instances of this class can compare strings. Case sensitive and case
  * insensitive comparison is supported, and comparison using a collator.
  */
-public class CompareMode {
+public class CompareMode implements Comparator<Value> {
 
     /**
      * This constant means there is no collator set, and the default string
@@ -284,6 +285,11 @@ public class CompareMode {
     @Override
     public int hashCode() {
         return getName().hashCode() ^ strength ^ (binaryUnsigned ? -1 : 0);
+    }
+
+    @Override
+    public int compare(Value o1, Value o2) {
+        return o1.compareTo(o2, this);
     }
 
 }

--- a/h2/src/test/org/h2/test/unit/TestValueHashMap.java
+++ b/h2/src/test/org/h2/test/unit/TestValueHashMap.java
@@ -85,7 +85,10 @@ public class TestValueHashMap extends TestBase implements DataHandler {
                 assertTrue(v1 == null ? v2 == null : v1.equals(v2));
                 break;
             case 3: {
-                ArrayList<Value> a1 = map.keys();
+                ArrayList<Value> a1 = new ArrayList<>();
+                for (Value v : map.keys()) {
+                    a1.add(v);
+                }
                 ArrayList<Value> a2 = new ArrayList<>(hash.keySet());
                 assertEquals(a1.size(), a2.size());
                 Collections.sort(a1, vc);


### PR DESCRIPTION
1. `CompareMode` now implements `Comparable<Value>` by itself. 4 custom implementations of comparators are removed.

2. `Comparator<SchemaObject>` with natural ordering is removed and replaced with a `null` parameter.

3. `Long.signum()` is used instead of `(int) Math.signum()`.

4. `ValueHashMap.keys()` now returns an iterable instead of `ArrayList`. This reduces memory allocation by aggregates. This list is not required anywhere, all callers use it only to get iterator from it. `values()` method is not touched because its caller use the returned list by itself.