### PR TITLE
Get rid of SysProperties.CHECK2

### DIFF
--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -83,7 +83,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Find a tool to view large text file (larger than 100 MB), with find, page up and down (like less), truncate before / after.
 </li><li>Implement, test, document XAConnection and so on.
 </li><li>Pluggable data type (for streaming, hashing, compression, validation, conversion, encryption).
-</li><li>CHECK: find out what makes CHECK=TRUE slow, move to CHECK2.
+</li><li>CHECK: find out what makes CHECK=TRUE slow, move to assertions.
 </li><li>Drop with invalidate views (so that source code is not lost). Check what other databases do exactly.
 </li><li>Index usage for (ID, NAME)=(1, 'Hi'); document.
 </li><li>Set a connection read only (Connection.setReadOnly) or using a connection parameter.

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -91,6 +91,15 @@ public class Database implements DataHandler {
 
     private static int initialPowerOffCount;
 
+    private static final boolean ASSERT;
+
+    static {
+        boolean a = false;
+        // Intentional side-effect
+        assert a = true;
+        ASSERT = a;
+    }
+
     private static final ThreadLocal<Session> META_LOCK_DEBUGGING = new ThreadLocal<>();
     private static final ThreadLocal<Database> META_LOCK_DEBUGGING_DB = new ThreadLocal<>();
     private static final ThreadLocal<Throwable> META_LOCK_DEBUGGING_STACK = new ThreadLocal<>();
@@ -919,7 +928,7 @@ public class Database implements DataHandler {
         if (meta == null) {
             return true;
         }
-        if (SysProperties.CHECK2) {
+        if (ASSERT) {
             // If we are locking two different databases in the same stack, just ignore it.
             // This only happens in TestLinkedTable where we connect to another h2 DB in the
             // same process.
@@ -961,7 +970,7 @@ public class Database implements DataHandler {
      * @param session the session
      */
     public void unlockMetaDebug(Session session) {
-        if (SysProperties.CHECK2) {
+        if (ASSERT) {
             if (META_LOCK_DEBUGGING.get() == session) {
                 META_LOCK_DEBUGGING.set(null);
                 META_LOCK_DEBUGGING_DB.set(null);
@@ -1405,7 +1414,7 @@ public class Database implements DataHandler {
                         unlockMeta(pageStore.getPageStoreSession());
                     }
                 } catch (DbException e) {
-                    if (SysProperties.CHECK2) {
+                    if (ASSERT) {
                         int code = e.getErrorCode();
                         if (code != ErrorCode.DATABASE_IS_CLOSED &&
                                 code != ErrorCode.LOCK_TIMEOUT_1 &&
@@ -1415,7 +1424,7 @@ public class Database implements DataHandler {
                     }
                     trace.error(e, "close");
                 } catch (Throwable t) {
-                    if (SysProperties.CHECK2) {
+                    if (ASSERT) {
                         t.printStackTrace();
                     }
                     trace.error(t, "close");

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -93,16 +93,25 @@ public class Database implements DataHandler {
 
     private static final boolean ASSERT;
 
+    private static final ThreadLocal<Session> META_LOCK_DEBUGGING;
+    private static final ThreadLocal<Database> META_LOCK_DEBUGGING_DB;
+    private static final ThreadLocal<Throwable> META_LOCK_DEBUGGING_STACK;
+
     static {
         boolean a = false;
         // Intentional side-effect
         assert a = true;
         ASSERT = a;
+        if (a) {
+            META_LOCK_DEBUGGING = new ThreadLocal<>();
+            META_LOCK_DEBUGGING_DB = new ThreadLocal<>();
+            META_LOCK_DEBUGGING_STACK = new ThreadLocal<>();
+        } else {
+            META_LOCK_DEBUGGING = null;
+            META_LOCK_DEBUGGING_DB = null;
+            META_LOCK_DEBUGGING_STACK = null;
+        }
     }
-
-    private static final ThreadLocal<Session> META_LOCK_DEBUGGING = new ThreadLocal<>();
-    private static final ThreadLocal<Database> META_LOCK_DEBUGGING_DB = new ThreadLocal<>();
-    private static final ThreadLocal<Throwable> META_LOCK_DEBUGGING_STACK = new ThreadLocal<>();
 
     /**
      * The default name of the system user. This name is only used as long as
@@ -217,9 +226,11 @@ public class Database implements DataHandler {
     private RowFactory rowFactory = RowFactory.DEFAULT;
 
     public Database(ConnectionInfo ci, String cipher) {
-        META_LOCK_DEBUGGING.set(null);
-        META_LOCK_DEBUGGING_DB.set(null);
-        META_LOCK_DEBUGGING_STACK.set(null);
+        if (ASSERT) {
+            META_LOCK_DEBUGGING.set(null);
+            META_LOCK_DEBUGGING_DB.set(null);
+            META_LOCK_DEBUGGING_STACK.set(null);
+        }
         String name = ci.getName();
         this.dbSettings = ci.getDbSettings();
         this.reconnectCheckDelayNs = TimeUnit.MILLISECONDS.toNanos(dbSettings.reconnectCheckDelay);

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -722,12 +722,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
     }
 
     private void removeTemporaryLobs(boolean onTimeout) {
-        if (SysProperties.CHECK2) {
-            if (this == getDatabase().getLobSession()
-                    && !Thread.holdsLock(this) && !Thread.holdsLock(getDatabase())) {
-                throw DbException.throwInternalError();
-            }
-        }
+        assert this != getDatabase().getLobSession() || Thread.holdsLock(this) || Thread.holdsLock(getDatabase());
         if (temporaryLobs != null) {
             for (Value v : temporaryLobs) {
                 if (!v.isLinkedToTable()) {

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -95,17 +95,10 @@ public class SysProperties {
     /**
      * System property <code>h2.check</code>
      * (default: true for JDK/JRE, false for Android).<br />
-     * Assertions in the database engine.
+     * Optional additional checks in the database engine.
      */
     public static final boolean CHECK =
             Utils.getProperty("h2.check", !"0.9".equals(Utils.getProperty("java.specification.version", null)));
-
-    /**
-     * System property <code>h2.check2</code> (default: false).<br />
-     * Additional assertions in the database engine.
-     */
-    public static final boolean CHECK2 =
-            Utils.getProperty("h2.check2", false);
 
     /**
      * System property <code>h2.clientTraceDirectory</code> (default:

--- a/h2/src/main/org/h2/index/PageDataLeaf.java
+++ b/h2/src/main/org/h2/index/PageDataLeaf.java
@@ -491,11 +491,7 @@ public class PageDataLeaf extends PageData {
         }
         data.writeByte((byte) type);
         data.writeShortInt(0);
-        if (SysProperties.CHECK2) {
-            if (data.length() != START_PARENT) {
-                DbException.throwInternalError();
-            }
-        }
+        assert data.length() == START_PARENT;
         data.writeInt(parentPageId);
         data.writeVarInt(index.getId());
         data.writeVarInt(columnCount);

--- a/h2/src/main/org/h2/index/PageDataNode.java
+++ b/h2/src/main/org/h2/index/PageDataNode.java
@@ -351,11 +351,7 @@ public class PageDataNode extends PageData {
         data.reset();
         data.writeByte((byte) Page.TYPE_DATA_NODE);
         data.writeShortInt(0);
-        if (SysProperties.CHECK2) {
-            if (data.length() != START_PARENT) {
-                DbException.throwInternalError();
-            }
-        }
+        assert data.length() == START_PARENT;
         data.writeInt(parentPageId);
         data.writeVarInt(index.getId());
         data.writeInt(rowCountStored);

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -705,13 +705,8 @@ public class Data {
             }
             DbException.throwInternalError("type=" + v.getType());
         }
-        if (SysProperties.CHECK2) {
-            if (pos - start != getValueLen(v, handler)) {
-                throw DbException.throwInternalError(
-                            "value size error: got " + (pos - start) +
-                            " expected " + getValueLen(v, handler));
-            }
-        }
+        assert pos - start == getValueLen(v, handler)
+                : "value size error: got " + (pos - start) + " expected " + getValueLen(v, handler);
     }
 
     /**

--- a/h2/src/main/org/h2/store/FileStore.java
+++ b/h2/src/main/org/h2/store/FileStore.java
@@ -36,6 +36,15 @@ public class FileStore {
     private static final String HEADER =
             "-- H2 0.5/B --      ".substring(0, Constants.FILE_BLOCK_SIZE - 1) + "\n";
 
+    private static final boolean ASSERT;
+
+    static {
+        boolean a = false;
+        // Intentional side-effect
+        assert a = true;
+        ASSERT = a;
+    }
+
     /**
      * The file name.
      */
@@ -371,20 +380,20 @@ public class FileStore {
     public long length() {
         try {
             long len = fileLength;
-            if (SysProperties.CHECK2) {
+            if (ASSERT) {
                 len = file.size();
                 if (len != fileLength) {
                     DbException.throwInternalError(
                             "file " + name + " length " + len + " expected " + fileLength);
                 }
-            }
-            if (SysProperties.CHECK2 && len % Constants.FILE_BLOCK_SIZE != 0) {
-                long newLength = len + Constants.FILE_BLOCK_SIZE -
-                        (len % Constants.FILE_BLOCK_SIZE);
-                file.truncate(newLength);
-                fileLength = newLength;
-                DbException.throwInternalError(
-                        "unaligned file length " + name + " len " + len);
+                if (len % Constants.FILE_BLOCK_SIZE != 0) {
+                    long newLength = len + Constants.FILE_BLOCK_SIZE -
+                            (len % Constants.FILE_BLOCK_SIZE);
+                    file.truncate(newLength);
+                    fileLength = newLength;
+                    DbException.throwInternalError(
+                            "unaligned file length " + name + " len " + len);
+                }
             }
             return len;
         } catch (IOException e) {
@@ -398,7 +407,7 @@ public class FileStore {
      * @return the location
      */
     public long getFilePointer() {
-        if (SysProperties.CHECK2) {
+        if (ASSERT) {
             try {
                 if (file.position() != filePos) {
                     DbException.throwInternalError(file.position() + " " + filePos);

--- a/h2/src/main/org/h2/store/LobStorageBackend.java
+++ b/h2/src/main/org/h2/store/LobStorageBackend.java
@@ -249,11 +249,7 @@ public class LobStorageBackend implements LobStorageInterface {
      * @return the prepared statement
      */
     PreparedStatement prepare(String sql) throws SQLException {
-        if (SysProperties.CHECK2) {
-            if (!Thread.holdsLock(database)) {
-                throw DbException.throwInternalError();
-            }
-        }
+        assert Thread.holdsLock(database);
         PreparedStatement prep = prepared.remove(sql);
         if (prep == null) {
             prep = conn.prepareStatement(sql);
@@ -268,11 +264,7 @@ public class LobStorageBackend implements LobStorageInterface {
      * @param prep the prepared statement
      */
     void reuse(String sql, PreparedStatement prep) {
-        if (SysProperties.CHECK2) {
-            if (!Thread.holdsLock(database)) {
-                throw DbException.throwInternalError();
-            }
-        }
+        assert Thread.holdsLock(database);
         prepared.put(sql, prep);
     }
 

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -465,7 +465,6 @@ java org.h2.test.TestAll timer
 
         System.setProperty("h2.maxMemoryRows", "100");
 
-        System.setProperty("h2.check2", "true");
         System.setProperty("h2.delayWrongPasswordMin", "0");
         System.setProperty("h2.delayWrongPasswordMax", "0");
         System.setProperty("h2.useThreadContextClassLoader", "true");
@@ -513,7 +512,6 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
                 test.testAll();
             } else if ("reopen".equals(args[0])) {
                 System.setProperty("h2.delayWrongPasswordMin", "0");
-                System.setProperty("h2.check2", "false");
                 System.setProperty("h2.analyzeAuto", "100");
                 System.setProperty("h2.pageSize", "64");
                 System.setProperty("h2.reopenShift", "5");

--- a/h2/src/test/org/h2/test/todo/TestTempTableCrash.java
+++ b/h2/src/test/org/h2/test/todo/TestTempTableCrash.java
@@ -34,7 +34,6 @@ public class TestTempTableCrash {
         Statement stat;
 
         System.setProperty("h2.delayWrongPasswordMin", "0");
-        System.setProperty("h2.check2", "false");
         FilePathRec.register();
         System.setProperty("reopenShift", "4");
         TestReopen reopen = new TestReopen();

--- a/h2/src/test/org/h2/test/unit/TestPageStore.java
+++ b/h2/src/test/org/h2/test/unit/TestPageStore.java
@@ -45,7 +45,6 @@ public class TestPageStore extends TestBase {
      * @param a ignored
      */
     public static void main(String... a) throws Exception {
-        System.setProperty("h2.check2", "true");
         TestBase.createCaller().init().test();
     }
 


### PR DESCRIPTION
Issue #1148.

`SysProperties.CHECK2` and assignments of `h2.check2` are removed. Assertions are used instead. Few complex cases where simple `assert` is not enough are reimplemented with a well-known way using a side effect of `assert` operator. `Database.ASSERT` and `Control.ASSERT` are set conditionally. I decided to use own constants in these classes instead of a shared one so assertions can be enabled separately for them in expected way.

I also removed assignments of thread locals in `Database` if assertions are not enabled. The actual minor problem was in `Datatabase()` constructor that created a map for thread locals in the current thread, but I also removed initialization of `ThreadLocal` constants to detect such incorrect and unexpected assignments in the future.