### PR TITLE
Misc small fixes

### DIFF
--- a/h2/src/main/org/h2/command/ddl/AlterIndexRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterIndexRename.java
@@ -23,7 +23,6 @@ public class AlterIndexRename extends DefineCommand {
     private boolean ifExists;
     private Schema oldSchema;
     private String oldIndexName;
-    private Index oldIndex;
     private String newIndexName;
 
     public AlterIndexRename(Session session) {
@@ -50,7 +49,7 @@ public class AlterIndexRename extends DefineCommand {
     public int update() {
         session.commit(true);
         Database db = session.getDatabase();
-        oldIndex = oldSchema.findIndex(session, oldIndexName);
+        Index oldIndex = oldSchema.findIndex(session, oldIndexName);
         if (oldIndex == null) {
             if (!ifExists) {
                 throw DbException.get(ErrorCode.INDEX_NOT_FOUND_1,

--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -137,7 +137,6 @@ public class CreateTable extends CommandWithColumns {
                 }
             }
             HashSet<DbObject> set = new HashSet<>();
-            set.clear();
             table.addDependencies(set);
             for (DbObject obj : set) {
                 if (obj == table) {

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -924,7 +924,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
                     if (!locks.contains(log.getTable())
                             && TableType.TABLE_LINK != tableType
                             && TableType.EXTERNAL_TABLE_ENGINE != tableType) {
-                        DbException.throwInternalError("" + tableType);
+                        DbException.throwInternalError(String.valueOf(tableType));
                     }
                 }
             }

--- a/h2/src/main/org/h2/index/PageBtreeIndex.java
+++ b/h2/src/main/org/h2/index/PageBtreeIndex.java
@@ -51,7 +51,7 @@ public class PageBtreeIndex extends PageIndex {
         // trace.setLevel(TraceSystem.DEBUG);
         tableData = table;
         if (!database.isPersistent() || id < 0) {
-            throw DbException.throwInternalError("" + indexName);
+            throw DbException.throwInternalError(indexName);
         }
         this.store = database.getPageStore();
         store.addIndex(this);
@@ -154,7 +154,7 @@ public class PageBtreeIndex extends PageIndex {
             store.update(empty);
             return empty;
         } else if (!(p instanceof PageBtree)) {
-            throw DbException.get(ErrorCode.FILE_CORRUPTED_1, "" + p);
+            throw DbException.get(ErrorCode.FILE_CORRUPTED_1, String.valueOf(p));
         }
         return (PageBtree) p;
     }

--- a/h2/src/main/org/h2/index/PageDataIndex.java
+++ b/h2/src/main/org/h2/index/PageDataIndex.java
@@ -237,7 +237,7 @@ public class PageDataIndex extends PageIndex {
             store.update(empty);
             return empty;
         } else if (!(pd instanceof PageData)) {
-            throw DbException.get(ErrorCode.FILE_CORRUPTED_1, "" + pd);
+            throw DbException.get(ErrorCode.FILE_CORRUPTED_1, String.valueOf(pd));
         }
         PageData p = (PageData) pd;
         if (parent != -1) {

--- a/h2/src/main/org/h2/index/PageDataLeaf.java
+++ b/h2/src/main/org/h2/index/PageDataLeaf.java
@@ -153,7 +153,7 @@ public class PageDataLeaf extends PageData {
     private int findInsertionPoint(long key) {
         int x = find(key);
         if (x < entryCount && keys[x] == key) {
-            throw index.getDuplicateKeyException(""+key);
+            throw index.getDuplicateKeyException(String.valueOf(key));
         }
         return x;
     }

--- a/h2/src/main/org/h2/index/PageDelegateIndex.java
+++ b/h2/src/main/org/h2/index/PageDelegateIndex.java
@@ -32,7 +32,7 @@ public class PageDelegateIndex extends PageIndex {
         this.initBaseIndex(table, id, name, cols, indexType);
         this.mainIndex = mainIndex;
         if (!database.isPersistent() || id < 0) {
-            throw DbException.throwInternalError("" + name);
+            throw DbException.throwInternalError(name);
         }
         PageStore store = database.getPageStore();
         store.addIndex(this);

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -1098,7 +1098,7 @@ public class JdbcConnection extends TraceObject
     private static JdbcSavepoint convertSavepoint(Savepoint savepoint) {
         if (!(savepoint instanceof JdbcSavepoint)) {
             throw DbException.get(ErrorCode.SAVEPOINT_IS_INVALID_1,
-                    "" + savepoint);
+                    String.valueOf(savepoint));
         }
         return (JdbcSavepoint) savepoint;
     }

--- a/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
@@ -35,7 +35,7 @@ public class MVDelegateIndex extends BaseIndex implements MVIndex {
         this.initBaseIndex(table, id, name, cols, indexType);
         this.mainIndex = mainIndex;
         if (id < 0) {
-            throw DbException.throwInternalError("" + name);
+            throw DbException.throwInternalError(name);
         }
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -368,7 +368,7 @@ public class MVPrimaryIndex extends BaseIndex {
     /**
      * A cursor.
      */
-    class MVStoreCursor implements Cursor {
+    static class MVStoreCursor implements Cursor {
 
         private final Session session;
         private final Iterator<Entry<Value, Value>> it;

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -49,7 +49,6 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
      */
     final MVTable mvTable;
 
-    private final String mapName;
     private final TransactionMap<SpatialKey, Value> dataMap;
     private final MVRTreeMap<VersionedValue> spatialMap;
 
@@ -93,7 +92,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
         if (!database.isStarting()) {
             checkIndexColumnTypes(columns);
         }
-        mapName = "index." + getId();
+        String mapName = "index." + getId();
         ValueDataType vt = new ValueDataType(null, null, null);
         VersionedValue.Type valueType = new VersionedValue.Type(vt);
         MVRTreeMap.Builder<VersionedValue> mapBuilder =

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -301,7 +301,7 @@ public class WebApp {
                 for (Map.Entry<String, String> entry : map.entrySet()) {
                     String key = entry.getKey();
                     String value = entry.getValue();
-                    String type = "" + key.charAt(0);
+                    String type = String.valueOf(key.charAt(0));
                     if (Integer.parseInt(type) > 2) {
                         continue;
                     }
@@ -1182,14 +1182,14 @@ public class WebApp {
             rs.addRow("conn.getCatalog", conn.getCatalog());
             rs.addRow("conn.getAutoCommit", Boolean.toString(conn.getAutoCommit()));
             rs.addRow("conn.getTransactionIsolation", Integer.toString(conn.getTransactionIsolation()));
-            rs.addRow("conn.getWarnings", "" + conn.getWarnings());
+            rs.addRow("conn.getWarnings", String.valueOf(conn.getWarnings()));
             String map;
             try {
-                map = "" + conn.getTypeMap();
+                map = String.valueOf(conn.getTypeMap());
             } catch (SQLException e) {
                 map = e.toString();
             }
-            rs.addRow("conn.getTypeMap", "" + map);
+            rs.addRow("conn.getTypeMap", map);
             rs.addRow("conn.isReadOnly", Boolean.toString(conn.isReadOnly()));
             rs.addRow("conn.getHoldability", Integer.toString(conn.getHoldability()));
             addDatabaseMetaData(rs, meta);
@@ -1229,7 +1229,7 @@ public class WebApp {
             if (m.getParameterTypes().length == 0) {
                 try {
                     Object o = m.invoke(meta);
-                    rs.addRow("meta." + m.getName(), "" + o);
+                    rs.addRow("meta." + m.getName(), String.valueOf(o));
                 } catch (InvocationTargetException e) {
                     rs.addRow("meta." + m.getName(), e.getTargetException().toString());
                 } catch (Exception e) {

--- a/h2/src/main/org/h2/store/FileLock.java
+++ b/h2/src/main/org/h2/store/FileLock.java
@@ -73,7 +73,7 @@ public class FileLock implements Runnable {
      */
     private long lastWrite;
 
-    private String method, ipAddress;
+    private String method;
     private Properties properties;
     private String uniqueId;
     private Thread watchdog;
@@ -350,7 +350,7 @@ public class FileLock implements Runnable {
         setUniqueId();
         // if this returns 127.0.0.1,
         // the computer is probably not networked
-        ipAddress = NetUtils.getLocalAddress();
+        String ipAddress = NetUtils.getLocalAddress();
         FileUtils.createDirectories(FileUtils.getParent(fileName));
         if (!FileUtils.createFile(fileName)) {
             waitUntilOld();

--- a/h2/src/main/org/h2/store/LobStorageMap.java
+++ b/h2/src/main/org/h2/store/LobStorageMap.java
@@ -279,8 +279,7 @@ public class LobStorageMap implements LobStorageInterface {
             if (lob.getTableId() == LobStorageFrontend.TABLE_RESULT ||
                     lob.getTableId() == LobStorageFrontend.TABLE_ID_SESSION_VARIABLE) {
                 throw DbException.get(
-                        ErrorCode.LOB_CLOSED_ON_TIMEOUT_1, "" +
-                                lob.getLobId() + "/" + lob.getTableId());
+                        ErrorCode.LOB_CLOSED_ON_TIMEOUT_1, lob.getLobId() + "/" + lob.getTableId());
             }
             throw DbException.throwInternalError("Lob not found: " +
                     lob.getLobId() + "/" + lob.getTableId());

--- a/h2/src/main/org/h2/store/LobStorageMap.java
+++ b/h2/src/main/org/h2/store/LobStorageMap.java
@@ -60,14 +60,6 @@ public class LobStorageMap implements LobStorageInterface {
      */
     private MVMap<Object[], Boolean> refMap;
 
-    /**
-     * The stream store data map.
-     *
-     * Key: stream store block id (long).
-     * Value: data (byte[]).
-     */
-    private MVMap<Long, byte[]> dataMap;
-
     private StreamStore streamStore;
 
     public LobStorageMap(Database database) {
@@ -90,7 +82,13 @@ public class LobStorageMap implements LobStorageInterface {
         }
         lobMap = mvStore.openMap("lobMap");
         refMap = mvStore.openMap("lobRef");
-        dataMap = mvStore.openMap("lobData");
+
+        /* The stream store data map.
+         *
+         * Key: stream store block id (long).
+         * Value: data (byte[]).
+         */
+        MVMap<Long, byte[]> dataMap = mvStore.openMap("lobData");
         streamStore = new StreamStore(dataMap);
         // garbage collection of the last blocks
         if (database.isReadOnly()) {

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1764,11 +1764,11 @@ public class MetaTable extends Table {
                         // SELECTIVITY INT
                         Integer.toString(col.getSelectivity()),
                         // CHECK_CONSTRAINT
-                        "" + col.getCheckConstraintSQL(session, "VALUE"),
+                        col.getCheckConstraintSQL(session, "VALUE"),
                         // REMARKS
                         replaceNullWithEmpty(dt.getComment()),
                         // SQL
-                        "" + dt.getCreateSQL(),
+                        dt.getCreateSQL(),
                         // ID
                         Integer.toString(dt.getId())
                 );

--- a/h2/src/main/org/h2/tools/SimpleResultSet.java
+++ b/h2/src/main/org/h2/tools/SimpleResultSet.java
@@ -606,8 +606,7 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData,
      */
     @Override
     public Clob getClob(int columnIndex) throws SQLException {
-        Clob c = (Clob) get(columnIndex);
-        return c == null ? null : c;
+        return (Clob) get(columnIndex);
     }
 
     /**

--- a/h2/src/main/org/h2/util/ColumnNamer.java
+++ b/h2/src/main/org/h2/util/ColumnNamer.java
@@ -18,14 +18,12 @@ public class ColumnNamer {
     private static final String DEFAULT_COLUMN_NAME = "DEFAULT";
 
     private final ColumnNamerConfiguration configuration;
-    private final Session session;
     private final Set<String> existingColumnNames = new HashSet<>();
 
     public ColumnNamer(Session session) {
-        this.session = session;
-        if (this.session != null && this.session.getColumnNamerConfiguration() != null) {
+        if (session != null && session.getColumnNamerConfiguration() != null) {
             // use original from session
-            this.configuration = this.session.getColumnNamerConfiguration();
+            this.configuration = session.getColumnNamerConfiguration();
         } else {
             // detached namer, create new
             this.configuration = ColumnNamerConfiguration.getDefault();

--- a/h2/src/main/org/h2/util/ThreadDeadlockDetector.java
+++ b/h2/src/main/org/h2/util/ThreadDeadlockDetector.java
@@ -32,13 +32,13 @@ public class ThreadDeadlockDetector {
 
     private final ThreadMXBean threadBean;
 
-    // a daemon thread
-    private final Timer threadCheck = new Timer("ThreadDeadlockDetector", true);
-
     private ThreadDeadlockDetector() {
         this.threadBean = ManagementFactory.getThreadMXBean();
+
+        // a daemon thread
         // delay: 10 ms
         // period: 10000 ms (100 seconds)
+        Timer threadCheck = new Timer("ThreadDeadlockDetector", true);
         threadCheck.schedule(new TimerTask() {
             @Override
             public void run() {


### PR DESCRIPTION
1. SimpleResultSet: removal of redundant null check.
2. MVPrimaryIndex: change inner class MVStoreCursor to static to avoid storing reference to outer class. No other code changes were necessary.
3. Removal of converting to string using concatenation with empty string. Using String.valueOf if necessary.
4. CreateTable: remove unnecessary clear() on newly created HashSet.
5. Removal of various unnecessary fields, where local variable can be used instead.

I wrote the code, it's mine, and I'm contributing it to H2 for distribution multiple-licensed under the MPL 2.0, and the EPL 1.0 (http://h2database.com/html/license.html).