### PR TITLE
Remove TestAll.mvcc

### DIFF
--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -309,11 +309,6 @@ java org.h2.test.TestAll timer
     public boolean codeCoverage;
 
     /**
-     * If the multi version concurrency control mode should be used.
-     */
-    public boolean mvcc = mvStore;
-
-    /**
      * If the multi-threaded mode should be used.
      */
     public boolean multiThreaded;
@@ -644,12 +639,10 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         memory = false;
         multiThreaded = false;
         mvStore = false;
-        mvcc = false;
         test();
         testUnit();
 
         mvStore = true;
-        mvcc = true;
         memory = true;
         multiThreaded = false;
         networked = true;
@@ -713,7 +706,6 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
 
         multiThreaded = false;
         mvStore = false;
-        mvcc = false;
         test();
         // testUnit();
     }
@@ -1130,7 +1122,6 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         appendIf(buff, networked, "net");
         appendIf(buff, memory, "memory");
         appendIf(buff, codeCoverage, "codeCoverage");
-        appendIf(buff, mvcc, "mvcc");
         appendIf(buff, multiThreaded, "multiThreaded");
         appendIf(buff, cipher != null, cipher);
         appendIf(buff, cacheType != null, cacheType);

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -314,9 +314,6 @@ public abstract class TestBase {
             // force operations to disk
             url = addOption(url, "MAX_OPERATION_MEMORY", "1");
         }
-        if (config.mvcc) {
-            url = addOption(url, "MVCC", "TRUE");
-        }
         url = addOption(url, "MULTI_THREADED", config.multiThreaded ? "TRUE" : "FALSE");
         if (config.lazy) {
             url = addOption(url, "LAZY_QUERY_EXECUTION", "1");

--- a/h2/src/test/org/h2/test/db/TestDeadlock.java
+++ b/h2/src/test/org/h2/test/db/TestDeadlock.java
@@ -235,7 +235,7 @@ public class TestDeadlock extends TestBase {
     }
 
     private void testThreePhilosophers() throws Exception {
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             return;
         }
         initTest();
@@ -281,7 +281,7 @@ public class TestDeadlock extends TestBase {
     // test case for issue # 61
     // http://code.google.com/p/h2database/issues/detail?id=61)
     private void testThreeSome() throws Exception {
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             return;
         }
         initTest();
@@ -326,7 +326,7 @@ public class TestDeadlock extends TestBase {
     }
 
     private void testLockUpgrade() throws Exception {
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             return;
         }
         initTest();
@@ -360,7 +360,7 @@ public class TestDeadlock extends TestBase {
     }
 
     private void testDiningPhilosophers() throws Exception {
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             return;
         }
         initTest();

--- a/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
+++ b/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
@@ -529,7 +529,7 @@ public class TestGeneralCommonTableQueries extends AbstractBaseForCommonTableExp
         try {
             // Test with settings: lazy mvStore memory mvcc multiThreaded
             // connection url is
-            // mem:script;MV_STORE=true;LOG=1;LOCK_TIMEOUT=50;MVCC=TRUE;
+            // mem:script;MV_STORE=true;LOG=1;LOCK_TIMEOUT=50;
             // MULTI_THREADED=TRUE;LAZY_QUERY_EXECUTION=1
             config.lazy = true;
             config.mvStore = true;

--- a/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
+++ b/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
@@ -534,7 +534,6 @@ public class TestGeneralCommonTableQueries extends AbstractBaseForCommonTableExp
             config.lazy = true;
             config.mvStore = true;
             config.memory = true;
-            config.mvcc = true;
             config.multiThreaded = true;
 
             String setupSQL = "--no config set";

--- a/h2/src/test/org/h2/test/db/TestLargeBlob.java
+++ b/h2/src/test/org/h2/test/db/TestLargeBlob.java
@@ -28,7 +28,7 @@ public class TestLargeBlob extends TestBase {
 
     @Override
     public void test() throws Exception {
-        if (!config.big || config.memory || config.mvcc || config.networked) {
+        if (!config.big || config.memory || config.mvStore || config.networked) {
             return;
         }
 

--- a/h2/src/test/org/h2/test/db/TestLinkedTable.java
+++ b/h2/src/test/org/h2/test/db/TestLinkedTable.java
@@ -693,10 +693,7 @@ public class TestLinkedTable extends TestBase {
     }
 
     private void testGeometry() throws SQLException {
-        if (!config.mvStore && config.mvcc) {
-            return;
-        }
-        if (config.memory && config.mvcc) {
+        if (config.memory && config.mvStore) {
             return;
         }
         if (DataType.GEOMETRY_CLASS == null) {

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -510,7 +510,7 @@ public class TestLob extends TestBase {
     }
 
     private void testDeadlock2() throws Exception {
-        if (config.mvcc || config.memory) {
+        if (config.mvStore || config.memory) {
             return;
         }
         deleteDb("lob");

--- a/h2/src/test/org/h2/test/db/TestMultiThread.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThread.java
@@ -142,7 +142,7 @@ public class TestMultiThread extends TestBase implements Runnable {
     }
 
     private void testConcurrentView() throws Exception {
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             return;
         }
         String db = getTestName();
@@ -206,7 +206,7 @@ public class TestMultiThread extends TestBase implements Runnable {
     }
 
     private void testConcurrentAnalyze() throws Exception {
-        if (config.mvcc) {
+        if (config.mvStore) {
             return;
         }
         deleteDb(getTestName());

--- a/h2/src/test/org/h2/test/db/TestMultiThreadedKernel.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThreadedKernel.java
@@ -43,9 +43,6 @@ public class TestMultiThreadedKernel extends TestBase {
 
     @Override
     public void test() throws Exception {
-        if (config.mvcc) {
-            return;
-        }
         if (config.mvStore) { // FIXME can't see why test should not work in MVStore mode
             return;
         }

--- a/h2/src/test/org/h2/test/db/TestOptimizations.java
+++ b/h2/src/test/org/h2/test/db/TestOptimizations.java
@@ -659,7 +659,7 @@ public class TestOptimizations extends TestBase {
             ResultSet rs = stat.executeQuery(
                     "explain select min(x), max(x) from test");
             rs.next();
-            if (!config.mvcc) {
+            if (!config.mvStore) {
                 String plan = rs.getString(1);
                 assertContains(plan, "direct");
             }

--- a/h2/src/test/org/h2/test/db/TestSessionsLocks.java
+++ b/h2/src/test/org/h2/test/db/TestSessionsLocks.java
@@ -31,7 +31,7 @@ public class TestSessionsLocks extends TestBase {
             return;
         }
         testCancelStatement();
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             testLocks();
         }
         deleteDb("sessionsLocks");
@@ -56,7 +56,7 @@ public class TestSessionsLocks extends TestBase {
         assertEquals("PUBLIC", rs.getString("TABLE_SCHEMA"));
         assertEquals("TEST", rs.getString("TABLE_NAME"));
         rs.getString("SESSION_ID");
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             assertEquals("READ", rs.getString("LOCK_TYPE"));
         } else {
             assertEquals("WRITE", rs.getString("LOCK_TYPE"));
@@ -67,7 +67,7 @@ public class TestSessionsLocks extends TestBase {
         stat2.execute("SELECT * FROM TEST");
         rs = stat.executeQuery("select * from information_schema.locks " +
                 "order by session_id");
-        if (!config.mvcc && !config.mvStore) {
+        if (!config.mvStore) {
             rs.next();
             assertEquals("PUBLIC", rs.getString("TABLE_SCHEMA"));
             assertEquals("TEST", rs.getString("TABLE_NAME"));

--- a/h2/src/test/org/h2/test/db/TestSpatial.java
+++ b/h2/src/test/org/h2/test/db/TestSpatial.java
@@ -53,10 +53,7 @@ public class TestSpatial extends TestBase {
 
     @Override
     public void test() throws SQLException {
-        if (!config.mvStore && config.mvcc) {
-            return;
-        }
-        if (config.memory && config.mvcc) {
+        if (config.memory && config.mvStore) {
             return;
         }
         if (DataType.GEOMETRY_CLASS != null) {

--- a/h2/src/test/org/h2/test/db/TestTransaction.java
+++ b/h2/src/test/org/h2/test/db/TestTransaction.java
@@ -85,7 +85,7 @@ public class TestTransaction extends TestBase {
         conn.setAutoCommit(false);
 
         ResultSet rs;
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             rs = stat2.executeQuery("select count(*) from test");
             rs.next();
             assertEquals(0, rs.getInt(1));
@@ -187,7 +187,7 @@ public class TestTransaction extends TestBase {
         Connection conn2 = getConnection("transaction");
         conn2.setAutoCommit(false);
         Statement stat2 = conn2.createStatement();
-        if (config.mvcc) {
+        if (config.mvStore) {
             stat2.execute("update test set name = 'Welt' where id = 2");
         }
         assertThrows(ErrorCode.LOCK_TIMEOUT_1, stat2).
@@ -321,7 +321,7 @@ public class TestTransaction extends TestBase {
         c2.setAutoCommit(false);
         s1.executeUpdate("insert into A(code) values('one')");
         Statement s2 = c2.createStatement();
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             assertThrows(
                     ErrorCode.REFERENTIAL_INTEGRITY_VIOLATED_PARENT_MISSING_1, s2).
                     executeUpdate("insert into B values('two', 1)");

--- a/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
+++ b/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
@@ -111,7 +111,7 @@ public class TestTriggersConstraints extends TestBase implements Trigger {
     }
 
     private void testDeleteInTrigger() throws SQLException {
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             return;
         }
         Connection conn;

--- a/h2/src/test/org/h2/test/db/TestUpgrade.java
+++ b/h2/src/test/org/h2/test/db/TestUpgrade.java
@@ -29,7 +29,6 @@ public class TestUpgrade extends TestBase {
      */
     public static void main(String... a) throws Exception {
         TestBase base = TestBase.createCaller().init();
-        base.config.mvcc = false;
         base.config.mvStore = false;
         base.test();
     }

--- a/h2/src/test/org/h2/test/db/TestUsingIndex.java
+++ b/h2/src/test/org/h2/test/db/TestUsingIndex.java
@@ -111,10 +111,7 @@ public class TestUsingIndex extends TestBase {
     }
 
     private void testSpatialIndex() throws SQLException {
-        if (!config.mvStore && config.mvcc) {
-            return;
-        }
-        if (config.memory && config.mvcc) {
+        if (config.memory && config.mvStore) {
             return;
         }
         if (DataType.GEOMETRY_CLASS == null) {
@@ -147,10 +144,7 @@ public class TestUsingIndex extends TestBase {
     }
 
     private void testBadSpatialSyntax() throws SQLException {
-        if (!config.mvStore && config.mvcc) {
-            return;
-        }
-        if (config.memory && config.mvcc) {
+        if (config.memory && config.mvStore) {
             return;
         }
         if (DataType.GEOMETRY_CLASS == null) {

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1271,7 +1271,7 @@ public class TestMetaData extends TestBase {
     }
 
     private void testSessionsUncommitted() throws SQLException {
-        if (config.mvcc || config.memory) {
+        if (config.mvStore || config.memory) {
             return;
         }
         Connection conn = getConnection("metaData");

--- a/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
+++ b/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
@@ -28,7 +28,7 @@ public class TestTransactionIsolation extends TestBase {
 
     @Override
     public void test() throws SQLException {
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             // no tests yet
         } else {
             testTableLevelLocking();

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
@@ -30,7 +30,6 @@ public class TestMvcc1 extends TestBase {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-        test.config.mvcc = true;
         test.test();
     }
 
@@ -59,7 +58,7 @@ public class TestMvcc1 extends TestBase {
     }
 
     private void testCases() throws SQLException {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
         ResultSet rs;

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
@@ -76,9 +76,9 @@ public class TestMvcc1 extends TestBase {
         //     selects new data (select * from test where id > ?) and deletes
 
         deleteDb("mvcc1");
-        c1 = getConnection("mvcc1;MVCC=TRUE;LOCK_TIMEOUT=10");
+        c1 = getConnection("mvcc1;LOCK_TIMEOUT=10");
         s1 = c1.createStatement();
-        c2 = getConnection("mvcc1;MVCC=TRUE;LOCK_TIMEOUT=10");
+        c2 = getConnection("mvcc1;LOCK_TIMEOUT=10");
         s2 = c2.createStatement();
         c1.setAutoCommit(false);
         c2.setAutoCommit(false);

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc2.java
@@ -34,13 +34,12 @@ public class TestMvcc2 extends TestBase {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-        test.config.mvcc = true;
         test.test();
     }
 
     @Override
     public void test() throws Exception {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
         deleteDb("mvcc2");

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc3.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc3.java
@@ -26,7 +26,6 @@ public class TestMvcc3 extends TestBase {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-        test.config.mvcc = true;
         test.test();
     }
 
@@ -63,7 +62,7 @@ public class TestMvcc3 extends TestBase {
     }
 
     private void testConcurrentUpdate() throws SQLException {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
         deleteDb("mvcc3");
@@ -102,7 +101,7 @@ public class TestMvcc3 extends TestBase {
     }
 
     private void testInsertUpdateRollback() throws SQLException {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
 
@@ -147,7 +146,7 @@ public class TestMvcc3 extends TestBase {
     }
 
     private void testCreateTableAsSelect() throws SQLException {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
         deleteDb("mvcc3");
@@ -165,7 +164,7 @@ public class TestMvcc3 extends TestBase {
     }
 
     private void testRollback() throws SQLException {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
 
@@ -218,7 +217,7 @@ public class TestMvcc3 extends TestBase {
     }
 
     private void testDisableAutoCommit() throws SQLException {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
         deleteDb("mvcc3");

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc4.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc4.java
@@ -26,7 +26,6 @@ public class TestMvcc4 extends TestBase {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-        test.config.mvcc = true;
         test.config.lockTimeout = 20000;
         test.config.memory = true;
         test.test();
@@ -34,7 +33,7 @@ public class TestMvcc4 extends TestBase {
 
     @Override
     public void test() throws SQLException {
-        if (config.networked || !config.mvcc) {
+        if (config.networked || !config.mvStore) {
             return;
         }
         testSelectForUpdateAndUpdateConcurrency();

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded.java
@@ -30,7 +30,7 @@ public class TestMvccMultiThreaded extends TestBase {
 
     @Override
     public void test() throws Exception {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
         testConcurrentSelectForUpdate();

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded.java
@@ -92,7 +92,7 @@ public class TestMvccMultiThreaded extends TestBase {
         final Connection[] connList = new Connection[len];
         for (int i = 0; i < len; i++) {
             Connection conn = getConnection(
-                    getTestName() + ";MVCC=TRUE;LOCK_TIMEOUT=500");
+                    getTestName() + ";LOCK_TIMEOUT=500");
             connList[i] = conn;
         }
         Connection conn = connList[0];
@@ -129,8 +129,7 @@ public class TestMvccMultiThreaded extends TestBase {
         int len = 2;
         final Connection[] connList = new Connection[len];
         for (int i = 0; i < len; i++) {
-            connList[i] = getConnection(
-                    getTestName() + ";MVCC=TRUE");
+            connList[i] = getConnection(getTestName());
         }
         Connection conn = connList[0];
         conn.createStatement().execute(

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
@@ -33,7 +33,6 @@ public class TestMvccMultiThreaded2 extends TestBase {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-        test.config.mvcc = true;
         test.config.lockTimeout = 120000;
         test.config.memory = true;
         test.config.multiThreaded = true;
@@ -47,7 +46,7 @@ public class TestMvccMultiThreaded2 extends TestBase {
 
     @Override
     public void test() throws SQLException, InterruptedException {
-        if (!config.mvcc) {
+        if (!config.mvStore) {
             return;
         }
         testSelectForUpdateConcurrency();

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
@@ -24,7 +24,7 @@ public class TestMvccMultiThreaded2 extends TestBase {
     private static final int TEST_TIME_SECONDS = 60;
     private static final boolean DISPLAY_STATS = false;
 
-    private static final String URL = ";MVCC=TRUE;LOCK_TIMEOUT=120000;MULTI_THREADED=TRUE";
+    private static final String URL = ";LOCK_TIMEOUT=120000;MULTI_THREADED=TRUE";
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/rowlock/TestRowLocks.java
+++ b/h2/src/test/org/h2/test/rowlock/TestRowLocks.java
@@ -38,7 +38,9 @@ public class TestRowLocks extends TestBase {
     @Override
     public void test() throws Exception {
         testSetMode();
-        testCases();
+        if (config.mvStore) {
+            testCases();
+        }
         deleteDb(getTestName());
     }
 
@@ -55,7 +57,7 @@ public class TestRowLocks extends TestBase {
 
     private void testCases() throws Exception {
         deleteDb(getTestName());
-        c1 = getConnection(getTestName() + ";MVCC=TRUE");
+        c1 = getConnection(getTestName());
         s1 = c1.createStatement();
         s1.execute("SET LOCK_TIMEOUT 10000");
         s1.execute("CREATE TABLE TEST AS " +

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -506,7 +506,7 @@ public class TestMVTableEngine extends TestBase {
         Statement stat;
         Statement stat2;
         deleteDb(getTestName());
-        String url = getTestName() + ";MV_STORE=TRUE;MVCC=TRUE";
+        String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
         conn = getConnection(url);
         stat = conn.createStatement();
@@ -563,7 +563,7 @@ public class TestMVTableEngine extends TestBase {
         Statement stat;
         Statement stat2;
         deleteDb(getTestName());
-        String url = getTestName() + ";MV_STORE=TRUE;MVCC=TRUE";
+        String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
         conn = getConnection(url);
         stat = conn.createStatement();
@@ -593,7 +593,7 @@ public class TestMVTableEngine extends TestBase {
         Statement stat;
         Statement stat2;
         deleteDb(getTestName());
-        String url = getTestName() + ";MV_STORE=TRUE;MVCC=TRUE";
+        String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
         conn = getConnection(url);
         stat = conn.createStatement();

--- a/h2/src/test/org/h2/test/synth/TestCrashAPI.java
+++ b/h2/src/test/org/h2/test/synth/TestCrashAPI.java
@@ -154,7 +154,7 @@ public class TestCrashAPI extends TestBase implements Runnable {
             recoverAll();
             return;
         }
-        if (config.mvcc || config.networked) {
+        if (config.mvStore || config.networked) {
             return;
         }
         int len = getSize(2, 6);
@@ -531,7 +531,7 @@ public class TestCrashAPI extends TestBase implements Runnable {
     @Override
     public TestBase init(TestAll conf) throws Exception {
         super.init(conf);
-        if (config.mvcc || config.networked) {
+        if (config.mvStore || config.networked) {
             return this;
         }
         startServerIfRequired();

--- a/h2/src/test/org/h2/test/synth/TestMultiThreaded.java
+++ b/h2/src/test/org/h2/test/synth/TestMultiThreaded.java
@@ -123,7 +123,7 @@ public class TestMultiThreaded extends TestBase {
 
     @Override
     public void test() throws Exception {
-        if (config.mvcc) {
+        if (config.mvStore) {
             return;
         }
         deleteDb("multiThreaded");

--- a/h2/src/test/org/h2/test/synth/TestReleaseSelectLock.java
+++ b/h2/src/test/org/h2/test/synth/TestReleaseSelectLock.java
@@ -27,7 +27,6 @@ public class TestReleaseSelectLock extends TestBase {
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
         test.config.mvStore = false;
-        test.config.mvcc = false;
         test.config.multiThreaded = true;
         test.test();
     }

--- a/h2/src/test/org/h2/test/unit/TestJmx.java
+++ b/h2/src/test/org/h2/test/unit/TestJmx.java
@@ -33,7 +33,6 @@ public class TestJmx extends TestBase {
     public static void main(String... a) throws Exception {
         TestBase base = TestBase.createCaller().init();
         base.config.mvStore = false;
-        base.config.mvcc = false;
         base.test();
     }
 
@@ -114,7 +113,7 @@ public class TestJmx extends TestBase {
 
         result = mbeanServer.invoke(name, "listSessions", null, null).toString();
         assertContains(result, "session id");
-        if (config.mvcc || config.mvStore) {
+        if (config.mvStore) {
             assertContains(result, "read lock");
         } else {
             assertContains(result, "write lock");

--- a/h2/src/test/org/h2/test/unit/TestMultiThreadedKernel.java
+++ b/h2/src/test/org/h2/test/unit/TestMultiThreadedKernel.java
@@ -33,7 +33,7 @@ public class TestMultiThreadedKernel extends TestBase implements Runnable {
 
     @Override
     public void test() throws Exception {
-        if (config.networked || config.mvcc) {
+        if (config.networked || config.mvStore) {
             return;
         }
         deleteDb("multiThreadedKernel");


### PR DESCRIPTION
A first part of changes for #1204.

Useless `TestAll.mvcc` is removed. Checks are replaced with `TestAll.mvStore` where necessary. I noticed also a lot of strange flags-based filters in tests, but I decided not to touch them now.

This pull request should not changes anything in behavior of tests.