### PR TITLE
Do not change ID of existing constraints in AlterTableAddConstraint

### DIFF
--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -137,25 +137,24 @@ public class AlterTableAddConstraint extends SchemaCommand {
                         throw DbException.get(ErrorCode.SECOND_PRIMARY_KEY);
                     }
                 }
-            }
-            if (index == null) {
+            } else {
                 IndexType indexType = IndexType.createPrimaryKey(
                         table.isPersistIndexes(), primaryKeyHash);
                 String indexName = table.getSchema().getUniqueIndexName(
                         session, table, Constants.PREFIX_PRIMARY_KEY);
-                int id = getObjectId();
+                int indexId = session.getDatabase().allocateObjectId();
                 try {
-                    index = table.addIndex(session, indexName, id,
+                    index = table.addIndex(session, indexName, indexId,
                             indexColumns, indexType, true, null);
                 } finally {
                     getSchema().freeUniqueName(indexName);
                 }
             }
             index.getIndexType().setBelongsToConstraint(true);
-            int constraintId = getObjectId();
+            int id = getObjectId();
             String name = generateConstraintName(table);
             ConstraintUnique pk = new ConstraintUnique(getSchema(),
-                    constraintId, name, table, true);
+                    id, name, table, true);
             pk.setColumns(indexColumns);
             pk.setIndex(index, true);
             constraint = pk;
@@ -277,7 +276,7 @@ public class AlterTableAddConstraint extends SchemaCommand {
     }
 
     private Index createIndex(Table t, IndexColumn[] cols, boolean unique) {
-        int indexId = getObjectId();
+        int indexId = session.getDatabase().allocateObjectId();
         IndexType indexType;
         if (unique) {
             // for unique constraints

--- a/h2/src/main/org/h2/command/ddl/CommandWithColumns.java
+++ b/h2/src/main/org/h2/command/ddl/CommandWithColumns.java
@@ -103,7 +103,7 @@ public abstract class CommandWithColumns extends SchemaCommand {
         if (columns != null) {
             for (Column c : columns) {
                 if (c.isAutoIncrement()) {
-                    int objId = getObjectId();
+                    int objId = session.getDatabase().allocateObjectId();
                     c.convertAutoIncrementToSequence(session, getSchema(), objId, temporary);
                     if (!Constants.CLUSTERING_DISABLED.equals(session.getDatabase().getCluster())) {
                         throw DbException.getUnsupportedException("CLUSTERING && auto-increment columns");


### PR DESCRIPTION
This fixes issue #1073.

See explanation in comment https://github.com/h2database/h2database/issues/1073#issuecomment-395008814.

I don't know how to add a normal test case for this issue, it requires either a database from the old version or some unsafe checks of internal states of metadata.

@grandinj, could you review it?