### PR TITLE
Add support of CONTINUE | RESTART IDENTITY to TRUNCATE TABLE

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -974,7 +974,7 @@ DROP VIEW TEST_VIEW
 "
 
 "Commands (DDL)","TRUNCATE TABLE","
-TRUNCATE TABLE tableName
+TRUNCATE TABLE tableName [ [ CONTINUE | RESTART ] IDENTITY ]
 ","
 Removes all rows from a table.
 Unlike DELETE FROM without where clause, this command can not be rolled back.
@@ -982,6 +982,7 @@ This command is faster than DELETE without where clause.
 Only regular data tables without foreign key constraints can be truncated
 (except if referential integrity is disabled for this database or for this table).
 Linked tables can't be truncated.
+If RESTART IDENTITY is specified next values for auto-incremented columns are restarted.
 
 This command commits an open transaction in this connection.
 ","

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1578,8 +1578,19 @@ public class Parser {
     private Prepared parseTruncate() {
         read("TABLE");
         Table table = readTableOrView();
+        boolean restart;
+        if (readIf("CONTINUE")) {
+            read("IDENTITY");
+            restart = false;
+        } else if (readIf("RESTART")) {
+            read("IDENTITY");
+            restart = true;
+        } else {
+            restart = false;
+        }
         TruncateTable command = new TruncateTable(session);
         command.setTable(table);
+        command.setRestart(restart);
         return command;
     }
 

--- a/h2/src/main/org/h2/command/ddl/TruncateTable.java
+++ b/h2/src/main/org/h2/command/ddl/TruncateTable.java
@@ -10,6 +10,8 @@ import org.h2.command.CommandInterface;
 import org.h2.engine.Right;
 import org.h2.engine.Session;
 import org.h2.message.DbException;
+import org.h2.schema.Sequence;
+import org.h2.table.Column;
 import org.h2.table.Table;
 
 /**
@@ -20,12 +22,18 @@ public class TruncateTable extends DefineCommand {
 
     private Table table;
 
+    private boolean restart;
+
     public TruncateTable(Session session) {
         super(session);
     }
 
     public void setTable(Table table) {
         this.table = table;
+    }
+
+    public void setRestart(boolean restart) {
+        this.restart = restart;
     }
 
     @Override
@@ -37,6 +45,18 @@ public class TruncateTable extends DefineCommand {
         session.getUser().checkRight(table, Right.DELETE);
         table.lock(session, true, true);
         table.truncate(session);
+        if (restart) {
+            for (Column column : table.getColumns()) {
+                Sequence sequence = column.getSequence();
+                if (sequence != null) {
+                    long min = sequence.getMinValue();
+                    if (min != sequence.getCurrentValue()) {
+                        sequence.modify(min, null, null, null);
+                        session.getDatabase().updateMeta(session, sequence);
+                    }
+                }
+            }
+        }
         return 0;
     }
 

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -117,7 +117,7 @@ public class TestScript extends TestBase {
         }
         for (String s : new String[] { "alterTableAdd", "alterTableDropColumn",
                 "createAlias", "createSynonym", "createView", "createTable", "createTrigger",
-                "dropSchema" }) {
+                "dropSchema", "truncateTable" }) {
             testScript("ddl/" + s + ".sql");
         }
         for (String s : new String[] { "error_reporting", "insertIgnore",

--- a/h2/src/test/org/h2/test/scripts/ddl/truncateTable.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/truncateTable.sql
@@ -55,3 +55,71 @@ DROP TABLE CHILD;
 
 DROP TABLE PARENT;
 > ok
+
+CREATE SEQUENCE SEQ2;
+> ok
+
+CREATE SEQUENCE SEQ3;
+> ok
+
+CREATE TABLE TEST(
+    ID1 BIGINT AUTO_INCREMENT NOT NULL,
+    ID2 BIGINT NOT NULL DEFAULT NEXT VALUE FOR SEQ2 NULL_TO_DEFAULT SEQUENCE SEQ2,
+    ID3 BIGINT NOT NULL DEFAULT NEXT VALUE FOR SEQ3 NULL_TO_DEFAULT,
+    VALUE INT NOT NULL);
+> ok
+
+INSERT INTO TEST(VALUE) VALUES (1), (2);
+> update count: 2
+
+SELECT * FROM TEST ORDER BY VALUE;
+> ID1 ID2 ID3 VALUE
+> --- --- --- -----
+> 1   1   1   1
+> 2   2   2   2
+> rows (ordered): 2
+
+TRUNCATE TABLE TEST;
+> ok
+
+INSERT INTO TEST(VALUE) VALUES (1), (2);
+> update count: 2
+
+SELECT * FROM TEST ORDER BY VALUE;
+> ID1 ID2 ID3 VALUE
+> --- --- --- -----
+> 3   3   3   1
+> 4   4   4   2
+> rows (ordered): 2
+
+TRUNCATE TABLE TEST CONTINUE IDENTITY;
+> ok
+
+INSERT INTO TEST(VALUE) VALUES (1), (2);
+> update count: 2
+
+SELECT * FROM TEST ORDER BY VALUE;
+> ID1 ID2 ID3 VALUE
+> --- --- --- -----
+> 5   5   5   1
+> 6   6   6   2
+> rows (ordered): 2
+
+TRUNCATE TABLE TEST RESTART IDENTITY;
+> ok
+
+INSERT INTO TEST(VALUE) VALUES (1), (2);
+> update count: 2
+
+SELECT * FROM TEST ORDER BY VALUE;
+> ID1 ID2 ID3 VALUE
+> --- --- --- -----
+> 1   1   7   1
+> 2   2   8   2
+> rows (ordered): 2
+
+DROP TABLE TEST;
+> ok
+
+DROP SEQUENCE SEQ3;
+> ok

--- a/h2/src/test/org/h2/test/scripts/ddl/truncateTable.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/truncateTable.sql
@@ -1,0 +1,57 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+create table FOO(id integer primary key);
+> ok
+
+create table BAR(fooId integer);
+> ok
+
+alter table bar add foreign key (fooId) references foo (id);
+> ok
+
+truncate table bar;
+> ok
+
+truncate table foo;
+> exception CANNOT_TRUNCATE_1
+
+drop table bar, foo;
+> ok
+
+CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR);
+> ok
+
+INSERT INTO TEST VALUES(1, 'Hello'), (2, 'World');
+> update count: 2
+
+TRUNCATE TABLE TEST;
+> ok
+
+SELECT * FROM TEST;
+> ID NAME
+> -- ----
+> rows: 0
+
+DROP TABLE TEST;
+> ok
+
+CREATE TABLE PARENT(ID INT PRIMARY KEY, NAME VARCHAR);
+> ok
+
+CREATE TABLE CHILD(PARENTID INT, FOREIGN KEY(PARENTID) REFERENCES PARENT(ID), NAME VARCHAR);
+> ok
+
+TRUNCATE TABLE CHILD;
+> ok
+
+TRUNCATE TABLE PARENT;
+> exception CANNOT_TRUNCATE_1
+
+DROP TABLE CHILD;
+> ok
+
+DROP TABLE PARENT;
+> ok

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -2161,24 +2161,6 @@ drop all objects;
 call abc;
 > exception COLUMN_NOT_FOUND_1
 
-create table FOO(id integer primary key);
-> ok
-
-create table BAR(fooId integer);
-> ok
-
-alter table bar add foreign key (fooId) references foo (id);
-> ok
-
-truncate table bar;
-> ok
-
-truncate table foo;
-> exception CANNOT_TRUNCATE_1
-
-drop table bar, foo;
-> ok
-
 CREATE TABLE test (family_name VARCHAR_IGNORECASE(63) NOT NULL);
 > ok
 
@@ -4263,42 +4245,6 @@ SELECT "ROWNUM", ROWNUM, "SELECT" "AS", "PRIMARY" AS "X", "KEY", "NEXTVAL", "IND
 > rows: 2
 
 DROP TABLE "CREATE";
-> ok
-
---- truncate table ---------------------------------------------------------------------------------------------
-CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR);
-> ok
-
-INSERT INTO TEST VALUES(1, 'Hello'), (2, 'World');
-> update count: 2
-
-TRUNCATE TABLE TEST;
-> ok
-
-SELECT * FROM TEST;
-> ID NAME
-> -- ----
-> rows: 0
-
-DROP TABLE TEST;
-> ok
-
-CREATE TABLE PARENT(ID INT PRIMARY KEY, NAME VARCHAR);
-> ok
-
-CREATE TABLE CHILD(PARENTID INT, FOREIGN KEY(PARENTID) REFERENCES PARENT(ID), NAME VARCHAR);
-> ok
-
-TRUNCATE TABLE CHILD;
-> ok
-
-TRUNCATE TABLE PARENT;
-> exception CANNOT_TRUNCATE_1
-
-DROP TABLE CHILD;
-> ok
-
-DROP TABLE PARENT;
 > ok
 
 --- test case for number like string ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Optional `CONTINUE IDENTITY` and `RESTART IDENTITY` are specified in the SQL standard and are supported by some databases, for example, by PostgreSQL.

It's possible to declare a sequence without `BELONGS_TO_TABLE` but linked with column by `SEQUENCE` parameter. I decided to reset such sequences too, because `DROP TABLE` drops also such sequences for some reason.

Sequences that are not linked with columns, but specified in `DEFAULT` value are not changed, it's not reasonable to treat such columns as normal identity columns and such sequence can be used by different tables, their restart can cause unexpected problems.

Normal identity columns and these specific cases are covered by tests. Old tests for `TRUNCATE TABLE` are extracted from `testScript.sql` into the same new file too.