### PR TITLE
fix deadlock between OnExitDatabaseCloser.DATABASES and Engine.DATABASES

### DIFF
--- a/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
@@ -5,6 +5,7 @@
  */
 package org.h2.engine;
 
+import java.util.ArrayList;
 import java.util.WeakHashMap;
 
 import org.h2.message.Trace;
@@ -65,10 +66,10 @@ class OnExitDatabaseCloser extends Thread {
         }
     }
 
-    private static synchronized void onShutdown() {
+    private static void onShutdown() {
         terminated = true;
         RuntimeException root = null;
-        for (Database database : DATABASES.keySet()) {
+        for (Database database : collectDatabasesToClose()) {
             try {
                 database.close(true);
             } catch (RuntimeException e) {
@@ -92,6 +93,10 @@ class OnExitDatabaseCloser extends Thread {
         if (root != null) {
             throw root;
         }
+    }
+
+    private static synchronized Iterable<Database> collectDatabasesToClose() {
+        return new ArrayList<>(DATABASES.keySet());
     }
 
     private OnExitDatabaseCloser() {

--- a/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
@@ -67,13 +67,11 @@ class OnExitDatabaseCloser extends Thread {
     }
 
     private static void onShutdown() {
-        ArrayList<Database> databases;
         synchronized(OnExitDatabaseCloser.class) {
             terminated = true;
-            databases = new ArrayList<>(DATABASES.keySet());
         }
         RuntimeException root = null;
-        for (Database database : databases) {
+        for (Database database : DATABASES.keySet()) {
             try {
                 database.close(true);
             } catch (RuntimeException e) {

--- a/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
@@ -67,9 +67,13 @@ class OnExitDatabaseCloser extends Thread {
     }
 
     private static void onShutdown() {
-        terminated = true;
+        ArrayList<Database> databases;
+        synchronized(OnExitDatabaseCloser.class) {
+            terminated = true;
+            databases = new ArrayList<>(DATABASES.keySet());
+        }
         RuntimeException root = null;
-        for (Database database : collectDatabasesToClose()) {
+        for (Database database : databases) {
             try {
                 database.close(true);
             } catch (RuntimeException e) {
@@ -93,10 +97,6 @@ class OnExitDatabaseCloser extends Thread {
         if (root != null) {
             throw root;
         }
-    }
-
-    private static synchronized Iterable<Database> collectDatabasesToClose() {
-        return new ArrayList<>(DATABASES.keySet());
     }
 
     private OnExitDatabaseCloser() {

--- a/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
@@ -5,7 +5,6 @@
  */
 package org.h2.engine;
 
-import java.util.ArrayList;
 import java.util.WeakHashMap;
 
 import org.h2.message.Trace;


### PR DESCRIPTION
This stack trace is from one of my branches, so line numbers may not be directly applicable to master, but I see no reason why this can't happened on master as well.


SelfDestructor timed out
"Thread-1" Id=11 in BLOCKED on lock=java.util.HashMap@11501ada
     owned by main Id=1
    at org.h2.engine.Engine.close(Engine.java:282)
    at org.h2.engine.Database.close(Database.java:1390)
    at org.h2.engine.OnExitDatabaseCloser.onShutdown(OnExitDatabaseCloser.java:73)
      - locked java.lang.Class@1f97e758
    at org.h2.engine.OnExitDatabaseCloser.run(OnExitDatabaseCloser.java:102)
...

"main" Id=1 in BLOCKED on lock=java.lang.Class@1f97e758
     owned by Thread-1 Id=11
    at org.h2.engine.OnExitDatabaseCloser.register(OnExitDatabaseCloser.java:26)
    at org.h2.engine.Database.openDatabase(Database.java:292)
    at org.h2.engine.Database.<init>(Database.java:284)
    at org.h2.engine.Engine.openSession(Engine.java:69)
      - locked java.util.HashMap@11501ada
    at org.h2.engine.Engine.openSession(Engine.java:182)
      - locked org.h2.engine.Engine@61f7c28f
    at org.h2.engine.Engine.createSessionAndValidate(Engine.java:160)
    at org.h2.engine.Engine.createSession(Engine.java:143)
    at org.h2.engine.Engine.createSession(Engine.java:31)
    at org.h2.engine.SessionRemote.connectEmbeddedOrServer(SessionRemote.java:335)
    at org.h2.jdbc.JdbcConnection.<init>(JdbcConnection.java:124)
    at org.h2.jdbc.JdbcConnection.<init>(JdbcConnection.java:103)
    at org.h2.Driver.connect(Driver.java:69)
    at java.sql.DriverManager.getConnection(DriverManager.java:664)
    at java.sql.DriverManager.getConnection(DriverManager.java:247)
    at org.h2.test.synth.TestKillRestartMulti.openConnection(TestKillRestartMulti.java:273)
    at org.h2.test.synth.TestKillRestartMulti.test(TestKillRestartMulti.java:194)
    at org.h2.test.synth.TestKillRestartMulti.main(TestKillRestartMulti.java:60)
