### PR TITLE
Fix a memory leak caused by DatabaseCloser objects

### DIFF
--- a/h2/src/main/org/h2/engine/DelayedDatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/DelayedDatabaseCloser.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.engine;
+
+import java.lang.ref.WeakReference;
+
+import org.h2.message.Trace;
+
+/**
+ * This class is responsible to close a database after the specified delay. A
+ * database closer object only exists if there is no user connected to the
+ * database.
+ */
+class DelayedDatabaseCloser extends Thread {
+
+    private final Trace trace;
+    private volatile WeakReference<Database> databaseRef;
+    private int delayInMillis;
+
+    DelayedDatabaseCloser(Database db, int delayInMillis) {
+        databaseRef = new WeakReference<>(db);
+        this.delayInMillis = delayInMillis;
+        trace = db.getTrace(Trace.DATABASE);
+        setName("H2 Close Delay " + db.getShortName());
+        setDaemon(true);
+        start();
+    }
+
+    /**
+     * Stop and disable the database closer. This method is called after a session
+     * has been created.
+     */
+    void reset() {
+        databaseRef = null;
+    }
+
+    @Override
+    public void run() {
+        while (delayInMillis > 0) {
+            try {
+                int step = 100;
+                Thread.sleep(step);
+                delayInMillis -= step;
+            } catch (Exception e) {
+                // ignore InterruptedException
+            }
+            WeakReference<Database> ref = databaseRef;
+            if (ref == null || ref.get() == null) {
+                return;
+            }
+        }
+        Database database;
+        WeakReference<Database> ref = databaseRef;
+        if (ref != null && (database = ref.get()) != null) {
+            try {
+                database.close(false);
+            } catch (RuntimeException e) {
+                // this can happen when stopping a web application,
+                // if loading classes is no longer allowed
+                // it would throw an IllegalStateException
+                try {
+                    trace.error(e, "could not close the database");
+                    // if this was successful, we ignore the exception
+                    // otherwise not
+                } catch (Throwable e2) {
+                    e.addSuppressed(e2);
+                    throw e;
+                }
+            }
+        }
+    }
+
+}

--- a/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
@@ -56,6 +56,7 @@ class OnExitDatabaseCloser extends Thread {
 
     @Override
     public void run() {
+        RuntimeException root = null;
         for (Database database : DATABASES.keySet()) {
             try {
                 database.close(true);
@@ -69,9 +70,16 @@ class OnExitDatabaseCloser extends Thread {
                     // otherwise not
                 } catch (Throwable e2) {
                     e.addSuppressed(e2);
-                    throw e;
+                    if (root == null) {
+                        root = e;
+                    } else {
+                        root.addSuppressed(e);
+                    }
                 }
             }
+        }
+        if (root != null) {
+            throw root;
         }
     }
 


### PR DESCRIPTION
This memory leak was only noticeable in processes that have a lot of opened and not always correctly closed databases such as application servers (unloading of applications is not always works properly), our test suit, etc. VisualVM dumps showed a lot of stalled `DatabaseCloser` instances kept by `java.langs.ApplicationShutdownHooks`.

1. `DB_CLOSE_ON_EXIT` and `DB_CLOSE_DELAY` are handled by a separate classes now due to large difference in their logic.

2. Only one instance of `OnExitDatabaseCloser` is created now instead of multiple `DatabaseCloser` instances. A shared `WeakHashMap` is used to track databases.