### PR TITLE
Add missing schema name with recursive view

### DIFF
--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.command.CommandInterface;
+import org.h2.command.Parser;
 import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.engine.Session;
@@ -1158,7 +1159,9 @@ public class Select extends Query {
                     // since using a with statement will re-create the common table expression
                     // views.
                 } else {
-                    buff.append("WITH RECURSIVE ").append(t.getName()).append('(');
+                    buff.append("WITH RECURSIVE ")
+                            .append(t.getSchema().getSQL()).append('.').append(Parser.quoteIdentifier(t.getName()))
+                            .append('(');
                     buff.resetCount();
                     for (Column c : t.getColumns()) {
                         buff.appendExceptFirst(",");

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -778,7 +778,7 @@ public class TableFilter implements ColumnResolver {
             return buff.toString();
         }
         if (table.isView() && ((TableView) table).isRecursive()) {
-            buff.append(table.getName());
+            buff.append(table.getSchema().getSQL()).append('.').append(table.getName());
         } else {
             buff.append(table.getSQL());
         }

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -778,7 +778,7 @@ public class TableFilter implements ColumnResolver {
             return buff.toString();
         }
         if (table.isView() && ((TableView) table).isRecursive()) {
-            buff.append(table.getSchema().getSQL()).append('.').append(table.getName());
+            buff.append(table.getSchema().getSQL()).append('.').append(Parser.quoteIdentifier(table.getName()));
         } else {
             buff.append(table.getSQL());
         }

--- a/h2/src/test/org/h2/test/scripts/dml/with.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/with.sql
@@ -6,13 +6,28 @@ explain with recursive r(n) as (
     (select 1) union all (select n+1 from r where n < 3)
 )
 select n from r;
->> WITH RECURSIVE R(N) AS ( (SELECT 1 FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX */) UNION ALL (SELECT (N + 1) FROM PUBLIC.R /* PUBLIC.R.tableScan */ WHERE N < 3) ) SELECT N FROM PUBLIC.R R /* null */
+>> WITH RECURSIVE PUBLIC.R(N) AS ( (SELECT 1 FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX */) UNION ALL (SELECT (N + 1) FROM PUBLIC.R /* PUBLIC.R.tableScan */ WHERE N < 3) ) SELECT N FROM PUBLIC.R R /* null */
+
+explain with recursive "r"(n) as (
+    (select 1) union all (select n+1 from "r" where n < 3)
+)
+select n from "r";
+>> WITH RECURSIVE PUBLIC."r"(N) AS ( (SELECT 1 FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX */) UNION ALL (SELECT (N + 1) FROM PUBLIC."r" /* PUBLIC."r".tableScan */ WHERE N < 3) ) SELECT N FROM PUBLIC."r" "r" /* null */
+
 
 select sum(n) from (
     with recursive r(n) as (
         (select 1) union all (select n+1 from r where n < 3)
     )
     select n from r
+);
+>> 6
+
+select sum(n) from (
+    with recursive "r"(n) as (
+        (select 1) union all (select n+1 from "r" where n < 3)
+    )
+    select n from "r"
 );
 >> 6
 

--- a/h2/src/test/org/h2/test/scripts/dml/with.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/with.sql
@@ -6,7 +6,7 @@ explain with recursive r(n) as (
     (select 1) union all (select n+1 from r where n < 3)
 )
 select n from r;
->> WITH RECURSIVE R(N) AS ( (SELECT 1 FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX */) UNION ALL (SELECT (N + 1) FROM PUBLIC.R /* PUBLIC.R.tableScan */ WHERE N < 3) ) SELECT N FROM R R /* null */
+>> WITH RECURSIVE R(N) AS ( (SELECT 1 FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX */) UNION ALL (SELECT (N + 1) FROM PUBLIC.R /* PUBLIC.R.tableScan */ WHERE N < 3) ) SELECT N FROM PUBLIC.R R /* null */
 
 select sum(n) from (
     with recursive r(n) as (

--- a/h2/src/test/org/h2/test/scripts/dml/with.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/with.sql
@@ -44,3 +44,26 @@ with
 > - -- -- --
 > 0 -1 1  10
 > rows: 1
+
+CREATE SCHEMA SCH;
+> ok
+
+CREATE FORCE VIEW TABLE_EXPRESSION SCH.R1(N) AS
+(SELECT 1)
+UNION ALL
+(SELECT (N + 1) FROM SCH.R1 WHERE N < 3);
+> ok
+
+CREATE VIEW SCH.R2(N) AS
+(SELECT 1)
+UNION ALL
+(SELECT (N + 1) FROM SCH.R1 WHERE N < 3);
+> ok
+
+SELECT * FROM SCH.R2;
+> N
+> -
+> 1
+> 2
+> 3
+> rows: 3


### PR DESCRIPTION
## Summary
When we create a view with call a recursive view, the schema of the view is not added.

## What is the current *bug* behavior?
Exemple:
```
CREATE VIEW D4X_CORE.V_DOMAIN_PROGENY_2(USER_ID, CHILD_DOMAIN_ID, CHILD_DOMAIN_CODE, CHILD_DOMAIN_LABEL) AS
SELECT
    ASSO.USER_ID,
    P.CHILD_DOMAIN_ID,
    P.CHILD_DOMAIN_CODE,
    P.CHILD_DOMAIN_LABEL
FROM (
    SELECT
        A.USER_ID,
        A.DOMAIN_ID,
        D.CODE AS DOMAIN_CODE,
        D.LABEL AS DOMAIN_LABEL
    FROM D4X_CORE.ASSO_D4X_USER_DOMAIN A
    INNER JOIN D4X_CORE.DOMAIN D
    WHERE D.ID = A.DOMAIN_ID
) ASSO
INNER JOIN D4X_CORE.V_DOMAIN_PROGENY_1 P
WHERE P.ROOT_DOMAIN_ID = ASSO.DOMAIN_ID;
```

And H2 create (in INFORMATION_SCHEMA.VIEW) :
```
CREATE VIEW D4X_CORE.V_DOMAIN_PROGENY_2(USER_ID, CHILD_DOMAIN_ID, CHILD_DOMAIN_CODE, CHILD_DOMAIN_LABEL) AS
SELECT
    ASSO.USER_ID,
    P.CHILD_DOMAIN_ID,
    P.CHILD_DOMAIN_CODE,
    P.CHILD_DOMAIN_LABEL
FROM (
    SELECT
        A.USER_ID,
        A.DOMAIN_ID,
        D.CODE AS DOMAIN_CODE,
        D.LABEL AS DOMAIN_LABEL
    FROM D4X_CORE.ASSO_D4X_USER_DOMAIN A
    INNER JOIN D4X_CORE.DOMAIN D
        ON 1=1
    WHERE D.ID = A.DOMAIN_ID
) ASSO
INNER JOIN V_DOMAIN_PROGENY_1 P
    ON 1=1
WHERE P.ROOT_DOMAIN_ID = ASSO.DOMAIN_ID
```
The schema of **V_DOMAIN_PROGENY_1** is not defined and the view appear INVALID in INFORMATION_SCHEMA.VIEWS.
(V_DOMAIN_PROGENY_1 is a recursive view)

### What is the expected *correct* behavior?

The schema name of the recursive view called should be defined.



