### PR TITLE
Make MVCC setting a no-op

### DIFF
--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -227,8 +227,7 @@ See the <a href="grammar.html">Grammar</a> for details.
 Transaction isolation is provided for all data manipulation language (DML) statements.
 </p>
 <p>
-Please note MVCC is enabled in version 1.4.x by default, when using the MVStore.
-In this case, table level locking is not used.
+Please note that with default MVStore storage engine table level locking is not used.
 Instead, rows are locked for update, and read committed is used in all cases
 (changing the isolation level has no effect).
 </p>
@@ -302,8 +301,8 @@ for each connection.
 <h2 id="mvcc">Multi-Version Concurrency Control (MVCC)</h2>
 <p>
 The MVCC feature allows higher concurrency than using (table level or row level) locks.
-When using MVCC in this database, delete, insert and update operations will only issue a
-shared lock on the table. An exclusive lock is still used when adding or removing columns,
+Delete, insert and update operations will only issue a shared lock on the table.
+An exclusive lock is still used when adding or removing columns,
 when dropping the table, and when using <code>SELECT ... FOR UPDATE</code>.
 Connections only 'see' committed data, and own changes. That means, if connection A updates
 a row but doesn't commit this change yet, connection B will see the old value.
@@ -312,30 +311,11 @@ Only when the change is committed, the new value is visible by other connections
 database waits until it can apply the change, but at most until the lock timeout expires.
 </p>
 <p>
-To use the MVCC feature, append <code>;MVCC=TRUE</code> to the database URL:
-</p>
-<pre>
-jdbc:h2:~/test;MVCC=TRUE
-</pre>
-<p>
-The setting must be specified in the first connection (the one that opens the database).
-It is not possible to enable or disable this setting while the database is already open.
+This feature is only available with the default MVStore storage engine.
+Changing the lock mode with it (<code>LOCK_MODE</code>) has no effect.
 </p>
 <p>
-If MVCC is enabled, changing the lock mode (<code>LOCK_MODE</code>) has no effect.
-</p>
-<p>
-The MVCC mode is enabled by default in version 1.4.x,
-with the default MVStore storage engine.
-MVCC is disabled by default when using the PageStore storage engine
-(which is the default in version 1.3.x).
-The following applies when using the PageStore storage engine:
-The MVCC feature is not fully tested yet.
-The limitations of the MVCC mode are:
-with the PageStore storage engine, it can not be used at the same time as
-<code>MULTI_THREADED=TRUE</code>;
-the complete undo log (the list of uncommitted changes) must fit in memory when using multi-version concurrency.
-The setting <code>MAX_MEMORY_UNDO</code> has no effect.
+MVCC is not used when using the PageStore storage engine.
 </p>
 
 <h2 id="clustering">Clustering / High Availability</h2>
@@ -1645,16 +1625,20 @@ If this file is in the classpath, every connect to an older database will result
 <p>
 The conversion itself is done internally via <code>'script to'</code> and <code>'runscript from'</code>. After the conversion process, the files will be
 renamed from
+</p>
 <ul>
 <li><code>dbName.data.db</code> to <code>dbName.data.db.backup</code>
 </li><li><code>dbName.index.db</code> to <code>dbName.index.db.backup</code>
 </li></ul>
+<p>
 by default. Also, the temporary script will be written to the database directory instead of a temporary directory.
 Both defaults can be customized via
+</p>
 <ul>
 <li><code>org.h2.upgrade.DbUpgrade.setDeleteOldDb(boolean)</code>
 </li><li><code>org.h2.upgrade.DbUpgrade.setScriptInTmpDir(boolean)</code>
 </li></ul>
+<p>
 prior opening a database connection.
 </p>
 <p>
@@ -1678,6 +1662,7 @@ To disable this feature set the system property <code>h2.serializeJavaObject=fal
 <p>
 Serialization and deserialization of java objects is customizable both at system level and at database level providing a
 <a href="http://www.h2database.com/javadoc/org/h2/api/JavaObjectSerializer.html">JavaObjectSerializer</a> implementation:
+</p>
 <ul>
 <li>
 At system level set the system property <code>h2.javaObjectSerializer</code> with the
@@ -1693,7 +1678,6 @@ Please note that this SQL statement can only be executed before any tables are d
 </p>
 </li>
 </ul>
-</p>
 
 <h2 id="custom_data_types_handler_api">Custom Data Types Handler API</h2>
 <p>
@@ -1704,6 +1688,7 @@ of minimal required API basically consisting of type identification and conversi
 In order to enable this feature, set the system property <code>h2.customDataTypesHandler</code> (default: null) to the fully qualified name of the class providing
 <a href="http://www.h2database.com/javadoc/org/h2/api/CustomDataTypesHandler.html">CustomDataTypesHandler</a> interface implementation. <br />
 The instance of that class will be created by H2 and used to:
+</p>
 <ul>
 <li>resolve the names and identifiers of extrinsic data types.
 </li>
@@ -1712,7 +1697,6 @@ The instance of that class will be created by H2 and used to:
 <li>provide order of the data types.
 </li>
 </ul>
-</p>
 <p>This is a system-level setting, i.e. affects all the databases.</p>
 
 <p><b>Note: </b>Please keep in mind that this feature may not possibly provide the same ABI stability level as other features as it exposes many of the H2 internals. You may be required to update your code occasionally due to internal changes in H2 if you are going to use this feature.

--- a/h2/src/main/org/h2/api/ErrorCode.java
+++ b/h2/src/main/org/h2/api/ErrorCode.java
@@ -1861,7 +1861,7 @@ public class ErrorCode {
      * connections at the same time, or trying to insert two rows with the same
      * key from two connections. Example:
      * <pre>
-     * jdbc:h2:~/test;MVCC=TRUE
+     * jdbc:h2:~/test
      * Session 1:
      * CREATE TABLE TEST(ID INT);
      * INSERT INTO TEST VALUES(1);
@@ -1887,8 +1887,7 @@ public class ErrorCode {
     /**
      * The error with code <code>90133</code> is thrown when
      * trying to change a specific database property while the database is
-     * already open. The MVCC property needs to be set in the first connection
-     * (in the connection opening the database) and can not be changed later on.
+     * already open.
      */
     public static final int CANNOT_CHANGE_SETTING_WHEN_OPEN_1 = 90133;
 

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -5589,10 +5589,8 @@ public class Parser {
             return new TransactionCommand(session, setting);
         } else if (readIf("MVCC")) {
             readIfEqualOrTo();
-            boolean value = readBooleanSetting();
-            Set command = new Set(session, SetTypes.MVCC);
-            command.setInt(value ? 1 : 0);
-            return command;
+            readBooleanSetting();
+            return new NoOperation(session);
         } else if (readIf("EXCLUSIVE")) {
             readIfEqualOrTo();
             Set command = new Set(session, SetTypes.EXCLUSIVE);

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -1308,7 +1308,7 @@ public class Select extends Query {
     public void setForUpdate(boolean b) {
         this.isForUpdate = b;
         if (session.getDatabase().getSettings().selectForUpdateMvcc &&
-                session.getDatabase().isMultiVersion()) {
+                session.getDatabase().isMVStore()) {
             isForUpdateMvcc = b;
         }
     }

--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -354,13 +354,6 @@ public class Set extends Prepared {
             }
             break;
         }
-        case SetTypes.MVCC: {
-            if (database.isMultiVersion() != (getIntValue() == 1)) {
-                throw DbException.get(
-                        ErrorCode.CANNOT_CHANGE_SETTING_WHEN_OPEN_1, "MVCC");
-            }
-            break;
-        }
         case SetTypes.OPTIMIZE_REUSE_RESULTS: {
             session.getUser().checkAdmin();
             database.setOptimizeReuseResults(getIntValue() != 0);

--- a/h2/src/main/org/h2/command/dml/SetTypes.java
+++ b/h2/src/main/org/h2/command/dml/SetTypes.java
@@ -163,99 +163,94 @@ public class SetTypes {
     public static final int REFERENTIAL_INTEGRITY = 30;
 
     /**
-     * The type of a SET MVCC statement.
-     */
-    public static final int MVCC = 31;
-
-    /**
      * The type of a SET MAX_OPERATION_MEMORY statement.
      */
-    public static final int MAX_OPERATION_MEMORY = 32;
+    public static final int MAX_OPERATION_MEMORY = 31;
 
     /**
      * The type of a SET EXCLUSIVE statement.
      */
-    public static final int EXCLUSIVE = 33;
+    public static final int EXCLUSIVE = 32;
 
     /**
      * The type of a SET CREATE_BUILD statement.
      */
-    public static final int CREATE_BUILD = 34;
+    public static final int CREATE_BUILD = 33;
 
     /**
      * The type of a SET \@VARIABLE statement.
      */
-    public static final int VARIABLE = 35;
+    public static final int VARIABLE = 34;
 
     /**
      * The type of a SET QUERY_TIMEOUT statement.
      */
-    public static final int QUERY_TIMEOUT = 36;
+    public static final int QUERY_TIMEOUT = 35;
 
     /**
      * The type of a SET REDO_LOG_BINARY statement.
      */
-    public static final int REDO_LOG_BINARY = 37;
+    public static final int REDO_LOG_BINARY = 36;
 
     /**
      * The type of a SET BINARY_COLLATION statement.
      */
-    public static final int BINARY_COLLATION = 38;
+    public static final int BINARY_COLLATION = 37;
 
     /**
      * The type of a SET JAVA_OBJECT_SERIALIZER statement.
      */
-    public static final int JAVA_OBJECT_SERIALIZER = 39;
+    public static final int JAVA_OBJECT_SERIALIZER = 38;
 
     /**
      * The type of a SET RETENTION_TIME statement.
      */
-    public static final int RETENTION_TIME = 40;
+    public static final int RETENTION_TIME = 39;
 
     /**
      * The type of a SET QUERY_STATISTICS statement.
      */
-    public static final int QUERY_STATISTICS = 41;
+    public static final int QUERY_STATISTICS = 40;
 
     /**
      * The type of a SET QUERY_STATISTICS_MAX_ENTRIES statement.
      */
-    public static final int QUERY_STATISTICS_MAX_ENTRIES = 42;
+    public static final int QUERY_STATISTICS_MAX_ENTRIES = 41;
 
     /**
      * The type of a SET ROW_FACTORY statement.
      */
-    public static final int ROW_FACTORY = 43;
+    public static final int ROW_FACTORY = 42;
 
     /**
      * The type of SET BATCH_JOINS statement.
      */
-    public static final int BATCH_JOINS = 44;
+    public static final int BATCH_JOINS = 43;
 
     /**
      * The type of SET FORCE_JOIN_ORDER statement.
      */
-    public static final int FORCE_JOIN_ORDER = 45;
+    public static final int FORCE_JOIN_ORDER = 44;
 
     /**
      * The type of SET LAZY_QUERY_EXECUTION statement.
      */
-    public static final int LAZY_QUERY_EXECUTION = 46;
+    public static final int LAZY_QUERY_EXECUTION = 45;
 
     /**
      * The type of SET BUILTIN_ALIAS_OVERRIDE statement.
      */
-    public static final int BUILTIN_ALIAS_OVERRIDE = 47;
+    public static final int BUILTIN_ALIAS_OVERRIDE = 46;
 
     /**
      * The type of a SET COLUMN_NAME_RULES statement.
      */
-    public static final int COLUMN_NAME_RULES = 48;
+    public static final int COLUMN_NAME_RULES = 47;
 
     /**
      * The type of a SET AUTHENTICATOR statement.
      */
-    public static final int AUTHENTICATOR= 49;
+    public static final int AUTHENTICATOR = 48;
 
     private static final int COUNT = AUTHENTICATOR + 1;
 
@@ -298,7 +293,6 @@ public class SetTypes {
         list.add(SCHEMA_SEARCH_PATH, "SCHEMA_SEARCH_PATH");
         list.add(UNDO_LOG, "UNDO_LOG");
         list.add(REFERENTIAL_INTEGRITY, "REFERENTIAL_INTEGRITY");
-        list.add(MVCC, "MVCC");
         list.add(MAX_OPERATION_MEMORY, "MAX_OPERATION_MEMORY");
         list.add(EXCLUSIVE, "EXCLUSIVE");
         list.add(CREATE_BUILD, "CREATE_BUILD");

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -92,7 +92,7 @@ public class ConnectionInfo implements Cloneable {
     static {
         String[] connectionTime = { "ACCESS_MODE_DATA", "AUTOCOMMIT", "CIPHER",
                 "CREATE", "CACHE_TYPE", "FILE_LOCK", "IGNORE_UNKNOWN_SETTINGS",
-                "IFEXISTS", "INIT", "PASSWORD", "RECOVER", "RECOVER_TEST",
+                "IFEXISTS", "INIT", "MVCC", "PASSWORD", "RECOVER", "RECOVER_TEST",
                 "USER", "AUTO_SERVER", "AUTO_SERVER_PORT", "NO_UPGRADE",
                 "AUTO_RECONNECT", "OPEN_NEW", "PAGE_SIZE", "PASSWORD_HASH", "JMX",
                 "SCOPE_GENERATED_KEYS", "AUTHREALM", "AUTHZPWD" };

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -693,7 +693,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         removeTemporaryLobs(true);
         if (undoLog.size() > 0) {
             // commit the rows when using MVCC
-            if (database.isMultiVersion()) {
+            if (database.isMVStore()) {
                 synchronized (database) {
                     ArrayList<Row> rows = new ArrayList<>(undoLog.size());
                     while (undoLog.size() > 0) {
@@ -916,7 +916,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
             if (SysProperties.CHECK) {
                 int lockMode = database.getLockMode();
                 if (lockMode != Constants.LOCK_MODE_OFF &&
-                        !database.isMultiVersion()) {
+                        !database.isMVStore()) {
                     TableType tableType = log.getTable().getTableType();
                     if (!locks.contains(log.getTable())
                             && TableType.TABLE_LINK != tableType
@@ -927,7 +927,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
             }
             undoLog.add(log);
         } else {
-            if (database.isMultiVersion()) {
+            if (database.isMVStore()) {
                 // see also UndoLogRecord.commit
                 ArrayList<Index> indexes = table.getIndexes();
                 for (Index index : indexes) {
@@ -943,7 +943,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
      * READ_COMMITTED.
      */
     public void unlockReadLocks() {
-        if (database.isMultiVersion()) {
+        if (database.isMVStore()) {
             // MVCC: keep shared locks (insert / update / delete)
             return;
         }

--- a/h2/src/main/org/h2/engine/UndoLog.java
+++ b/h2/src/main/org/h2/engine/UndoLog.java
@@ -156,7 +156,7 @@ public class UndoLog {
             memoryUndo++;
             if (memoryUndo > database.getMaxMemoryUndo() &&
                     database.isPersistent() &&
-                    !database.isMultiVersion()) {
+                    !database.isMVStore()) {
                 if (file == null) {
                     String fileName = database.createTempFile();
                     file = database.openFile(fileName, "rw", false);
@@ -185,7 +185,7 @@ public class UndoLog {
             }
             if (memoryUndo > database.getMaxMemoryUndo() &&
                     database.isPersistent() &&
-                    !database.isMultiVersion()) {
+                    !database.isMVStore()) {
                 if (file == null) {
                     String fileName = database.createTempFile();
                     file = database.openFile(fileName, "rw", false);

--- a/h2/src/main/org/h2/index/PageDataIndex.java
+++ b/h2/src/main/org/h2/index/PageDataIndex.java
@@ -58,7 +58,7 @@ public class PageDataIndex extends PageIndex {
     public PageDataIndex(RegularTable table, int id, IndexColumn[] columns,
             IndexType indexType, boolean create, Session session) {
         initBaseIndex(table, id, table.getName() + "_DATA", columns, indexType);
-        this.multiVersion = database.isMultiVersion();
+        this.multiVersion = database.isMVStore();
 
         // trace = database.getTrace(Trace.PAGE_STORE + "_di");
         // trace.setLevel(TraceSystem.DEBUG);

--- a/h2/src/main/org/h2/jmx/DatabaseInfo.java
+++ b/h2/src/main/org/h2/jmx/DatabaseInfo.java
@@ -116,7 +116,7 @@ public class DatabaseInfo implements DatabaseInfoMBean {
 
     @Override
     public boolean isMvcc() {
-        return database.isMultiVersion();
+        return database.isMVStore();
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -167,7 +167,7 @@ public class MVTable extends TableBase {
         if (lockMode == Constants.LOCK_MODE_OFF) {
             return false;
         }
-        if (!forceLockEvenInMvcc && database.isMultiVersion()) {
+        if (!forceLockEvenInMvcc && database.isMVStore()) {
             // MVCC: update, delete, and insert use a shared lock.
             // Select doesn't lock except when using FOR UPDATE and
             // the system property h2.selectForUpdateMvcc
@@ -310,7 +310,7 @@ public class MVTable extends TableBase {
             if (lockExclusiveSession == null) {
                 if (lockMode == Constants.LOCK_MODE_READ_COMMITTED) {
                     if (!database.isMultiThreaded() &&
-                            !database.isMultiVersion()) {
+                            !database.isMVStore()) {
                         // READ_COMMITTED: a read lock is acquired,
                         // but released immediately after the operation
                         // is complete.

--- a/h2/src/main/org/h2/store/PageStore.java
+++ b/h2/src/main/org/h2/store/PageStore.java
@@ -360,13 +360,7 @@ public class PageStore implements CacheWriter {
         readVariableHeader();
         log = new PageLog(this);
         log.openForReading(logKey, logFirstTrunkPage, logFirstDataPage);
-        boolean old = database.isMultiVersion();
-        // temporarily disabling multi-version concurrency, because
-        // the multi-version index sometimes compares rows
-        // and the LOB storage is not yet available.
-        database.setMultiVersion(false);
         boolean isEmpty = recover();
-        database.setMultiVersion(old);
         if (!database.isReadOnly()) {
             readMode = true;
             if (!isEmpty || !SysProperties.MODIFY_ON_WRITE || tempObjects != null) {

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1043,7 +1043,7 @@ public class MetaTable extends Table {
                     "FALSE" : "TRUE");
             add(rows, "MODE", database.getMode().getName());
             add(rows, "MULTI_THREADED", database.isMultiThreaded() ? "1" : "0");
-            add(rows, "MVCC", database.isMultiVersion() ? "TRUE" : "FALSE");
+            add(rows, "MVCC", database.isMVStore() ? "TRUE" : "FALSE");
             add(rows, "QUERY_TIMEOUT", Integer.toString(session.getQueryTimeout()));
             add(rows, "RETENTION_TIME", Integer.toString(database.getRetentionTime()));
             add(rows, "LOG", Integer.toString(database.getLogMode()));

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1043,7 +1043,6 @@ public class MetaTable extends Table {
                     "FALSE" : "TRUE");
             add(rows, "MODE", database.getMode().getName());
             add(rows, "MULTI_THREADED", database.isMultiThreaded() ? "1" : "0");
-            add(rows, "MVCC", database.isMVStore() ? "TRUE" : "FALSE");
             add(rows, "QUERY_TIMEOUT", Integer.toString(session.getQueryTimeout()));
             add(rows, "RETENTION_TIME", Integer.toString(database.getRetentionTime()));
             add(rows, "LOG", Integer.toString(database.getLogMode()));

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -116,7 +116,7 @@ public class RegularTable extends TableBase {
     @Override
     public void addRow(Session session, Row row) {
         lastModificationId = database.getNextModificationDataId();
-        if (database.isMultiVersion()) {
+        if (database.isMVStore()) {
             row.setSessionId(session.getId());
         }
         int i = 0;
@@ -167,7 +167,7 @@ public class RegularTable extends TableBase {
     }
 
     private void checkRowCount(Session session, Index index, int offset) {
-        if (SysProperties.CHECK && !database.isMultiVersion()) {
+        if (SysProperties.CHECK && !database.isMVStore()) {
             if (!(index instanceof PageDelegateIndex)) {
                 long rc = index.getRowCount(session);
                 if (rc != rowCount + offset) {
@@ -259,7 +259,7 @@ public class RegularTable extends TableBase {
                 index = new TreeIndex(this, indexId, indexName, cols, indexType);
             }
         }
-        if (database.isMultiVersion()) {
+        if (database.isMVStore()) {
             index = new MultiVersionIndex(index, this);
         }
         if (index.needRebuild() && rowCount > 0) {
@@ -366,7 +366,7 @@ public class RegularTable extends TableBase {
 
     @Override
     public long getRowCount(Session session) {
-        if (database.isMultiVersion()) {
+        if (database.isMVStore()) {
             return getScanIndex(session).getRowCount(session);
         }
         return rowCount;
@@ -374,7 +374,7 @@ public class RegularTable extends TableBase {
 
     @Override
     public void removeRow(Session session, Row row) {
-        if (database.isMultiVersion()) {
+        if (database.isMVStore()) {
             if (row.isDeleted()) {
                 throw DbException.get(ErrorCode.CONCURRENT_UPDATE_1, getName());
             }
@@ -444,7 +444,7 @@ public class RegularTable extends TableBase {
         if (lockMode == Constants.LOCK_MODE_OFF) {
             return lockExclusiveSession != null;
         }
-        if (!forceLockEvenInMvcc && database.isMultiVersion()) {
+        if (!forceLockEvenInMvcc && database.isMVStore()) {
             // MVCC: update, delete, and insert use a shared lock.
             // Select doesn't lock except when using FOR UPDATE
             if (exclusive) {
@@ -550,7 +550,7 @@ public class RegularTable extends TableBase {
         } else {
             if (lockExclusiveSession == null) {
                 if (lockMode == Constants.LOCK_MODE_READ_COMMITTED) {
-                    if (!database.isMultiThreaded() && !database.isMultiVersion()) {
+                    if (!database.isMultiThreaded() && !database.isMVStore()) {
                         // READ_COMMITTED: a read lock is acquired,
                         // but released immediately after the operation
                         // is complete.

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -251,7 +251,6 @@ public abstract class TestBase {
         if (name.startsWith("jdbc:")) {
             if (config.mvStore) {
                 name = addOption(name, "MV_STORE", "true");
-                // name = addOption(name, "MVCC", "true");
             } else {
                 name = addOption(name, "MV_STORE", "false");
             }

--- a/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
+++ b/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
@@ -527,7 +527,7 @@ public class TestGeneralCommonTableQueries extends AbstractBaseForCommonTableExp
         config = new TestAll();
 
         try {
-            // Test with settings: lazy mvStore memory mvcc multiThreaded
+            // Test with settings: lazy mvStore memory multiThreaded
             // connection url is
             // mem:script;MV_STORE=true;LOG=1;LOCK_TIMEOUT=50;
             // MULTI_THREADED=TRUE;LAZY_QUERY_EXECUTION=1

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
@@ -36,25 +36,7 @@ public class TestMvcc1 extends TestBase {
     @Override
     public void test() throws SQLException {
         testCases();
-        testSetMode();
         deleteDb("mvcc1");
-    }
-
-    private void testSetMode() throws SQLException {
-        deleteDb("mvcc1");
-        c1 = getConnection("mvcc1;MVCC=FALSE");
-        Statement stat = c1.createStatement();
-        ResultSet rs = stat.executeQuery(
-                "select * from information_schema.settings where name='MVCC'");
-        rs.next();
-        assertEquals("FALSE", rs.getString("VALUE"));
-        assertThrows(ErrorCode.CANNOT_CHANGE_SETTING_WHEN_OPEN_1, stat).
-                execute("SET MVCC TRUE");
-        rs = stat.executeQuery("select * from information_schema.settings " +
-                "where name='MVCC'");
-        rs.next();
-        assertEquals("FALSE", rs.getString("VALUE"));
-        c1.close();
     }
 
     private void testCases() throws SQLException {

--- a/h2/src/test/org/h2/test/synth/TestConcurrentUpdate.java
+++ b/h2/src/test/org/h2/test/synth/TestConcurrentUpdate.java
@@ -31,7 +31,6 @@ public class TestConcurrentUpdate extends TestBase {
         config.memory = true;
         config.multiThreaded = true;
 //        config.mvStore = false;
-//        config.mvcc = false;
         System.out.println(config);
         TestBase test = createCaller().init(config);
         for (int i = 0; i < 10; i++) {

--- a/h2/src/test/org/h2/test/unit/TestPageStore.java
+++ b/h2/src/test/org/h2/test/unit/TestPageStore.java
@@ -167,7 +167,7 @@ public class TestPageStore extends TestBase {
     private void testRecoverLobInDatabase() throws SQLException {
         deleteDb("pageStoreRecoverLobInDatabase");
         String url = getURL("pageStoreRecoverLobInDatabase;" +
-                "MVCC=TRUE;CACHE_SIZE=1", true);
+                "CACHE_SIZE=1", true);
         Connection conn;
         Statement stat;
         conn = getConnection(url, getUser(), getPassword());
@@ -182,7 +182,7 @@ public class TestPageStore extends TestBase {
             Connection conn2 = getConnection(url, getUser(), getPassword());
             list.add(conn2);
             Statement stat2 = conn2.createStatement();
-            conn2.setAutoCommit(false);
+            // conn2.setAutoCommit(false);
             if (r.nextBoolean()) {
                 stat2.execute("update test set id = id where id = " + r.nextInt(100));
             } else {


### PR DESCRIPTION
A second part of changes for #1204.

`MVCC` setting is now ignored. MVCC logic is always used for MVStore and never used for PageStore.

I removed a couple of tests for table-level locking with disabled MVCC in MVStore mode, this is not possible with MVCC. I also changed a one of PageStore tests to use auto-commit feature, because this test used MVCC and without MVCC it can only get a lock timeout.

`Database.isMultiVersion()` is renamed to `isMVStore()`.