### PR TITLE
Fix comparison in ARRAY_CONTAINS

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4155,7 +4155,7 @@ ISO_YEAR(CREATED)
 ARRAY_GET(arrayExpression, indexExpression)
 ","
 Returns one element of an array.
-This method returns a string.
+Returns NULL if there is no such element or array is NULL.
 ","
 CALL ARRAY_GET(('Hello', 'World'), 2)
 "
@@ -4164,6 +4164,7 @@ CALL ARRAY_GET(('Hello', 'World'), 2)
 ARRAY_LENGTH(arrayExpression)
 ","
 Returns the length of an array.
+Returns NULL if the specified array is NULL.
 ","
 CALL ARRAY_LENGTH(('Hello', 'World'))
 "
@@ -4171,7 +4172,8 @@ CALL ARRAY_LENGTH(('Hello', 'World'))
 "Functions (System)","ARRAY_CONTAINS","
 ARRAY_CONTAINS(arrayExpression, value)
 ","
-Returns a boolean true if the array contains the value.
+Returns a boolean TRUE if the array contains the value or FALSE if it does not contain it.
+Returns NULL if the specified array is NULL.
 ","
 CALL ARRAY_CONTAINS(('Hello', 'World'), 'Hello')
 "

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1054,7 +1054,7 @@ public class Function extends Expression implements FunctionCall {
                 Value v1 = getNullOrValue(session, args, values, 1);
                 Value[] list = ((ValueArray) v0).getList();
                 for (Value v : list) {
-                    if (v.equals(v1)) {
+                    if (database.areEqual(v, v1)) {
                         result = ValueBoolean.TRUE;
                         break;
                     }

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -414,7 +414,7 @@ public class Function extends Expression implements FunctionCall {
         addFunctionNotDeterministic("CURRVAL", CURRVAL,
                 VAR_ARGS, Value.LONG);
         addFunction("ARRAY_GET", ARRAY_GET,
-                2, Value.STRING);
+                2, Value.NULL);
         addFunction("ARRAY_CONTAINS", ARRAY_CONTAINS,
                 2, Value.BOOLEAN, false, true, true);
         addFunction("CSVREAD", CSVREAD,
@@ -1059,6 +1059,8 @@ public class Function extends Expression implements FunctionCall {
                         break;
                     }
                 }
+            } else {
+                result = ValueNull.INSTANCE;
             }
             break;
         }

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -180,10 +180,10 @@ public class TestMetaData extends TestBase {
         stat.execute("insert into a values((1, 2))");
         rs = stat.executeQuery("SELECT x[1] FROM a");
         ResultSetMetaData rsMeta = rs.getMetaData();
-        assertEquals(Types.VARCHAR, rsMeta.getColumnType(1));
+        assertEquals(Types.NULL, rsMeta.getColumnType(1));
         rs.next();
-        // assertEquals(String.class.getName(),
-        //         rs.getObject(1).getClass().getName());
+        assertEquals(Integer.class.getName(),
+                rs.getObject(1).getClass().getName());
         stat.execute("drop table a");
         conn.close();
     }

--- a/h2/src/test/org/h2/test/scripts/functions/system/array-contains.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/array-contains.sql
@@ -22,7 +22,7 @@ select array_contains((null, 'two'), null);
 >> TRUE
 
 select array_contains(null, 'one');
->> FALSE
+>> null
 
 select array_contains(((1, 2), (3, 4)), (1, 2));
 >> TRUE

--- a/h2/src/test/org/h2/test/scripts/functions/system/array-contains.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/array-contains.sql
@@ -29,3 +29,28 @@ select array_contains(((1, 2), (3, 4)), (1, 2));
 
 select array_contains(((1, 2), (3, 4)), (5, 6));
 >> FALSE
+
+CREATE TABLE TEST (ID INT PRIMARY KEY AUTO_INCREMENT, A ARRAY);
+> ok
+
+INSERT INTO TEST (A) VALUES ((1L, 2L)), ((3L, 4L));
+> update count: 2
+
+SELECT ID, ARRAY_CONTAINS(A, 1L), ARRAY_CONTAINS(A, 2L), ARRAY_CONTAINS(A, 3L), ARRAY_CONTAINS(A, 4L) FROM TEST;
+> ID ARRAY_CONTAINS(A, 1) ARRAY_CONTAINS(A, 2) ARRAY_CONTAINS(A, 3) ARRAY_CONTAINS(A, 4)
+> -- -------------------- -------------------- -------------------- --------------------
+> 1  TRUE                 TRUE                 FALSE                FALSE
+> 2  FALSE                FALSE                TRUE                 TRUE
+> rows: 2
+
+SELECT * FROM (
+    SELECT ID, ARRAY_CONTAINS(A, 1L), ARRAY_CONTAINS(A, 2L), ARRAY_CONTAINS(A, 3L), ARRAY_CONTAINS(A, 4L) FROM TEST
+);
+> ID ARRAY_CONTAINS(A, 1) ARRAY_CONTAINS(A, 2) ARRAY_CONTAINS(A, 3) ARRAY_CONTAINS(A, 4)
+> -- -------------------- -------------------- -------------------- --------------------
+> 1  TRUE                 TRUE                 FALSE                FALSE
+> 2  FALSE                FALSE                TRUE                 TRUE
+> rows: 2
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
This fixes issue #1168.

Inner query is rebuilded with `getSQL()` methods and `BIGINT` literals with `L` suffix may change their types to `INT`. Functions like `CASE` compare values without requiring that their data type should match exactly so there is no sense to require such match in `ARRAY_CONTAINS`.