### PR TITLE
TestKillRestartMulti: A map named undoLog-1 already exists

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -511,16 +511,18 @@ public class MVStore {
             M map = (M) getMap(id);
             if (map == null) {
                 String configAsString = meta.get(MVMap.getMapKey(id));
-                if(configAsString != null) {
-                    HashMap<String, Object> config =
-                            new HashMap<String, Object>(DataUtils.parseMap(configAsString));
-                    config.put("id", id);
-                    map = builder.create(this, config);
-                    map.init();
-                    long root = getRootPos(meta, id);
-                    map.setRootPos(root, lastStoredVersion);
-                    maps.put(id, map);
+                HashMap<String, Object> config;
+                if (configAsString != null) {
+                    config = new HashMap<String, Object>(DataUtils.parseMap(configAsString));
+                } else {
+                    config = new HashMap<>();
                 }
+                config.put("id", id);
+                map = builder.create(this, config);
+                map.init();
+                long root = getRootPos(meta, id);
+                map.setRootPos(root, lastStoredVersion);
+                maps.put(id, map);
             }
             return map;
         } finally {

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -247,21 +247,6 @@ public class MVTableEngine implements TableEngine {
         }
 
         /**
-         * Commit all transactions that are in the committing state, and
-         * rollback all open transactions.
-         */
-        public void initTransactions() {
-            List<Transaction> list = transactionStore.getOpenTransactions();
-            for (Transaction t : list) {
-                if (t.getStatus() == Transaction.STATUS_COMMITTED) {
-                    t.commit();
-                } else if (t.getStatus() != Transaction.STATUS_PREPARED) {
-                    t.rollback();
-                }
-            }
-        }
-
-        /**
          * Remove all temporary maps.
          *
          * @param objectIds the ids of the objects to keep

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -436,7 +436,7 @@ public class Transaction {
         return store.getChanges(this, getLogId(), savepointId);
     }
 
-    long getLogId() {
+    private long getLogId() {
         return getLogId(statusAndLogId.get());
     }
 
@@ -454,7 +454,7 @@ public class Transaction {
     /**
      * Check whether this transaction is open or prepared.
      */
-    void checkNotClosed() {
+    private void checkNotClosed() {
         if (getStatus() == STATUS_CLOSED) {
             throw DataUtils.newIllegalStateException(
                     DataUtils.ERROR_CLOSED, "Transaction {0} is closed", transactionId);

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -89,11 +89,6 @@ public class TransactionStore {
     private final AtomicReferenceArray<Transaction> transactions =
                                                         new AtomicReferenceArray<>(MAX_OPEN_TRANSACTIONS + 1);
 
-    /**
-     * The next id of a temporary map.
-     */
-    private int nextTempMapId;
-
     private static final String UNDO_LOG_NAME_PEFIX = "undoLog";
     private static final char UNDO_LOG_COMMITTED = '-'; // must come before open in lexicographical order
     private static final char UNDO_LOG_OPEN = '.';
@@ -515,29 +510,6 @@ public class TransactionStore {
             map = store.openMap(mapName, mapBuilder);
         }
         return map;
-    }
-
-    /**
-     * Create a temporary map. Such maps are removed when opening the store.
-     *
-     * @return the map
-     */
-    synchronized MVMap<Object, Integer> createTempMap() {
-        String mapName = "temp." + nextTempMapId++;
-        return openTempMap(mapName);
-    }
-
-    /**
-     * Open a temporary map.
-     *
-     * @param mapName the map name
-     * @return the map
-     */
-    private MVMap<Object, Integer> openTempMap(String mapName) {
-        MVMap.Builder<Object, Integer> mapBuilder =
-                new MVMap.Builder<Object, Integer>().
-                keyType(dataType);
-        return store.openMap(mapName, mapBuilder);
     }
 
     /**


### PR DESCRIPTION
Hopefully this will eliminate random failures like this:
```
14:39:37 00:02.378 org.h2.test.synth.TestKillRestartMulti FAIL org.h2.jdbc.JdbcSQLException: General error: "java.lang.IllegalArgumentException: A map named undoLog-1 already exists [1.4.197/0]" [50000-197]
```
Also some exception handling improvements
Moved and better named method dealing with leftover transactions
Execute Database.removeOrphanedLobs() under Database lock, because removeOrphanedLobs() ->  LobStorageBackend.removeAllForTable() -> LobStorageBackend.prepare() makes that assumption
