### PR TITLE
Assorted minor optimizations

### DIFF
--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -415,7 +415,7 @@ public class Insert extends Prepared implements ResultTarget {
         for (Column column : duplicateKeyAssignmentMap.keySet()) {
             buff.appendExceptFirst(", ");
             Expression ex = duplicateKeyAssignmentMap.get(column);
-            buff.append(column.getSQL()).append("=").append(ex.getSQL());
+            buff.append(column.getSQL()).append('=').append(ex.getSQL());
         }
         buff.append(" WHERE ");
         Index foundIndex = (Index) de.getSource();

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -1164,7 +1164,7 @@ public class Select extends Query {
                         buff.appendExceptFirst(",");
                         buff.append(c.getName());
                     }
-                    buff.append(") AS ").append(t.getSQL()).append("\n");
+                    buff.append(") AS ").append(t.getSQL()).append('\n');
                 }
             }
         }

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -2492,7 +2492,7 @@ public class Function extends Expression implements FunctionCall {
         StatementBuilder buff = new StatementBuilder(info.name);
         if (info.type == CASE) {
             if (args[0] != null) {
-                buff.append(" ").append(args[0].getSQL());
+                buff.append(' ').append(args[0].getSQL());
             }
             for (int i = 1, len = args.length - 1; i < len; i += 2) {
                 buff.append(" WHEN ").append(args[i].getSQL());

--- a/h2/src/main/org/h2/fulltext/FullTextSettings.java
+++ b/h2/src/main/org/h2/fulltext/FullTextSettings.java
@@ -10,11 +10,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.h2.util.SoftHashMap;
 
 /**
@@ -45,8 +46,7 @@ final class FullTextSettings {
     /**
      * The set of indexes in this database.
      */
-    private final Map<Integer, IndexInfo> indexes = Collections
-            .synchronizedMap(new HashMap<Integer, IndexInfo>());
+    private final ConcurrentHashMap<Integer, IndexInfo> indexes = new ConcurrentHashMap<>();
 
     /**
      * The prepared statement cache.

--- a/h2/src/main/org/h2/index/PageDataIndex.java
+++ b/h2/src/main/org/h2/index/PageDataIndex.java
@@ -491,8 +491,7 @@ public class PageDataIndex extends PageIndex {
 
     Iterator<Row> getDelta() {
         if (delta == null) {
-            List<Row> e = Collections.emptyList();
-            return e.iterator();
+            return Collections.emptyIterator();
         }
         return delta.iterator();
     }

--- a/h2/src/main/org/h2/index/ScanIndex.java
+++ b/h2/src/main/org/h2/index/ScanIndex.java
@@ -251,8 +251,7 @@ public class ScanIndex extends BaseIndex {
 
     Iterator<Row> getDelta() {
         if (delta == null) {
-            List<Row> e = Collections.emptyList();
-            return e.iterator();
+            return Collections.emptyIterator();
         }
         return delta.iterator();
     }

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -258,7 +258,7 @@ public class MVPrimaryIndex extends BaseIndex {
         ValueLong v = (ValueLong) (first ? map.firstKey() : map.lastKey());
         if (v == null) {
             return new MVStoreCursor(session,
-                    Collections.<Entry<Value, Value>> emptyList().iterator());
+                    Collections.<Entry<Value, Value>> emptyIterator());
         }
         Value value = map.get(v);
         Entry<Value, Value> e = new AbstractMap.SimpleImmutableEntry<Value, Value>(v, value);

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -307,7 +307,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
             }
             if (min == null) {
                 return new MVStoreCursor(session,
-                        Collections.<Value>emptyList().iterator(), null);
+                        Collections.<Value>emptyIterator(), null);
             }
         }
         return new MVStoreCursor(session, map.keyIterator(min), last);
@@ -394,7 +394,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         while (true) {
             if (key == null) {
                 return new MVStoreCursor(session,
-                        Collections.<Value>emptyList().iterator(), null);
+                        Collections.<Value>emptyIterator(), null);
             }
             if (((ValueArray) key).getList()[0] != ValueNull.INSTANCE) {
                 break;

--- a/h2/src/main/org/h2/server/TcpServer.java
+++ b/h2/src/main/org/h2/server/TcpServer.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.h2.Driver;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
@@ -49,8 +51,7 @@ public class TcpServer implements Service {
      */
     private static final String MANAGEMENT_DB_PREFIX = "management_db_";
 
-    private static final Map<Integer, TcpServer> SERVERS =
-            Collections.synchronizedMap(new HashMap<Integer, TcpServer>());
+    private static final ConcurrentHashMap<Integer, TcpServer> SERVERS = new ConcurrentHashMap<>();
 
     private int port;
     private boolean portIsSet;

--- a/h2/src/main/org/h2/store/fs/FilePath.java
+++ b/h2/src/main/org/h2/store/fs/FilePath.java
@@ -9,10 +9,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.FileChannel;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.h2.util.MathUtils;
 
 /**
@@ -25,7 +23,7 @@ public abstract class FilePath {
 
     private static FilePath defaultProvider;
 
-    private static Map<String, FilePath> providers;
+    private static ConcurrentHashMap<String, FilePath> providers;
 
     /**
      * The prefix for temporary files.
@@ -66,8 +64,7 @@ public abstract class FilePath {
 
     private static void registerDefaultProviders() {
         if (providers == null || defaultProvider == null) {
-            Map<String, FilePath> map = Collections.synchronizedMap(
-                    new HashMap<String, FilePath>());
+            ConcurrentHashMap<String, FilePath> map = new ConcurrentHashMap<>();
             for (String c : new String[] {
                     "org.h2.store.fs.FilePathDisk",
                     "org.h2.store.fs.FilePathMem",

--- a/h2/src/main/org/h2/util/SynchronizedVerifier.java
+++ b/h2/src/main/org/h2/util/SynchronizedVerifier.java
@@ -5,10 +5,7 @@
  */
 package org.h2.util;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -17,10 +14,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class SynchronizedVerifier {
 
     private static volatile boolean enabled;
-    private static final Map<Class<?>, AtomicBoolean> DETECT =
-        Collections.synchronizedMap(new HashMap<Class<?>, AtomicBoolean>());
-    private static final Map<Object, Object> CURRENT =
-        Collections.synchronizedMap(new IdentityHashMap<>());
+    private static final ConcurrentHashMap<Class<?>, AtomicBoolean> DETECT = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<Object, Object> CURRENT = new ConcurrentHashMap<>();
 
     /**
      * Enable or disable detection for a given class.

--- a/h2/src/main/org/h2/util/ToDateParser.java
+++ b/h2/src/main/org/h2/util/ToDateParser.java
@@ -265,7 +265,7 @@ public class ToDateParser {
         while (p.hasToParseData()) {
             List<ToDateTokenizer.FormatTokenEnum> tokenList =
                     ToDateTokenizer.FormatTokenEnum.getTokensInQuestion(p.getFormatStr());
-            if (tokenList.isEmpty()) {
+            if (tokenList == null) {
                 p.removeFirstChar();
                 continue;
             }

--- a/h2/src/test/org/h2/samples/CachedPreparedStatements.java
+++ b/h2/src/test/org/h2/samples/CachedPreparedStatements.java
@@ -10,9 +10,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This sample application shows how to cache prepared statements.
@@ -21,9 +19,7 @@ public class CachedPreparedStatements {
 
     private Connection conn;
     private Statement stat;
-    private final Map<String, PreparedStatement> prepared =
-        Collections.synchronizedMap(
-                new HashMap<String, PreparedStatement>());
+    private final ConcurrentHashMap<String, PreparedStatement> prepared = new ConcurrentHashMap<>();
 
     /**
      * This method is called when executing this sample application from the

--- a/h2/src/test/org/h2/samples/TriggerPassData.java
+++ b/h2/src/test/org/h2/samples/TriggerPassData.java
@@ -10,9 +10,8 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.h2.api.Trigger;
 
 /**
@@ -21,8 +20,7 @@ import org.h2.api.Trigger;
  */
 public class TriggerPassData implements Trigger {
 
-    private static final Map<String, TriggerPassData> TRIGGERS =
-        Collections.synchronizedMap(new HashMap<String, TriggerPassData>());
+    private static final ConcurrentHashMap<String, TriggerPassData> TRIGGERS = new ConcurrentHashMap<>();
     private String triggerData;
 
     /**

--- a/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
+++ b/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
@@ -117,11 +117,16 @@ public class TestFuzzOptimizations extends TestBase {
                 }
                 executeAndCompare(condition, params, message);
             }
-            if (!config.mvStore) {
+            if (!config.mvStore && config.travis) {
                 /*
                  * Travis tests have problems with automatic garbage collection, so request a GC
                  * explicitly and print its results.
                  */
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
                 println((Utils.getMemoryUsed() >> 10) + " MiB used");
             }
         }

--- a/h2/src/tools/org/h2/jaqu/SQLDialect.java
+++ b/h2/src/tools/org/h2/jaqu/SQLDialect.java
@@ -98,12 +98,12 @@ public interface SQLDialect {
             buff.append(index.indexName);
             buff.append(" ON ");
             buff.append(table);
-            buff.append("(");
+            buff.append('(');
             for (String col : index.columnNames) {
                 buff.appendExceptFirst(", ");
                 buff.append(col);
             }
-            buff.append(")");
+            buff.append(')');
             return buff.toString();
         }
 


### PR DESCRIPTION
1. `Collections.emptyIterator()` that is available since Java 7 / Android API 19 is used instead of `Collections.emptyList().iterator()`.

2. `StatementBuilder.append(char)` is used instead of `append(String)` where possible.

3. `ConcurrentHashMap` is used instead of `Collections.synchronizedMap(new HashMap<>())`. On Java 7 it may create a some memory overhead (but provide better concurrency) due to usages of segments, but on Java 8+ there are no additional segments, it was completely reimplemented. Fields are redeclared with `ConcurrentHashMap` type for better readability. It's more oblivious that these maps are thread-safe with this data type.

4. `ToDateTokenizer.getTokensInQuestion()` is reimplemented in faster and safer way. Unnecessary synchronization is removed, unsafe assignment of uninitialized value and unsafe reads are reorganized to make them safe, map is replaced with a plain array that works better in this situation, empty lists are replaced with null, etc.