### PR TITLE
Enable MULTI_THREADED by default for MVStore mode

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -1583,9 +1583,9 @@ SET MODE HSQLDB
 "Commands (Other)","SET MULTI_THREADED","
 SET MULTI_THREADED { 0 | 1 }
 ","
-Enabled (1) or disabled (0) multi-threading inside the database engine. By
-default, this setting is disabled. Currently, enabling this is experimental
-only.
+Enabled (1) or disabled (0) multi-threading inside the database engine.
+MULTI_THREADED is enabled by default with default MVStore storage engine.
+MULTI_THREADED is disabled by default when using PageStore storage engine, enabling this with PageStore is experimental only.
 
 This is a global setting, which means it is not possible to open multiple databases with different modes at the same time in the same virtual machine.
 This setting is not persistent, however the value is kept until the virtual machine exits or it is changed.

--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -347,8 +347,11 @@ public class Set extends Prepared {
             }
             break;
         case SetTypes.MULTI_THREADED: {
-            session.getUser().checkAdmin();
-            database.setMultiThreaded(getIntValue() == 1);
+            boolean v = getIntValue() == 1;
+            if (database.isMultiThreaded() != v) {
+                session.getUser().checkAdmin();
+                database.setMultiThreaded(v);
+            }
             break;
         }
         case SetTypes.MVCC: {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -188,6 +188,7 @@ public class Database implements DataHandler {
     /** ie. the MVCC setting */
     private boolean multiVersion;
     private Mode mode = Mode.getRegular();
+    /** ie. the MULTI_THREADED setting */
     private boolean multiThreaded;
     private int maxOperationMemory =
             Constants.DEFAULT_MAX_OPERATION_MEMORY;
@@ -290,7 +291,7 @@ public class Database implements DataHandler {
         this.javaObjectSerializerName =
                 ci.getProperty("JAVA_OBJECT_SERIALIZER", null);
         this.multiThreaded =
-                ci.getProperty("MULTI_THREADED", false);
+                ci.getProperty("MULTI_THREADED", dbSettings.mvStore);
         this.allowBuiltinAliasOverride =
                 ci.getProperty("BUILTIN_ALIAS_OVERRIDE", false);
         boolean closeAtVmShutdown =
@@ -657,6 +658,7 @@ public class Database implements DataHandler {
                 // Need to re-init this because the first time we do it we don't
                 // know if we have an mvstore or a pagestore.
                 multiVersion = ci.getProperty("MVCC", false);
+                multiThreaded = ci.getProperty("MULTI_THREADED", false);
             }
             if (readOnly) {
                 if (traceLevelFile >= TraceSystem.DEBUG) {
@@ -2461,7 +2463,7 @@ public class Database implements DataHandler {
                 // supported
                 throw DbException.get(
                         ErrorCode.UNSUPPORTED_SETTING_COMBINATION,
-                        "MVCC & MULTI_THREADED");
+                        "MVCC & MULTI_THREADED & !MV_STORE");
             }
             if (lockMode == 0) {
                 // currently the combination of LOCK_MODE=0 and MULTI_THREADED

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -342,12 +342,6 @@ public class DbSettings extends SettingsBase {
     public final boolean compressData = get("COMPRESS", false);
 
     /**
-     * Database setting <code>MULTI_THREADED</code>
-     * (default: false).<br />
-     */
-    public final boolean multiThreaded = get("MULTI_THREADED", false);
-
-    /**
      * Database setting <code>STANDARD_DROP_TABLE_RESTRICT</code> (default:
      * false).<br />
      * <code>true</code> if DROP TABLE RESTRICT should fail if there's any

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -317,9 +317,7 @@ public abstract class TestBase {
         if (config.mvcc) {
             url = addOption(url, "MVCC", "TRUE");
         }
-        if (config.multiThreaded) {
-            url = addOption(url, "MULTI_THREADED", "TRUE");
-        }
+        url = addOption(url, "MULTI_THREADED", config.multiThreaded ? "TRUE" : "FALSE");
         if (config.lazy) {
             url = addOption(url, "LAZY_QUERY_EXECUTION", "1");
         }

--- a/h2/src/test/org/h2/test/db/TestMultiThread.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThread.java
@@ -74,6 +74,7 @@ public class TestMultiThread extends TestBase implements Runnable {
         testViews();
         testConcurrentInsert();
         testConcurrentUpdate();
+        testConcurrentUpdate2();
     }
 
     private void testConcurrentSchemaChange() throws Exception {
@@ -489,5 +490,65 @@ public class TestMultiThread extends TestBase implements Runnable {
         }
 
         deleteDb("lockMode");
+    }
+
+    private final class ConcurrentUpdate2 extends Thread {
+        private final String column;
+
+        Throwable exception;
+
+        ConcurrentUpdate2(String column) {
+            this.column = column;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Connection c = getConnection("concurrentUpdate2");
+                PreparedStatement ps = c.prepareStatement("UPDATE TEST SET V = ? WHERE " + column + " = ?");
+                for (int test = 0; test < 1000; test++) {
+                    for (int i = 0; i < 16; i++) {
+                        ps.setInt(1, test);
+                        ps.setInt(2, i);
+                        assertEquals(16, ps.executeUpdate());
+                    }
+                }
+            } catch (Throwable e) {
+                exception = e;
+            }
+        }
+    }
+
+    private void testConcurrentUpdate2() throws Exception {
+        deleteDb("concurrentUpdate2");
+        Connection c = getConnection("concurrentUpdate2");
+        Statement s = c.createStatement();
+        s.execute("CREATE TABLE TEST(A INT, B INT, V INT, PRIMARY KEY(A, B))");
+        PreparedStatement ps = c.prepareStatement("INSERT INTO TEST VALUES (?, ?, ?)");
+        for (int i = 0; i < 16; i++) {
+            for (int j = 0; j < 16; j++) {
+                ps.setInt(1, i);
+                ps.setInt(2, j);
+                ps.setInt(3, 0);
+                ps.executeUpdate();
+            }
+        }
+        ConcurrentUpdate2 a = new ConcurrentUpdate2("A");
+        ConcurrentUpdate2 b = new ConcurrentUpdate2("B");
+        a.start();
+        b.start();
+        a.join();
+        b.join();
+        deleteDb("concurrentUpdate2");
+        Throwable e = a.exception;
+        if (e == null) {
+            e = b.exception;
+        }
+        if (e != null) {
+            if (e instanceof Exception) {
+                throw (Exception) e;
+            }
+            throw (Error) e;
+        }
     }
 }

--- a/h2/src/test/org/h2/test/db/TestSessionsLocks.java
+++ b/h2/src/test/org/h2/test/db/TestSessionsLocks.java
@@ -27,6 +27,9 @@ public class TestSessionsLocks extends TestBase {
 
     @Override
     public void test() throws Exception {
+        if (!config.multiThreaded) {
+            return;
+        }
         testCancelStatement();
         if (!config.mvcc) {
             testLocks();
@@ -36,7 +39,7 @@ public class TestSessionsLocks extends TestBase {
 
     private void testLocks() throws SQLException {
         deleteDb("sessionsLocks");
-        Connection conn = getConnection("sessionsLocks;MULTI_THREADED=1");
+        Connection conn = getConnection("sessionsLocks");
         Statement stat = conn.createStatement();
         ResultSet rs;
         rs = stat.executeQuery("select * from information_schema.locks " +
@@ -82,7 +85,7 @@ public class TestSessionsLocks extends TestBase {
 
     private void testCancelStatement() throws Exception {
         deleteDb("sessionsLocks");
-        Connection conn = getConnection("sessionsLocks;MULTI_THREADED=1");
+        Connection conn = getConnection("sessionsLocks");
         Statement stat = conn.createStatement();
         ResultSet rs;
         rs = stat.executeQuery("select * from information_schema.sessions " +


### PR DESCRIPTION
Issue #1198.

I removed `DbSettings.multiThreaded` because this field was not used anywhere and MVCC also does not have such field there.

Documentation is updated.