### PR TITLE
Assorted minor optimizations

### DIFF
--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -146,7 +146,7 @@ public class Function extends Expression implements FunctionCall {
     private static final int VAR_ARGS = -1;
     private static final long PRECISION_UNKNOWN = -1;
 
-    private static final HashMap<String, FunctionInfo> FUNCTIONS = new HashMap<>();
+    private static final HashMap<String, FunctionInfo> FUNCTIONS = new HashMap<>(256);
     private static final char[] SOUNDEX_INDEX = new char[128];
 
     protected Expression[] args;

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -1866,10 +1866,9 @@ public class JdbcConnection extends TraceObject
                 }
             }
 
-            p.setProperty(NUM_SERVERS, String.valueOf(serverList.size()));
+            p.setProperty(NUM_SERVERS, Integer.toString(serverList.size()));
             for (int i = 0; i < serverList.size(); i++) {
-                p.setProperty(PREFIX_SERVER + String.valueOf(i),
-                        serverList.get(i));
+                p.setProperty(PREFIX_SERVER + i, serverList.get(i));
             }
 
             return p;

--- a/h2/src/main/org/h2/jdbcx/JdbcDataSource.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcDataSource.java
@@ -335,7 +335,7 @@ public class JdbcDataSource extends TraceObject implements XADataSource,
         ref.add(new StringRefAddr("url", url));
         ref.add(new StringRefAddr("user", userName));
         ref.add(new StringRefAddr("password", convertToString(passwordChars)));
-        ref.add(new StringRefAddr("loginTimeout", String.valueOf(loginTimeout)));
+        ref.add(new StringRefAddr("loginTimeout", Integer.toString(loginTimeout)));
         ref.add(new StringRefAddr("description", description));
         return ref;
     }

--- a/h2/src/main/org/h2/schema/Sequence.java
+++ b/h2/src/main/org/h2/schema/Sequence.java
@@ -83,9 +83,9 @@ public class Sequence extends SchemaObjectBase {
         this.belongsToTable = belongsToTable;
         if (!isValid(this.value, this.minValue, this.maxValue, this.increment)) {
             throw DbException.get(ErrorCode.SEQUENCE_ATTRIBUTES_INVALID, name,
-                    String.valueOf(this.value), String.valueOf(this.minValue),
-                    String.valueOf(this.maxValue),
-                    String.valueOf(this.increment));
+                    Long.toString(this.value), Long.toString(this.minValue),
+                    Long.toString(this.maxValue),
+                    Long.toString(this.increment));
         }
     }
 

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -349,7 +349,7 @@ public class WebApp {
         try {
             Properties prop = new SortedProperties();
             int port = Integer.decode((String) attributes.get("port"));
-            prop.setProperty("webPort", String.valueOf(port));
+            prop.setProperty("webPort", Integer.toString(port));
             server.setPort(port);
             boolean allowOthers = Utils.parseBoolean((String) attributes.get("allowOthers"), false, false);
             prop.setProperty("webAllowOthers", String.valueOf(allowOthers));

--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -645,7 +645,7 @@ public class WebServer implements Service {
                 }
             } else {
                 for (int i = 0;; i++) {
-                    String data = prop.getProperty(String.valueOf(i));
+                    String data = prop.getProperty(Integer.toString(i));
                     if (data == null) {
                         break;
                     }
@@ -689,7 +689,7 @@ public class WebServer implements Service {
             for (int i = 0; i < len; i++) {
                 ConnectionInfo info = settings.get(i);
                 if (info != null) {
-                    prop.setProperty(String.valueOf(len - i - 1), info.getString());
+                    prop.setProperty(Integer.toString(len - i - 1), info.getString());
                 }
             }
             if (!"null".equals(serverPropertiesDir)) {

--- a/h2/src/main/org/h2/store/FileLock.java
+++ b/h2/src/main/org/h2/store/FileLock.java
@@ -401,7 +401,7 @@ public class FileLock implements Runnable {
             serverSocket = NetUtils.createServerSocket(0, false);
             int port = serverSocket.getLocalPort();
             properties.setProperty("ipAddress", ipAddress);
-            properties.setProperty("port", String.valueOf(port));
+            properties.setProperty("port", Integer.toString(port));
         } catch (Exception e) {
             trace.debug(e, "lock");
             serverSocket = null;

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -843,7 +843,7 @@ public class MetaTable extends Table {
                             // COLUMN_NAME
                             identifier(c.getName()),
                             // ORDINAL_POSITION
-                            String.valueOf(j + 1),
+                            Integer.toString(j + 1),
                             // COLUMN_DEFAULT
                             c.getDefaultSQL(),
                             // IS_NULLABLE
@@ -1104,9 +1104,9 @@ public class MetaTable extends Table {
                         // TYPE_NAME
                         t.name,
                         // DATA_TYPE
-                        String.valueOf(t.sqlType),
+                        Integer.toString(t.sqlType),
                         // PRECISION
-                        String.valueOf(MathUtils.convertLongToInt(t.maxPrecision)),
+                        Integer.toString(MathUtils.convertLongToInt(t.maxPrecision)),
                         // PREFIX
                         t.prefix,
                         // SUFFIX
@@ -1116,13 +1116,13 @@ public class MetaTable extends Table {
                         // AUTO_INCREMENT
                         String.valueOf(t.autoIncrement),
                         // MINIMUM_SCALE
-                        String.valueOf(t.minScale),
+                        Integer.toString(t.minScale),
                         // MAXIMUM_SCALE
-                        String.valueOf(t.maxScale),
+                        Integer.toString(t.maxScale),
                         // RADIX
                         t.decimal ? "10" : null,
                         // POS
-                        String.valueOf(t.sqlTypePos),
+                        Integer.toString(t.sqlTypePos),
                         // CASE_SENSITIVE
                         String.valueOf(t.caseSensitive),
                         // NULLABLE
@@ -1145,7 +1145,7 @@ public class MetaTable extends Table {
                 for (int i = 0; rs.next(); i++) {
                     add(rows,
                         // ID
-                        String.valueOf(i),
+                        Integer.toString(i),
                         // SECTION
                         rs.getString(1).trim(),
                         // TOPIC
@@ -1627,11 +1627,11 @@ public class MetaTable extends Table {
                             // FKCOLUMN_NAME
                             identifier(cols[j].column.getName()),
                             // ORDINAL_POSITION
-                            String.valueOf(j + 1),
+                            Integer.toString(j + 1),
                             // UPDATE_RULE SMALLINT
-                            String.valueOf(update),
+                            Integer.toString(update),
                             // DELETE_RULE SMALLINT
-                            String.valueOf(delete),
+                            Integer.toString(delete),
                             // FK_NAME
                             identifier(ref.getName()),
                             // PK_NAME

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1173,19 +1173,19 @@ public class MetaTable extends Table {
                         // SEQUENCE_NAME
                         identifier(s.getName()),
                         // CURRENT_VALUE
-                        String.valueOf(s.getCurrentValue()),
+                        Long.toString(s.getCurrentValue()),
                         // INCREMENT
-                        String.valueOf(s.getIncrement()),
+                        Long.toString(s.getIncrement()),
                         // IS_GENERATED
                         s.getBelongsToTable() ? "TRUE" : "FALSE",
                         // REMARKS
                         replaceNullWithEmpty(s.getComment()),
                         // CACHE
-                        String.valueOf(s.getCacheSize()),
+                        Long.toString(s.getCacheSize()),
                         // MIN_VALUE
-                        String.valueOf(s.getMinValue()),
+                        Long.toString(s.getMinValue()),
                         // MAX_VALUE
-                        String.valueOf(s.getMaxValue()),
+                        Long.toString(s.getMaxValue()),
                         // IS_CYCLE
                         s.getCycle() ? "TRUE" : "FALSE",
                         // ID

--- a/h2/src/main/org/h2/tools/ConvertTraceFile.java
+++ b/h2/src/main/org/h2/tools/ConvertTraceFile.java
@@ -207,7 +207,7 @@ public class ConvertTraceFile extends Tool {
     }
 
     private static String padNumberLeft(long number, int digits) {
-        return StringUtils.pad(String.valueOf(number), digits, " ", false);
+        return StringUtils.pad(Long.toString(number), digits, " ", false);
     }
 
     private void addToStats(String sql, int resultCount, long time) {

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -1070,7 +1070,7 @@ public class Recover extends Tool implements DataHandler {
 
     private String setStorage(int storageId) {
         this.storageId = storageId;
-        this.storageName = "O_" + String.valueOf(storageId).replace('-', 'M');
+        this.storageName = "O_" + Integer.toString(storageId).replace('-', 'M');
         return storageName;
     }
 

--- a/h2/src/main/org/h2/tools/Shell.java
+++ b/h2/src/main/org/h2/tools/Shell.java
@@ -333,7 +333,7 @@ public class Shell extends Tool implements Runnable {
             String data = null;
             boolean found = false;
             for (int i = 0;; i++) {
-                String d = prop.getProperty(String.valueOf(i));
+                String d = prop.getProperty(Integer.toString(i));
                 if (d == null) {
                     break;
                 }

--- a/h2/src/main/org/h2/util/DateTimeFunctions.java
+++ b/h2/src/main/org/h2/util/DateTimeFunctions.java
@@ -49,7 +49,7 @@ import org.h2.value.ValueTimestampTimeZone;
  * Date and time functions.
  */
 public final class DateTimeFunctions {
-    private static final HashMap<String, Integer> DATE_PART = new HashMap<>();
+    private static final HashMap<String, Integer> DATE_PART = new HashMap<>(128);
 
     /**
      * English names of months and week days.

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -22,8 +22,7 @@ import org.h2.message.DbException;
  */
 public class StringUtils {
 
-    private static SoftReference<String[]> softCache =
-            new SoftReference<>(null);
+    private static SoftReference<String[]> softCache;
     private static long softCacheCreatedNs;
 
     private static final char[] HEX = "0123456789abcdef".toCharArray();
@@ -902,7 +901,7 @@ public class StringUtils {
      * Clear the cache. This method is used for testing.
      */
     public static void clearCache() {
-        softCache = new SoftReference<>(null);
+        softCache = null;
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueByte.java
+++ b/h2/src/main/org/h2/value/ValueByte.java
@@ -40,7 +40,7 @@ public class ValueByte extends Value {
     }
 
     private static ValueByte checkRange(int x) {
-        if (x < Byte.MIN_VALUE || x > Byte.MAX_VALUE) {
+        if ((byte) x != x) {
             throw DbException.get(ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE_1,
                     Integer.toString(x));
         }

--- a/h2/src/main/org/h2/value/ValueByte.java
+++ b/h2/src/main/org/h2/value/ValueByte.java
@@ -115,7 +115,7 @@ public class ValueByte extends Value {
 
     @Override
     public String getString() {
-        return String.valueOf(value);
+        return Integer.toString(value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueDouble.java
+++ b/h2/src/main/org/h2/value/ValueDouble.java
@@ -118,7 +118,7 @@ public class ValueDouble extends Value {
 
     @Override
     public String getString() {
-        return String.valueOf(value);
+        return Double.toString(value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueFloat.java
+++ b/h2/src/main/org/h2/value/ValueFloat.java
@@ -119,7 +119,7 @@ public class ValueFloat extends Value {
 
     @Override
     public String getString() {
-        return String.valueOf(value);
+        return Float.toString(value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueInt.java
+++ b/h2/src/main/org/h2/value/ValueInt.java
@@ -70,7 +70,7 @@ public class ValueInt extends Value {
     }
 
     private static ValueInt checkRange(long x) {
-        if (x < Integer.MIN_VALUE || x > Integer.MAX_VALUE) {
+        if ((int) x != x) {
             throw DbException.get(ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE_1, Long.toString(x));
         }
         return ValueInt.get((int) x);

--- a/h2/src/main/org/h2/value/ValueInt.java
+++ b/h2/src/main/org/h2/value/ValueInt.java
@@ -148,7 +148,7 @@ public class ValueInt extends Value {
 
     @Override
     public String getString() {
-        return String.valueOf(value);
+        return Integer.toString(value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueLong.java
+++ b/h2/src/main/org/h2/value/ValueLong.java
@@ -170,7 +170,7 @@ public class ValueLong extends Value {
 
     @Override
     public String getString() {
-        return String.valueOf(value);
+        return Long.toString(value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueLong.java
+++ b/h2/src/main/org/h2/value/ValueLong.java
@@ -61,19 +61,17 @@ public class ValueLong extends Value {
 
     @Override
     public Value add(Value v) {
-        ValueLong other = (ValueLong) v;
-        long result = value + other.value;
-        int sv = Long.signum(value);
-        int so = Long.signum(other.value);
-        int sr = Long.signum(result);
-        // if the operands have different signs overflow can not occur
-        // if the operands have the same sign,
-        // and the result has a different sign, then it is an overflow
-        // it can not be an overflow when one of the operands is 0
-        if (sv != so || sr == so || sv == 0 || so == 0) {
-            return ValueLong.get(result);
+        long x = value;
+        long y = ((ValueLong) v).value;
+        long result = x + y;
+        /*
+         * If signs of both summands are different from the sign of the sum there is an
+         * overflow.
+         */
+        if (((x ^ result) & (y ^ result)) < 0) {
+            throw getOverflow();
         }
-        throw getOverflow();
+        return ValueLong.get(result);
     }
 
     @Override
@@ -96,17 +94,17 @@ public class ValueLong extends Value {
 
     @Override
     public Value subtract(Value v) {
-        ValueLong other = (ValueLong) v;
-        int sv = Long.signum(value);
-        int so = Long.signum(other.value);
-        // if the operands have the same sign, then overflow can not occur
-        // if the second operand is 0, then overflow can not occur
-        if (sv == so || so == 0) {
-            return ValueLong.get(value - other.value);
+        long x = value;
+        long y = ((ValueLong) v).value;
+        long result = x - y;
+        /*
+         * If minuend and subtrahend have different signs and minuend and difference
+         * have different signs there is an overflow.
+         */
+        if (((x ^ y) & (x ^ result)) < 0) {
+            throw getOverflow();
         }
-        // now, if the other value is Long.MIN_VALUE, it must be an overflow
-        // x - Long.MIN_VALUE overflows for x>=0
-        return add(other.negate());
+        return ValueLong.get(result);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueShort.java
+++ b/h2/src/main/org/h2/value/ValueShort.java
@@ -40,7 +40,7 @@ public class ValueShort extends Value {
     }
 
     private static ValueShort checkRange(int x) {
-        if (x < Short.MIN_VALUE || x > Short.MAX_VALUE) {
+        if ((short) x != x) {
             throw DbException.get(ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE_1,
                     Integer.toString(x));
         }

--- a/h2/src/main/org/h2/value/ValueShort.java
+++ b/h2/src/main/org/h2/value/ValueShort.java
@@ -115,7 +115,7 @@ public class ValueShort extends Value {
 
     @Override
     public String getString() {
-        return String.valueOf(value);
+        return Integer.toString(value);
     }
 
     @Override

--- a/h2/src/test/org/h2/samples/Function.java
+++ b/h2/src/test/org/h2/samples/Function.java
@@ -102,7 +102,7 @@ public class Function {
      * @return true if it is a prime number
      */
     public static boolean isPrime(int value) {
-        return new BigInteger(String.valueOf(value)).isProbablePrime(100);
+        return BigInteger.valueOf(value).isProbablePrime(100);
     }
 
     /**

--- a/h2/src/test/org/h2/test/bench/BenchCRandom.java
+++ b/h2/src/test/org/h2/test/bench/BenchCRandom.java
@@ -157,7 +157,7 @@ public class BenchCRandom {
      * @return the big decimal object
      */
     BigDecimal getBigDecimal(int value, int scale) {
-        return new BigDecimal(new BigInteger(String.valueOf(value)), scale);
+        return new BigDecimal(BigInteger.valueOf(value), scale);
     }
 
     /**

--- a/h2/src/tools/org/h2/dev/ftp/server/FtpControl.java
+++ b/h2/src/tools/org/h2/dev/ftp/server/FtpControl.java
@@ -304,7 +304,7 @@ public class FtpControl extends Thread {
             } else if ("SIZE".equals(command)) {
                 param = getFileName(param);
                 if (FileUtils.exists(param) && !FileUtils.isDirectory(param)) {
-                    reply(250, String.valueOf(FileUtils.size(param)));
+                    reply(250, Long.toString(FileUtils.size(param)));
                 } else {
                     reply(500, "Failed");
                 }

--- a/h2/src/tools/org/h2/dev/ftp/server/FtpServer.java
+++ b/h2/src/tools/org/h2/dev/ftp/server/FtpServer.java
@@ -230,7 +230,7 @@ public class FtpServer extends Tool implements Service {
         buff.append('r');
         buff.append(FileUtils.canWrite(fileName) ? 'w' : '-');
         buff.append("------- 1 owner group ");
-        String size = String.valueOf(FileUtils.size(fileName));
+        String size = Long.toString(FileUtils.size(fileName));
         for (int i = size.length(); i < 15; i++) {
             buff.append(' ');
         }


### PR DESCRIPTION
1. Remove initialization of `StringUtils.softCache` to a useless value. This field can safely be `null` in uninitialized state anyway.

2. Invocations of `String.valueOf()` methods with `long`, `int`, etc arguments are inlined (replaced with direct invocations of `Long.toString(long)`, `Integer.toString(int)` and similar methods) to simplify stepping in debugger (no additional method call) and improve readability in places where type of the argument is not oblivious (see `MetaTable`). Inlining is performed by IDE with additional manual changes in places where conversion to string is not needed at all (like initialization of `BigInteger`).

3. Overflow checks in implementations of `ValueLong.add()` and `ValueLong.subtract()` are optimized. There are well-known faster and shorter alternatives.

4. Range checks in `ValueByte`, `ValueShort`, and `ValueInt` are replaced with cast and single comparison. Bytecode is shorter and compiled machine code is much shorter and faster too, at least on x86-64.

5. Initial capacities are specified for `Function.FUNCTIONS` and `DateTimeUtils.DATE_PART`. These maps are large enough and require a lot of rehashing if capacity is not specified.