### PR TITLE
Assorted optimizations and fixes

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,24 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1138, #1139: Fix a memory leak caused by DatabaseCloser objects
+</li>
+<li>PR #1137: Step toward making transaction commit atomic
+</li>
+<li>PR #1136: Assorted minor optimizations
+</li>
+<li>PR #1134: Detect possible overflow in integer division and optimize some code
+</li>
+<li>PR #1133: Implement Comparable&lt;Value&gt; in CompareMode and optimize ValueHashMap.keys()
+</li>
+<li>PR #1132: Reduce allocation of ExpressionVisitor instances
+</li>
+<li>PR #1130: Improve TestScript and TestCrashAPI
+</li>
+<li>PR #1128: Fix ON DUPLICATE KEY UPDATE with ENUM
+</li>
+<li>PR #1127: Update JdbcDatabaseMetaData.getSQLKeywords() and perform some minor optimizations
+</li>
 <li>PR #1126: Fix an issue with code coverage and building of documentation
 </li>
 <li>PR #1123: Fix TCP version check

--- a/h2/src/main/org/h2/api/ErrorCode.java
+++ b/h2/src/main/org/h2/api/ErrorCode.java
@@ -2062,7 +2062,7 @@ public class ErrorCode {
         case FEATURE_NOT_SUPPORTED_1: return "HYC00";
         case LOCK_TIMEOUT_1: return "HYT00";
         default:
-            return "" + errorCode;
+            return Integer.toString(errorCode);
         }
     }
 

--- a/h2/src/main/org/h2/command/Prepared.java
+++ b/h2/src/main/org/h2/command/Prepared.java
@@ -343,7 +343,7 @@ public abstract class Prepared {
      *
      * @param rowNumber the row number
      */
-    protected void setCurrentRowNumber(int rowNumber) {
+    public void setCurrentRowNumber(int rowNumber) {
         if ((++rowScanCount & 127) == 0) {
             checkCanceled();
         }

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -520,7 +520,7 @@ public abstract class Query extends Prepared {
                 }
                 idx -= 1;
                 if (idx < 0 || idx >= expressionCount) {
-                    throw DbException.get(ErrorCode.ORDER_BY_NOT_IN_RESULT, "" + (idx + 1));
+                    throw DbException.get(ErrorCode.ORDER_BY_NOT_IN_RESULT, Integer.toString(idx + 1));
                 }
             }
             index[i] = idx;

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -411,7 +411,7 @@ public class Database implements DataHandler {
                 if (now > reconnectCheckNext) {
                     if (pending) {
                         String pos = pageStore == null ?
-                                null : "" + pageStore.getWriteCountTotal();
+                                null : Long.toString(pageStore.getWriteCountTotal());
                         lock.setProperty("logPos", pos);
                         lock.save();
                     }
@@ -433,7 +433,7 @@ public class Database implements DataHandler {
                 }
             }
             String pos = pageStore == null ?
-                    null : "" + pageStore.getWriteCountTotal();
+                    null : Long.toString(pageStore.getWriteCountTotal());
             lock.setProperty("logPos", pos);
             if (pending) {
                 lock.setProperty("changePending", "true-" + Math.random());
@@ -2646,7 +2646,7 @@ public class Database implements DataHandler {
         long now = System.nanoTime();
         if (now > reconnectCheckNext + reconnectCheckDelayNs) {
             if (SysProperties.CHECK && checkpointAllowed < 0) {
-                DbException.throwInternalError("" + checkpointAllowed);
+                DbException.throwInternalError(Integer.toString(checkpointAllowed));
             }
             synchronized (reconnectSync) {
                 if (checkpointAllowed > 0) {
@@ -2716,7 +2716,7 @@ public class Database implements DataHandler {
             if (reconnectModified(true)) {
                 checkpointAllowed++;
                 if (SysProperties.CHECK && checkpointAllowed > 20) {
-                    throw DbException.throwInternalError("" + checkpointAllowed);
+                    throw DbException.throwInternalError(Integer.toString(checkpointAllowed));
                 }
                 return true;
             }
@@ -2738,7 +2738,7 @@ public class Database implements DataHandler {
             checkpointAllowed--;
         }
         if (SysProperties.CHECK && checkpointAllowed < 0) {
-            throw DbException.throwInternalError("" + checkpointAllowed);
+            throw DbException.throwInternalError(Integer.toString(checkpointAllowed));
         }
     }
 

--- a/h2/src/main/org/h2/engine/Right.java
+++ b/h2/src/main/org/h2/engine/Right.java
@@ -75,7 +75,7 @@ public class Right extends DbObjectBase {
 
     public Right(Database db, int id, RightOwner grantee, int grantedRight,
             DbObject grantedObject) {
-        initDbObjectBase(db, id, "" + id, Trace.USER);
+        initDbObjectBase(db, id, Integer.toString(id), Trace.USER);
         this.grantee = grantee;
         this.grantedRight = grantedRight;
         this.grantedObject = grantedObject;

--- a/h2/src/main/org/h2/engine/SettingsBase.java
+++ b/h2/src/main/org/h2/engine/SettingsBase.java
@@ -47,7 +47,7 @@ public class SettingsBase {
      * @return the setting
      */
     protected int get(String key, int defaultValue) {
-        String s = get(key, "" + defaultValue);
+        String s = get(key, Integer.toString(defaultValue));
         try {
             return Integer.decode(s);
         } catch (NumberFormatException e) {

--- a/h2/src/main/org/h2/expression/CompareLike.java
+++ b/h2/src/main/org/h2/expression/CompareLike.java
@@ -333,7 +333,7 @@ public class CompareLike extends Condition {
                 }
                 return false;
             default:
-                DbException.throwInternalError("" + types[pi]);
+                DbException.throwInternalError(Integer.toString(types[pi]));
             }
         }
         return si == sLen;

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -557,7 +557,7 @@ public class Function extends Expression implements FunctionCall {
         } else {
             if (index >= args.length) {
                 throw DbException.get(ErrorCode.INVALID_PARAMETER_COUNT_2,
-                        info.name, "" + args.length);
+                        info.name, Integer.toString(args.length));
             }
             args[index] = param;
         }
@@ -2165,7 +2165,7 @@ public class Function extends Expression implements FunctionCall {
             if (len > 0 && args[len - 1] == null) {
                 throw DbException.get(
                         ErrorCode.INVALID_PARAMETER_COUNT_2,
-                        info.name, "" + len);
+                        info.name, Integer.toString(len));
             }
         }
     }

--- a/h2/src/main/org/h2/expression/Wildcard.java
+++ b/h2/src/main/org/h2/expression/Wildcard.java
@@ -100,7 +100,7 @@ public class Wildcard extends Expression {
         if (visitor.getType() == ExpressionVisitor.QUERY_COMPARABLE) {
             return true;
         }
-        throw DbException.throwInternalError("" + visitor.getType());
+        throw DbException.throwInternalError(Integer.toString(visitor.getType()));
     }
 
     @Override

--- a/h2/src/main/org/h2/index/PageBtreeLeaf.java
+++ b/h2/src/main/org/h2/index/PageBtreeLeaf.java
@@ -176,7 +176,7 @@ public class PageBtreeLeaf extends PageBtree {
         written = false;
         changeCount = index.getPageStore().getChangeCount();
         if (entryCount <= 0) {
-            DbException.throwInternalError("" + entryCount);
+            DbException.throwInternalError(Integer.toString(entryCount));
         }
         int startNext = at > 0 ? offsets[at - 1] : index.getPageStore().getPageSize();
         int rowLength = startNext - offsets[at];

--- a/h2/src/main/org/h2/index/PageBtreeNode.java
+++ b/h2/src/main/org/h2/index/PageBtreeNode.java
@@ -474,7 +474,7 @@ public class PageBtreeNode extends PageBtree {
         written = false;
         changeCount = index.getPageStore().getChangeCount();
         if (entryCount < 0) {
-            DbException.throwInternalError("" + entryCount);
+            DbException.throwInternalError(Integer.toString(entryCount));
         }
         if (entryCount > i) {
             int startNext = i > 0 ? offsets[i - 1] : index.getPageStore().getPageSize();

--- a/h2/src/main/org/h2/index/PageDataLeaf.java
+++ b/h2/src/main/org/h2/index/PageDataLeaf.java
@@ -220,7 +220,7 @@ public class PageDataLeaf extends PageData {
         if (offset < start) {
             writtenData = false;
             if (entryCount > 1) {
-                DbException.throwInternalError("" + entryCount);
+                DbException.throwInternalError(Integer.toString(entryCount));
             }
             // need to write the overflow page id
             start += 4;
@@ -283,7 +283,7 @@ public class PageDataLeaf extends PageData {
         }
         entryCount--;
         if (entryCount < 0) {
-            DbException.throwInternalError("" + entryCount);
+            DbException.throwInternalError(Integer.toString(entryCount));
         }
         if (firstOverflowPageId != 0) {
             start -= 4;

--- a/h2/src/main/org/h2/index/PageDataNode.java
+++ b/h2/src/main/org/h2/index/PageDataNode.java
@@ -388,7 +388,7 @@ public class PageDataNode extends PageData {
         entryCount--;
         length -= 4 + Data.getVarLongLen(keys[removedKeyIndex]);
         if (entryCount < 0) {
-            DbException.throwInternalError("" + entryCount);
+            DbException.throwInternalError(Integer.toString(entryCount));
         }
         keys = remove(keys, entryCount + 1, removedKeyIndex);
         childPageIds = remove(childPageIds, entryCount + 2, i);

--- a/h2/src/main/org/h2/jdbc/JdbcSQLException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLException.java
@@ -46,7 +46,7 @@ public class JdbcSQLException extends SQLException {
         this.originalMessage = message;
         this.cause = cause;
         this.stackTrace = stackTrace;
-        // setSQL() invokes buildBessage() by itself
+        // setSQL() invokes buildMessage() by itself
         setSQL(sql);
         initCause(cause);
     }

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -432,7 +432,7 @@ public class TransactionMap<K, V> {
      *                               at the time when snapshot was taken
      * @return the value
      */
-    private VersionedValue getValue(Page root, Page undoRoot, K key, long maxLog,
+    VersionedValue getValue(Page root, Page undoRoot, K key, long maxLog,
                                     VersionedValue data, BitSet committingTransactions) {
         while (true) {
             if (data == null) {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -281,7 +281,8 @@ public class TransactionMap<K, V> {
 
             Page mapRootPage = mapRootReference.root;
             current = map.get(mapRootPage, key);
-            VersionedValue old = getValue(mapRootPage, undoLogRootReference.root, key, readLogId, current, committingTransactions);
+            VersionedValue old = getValue(mapRootPage, undoLogRootReference.root, key, readLogId, current,
+                    committingTransactions);
             if (!map.areValuesEqual(old, current)) {
                 assert current != null;
                 long tx = TransactionStore.getTransactionId(current.getOperationId());
@@ -681,8 +682,7 @@ public class TransactionMap<K, V> {
 
     private static final class KeyIterator<K> extends TMIterator<K,K> {
 
-        public KeyIterator(TransactionMap<K, ?> transactionMap,
-                           K from, K to, boolean includeUncommitted) {
+        public KeyIterator(TransactionMap<K, ?> transactionMap, K from, K to, boolean includeUncommitted) {
             super(transactionMap, from, to, includeUncommitted);
         }
 
@@ -714,8 +714,7 @@ public class TransactionMap<K, V> {
         private final boolean includeAllUncommitted;
         private X current;
 
-        protected TMIterator(TransactionMap<K,?> transactionMap, K from, K to, boolean includeAllUncommitted)
-        {
+        protected TMIterator(TransactionMap<K,?> transactionMap, K from, K to, boolean includeAllUncommitted) {
             this.transactionMap = transactionMap;
             TransactionStore store = transactionMap.transaction.store;
             MVMap<K, VersionedValue> map = transactionMap.map;
@@ -726,7 +725,8 @@ public class TransactionMap<K, V> {
                 committingTransactions = store.committingTransactions.get();
                 undoRoot = store.undoLog.getRootPage();
                 mapRootReference = map.getRoot();
-            } while(committingTransactions != store.committingTransactions.get() || undoRoot != store.undoLog.getRootPage());
+            } while (committingTransactions != store.committingTransactions.get()
+                    || undoRoot != store.undoLog.getRootPage());
 
             this.root = mapRootReference.root;
             this.undoRoot = undoRoot;

--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -91,15 +91,15 @@ public class TcpServerThread implements Runnable {
                 int minClientVersion = transfer.readInt();
                 if (minClientVersion < 6) {
                     throw DbException.get(ErrorCode.DRIVER_VERSION_ERROR_2,
-                            "" + minClientVersion, "" + Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED);
+                            Integer.toString(minClientVersion), "" + Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED);
                 }
                 int maxClientVersion = transfer.readInt();
                 if (maxClientVersion < Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED) {
                     throw DbException.get(ErrorCode.DRIVER_VERSION_ERROR_2,
-                            "" + maxClientVersion, "" + Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED);
+                            Integer.toString(maxClientVersion), "" + Constants.TCP_PROTOCOL_VERSION_MIN_SUPPORTED);
                 } else if (minClientVersion > Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED) {
                     throw DbException.get(ErrorCode.DRIVER_VERSION_ERROR_2,
-                            "" + minClientVersion, "" + Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED);
+                            Integer.toString(minClientVersion), "" + Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED);
                 }
                 if (maxClientVersion >= Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED) {
                     clientVersion = Constants.TCP_PROTOCOL_VERSION_MAX_SUPPORTED;

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -338,8 +338,8 @@ public class WebApp {
     }
 
     private String admin() {
-        session.put("port", "" + server.getPort());
-        session.put("allowOthers", "" + server.getAllowOthers());
+        session.put("port", Integer.toString(server.getPort()));
+        session.put("allowOthers", Boolean.toString(server.getAllowOthers()));
         session.put("ssl", String.valueOf(server.getSSL()));
         session.put("sessions", server.getSessions());
         return "admin.jsp";
@@ -1172,16 +1172,16 @@ public class WebApp {
             SimpleResultSet rs = new SimpleResultSet();
             rs.addColumn("Type", Types.VARCHAR, 0, 0);
             rs.addColumn("KB", Types.VARCHAR, 0, 0);
-            rs.addRow("Used Memory", "" + Utils.getMemoryUsed());
-            rs.addRow("Free Memory", "" + Utils.getMemoryFree());
+            rs.addRow("Used Memory", Integer.toString(Utils.getMemoryUsed()));
+            rs.addRow("Free Memory", Integer.toString(Utils.getMemoryFree()));
             return rs;
         } else if (isBuiltIn(sql, "@info")) {
             SimpleResultSet rs = new SimpleResultSet();
             rs.addColumn("KEY", Types.VARCHAR, 0, 0);
             rs.addColumn("VALUE", Types.VARCHAR, 0, 0);
             rs.addRow("conn.getCatalog", conn.getCatalog());
-            rs.addRow("conn.getAutoCommit", "" + conn.getAutoCommit());
-            rs.addRow("conn.getTransactionIsolation", "" + conn.getTransactionIsolation());
+            rs.addRow("conn.getAutoCommit", Boolean.toString(conn.getAutoCommit()));
+            rs.addRow("conn.getTransactionIsolation", Integer.toString(conn.getTransactionIsolation()));
             rs.addRow("conn.getWarnings", "" + conn.getWarnings());
             String map;
             try {
@@ -1190,8 +1190,8 @@ public class WebApp {
                 map = e.toString();
             }
             rs.addRow("conn.getTypeMap", "" + map);
-            rs.addRow("conn.isReadOnly", "" + conn.isReadOnly());
-            rs.addRow("conn.getHoldability", "" + conn.getHoldability());
+            rs.addRow("conn.isReadOnly", Boolean.toString(conn.isReadOnly()));
+            rs.addRow("conn.getHoldability", Integer.toString(conn.getHoldability()));
             addDatabaseMetaData(rs, meta);
             return rs;
         } else if (isBuiltIn(sql, "@attributes")) {
@@ -1328,7 +1328,7 @@ public class WebApp {
             } else if (isBuiltIn(sql, "@maxrows")) {
                 int maxrows = (int) Double.parseDouble(
                         sql.substring("@maxrows".length()).trim());
-                session.put("maxrows", "" + maxrows);
+                session.put("maxrows", Integer.toString(maxrows));
                 return "${text.result.maxrowsSet}";
             } else if (isBuiltIn(sql, "@parameter_meta")) {
                 sql = sql.substring("@parameter_meta".length()).trim();

--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -672,14 +672,11 @@ public class WebServer implements Service {
                 Properties old = loadProperties();
                 prop = new SortedProperties();
                 prop.setProperty("webPort",
-                        "" + SortedProperties.getIntProperty(old,
-                        "webPort", port));
+                        Integer.toString(SortedProperties.getIntProperty(old, "webPort", port)));
                 prop.setProperty("webAllowOthers",
-                        "" + SortedProperties.getBooleanProperty(old,
-                        "webAllowOthers", allowOthers));
+                        Boolean.toString(SortedProperties.getBooleanProperty(old, "webAllowOthers", allowOthers)));
                 prop.setProperty("webSSL",
-                        "" + SortedProperties.getBooleanProperty(old,
-                        "webSSL", ssl));
+                        Boolean.toString(SortedProperties.getBooleanProperty(old, "webSSL", ssl)));
                 if (commandHistoryString != null) {
                     prop.setProperty(COMMAND_HISTORY, commandHistoryString);
                 }

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -12,6 +12,7 @@ import java.io.Reader;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -797,15 +798,15 @@ public class MetaTable extends Table {
                         // REMARKS
                         replaceNullWithEmpty(table.getComment()),
                         // LAST_MODIFICATION
-                        "" + table.getMaxDataModificationId(),
+                        Long.toString(table.getMaxDataModificationId()),
                         // ID
-                        "" + table.getId(),
+                        Integer.toString(table.getId()),
                         // TYPE_NAME
                         null,
                         // TABLE_CLASS
                         table.getClass().getName(),
                         // ROW_COUNT_ESTIMATE
-                        "" + table.getRowCountApproximation()
+                        Long.toString(table.getRowCountApproximation())
                 );
             }
             break;
@@ -833,6 +834,7 @@ public class MetaTable extends Table {
                 for (int j = 0; j < cols.length; j++) {
                     Column c = cols[j];
                     DataType dataType = c.getDataType();
+                    String precision = Integer.toString(c.getPrecisionAsInt());
                     Sequence sequence = c.getSequence();
                     add(rows,
                             // TABLE_CATALOG
@@ -850,17 +852,17 @@ public class MetaTable extends Table {
                             // IS_NULLABLE
                             c.isNullable() ? "YES" : "NO",
                             // DATA_TYPE
-                            "" + dataType.sqlType,
+                            Integer.toString(dataType.sqlType),
                             // CHARACTER_MAXIMUM_LENGTH
-                            "" + c.getPrecisionAsInt(),
+                            precision,
                             // CHARACTER_OCTET_LENGTH
-                            "" + c.getPrecisionAsInt(),
+                            precision,
                             // NUMERIC_PRECISION
-                            "" + c.getPrecisionAsInt(),
+                            precision,
                             // NUMERIC_PRECISION_RADIX
                             "10",
                             // NUMERIC_SCALE
-                            "" + c.getScale(),
+                            Integer.toString(c.getScale()),
                             // CHARACTER_SET_NAME
                             CHARACTER_SET_NAME,
                             // COLLATION_NAME
@@ -868,13 +870,13 @@ public class MetaTable extends Table {
                             // TYPE_NAME
                             identifier(dataType.name),
                             // NULLABLE
-                            "" + (c.isNullable() ?
-                                    DatabaseMetaData.columnNullable :
-                                    DatabaseMetaData.columnNoNulls) ,
+                            c.isNullable() ?
+                                    "" + DatabaseMetaData.columnNullable :
+                                    "" + DatabaseMetaData.columnNoNulls,
                             // IS_COMPUTED
-                            "" + (c.getComputed() ? "TRUE" : "FALSE"),
+                            c.getComputed() ? "TRUE" : "FALSE",
                             // SELECTIVITY
-                            "" + (c.getSelectivity()),
+                            Integer.toString(c.getSelectivity()),
                             // CHECK_CONSTRAINT
                             c.getCheckConstraintSQL(session, c.getName()),
                             // SEQUENCE_NAME
@@ -954,7 +956,7 @@ public class MetaTable extends Table {
                                 // INDEX_NAME
                                 identifier(index.getName()),
                                 // ORDINAL_POSITION
-                                "" + (k+1),
+                                Integer.toString(k + 1),
                                 // COLUMN_NAME
                                 identifier(column.getName()),
                                 // CARDINALITY
@@ -981,9 +983,9 @@ public class MetaTable extends Table {
                                 // SQL
                                 index.getCreateSQL(),
                                 // ID
-                                "" + index.getId(),
+                                Integer.toString(index.getId()),
                                 // SORT_TYPE
-                                "" + idxCol.sortType,
+                                Integer.toString(idxCol.sortType),
                                 // CONSTRAINT_NAME
                                 constraintName,
                                 // INDEX_CLASS
@@ -1013,7 +1015,7 @@ public class MetaTable extends Table {
             for (Setting s : database.getAllSettings()) {
                 String value = s.getStringValue();
                 if (value == null) {
-                    value = "" + s.getIntValue();
+                    value = Integer.toString(s.getIntValue());
                 }
                 add(rows,
                         identifier(s.getName()),
@@ -1023,7 +1025,7 @@ public class MetaTable extends Table {
             add(rows, "info.BUILD_ID", "" + Constants.BUILD_ID);
             add(rows, "info.VERSION_MAJOR", "" + Constants.VERSION_MAJOR);
             add(rows, "info.VERSION_MINOR", "" + Constants.VERSION_MINOR);
-            add(rows, "info.VERSION", "" + Constants.getFullVersion());
+            add(rows, "info.VERSION", Constants.getFullVersion());
             if (admin) {
                 String[] settings = {
                         "java.runtime.version", "java.vm.name",
@@ -1040,9 +1042,9 @@ public class MetaTable extends Table {
             add(rows, "MODE", database.getMode().getName());
             add(rows, "MULTI_THREADED", database.isMultiThreaded() ? "1" : "0");
             add(rows, "MVCC", database.isMultiVersion() ? "TRUE" : "FALSE");
-            add(rows, "QUERY_TIMEOUT", "" + session.getQueryTimeout());
-            add(rows, "RETENTION_TIME", "" + database.getRetentionTime());
-            add(rows, "LOG", "" + database.getLogMode());
+            add(rows, "QUERY_TIMEOUT", Integer.toString(session.getQueryTimeout()));
+            add(rows, "RETENTION_TIME", Integer.toString(database.getRetentionTime()));
+            add(rows, "LOG", Integer.toString(database.getLogMode()));
             // database settings
             ArrayList<String> settingNames = Utils.newSmallArrayList();
             HashMap<String, String> s = database.getSettings().getSettings();
@@ -1055,27 +1057,27 @@ public class MetaTable extends Table {
                 PageStore store = database.getPageStore();
                 if (store != null) {
                     add(rows, "info.FILE_WRITE_TOTAL",
-                            "" + store.getWriteCountTotal());
+                            Long.toString(store.getWriteCountTotal()));
                     add(rows, "info.FILE_WRITE",
-                            "" + store.getWriteCount());
+                            Long.toString(store.getWriteCount()));
                     add(rows, "info.FILE_READ",
-                            "" + store.getReadCount());
+                            Long.toString(store.getReadCount()));
                     add(rows, "info.PAGE_COUNT",
-                            "" + store.getPageCount());
+                            Integer.toString(store.getPageCount()));
                     add(rows, "info.PAGE_SIZE",
-                            "" + store.getPageSize());
+                            Integer.toString(store.getPageSize()));
                     add(rows, "info.CACHE_MAX_SIZE",
-                            "" + store.getCache().getMaxMemory());
+                            Integer.toString(store.getCache().getMaxMemory()));
                     add(rows, "info.CACHE_SIZE",
-                            "" + store.getCache().getMemory());
+                            Integer.toString(store.getCache().getMemory()));
                 }
                 Store mvStore = database.getMvStore();
                 if (mvStore != null) {
                     FileStore fs = mvStore.getStore().getFileStore();
-                    add(rows, "info.FILE_WRITE", "" +
-                            fs.getWriteCount());
-                    add(rows, "info.FILE_READ", "" +
-                            fs.getReadCount());
+                    add(rows, "info.FILE_WRITE",
+                            Long.toString(fs.getWriteCount()));
+                    add(rows, "info.FILE_READ",
+                            Long.toString(fs.getReadCount()));
                     long size;
                     try {
                         size = fs.getFile().size();
@@ -1084,14 +1086,14 @@ public class MetaTable extends Table {
                     }
                     int pageSize = 4 * 1024;
                     long pageCount = size / pageSize;
-                    add(rows, "info.PAGE_COUNT", "" +
-                            pageCount);
-                    add(rows, "info.PAGE_SIZE", "" +
-                            pageSize);
-                    add(rows, "info.CACHE_MAX_SIZE", "" +
-                            mvStore.getStore().getCacheSize());
-                    add(rows, "info.CACHE_SIZE", "" +
-                            mvStore.getStore().getCacheSizeUsed());
+                    add(rows, "info.PAGE_COUNT",
+                            Long.toString(pageCount));
+                    add(rows, "info.PAGE_SIZE",
+                            Integer.toString(pageSize));
+                    add(rows, "info.CACHE_MAX_SIZE",
+                            Integer.toString(mvStore.getStore().getCacheSize()));
+                    add(rows, "info.CACHE_SIZE",
+                            Integer.toString(mvStore.getStore().getCacheSizeUsed()));
                 }
             }
             break;
@@ -1190,7 +1192,7 @@ public class MetaTable extends Table {
                         // IS_CYCLE
                         s.getCycle() ? "TRUE" : "FALSE",
                         // ID
-                        "" + s.getId()
+                        Integer.toString(s.getId())
                     );
             }
             break;
@@ -1206,7 +1208,7 @@ public class MetaTable extends Table {
                             // REMARKS
                             replaceNullWithEmpty(u.getComment()),
                             // ID
-                            "" + u.getId()
+                            Integer.toString(u.getId())
                     );
                 }
             }
@@ -1221,7 +1223,7 @@ public class MetaTable extends Table {
                             // REMARKS
                             replaceNullWithEmpty(r.getComment()),
                             // ID
-                            "" + r.getId()
+                            Integer.toString(r.getId())
                     );
                 }
             }
@@ -1265,7 +1267,7 @@ public class MetaTable extends Table {
                                 // TABLE_NAME
                                 tableName,
                                 // ID
-                                "" + r.getId()
+                                Integer.toString(r.getId())
                         );
                     } else {
                         add(rows,
@@ -1282,7 +1284,7 @@ public class MetaTable extends Table {
                                 // TABLE_NAME
                                 "",
                                 // ID
-                                "" + r.getId()
+                                Integer.toString(r.getId())
                         );
                     }
                 }
@@ -1315,17 +1317,17 @@ public class MetaTable extends Table {
                             // JAVA_METHOD
                             alias.getJavaMethodName(),
                             // DATA_TYPE
-                            "" + DataType.convertTypeToSQLType(method.getDataType()),
+                            Integer.toString(DataType.convertTypeToSQLType(method.getDataType())),
                             // TYPE_NAME
                             DataType.getDataType(method.getDataType()).name,
                             // COLUMN_COUNT INT
-                            "" + method.getParameterCount(),
+                            Integer.toString(method.getParameterCount()),
                             // RETURNS_RESULT SMALLINT
-                            "" + returnsResult,
+                            Integer.toString(returnsResult),
                             // REMARKS
                             replaceNullWithEmpty(alias.getComment()),
                             // ID
-                            "" + alias.getId(),
+                            Integer.toString(alias.getId()),
                             // SOURCE
                             alias.getSource()
                             // when adding more columns, see also below
@@ -1346,17 +1348,17 @@ public class MetaTable extends Table {
                         // JAVA_METHOD
                         "",
                         // DATA_TYPE
-                        "" + DataType.convertTypeToSQLType(Value.NULL),
+                        "" + Types.NULL,
                         // TYPE_NAME
                         DataType.getDataType(Value.NULL).name,
                         // COLUMN_COUNT INT
                         "1",
                         // RETURNS_RESULT SMALLINT
-                        "" + returnsResult,
+                        Integer.toString(returnsResult),
                         // REMARKS
                         replaceNullWithEmpty(agg.getComment()),
                         // ID
-                        "" + agg.getId(),
+                        Integer.toString(agg.getId()),
                         // SOURCE
                         ""
                         // when adding more columns, see also below
@@ -1390,19 +1392,19 @@ public class MetaTable extends Table {
                                 // JAVA_METHOD
                                 alias.getJavaMethodName(),
                                 // COLUMN_COUNT
-                                "" + method.getParameterCount(),
+                                Integer.toString(method.getParameterCount()),
                                 // POS INT
                                 "0",
                                 // COLUMN_NAME
                                 "P0",
                                 // DATA_TYPE
-                                "" + DataType.convertTypeToSQLType(method.getDataType()),
+                                Integer.toString(DataType.convertTypeToSQLType(method.getDataType())),
                                 // TYPE_NAME
                                 dt.name,
                                 // PRECISION INT
-                                "" + MathUtils.convertLongToInt(dt.defaultPrecision),
+                                Integer.toString(MathUtils.convertLongToInt(dt.defaultPrecision)),
                                 // SCALE
-                                "" + dt.defaultScale,
+                                Integer.toString(dt.defaultScale),
                                 // RADIX
                                 "10",
                                 // NULLABLE SMALLINT
@@ -1437,23 +1439,23 @@ public class MetaTable extends Table {
                                 // JAVA_METHOD
                                 alias.getJavaMethodName(),
                                 // COLUMN_COUNT
-                                "" + method.getParameterCount(),
+                                Integer.toString(method.getParameterCount()),
                                 // POS INT
-                                "" + (k + (method.hasConnectionParam() ? 0 : 1)),
+                                Integer.toString(k + (method.hasConnectionParam() ? 0 : 1)),
                                 // COLUMN_NAME
                                 "P" + (k + 1),
                                 // DATA_TYPE
-                                "" + DataType.convertTypeToSQLType(dt.type),
+                                Integer.toString(DataType.convertTypeToSQLType(dt.type)),
                                 // TYPE_NAME
                                 dt.name,
                                 // PRECISION INT
-                                "" + MathUtils.convertLongToInt(dt.defaultPrecision),
+                                Integer.toString(MathUtils.convertLongToInt(dt.defaultPrecision)),
                                 // SCALE
-                                "" + dt.defaultScale,
+                                Integer.toString(dt.defaultScale),
                                 // RADIX
                                 "10",
                                 // NULLABLE SMALLINT
-                                "" + nullable,
+                                Integer.toString(nullable),
                                 // COLUMN_TYPE
                                 "" + DatabaseMetaData.procedureColumnIn,
                                 // REMARKS
@@ -1486,7 +1488,7 @@ public class MetaTable extends Table {
                         // REMARKS
                         replaceNullWithEmpty(schema.getComment()),
                         // ID
-                        "" + schema.getId()
+                        Integer.toString(schema.getId())
                 );
             }
             break;
@@ -1572,7 +1574,7 @@ public class MetaTable extends Table {
                         // REMARKS
                         replaceNullWithEmpty(view.getComment()),
                         // ID
-                        "" + view.getId()
+                        Integer.toString(view.getId())
                 );
             }
             break;
@@ -1708,7 +1710,7 @@ public class MetaTable extends Table {
                         // SQL
                         constraint.getCreateSQL(),
                         // ID
-                        "" + constraint.getId()
+                        Integer.toString(constraint.getId())
                     );
             }
             break;
@@ -1726,13 +1728,13 @@ public class MetaTable extends Table {
                         // CONSTANT_NAME
                         identifier(constant.getName()),
                         // CONSTANT_TYPE
-                        "" + DataType.convertTypeToSQLType(expr.getType()),
+                        Integer.toString(DataType.convertTypeToSQLType(expr.getType())),
                         // REMARKS
                         replaceNullWithEmpty(constant.getComment()),
                         // SQL
                         expr.getSQL(),
                         // ID
-                        "" + constant.getId()
+                        Integer.toString(constant.getId())
                     );
             }
             break;
@@ -1752,15 +1754,15 @@ public class MetaTable extends Table {
                         // IS_NULLABLE
                         col.isNullable() ? "YES" : "NO",
                         // DATA_TYPE
-                        "" + col.getDataType().sqlType,
+                        Integer.toString(col.getDataType().sqlType),
                         // PRECISION INT
-                        "" + col.getPrecisionAsInt(),
+                        Integer.toString(col.getPrecisionAsInt()),
                         // SCALE INT
-                        "" + col.getScale(),
+                        Integer.toString(col.getScale()),
                         // TYPE_NAME
                         col.getDataType().name,
                         // SELECTIVITY INT
-                        "" + col.getSelectivity(),
+                        Integer.toString(col.getSelectivity()),
                         // CHECK_CONSTRAINT
                         "" + col.getCheckConstraintSQL(session, "VALUE"),
                         // REMARKS
@@ -1768,7 +1770,7 @@ public class MetaTable extends Table {
                         // SQL
                         "" + dt.getCreateSQL(),
                         // ID
-                        "" + dt.getId()
+                        Integer.toString(dt.getId())
                 );
             }
             break;
@@ -1794,19 +1796,19 @@ public class MetaTable extends Table {
                         // TABLE_NAME
                         identifier(table.getName()),
                         // BEFORE BIT
-                        "" + trigger.isBefore(),
+                        Boolean.toString(trigger.isBefore()),
                         // JAVA_CLASS
                         trigger.getTriggerClassName(),
                         // QUEUE_SIZE INT
-                        "" + trigger.getQueueSize(),
+                        Integer.toString(trigger.getQueueSize()),
                         // NO_WAIT BIT
-                        "" + trigger.isNoWait(),
+                        Boolean.toString(trigger.isNoWait()),
                         // REMARKS
                         replaceNullWithEmpty(trigger.getComment()),
                         // SQL
                         trigger.getCreateSQL(),
                         // ID
-                        "" + trigger.getId()
+                        Integer.toString(trigger.getId())
                 );
             }
             break;
@@ -1822,7 +1824,7 @@ public class MetaTable extends Table {
                     }
                     add(rows,
                             // ID
-                            "" + s.getId(),
+                            Integer.toString(s.getId()),
                             // USER_NAME
                             s.getUser().getName(),
                             // SESSION_START
@@ -1832,7 +1834,7 @@ public class MetaTable extends Table {
                             // STATEMENT_START
                             new Timestamp(start).toString(),
                             // CONTAINS_UNCOMMITTED
-                            "" + s.containsUncommitted()
+                            Boolean.toString(s.containsUncommitted())
                     );
                 }
             }
@@ -1848,7 +1850,7 @@ public class MetaTable extends Table {
                                 // TABLE_NAME
                                 table.getName(),
                                 // SESSION_ID
-                                "" + s.getId(),
+                                Integer.toString(s.getId()),
                                 // LOCK_TYPE
                                 table.isLockedExclusivelyBy(s) ? "WRITE" : "READ"
                         );
@@ -1909,27 +1911,27 @@ public class MetaTable extends Table {
                             // SQL_STATEMENT
                             entry.sqlStatement,
                             // EXECUTION_COUNT
-                            "" + entry.count,
+                            Integer.toString(entry.count),
                             // MIN_EXECUTION_TIME
-                            "" + entry.executionTimeMinNanos / 1000d / 1000,
+                            Double.toString(entry.executionTimeMinNanos / 1_000_000d),
                             // MAX_EXECUTION_TIME
-                            "" + entry.executionTimeMaxNanos / 1000d / 1000,
+                            Double.toString(entry.executionTimeMaxNanos / 1_000_000d),
                             // CUMULATIVE_EXECUTION_TIME
-                            "" + entry.executionTimeCumulativeNanos / 1000d / 1000,
+                            Double.toString(entry.executionTimeCumulativeNanos / 1_000_000d),
                             // AVERAGE_EXECUTION_TIME
-                            "" + entry.executionTimeMeanNanos / 1000d / 1000,
+                            Double.toString(entry.executionTimeMeanNanos / 1_000_000d),
                             // STD_DEV_EXECUTION_TIME
-                            "" + entry.getExecutionTimeStandardDeviation() / 1000d / 1000,
+                            Double.toString(entry.getExecutionTimeStandardDeviation() / 1_000_000d),
                             // MIN_ROW_COUNT
-                            "" + entry.rowCountMin,
+                            Integer.toString(entry.rowCountMin),
                             // MAX_ROW_COUNT
-                            "" + entry.rowCountMax,
+                            Integer.toString(entry.rowCountMax),
                             // CUMULATIVE_ROW_COUNT
-                            "" + entry.rowCountCumulative,
+                            Long.toString(entry.rowCountCumulative),
                             // AVERAGE_ROW_COUNT
-                            "" + entry.rowCountMean,
+                            Double.toString(entry.rowCountMean),
                             // STD_DEV_ROW_COUNT
-                            "" + entry.getRowCountStandardDeviation()
+                            Double.toString(entry.getRowCountStandardDeviation())
                     );
                 }
             }
@@ -1955,7 +1957,7 @@ public class MetaTable extends Table {
                         // REMARKS
                         replaceNullWithEmpty(synonym.getComment()),
                         // ID
-                        "" + synonym.getId()
+                        Integer.toString(synonym.getId())
                 );
             }
             break;

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -832,6 +832,7 @@ public class MetaTable extends Table {
                 String collation = database.getCompareMode().getName();
                 for (int j = 0; j < cols.length; j++) {
                     Column c = cols[j];
+                    DataType dataType = c.getDataType();
                     Sequence sequence = c.getSequence();
                     add(rows,
                             // TABLE_CATALOG
@@ -849,7 +850,7 @@ public class MetaTable extends Table {
                             // IS_NULLABLE
                             c.isNullable() ? "YES" : "NO",
                             // DATA_TYPE
-                            "" + DataType.convertTypeToSQLType(c.getType()),
+                            "" + dataType.sqlType,
                             // CHARACTER_MAXIMUM_LENGTH
                             "" + c.getPrecisionAsInt(),
                             // CHARACTER_OCTET_LENGTH
@@ -865,7 +866,7 @@ public class MetaTable extends Table {
                             // COLLATION_NAME
                             collation,
                             // TYPE_NAME
-                            identifier(DataType.getDataType(c.getType()).name),
+                            identifier(dataType.name),
                             // NULLABLE
                             "" + (c.isNullable() ?
                                     DatabaseMetaData.columnNullable :

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -808,7 +808,7 @@ public class TableFilter implements ColumnResolver {
                 IndexLookupBatch lookupBatch = joinBatch.getLookupBatch(joinFilterId);
                 if (lookupBatch == null) {
                     if (joinFilterId != 0) {
-                        throw DbException.throwInternalError("" + joinFilterId);
+                        throw DbException.throwInternalError(Integer.toString(joinFilterId));
                     }
                 } else {
                     planBuff.append("batched:");

--- a/h2/src/main/org/h2/tools/CompressTool.java
+++ b/h2/src/main/org/h2/tools/CompressTool.java
@@ -264,7 +264,7 @@ public class CompressTool {
         default:
             throw DbException.get(
                     ErrorCode.UNSUPPORTED_COMPRESSION_ALGORITHM_1,
-                    "" + algorithm);
+                    Integer.toString(algorithm));
         }
     }
 

--- a/h2/src/main/org/h2/tools/MultiDimension.java
+++ b/h2/src/main/org/h2/tools/MultiDimension.java
@@ -65,7 +65,7 @@ public class MultiDimension implements Comparator<long[]> {
      */
     public int getMaxValue(int dimensions) {
         if (dimensions < 2 || dimensions > 32) {
-            throw new IllegalArgumentException("" + dimensions);
+            throw new IllegalArgumentException(Integer.toString(dimensions));
         }
         int bitsPerValue = getBitsPerValue(dimensions);
         return (int) ((1L << bitsPerValue) - 1);
@@ -270,18 +270,18 @@ public class MultiDimension implements Comparator<long[]> {
     private void addMortonRanges(ArrayList<long[]> list, int[] min, int[] max,
             int len, int level) {
         if (level > 100) {
-            throw new IllegalArgumentException("" + level);
+            throw new IllegalArgumentException(Integer.toString(level));
         }
         int largest = 0, largestDiff = 0;
         long size = 1;
         for (int i = 0; i < len; i++) {
             int diff = max[i] - min[i];
             if (diff < 0) {
-                throw new IllegalArgumentException(""+ diff);
+                throw new IllegalArgumentException(Integer.toString(diff));
             }
             size *= diff + 1;
             if (size < 0) {
-                throw new IllegalArgumentException("" + size);
+                throw new IllegalArgumentException(Long.toString(size));
             }
             if (diff > largestDiff) {
                 largestDiff = diff;

--- a/h2/src/main/org/h2/util/ColumnNamer.java
+++ b/h2/src/main/org/h2/util/ColumnNamer.java
@@ -102,7 +102,8 @@ public class ColumnNamer {
         }
         // go with a innocuous default name pattern
         if (columnName == null) {
-            columnName = configuration.getDefaultColumnNamePattern().replace("$$", "" + (indexOfColumn + 1));
+            columnName = configuration.getDefaultColumnNamePattern()
+                    .replace("$$", Integer.toString(indexOfColumn + 1));
         }
         if (existingColumnNames.contains(columnName) && configuration.isGenerateUniqueColumnNames()) {
             columnName = generateUniqueName(columnName);

--- a/h2/src/main/org/h2/util/LazyFuture.java
+++ b/h2/src/main/org/h2/util/LazyFuture.java
@@ -86,7 +86,7 @@ public abstract class LazyFuture<T> implements Future<T> {
         case S_CANCELED:
             throw new CancellationException();
         default:
-            throw DbException.throwInternalError("" + state);
+            throw DbException.throwInternalError(Integer.toString(state));
         }
     }
 

--- a/h2/src/main/org/h2/util/NetUtils.java
+++ b/h2/src/main/org/h2/util/NetUtils.java
@@ -178,7 +178,7 @@ public class NetUtils {
             return new ServerSocket(port, 0, bindAddress);
         } catch (BindException be) {
             throw DbException.get(ErrorCode.EXCEPTION_OPENING_PORT_2,
-                    be, "" + port, be.toString());
+                    be, Integer.toString(port), be.toString());
         } catch (IOException e) {
             throw DbException.convertIOException(e, "port: " + port + " ssl: " + ssl);
         }

--- a/h2/src/main/org/h2/util/Profiler.java
+++ b/h2/src/main/org/h2/util/Profiler.java
@@ -207,7 +207,7 @@ public class Profiler implements Runnable {
 
     private static List<Object[]> readRunnableStackTraces(int pid) {
         try {
-            String jstack = exec("jstack", "" + pid);
+            String jstack = exec("jstack", Integer.toString(pid));
             LineNumberReader r = new LineNumberReader(
                     new StringReader(jstack));
             return readStackTrace(r);

--- a/h2/src/main/org/h2/util/SortedProperties.java
+++ b/h2/src/main/org/h2/util/SortedProperties.java
@@ -69,7 +69,7 @@ public class SortedProperties extends Properties {
      * @return the value if set, or the default value if not
      */
     public static int getIntProperty(Properties prop, String key, int def) {
-        String value = prop.getProperty(key, "" + def);
+        String value = prop.getProperty(key, Integer.toString(def));
         try {
             return Integer.decode(value);
         } catch (Exception e) {

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -948,7 +948,7 @@ public class DataType {
             return Value.RESULT_SET;
         default:
             throw DbException.get(
-                    ErrorCode.UNKNOWN_DATA_TYPE_1, "" + sqlType);
+                    ErrorCode.UNKNOWN_DATA_TYPE_1, Integer.toString(sqlType));
         }
     }
 

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -779,7 +779,7 @@ public abstract class Value {
                     double d = getDouble();
                     if (Double.isInfinite(d) || Double.isNaN(d)) {
                         throw DbException.get(
-                                ErrorCode.DATA_CONVERSION_ERROR_1, "" + d);
+                                ErrorCode.DATA_CONVERSION_ERROR_1, Double.toString(d));
                     }
                     return ValueDecimal.get(BigDecimal.valueOf(d));
                 }
@@ -787,7 +787,7 @@ public abstract class Value {
                     float f = getFloat();
                     if (Float.isInfinite(f) || Float.isNaN(f)) {
                         throw DbException.get(
-                                ErrorCode.DATA_CONVERSION_ERROR_1, "" + f);
+                                ErrorCode.DATA_CONVERSION_ERROR_1, Float.toString(f));
                     }
                     // better rounding behavior than BigDecimal.valueOf(f)
                     return ValueDecimal.get(new BigDecimal(Float.toString(f)));

--- a/h2/src/main/org/h2/value/ValueNull.java
+++ b/h2/src/main/org/h2/value/ValueNull.java
@@ -13,6 +13,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
 
 import org.h2.engine.Mode;
 import org.h2.message.DbException;
@@ -160,7 +161,7 @@ public class ValueNull extends Value {
     @Override
     public void set(PreparedStatement prep, int parameterIndex)
             throws SQLException {
-        prep.setNull(parameterIndex, DataType.convertTypeToSQLType(Value.NULL));
+        prep.setNull(parameterIndex, Types.NULL);
     }
 
     @Override

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -776,3 +776,5 @@ geometries sourceschema destschema generatedcolumn alphanumerically usages
 
 sizable instantiates renders sdt txcommit unhelpful optimiser treats rejects referring untrusted computes vacate inverted
 reordered colliding evgenij archaic invocations apostrophe hypothetically testref ryazanov useless completes highlighting tends degrade
+
+summands minuend subtrahend


### PR DESCRIPTION
1. `DataType.getDataType()` is not invoked any more two times with the same argument.

2. Concatenation with an empty string is not used to convert non-constant numbers or booleans to strings. This reduces size of bytecode and machine code. Concatenations of constant values are not changed because such concatenations are reduced to the constant strings by compiler.

3. Synthetic access is fixed.

4. `OnExitDatabaseCloser` can throw `ConcurrentModificationException` sometimes, this is now fixed.

5. Long lines, bad indentation and a typo are fixed.

6. `changelog.html` and `dictionary.txt` are updated.