### PR TITLE
Yet another attempt to tighten that testing loop

### DIFF
--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -402,7 +402,7 @@ java org.h2.test.TestAll timer
     /**
      * The THROTTLE value to use.
      */
-    int throttle;
+    public int throttle;
 
     /**
      * The THROTTLE value to use by default.

--- a/h2/src/test/org/h2/test/db/TestTempTables.java
+++ b/h2/src/test/org/h2/test/db/TestTempTables.java
@@ -327,6 +327,9 @@ public class TestTempTables extends TestBase {
      * transaction table in the MVStore
      */
     private void testLotsOfTables() throws SQLException {
+        if (config.networked || config.throttle > 0) {
+            return; // just to save some testing time
+        }
         deleteDb("tempTables");
         Connection conn = getConnection("tempTables");
         Statement stat = conn.createStatement();


### PR DESCRIPTION
Just reduce time for a couple of longer looping tests. In my experience TestMvccMultiThread2 either blows up on a first second or heats up my CPU for a whole minute to no avail. 
TestTempTables should behave "identically" regardless of connection type, so why bother in slow net mode?