### PR TITLE
Test utilities only once during TestAll

### DIFF
--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -614,7 +614,12 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         if (vmlens) {
             return;
         }
-        testUnit();
+        testAdditional();
+
+        // test utilities
+        big = !travis;
+        testUtils();
+        big = false;
 
         // lazy
         lazy = true;
@@ -627,20 +632,20 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         memory = false;
         multiThreaded = true;
         test();
-        testUnit();
+        testAdditional();
 
         // a more normal setup
         memory = false;
         multiThreaded = false;
         test();
-        testUnit();
+        testAdditional();
 
         // basic pagestore testing
         memory = false;
         multiThreaded = false;
         mvStore = false;
         test();
-        testUnit();
+        testAdditional();
 
         mvStore = true;
         memory = true;
@@ -681,7 +686,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
             ssl = false;
             traceLevelFile = 0;
             test();
-            testUnit();
+            testAdditional();
 
             big = false;
             cipher = "AES";
@@ -702,7 +707,8 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         memory = true;
         multiThreaded = true;
         test();
-        testUnit();
+        testAdditional();
+        testUtils();
 
         multiThreaded = false;
         mvStore = false;
@@ -876,7 +882,58 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         afterTest();
     }
 
-    private void testUnit() {
+    /**
+     * Run additional tests.
+     */
+    private void testAdditional() {
+        if (networked) {
+            throw new RuntimeException("testAditional() is not allowed in networked mode");
+        }
+
+        addTest(new TestMVTableEngine());
+        addTest(new TestAutoReconnect());
+        addTest(new TestBnf());
+        addTest(new TestCache());
+        addTest(new TestCollation());
+        addTest(new TestCompress());
+        addTest(new TestConnectionInfo());
+        addTest(new TestExit());
+        addTest(new TestFileLock());
+        addTest(new TestJmx());
+        addTest(new TestModifyOnWrite());
+        addTest(new TestOldVersion());
+        addTest(new TestMultiThreadedKernel());
+        addTest(new TestPageStore());
+        addTest(new TestPageStoreCoverage());
+        addTest(new TestPgServer());
+        addTest(new TestRecovery());
+        addTest(new RecoverLobTest());
+        addTest(createTest("org.h2.test.unit.TestServlet"));
+        addTest(new TestTimeStampWithTimeZone());
+        addTest(new TestUpgrade());
+        addTest(new TestUsingIndex());
+        addTest(new TestValue());
+        addTest(new TestWeb());
+
+        runAddedTests();
+
+        addTest(new TestCluster());
+        addTest(new TestFileLockSerialized());
+        addTest(new TestFileLockProcess());
+        addTest(new TestFileSystem());
+        addTest(new TestTools());
+        addTest(new TestSampleApps());
+
+        runAddedTests(1);
+    }
+
+    /**
+     * Run tests for utilities.
+     */
+    private void testUtils() {
+        System.out.println();
+        System.out.println("Test utilities (" + Utils.getMemoryUsed() + " KB used)");
+
         // mv store
         addTest(new TestCacheConcurrentLIRS());
         addTest(new TestCacheLIRS());
@@ -889,7 +946,6 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestMVStoreBenchmark());
         addTest(new TestMVStoreStopCompact());
         addTest(new TestMVStoreTool());
-        addTest(new TestMVTableEngine());
         addTest(new TestObjectDataType());
         addTest(new TestRandomMapOps());
         addTest(new TestSpinLock());
@@ -898,77 +954,46 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
 
         // unit
         addTest(new TestAnsCompression());
-        addTest(new TestAutoReconnect());
         addTest(new TestBinaryArithmeticStream());
         addTest(new TestBitStream());
-        addTest(new TestBnf());
-        addTest(new TestCache());
         addTest(new TestCharsetCollator());
         addTest(new TestClearReferences());
-        addTest(new TestCollation());
-        addTest(new TestCompress());
-        addTest(new TestConnectionInfo());
         addTest(new TestDataPage());
         addTest(new TestDateIso8601());
-        addTest(new TestExit());
         addTest(new TestFile());
-        addTest(new TestFileLock());
         addTest(new TestFtp());
         addTest(new TestIntArray());
         addTest(new TestIntIntHashMap());
         addTest(new TestIntPerfectHash());
-        addTest(new TestJmx());
         addTest(new TestMathUtils());
         addTest(new TestMode());
-        addTest(new TestModifyOnWrite());
-        addTest(new TestOldVersion());
         addTest(new TestObjectDeserialization());
-        addTest(new TestMultiThreadedKernel());
         addTest(new TestOverflow());
-        addTest(new TestPageStore());
-        addTest(new TestPageStoreCoverage());
         addTest(new TestPerfectHash());
-        addTest(new TestPgServer());
         addTest(new TestReader());
-        addTest(new TestRecovery());
         addTest(new TestScriptReader());
-        addTest(new RecoverLobTest());
-        addTest(createTest("org.h2.test.unit.TestServlet"));
         addTest(new TestSecurity());
         addTest(new TestShell());
         addTest(new TestSort());
         addTest(new TestStreams());
         addTest(new TestStringUtils());
-        addTest(new TestTimeStampWithTimeZone());
         addTest(new TestTraceSystem());
-        addTest(new TestUpgrade());
-        addTest(new TestUsingIndex());
         addTest(new TestUtils());
-        addTest(new TestValue());
         addTest(new TestValueHashMap());
-        addTest(new TestWeb());
-
 
         runAddedTests();
 
         // serial
         addTest(new TestDate());
         addTest(new TestDateTimeUtils());
-        addTest(new TestCluster());
         addTest(new TestConcurrent());
-        addTest(new TestFileLockSerialized());
-        addTest(new TestFileLockProcess());
-        addTest(new TestFileSystem());
         addTest(new TestNetUtils());
         addTest(new TestPattern());
-        addTest(new TestTools());
-        addTest(new TestSampleApps());
         addTest(new TestStringCache());
         addTest(new TestValueMemory());
         addTest(new TestAuthentication());
 
         runAddedTests(1);
-
     }
 
     private void addTest(TestBase test) {

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -762,7 +762,6 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestMultiDimension());
         addTest(new TestMultiThreadedKernel());
         addTest(new TestOpenClose());
-        addTest(new TestOptimizations());
         addTest(new TestOptimizerHints());
         addTest(new TestReadOnly());
         addTest(new TestRecursiveQueries());
@@ -877,6 +876,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestWeb());
 
         // other unsafe
+        addTest(new TestOptimizations());
         addTest(new TestOutOfMemory());
 
         runAddedTests(1);

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -764,7 +764,6 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestOpenClose());
         addTest(new TestOptimizations());
         addTest(new TestOptimizerHints());
-        addTest(new TestOutOfMemory());
         addTest(new TestReadOnly());
         addTest(new TestRecursiveQueries());
         addTest(new TestGeneralCommonTableQueries());
@@ -876,6 +875,9 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestQueryCache());
         addTest(new TestUrlJavaObjectSerializer());
         addTest(new TestWeb());
+
+        // other unsafe
+        addTest(new TestOutOfMemory());
 
         runAddedTests(1);
 

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -6,7 +6,6 @@
 package org.h2.test;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,7 +20,6 @@ import java.lang.reflect.Proxy;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -31,20 +29,17 @@ import java.sql.Types;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Objects;
 import java.util.SimpleTimeZone;
 import java.util.concurrent.TimeUnit;
+
 import org.h2.jdbc.JdbcConnection;
 import org.h2.message.DbException;
 import org.h2.store.fs.FilePath;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.utils.ProxyCodeGenerator;
 import org.h2.test.utils.ResultVerifier;
-import org.h2.test.utils.SelfDestructor;
-import org.h2.tools.DeleteDbFiles;
 import org.h2.util.Utils;
 
 /**
@@ -94,13 +89,6 @@ public abstract class TestBase {
      */
     public static String getTestDir(String name) {
         return BASE_TEST_DIR + "/test" + name;
-    }
-
-    /**
-     * Start the TCP server if enabled in the configuration.
-     */
-    protected void startServerIfRequired() throws SQLException {
-        config.beforeTest();
     }
 
     /**
@@ -163,31 +151,6 @@ public abstract class TestBase {
     }
 
     /**
-     * Open a database connection in admin mode. The default user name and
-     * password is used.
-     *
-     * @param name the database name
-     * @return the connection
-     */
-    public Connection getConnection(String name) throws SQLException {
-        return getConnectionInternal(getURL(name, true), getUser(),
-                getPassword());
-    }
-
-    /**
-     * Open a database connection.
-     *
-     * @param name the database name
-     * @param user the user name to use
-     * @param password the password to use
-     * @return the connection
-     */
-    public Connection getConnection(String name, String user, String password)
-            throws SQLException {
-        return getConnectionInternal(getURL(name, false), user, password);
-    }
-
-    /**
      * Get the password to use to login for the given user password. The file
      * password is added if required.
      *
@@ -238,119 +201,7 @@ public abstract class TestBase {
         return dir;
     }
 
-    /**
-     * Get the database URL for the given database name using the current
-     * configuration options.
-     *
-     * @param name the database name
-     * @param admin true if the current user is an admin
-     * @return the database URL
-     */
-    protected String getURL(String name, boolean admin) {
-        String url;
-        if (name.startsWith("jdbc:")) {
-            if (config.mvStore) {
-                name = addOption(name, "MV_STORE", "true");
-            } else {
-                name = addOption(name, "MV_STORE", "false");
-            }
-            return name;
-        }
-        if (admin) {
-            // name = addOption(name, "RETENTION_TIME", "10");
-            // name = addOption(name, "WRITE_DELAY", "10");
-        }
-        int idx = name.indexOf(':');
-        if (idx == -1 && config.memory) {
-            name = "mem:" + name;
-        } else {
-            if (idx < 0 || idx > 10) {
-                // index > 10 if in options
-                name = getBaseDir() + "/" + name;
-            }
-        }
-        if (config.networked) {
-            if (config.ssl) {
-                url = "ssl://localhost:"+config.getPort()+"/" + name;
-            } else {
-                url = "tcp://localhost:"+config.getPort()+"/" + name;
-            }
-        } else if (config.googleAppEngine) {
-            url = "gae://" + name +
-                    ";FILE_LOCK=NO;AUTO_SERVER=FALSE;DB_CLOSE_ON_EXIT=FALSE";
-        } else {
-            url = name;
-        }
-        if (config.mvStore) {
-            url = addOption(url, "MV_STORE", "true");
-            // url = addOption(url, "MVCC", "true");
-        } else {
-            url = addOption(url, "MV_STORE", "false");
-        }
-        if (!config.memory) {
-            if (config.smallLog && admin) {
-                url = addOption(url, "MAX_LOG_SIZE", "1");
-            }
-        }
-        if (config.traceSystemOut) {
-            url = addOption(url, "TRACE_LEVEL_SYSTEM_OUT", "2");
-        }
-        if (config.traceLevelFile > 0 && admin) {
-            url = addOption(url, "TRACE_LEVEL_FILE", "" + config.traceLevelFile);
-            url = addOption(url, "TRACE_MAX_FILE_SIZE", "8");
-        }
-        url = addOption(url, "LOG", "1");
-        if (config.throttleDefault > 0) {
-            url = addOption(url, "THROTTLE", "" + config.throttleDefault);
-        } else if (config.throttle > 0) {
-            url = addOption(url, "THROTTLE", "" + config.throttle);
-        }
-        url = addOption(url, "LOCK_TIMEOUT", "" + config.lockTimeout);
-        if (config.diskUndo && admin) {
-            url = addOption(url, "MAX_MEMORY_UNDO", "3");
-        }
-        if (config.big && admin) {
-            // force operations to disk
-            url = addOption(url, "MAX_OPERATION_MEMORY", "1");
-        }
-        url = addOption(url, "MULTI_THREADED", config.multiThreaded ? "TRUE" : "FALSE");
-        if (config.lazy) {
-            url = addOption(url, "LAZY_QUERY_EXECUTION", "1");
-        }
-        if (config.cacheType != null && admin) {
-            url = addOption(url, "CACHE_TYPE", config.cacheType);
-        }
-        if (config.diskResult && admin) {
-            url = addOption(url, "MAX_MEMORY_ROWS", "100");
-            url = addOption(url, "CACHE_SIZE", "0");
-        }
-        if (config.cipher != null) {
-            url = addOption(url, "CIPHER", config.cipher);
-        }
-        if (config.defrag) {
-            url = addOption(url, "DEFRAG_ALWAYS", "TRUE");
-        }
-        if (config.collation != null) {
-            url = addOption(url, "COLLATION", config.collation);
-        }
-        return "jdbc:h2:" + url;
-    }
 
-    private static String addOption(String url, String option, String value) {
-        if (url.indexOf(";" + option + "=") < 0) {
-            url += ";" + option + "=" + value;
-        }
-        return url;
-    }
-
-    private static Connection getConnectionInternal(String url, String user,
-            String password) throws SQLException {
-        org.h2.Driver.load();
-        // url += ";DEFAULT_TABLE_TYPE=1";
-        // Class.forName("org.hsqldb.jdbcDriver");
-        // return DriverManager.getConnection("jdbc:hsqldb:" + name, "sa", "");
-        return DriverManager.getConnection(url, user, password);
-    }
 
     /**
      * Get the small or the big value depending on the configuration.
@@ -584,30 +435,6 @@ public abstract class TestBase {
             s = s.substring(3);
         }
         return s;
-    }
-
-    /**
-     * Delete all database files for this database.
-     *
-     * @param name the database name
-     */
-    protected void deleteDb(String name) {
-        deleteDb(getBaseDir(), name);
-    }
-
-    /**
-     * Delete all database files for a database.
-     *
-     * @param dir the directory where the database files are located
-     * @param name the database name
-     */
-    protected void deleteDb(String dir, String name) {
-        DeleteDbFiles.execute(dir, name, true);
-        // ArrayList<String> list;
-        // list = FileLister.getDatabaseFiles(baseDir, name, true);
-        // if (list.size() >  0) {
-        //    System.out.println("Not deleted: " + list);
-        // }
     }
 
     /**
@@ -1491,16 +1318,6 @@ public abstract class TestBase {
     }
 
     /**
-     * Get the path to a java executable of the current process
-     *
-     * @return the path to java
-     */
-    private static String getJVM() {
-        return System.getProperty("java.home") + File.separatorChar + "bin"
-                + File.separator + "java";
-    }
-
-    /**
      * Use up almost all memory.
      *
      * @param remainingKB the number of kilobytes that are not referenced
@@ -1701,7 +1518,6 @@ public abstract class TestBase {
         }
     }
 
-
     /**
      * Construct a stream of 20 KB that fails while reading with the provided
      * exception.
@@ -1743,56 +1559,5 @@ public abstract class TestBase {
      */
     public String getTestName() {
         return getClass().getSimpleName();
-    }
-
-    /**
-     * Build a child process.
-     *
-     * @param name the name
-     * @param childClass the class
-     * @param jvmArgs the argument list
-     * @return the process builder
-     */
-    public ProcessBuilder buildChild(String name, Class<? extends TestBase> childClass,
-            String... jvmArgs) {
-        List<String> args = new ArrayList<>(16);
-        args.add(getJVM());
-        Collections.addAll(args, jvmArgs);
-        Collections.addAll(args, "-cp", getClassPath(),
-                        SelfDestructor.getPropertyString(1),
-                        childClass.getName(),
-                        "-url", getURL(name, true),
-                        "-user", getUser(),
-                        "-password", getPassword());
-        ProcessBuilder processBuilder = new ProcessBuilder()
-//                            .redirectError(ProcessBuilder.Redirect.INHERIT)
-                            .redirectErrorStream(true)
-                            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
-                            .command(args);
-        return processBuilder;
-    }
-
-    public abstract static class Child extends TestBase {
-        private String url;
-        private String user;
-        private String password;
-
-        public Child(String... args) {
-            for (int i = 0; i < args.length; i++) {
-                if ("-url".equals(args[i])) {
-                    url = args[++i];
-                } else if ("-user".equals(args[i])) {
-                    user = args[++i];
-                } else if ("-password".equals(args[i])) {
-                    password = args[++i];
-                }
-                SelfDestructor.startCountdown(60);
-            }
-        }
-
-        public Connection getConnection() throws SQLException {
-            return getConnection(url, user, password);
-        }
-
     }
 }

--- a/h2/src/test/org/h2/test/TestDb.java
+++ b/h2/src/test/org/h2/test/TestDb.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.test;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.h2.test.utils.SelfDestructor;
+import org.h2.tools.DeleteDbFiles;
+
+/**
+ * The base class for tests that use connections to database.
+ */
+public abstract class TestDb extends TestBase {
+
+    /**
+     * Start the TCP server if enabled in the configuration.
+     */
+    protected void startServerIfRequired() throws SQLException {
+        config.beforeTest();
+    }
+
+    /**
+     * Open a database connection in admin mode. The default user name and
+     * password is used.
+     *
+     * @param name the database name
+     * @return the connection
+     */
+    public Connection getConnection(String name) throws SQLException {
+        return getConnectionInternal(getURL(name, true), getUser(),
+                getPassword());
+    }
+
+    /**
+     * Open a database connection.
+     *
+     * @param name the database name
+     * @param user the user name to use
+     * @param password the password to use
+     * @return the connection
+     */
+    public Connection getConnection(String name, String user, String password)
+            throws SQLException {
+        return getConnectionInternal(getURL(name, false), user, password);
+    }
+
+    /**
+     * Get the database URL for the given database name using the current
+     * configuration options.
+     *
+     * @param name the database name
+     * @param admin true if the current user is an admin
+     * @return the database URL
+     */
+    protected String getURL(String name, boolean admin) {
+        String url;
+        if (name.startsWith("jdbc:")) {
+            if (config.mvStore) {
+                name = addOption(name, "MV_STORE", "true");
+            } else {
+                name = addOption(name, "MV_STORE", "false");
+            }
+            return name;
+        }
+        if (admin) {
+            // name = addOption(name, "RETENTION_TIME", "10");
+            // name = addOption(name, "WRITE_DELAY", "10");
+        }
+        int idx = name.indexOf(':');
+        if (idx == -1 && config.memory) {
+            name = "mem:" + name;
+        } else {
+            if (idx < 0 || idx > 10) {
+                // index > 10 if in options
+                name = getBaseDir() + "/" + name;
+            }
+        }
+        if (config.networked) {
+            if (config.ssl) {
+                url = "ssl://localhost:"+config.getPort()+"/" + name;
+            } else {
+                url = "tcp://localhost:"+config.getPort()+"/" + name;
+            }
+        } else if (config.googleAppEngine) {
+            url = "gae://" + name +
+                    ";FILE_LOCK=NO;AUTO_SERVER=FALSE;DB_CLOSE_ON_EXIT=FALSE";
+        } else {
+            url = name;
+        }
+        if (config.mvStore) {
+            url = addOption(url, "MV_STORE", "true");
+            // url = addOption(url, "MVCC", "true");
+        } else {
+            url = addOption(url, "MV_STORE", "false");
+        }
+        if (!config.memory) {
+            if (config.smallLog && admin) {
+                url = addOption(url, "MAX_LOG_SIZE", "1");
+            }
+        }
+        if (config.traceSystemOut) {
+            url = addOption(url, "TRACE_LEVEL_SYSTEM_OUT", "2");
+        }
+        if (config.traceLevelFile > 0 && admin) {
+            url = addOption(url, "TRACE_LEVEL_FILE", "" + config.traceLevelFile);
+            url = addOption(url, "TRACE_MAX_FILE_SIZE", "8");
+        }
+        url = addOption(url, "LOG", "1");
+        if (config.throttleDefault > 0) {
+            url = addOption(url, "THROTTLE", "" + config.throttleDefault);
+        } else if (config.throttle > 0) {
+            url = addOption(url, "THROTTLE", "" + config.throttle);
+        }
+        url = addOption(url, "LOCK_TIMEOUT", "" + config.lockTimeout);
+        if (config.diskUndo && admin) {
+            url = addOption(url, "MAX_MEMORY_UNDO", "3");
+        }
+        if (config.big && admin) {
+            // force operations to disk
+            url = addOption(url, "MAX_OPERATION_MEMORY", "1");
+        }
+        url = addOption(url, "MULTI_THREADED", config.multiThreaded ? "TRUE" : "FALSE");
+        if (config.lazy) {
+            url = addOption(url, "LAZY_QUERY_EXECUTION", "1");
+        }
+        if (config.cacheType != null && admin) {
+            url = addOption(url, "CACHE_TYPE", config.cacheType);
+        }
+        if (config.diskResult && admin) {
+            url = addOption(url, "MAX_MEMORY_ROWS", "100");
+            url = addOption(url, "CACHE_SIZE", "0");
+        }
+        if (config.cipher != null) {
+            url = addOption(url, "CIPHER", config.cipher);
+        }
+        if (config.defrag) {
+            url = addOption(url, "DEFRAG_ALWAYS", "TRUE");
+        }
+        if (config.collation != null) {
+            url = addOption(url, "COLLATION", config.collation);
+        }
+        return "jdbc:h2:" + url;
+    }
+
+    private static String addOption(String url, String option, String value) {
+        if (url.indexOf(";" + option + "=") < 0) {
+            url += ";" + option + "=" + value;
+        }
+        return url;
+    }
+
+    private static Connection getConnectionInternal(String url, String user,
+            String password) throws SQLException {
+        org.h2.Driver.load();
+        // url += ";DEFAULT_TABLE_TYPE=1";
+        // Class.forName("org.hsqldb.jdbcDriver");
+        // return DriverManager.getConnection("jdbc:hsqldb:" + name, "sa", "");
+        return DriverManager.getConnection(url, user, password);
+    }
+
+    /**
+     * Delete all database files for this database.
+     *
+     * @param name the database name
+     */
+    protected void deleteDb(String name) {
+        deleteDb(getBaseDir(), name);
+    }
+
+    /**
+     * Delete all database files for a database.
+     *
+     * @param dir the directory where the database files are located
+     * @param name the database name
+     */
+    protected void deleteDb(String dir, String name) {
+        DeleteDbFiles.execute(dir, name, true);
+        // ArrayList<String> list;
+        // list = FileLister.getDatabaseFiles(baseDir, name, true);
+        // if (list.size() >  0) {
+        //    System.out.println("Not deleted: " + list);
+        // }
+    }
+
+    /**
+     * Get the path to a java executable of the current process
+     *
+     * @return the path to java
+     */
+    private static String getJVM() {
+        return System.getProperty("java.home") + File.separatorChar + "bin"
+                + File.separator + "java";
+    }
+
+    /**
+     * Build a child process.
+     *
+     * @param name the name
+     * @param childClass the class
+     * @param jvmArgs the argument list
+     * @return the process builder
+     */
+    public ProcessBuilder buildChild(String name, Class<? extends TestDb> childClass,
+            String... jvmArgs) {
+        List<String> args = new ArrayList<>(16);
+        args.add(getJVM());
+        Collections.addAll(args, jvmArgs);
+        Collections.addAll(args, "-cp", getClassPath(),
+                        SelfDestructor.getPropertyString(1),
+                        childClass.getName(),
+                        "-url", getURL(name, true),
+                        "-user", getUser(),
+                        "-password", getPassword());
+        ProcessBuilder processBuilder = new ProcessBuilder()
+//                            .redirectError(ProcessBuilder.Redirect.INHERIT)
+                            .redirectErrorStream(true)
+                            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                            .command(args);
+        return processBuilder;
+    }
+
+    public abstract static class Child extends TestDb {
+        private String url;
+        private String user;
+        private String password;
+
+        public Child(String... args) {
+            for (int i = 0; i < args.length; i++) {
+                if ("-url".equals(args[i])) {
+                    url = args[++i];
+                } else if ("-user".equals(args[i])) {
+                    user = args[++i];
+                } else if ("-password".equals(args[i])) {
+                    password = args[++i];
+                }
+                SelfDestructor.startCountdown(60);
+            }
+        }
+
+        public Connection getConnection() throws SQLException {
+            return getConnection(url, user, password);
+        }
+    }
+
+}

--- a/h2/src/test/org/h2/test/db/AbstractBaseForCommonTableExpressions.java
+++ b/h2/src/test/org/h2/test/db/AbstractBaseForCommonTableExpressions.java
@@ -14,12 +14,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Base class for common table expression tests
  */
-public abstract class AbstractBaseForCommonTableExpressions extends TestBase {
+public abstract class AbstractBaseForCommonTableExpressions extends TestDb {
 
     /**
      * Test a query.

--- a/h2/src/test/org/h2/test/db/TestAlter.java
+++ b/h2/src/test/org/h2/test/db/TestAlter.java
@@ -12,11 +12,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test ALTER statements.
  */
-public class TestAlter extends TestBase {
+public class TestAlter extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/db/TestAlterSchemaRename.java
+++ b/h2/src/test/org/h2/test/db/TestAlterSchemaRename.java
@@ -7,6 +7,7 @@ package org.h2.test.db;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -16,7 +17,7 @@ import java.sql.Statement;
 /**
  * Test ALTER SCHEMA RENAME statements.
  */
-public class TestAlterSchemaRename extends TestBase {
+public class TestAlterSchemaRename extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/db/TestAutoRecompile.java
+++ b/h2/src/test/org/h2/test/db/TestAutoRecompile.java
@@ -12,11 +12,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests if prepared statements are re-compiled when required.
  */
-public class TestAutoRecompile extends TestBase {
+public class TestAutoRecompile extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestBackup.java
+++ b/h2/src/test/org/h2/test/db/TestBackup.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.h2.api.DatabaseEventListener;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Backup;
 import org.h2.tools.Restore;
 import org.h2.util.Task;
@@ -22,7 +23,7 @@ import org.h2.util.Task;
 /**
  * Test for the BACKUP SQL statement.
  */
-public class TestBackup extends TestBase {
+public class TestBackup extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestBigDb.java
+++ b/h2/src/test/org/h2/test/db/TestBigDb.java
@@ -13,12 +13,13 @@ import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Utils;
 
 /**
  * Test for big databases.
  */
-public class TestBigDb extends TestBase {
+public class TestBigDb extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestBigResult.java
+++ b/h2/src/test/org/h2/test/db/TestBigResult.java
@@ -20,11 +20,12 @@ import java.util.BitSet;
 import org.h2.message.TraceSystem;
 import org.h2.store.FileLister;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test for big result sets.
  */
-public class TestBigResult extends TestBase {
+public class TestBigResult extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestCases.java
+++ b/h2/src/test/org/h2/test/db/TestCases.java
@@ -23,11 +23,12 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Various test cases.
  */
-public class TestCases extends TestBase {
+public class TestCases extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestCheckpoint.java
+++ b/h2/src/test/org/h2/test/db/TestCheckpoint.java
@@ -10,11 +10,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the CHECKPOINT SQL statement.
  */
-public class TestCheckpoint extends TestBase {
+public class TestCheckpoint extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestCluster.java
+++ b/h2/src/test/org/h2/test/db/TestCluster.java
@@ -15,6 +15,7 @@ import java.util.Properties;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.CreateCluster;
 import org.h2.tools.DeleteDbFiles;
 import org.h2.tools.Server;
@@ -23,7 +24,7 @@ import org.h2.util.JdbcUtils;
 /**
  * Test the cluster feature.
  */
-public class TestCluster extends TestBase {
+public class TestCluster extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -15,11 +15,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the compatibility with other databases.
  */
-public class TestCompatibility extends TestBase {
+public class TestCompatibility extends TestDb {
 
     private Connection conn;
 

--- a/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
@@ -16,12 +16,13 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Locale;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.SimpleResultSet;
 
 /**
  * Test Oracle compatibility mode.
  */
-public class TestCompatibilityOracle extends TestBase {
+public class TestCompatibilityOracle extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestCsv.java
+++ b/h2/src/test/org/h2/test/db/TestCsv.java
@@ -28,6 +28,7 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Csv;
 import org.h2.util.IOUtils;
 import org.h2.util.StringUtils;
@@ -38,7 +39,7 @@ import org.h2.util.StringUtils;
  * @author Thomas Mueller
  * @author Sylvain Cuaz (testNull)
  */
-public class TestCsv extends TestBase {
+public class TestCsv extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestDateStorage.java
+++ b/h2/src/test/org/h2/test/db/TestDateStorage.java
@@ -19,6 +19,7 @@ import java.util.GregorianCalendar;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.unit.TestDate;
 import org.h2.util.DateTimeUtils;
 import org.h2.value.ValueTimestamp;
@@ -26,7 +27,7 @@ import org.h2.value.ValueTimestamp;
 /**
  * Tests the date transfer and storage.
  */
-public class TestDateStorage extends TestBase {
+public class TestDateStorage extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestDeadlock.java
+++ b/h2/src/test/org/h2/test/db/TestDeadlock.java
@@ -14,12 +14,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Test for deadlocks in the code, and test the deadlock detection mechanism.
  */
-public class TestDeadlock extends TestBase {
+public class TestDeadlock extends TestDb {
 
     /**
      * The first connection.

--- a/h2/src/test/org/h2/test/db/TestDrop.java
+++ b/h2/src/test/org/h2/test/db/TestDrop.java
@@ -9,11 +9,12 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test DROP statement
  */
-public class TestDrop extends TestBase {
+public class TestDrop extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/db/TestDuplicateKeyUpdate.java
+++ b/h2/src/test/org/h2/test/db/TestDuplicateKeyUpdate.java
@@ -13,11 +13,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests for the ON DUPLICATE KEY UPDATE in the Insert class.
  */
-public class TestDuplicateKeyUpdate extends TestBase {
+public class TestDuplicateKeyUpdate extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestEncryptedDb.java
+++ b/h2/src/test/org/h2/test/db/TestEncryptedDb.java
@@ -12,11 +12,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test using an encrypted database.
  */
-public class TestEncryptedDb extends TestBase {
+public class TestEncryptedDb extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestExclusive.java
+++ b/h2/src/test/org/h2/test/db/TestExclusive.java
@@ -12,12 +12,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Test for the exclusive mode.
  */
-public class TestExclusive extends TestBase {
+public class TestExclusive extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestFullText.java
+++ b/h2/src/test/org/h2/test/db/TestFullText.java
@@ -23,13 +23,14 @@ import java.util.concurrent.TimeUnit;
 import org.h2.fulltext.FullText;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.IOUtils;
 import org.h2.util.Task;
 
 /**
  * Fulltext search tests.
  */
-public class TestFullText extends TestBase {
+public class TestFullText extends TestDb {
 
     /**
      * The words used in this test.

--- a/h2/src/test/org/h2/test/db/TestFunctionOverload.java
+++ b/h2/src/test/org/h2/test/db/TestFunctionOverload.java
@@ -13,13 +13,14 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests for overloaded user defined functions.
  *
  * @author Gary Tong
  */
-public class TestFunctionOverload extends TestBase {
+public class TestFunctionOverload extends TestDb {
 
     private static final String ME = TestFunctionOverload.class.getName();
     private Connection conn;

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -50,6 +50,7 @@ import org.h2.jdbc.JdbcSQLException;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.ap.TestAnnotationProcessor;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.DateTimeUtils;
@@ -64,7 +65,7 @@ import org.h2.value.ValueTimestampTimeZone;
 /**
  * Tests for user defined functions and aggregates.
  */
-public class TestFunctions extends TestBase implements AggregateFunction {
+public class TestFunctions extends TestDb implements AggregateFunction {
 
     static int count;
 

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -20,13 +20,14 @@ import org.h2.api.ErrorCode;
 import org.h2.command.dml.Select;
 import org.h2.result.SortOrder;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.SimpleResultSet;
 import org.h2.value.ValueInt;
 
 /**
  * Index tests.
  */
-public class TestIndex extends TestBase {
+public class TestIndex extends TestDb {
 
     private static int testFunctionIndexCounter;
 

--- a/h2/src/test/org/h2/test/db/TestIndexHints.java
+++ b/h2/src/test/org/h2/test/db/TestIndexHints.java
@@ -7,6 +7,7 @@ package org.h2.test.db;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -16,7 +17,7 @@ import java.sql.Statement;
 /**
  * Tests the index hints feature of this database.
  */
-public class TestIndexHints extends TestBase {
+public class TestIndexHints extends TestDb {
 
     private Connection conn;
 

--- a/h2/src/test/org/h2/test/db/TestLargeBlob.java
+++ b/h2/src/test/org/h2/test/db/TestLargeBlob.java
@@ -11,11 +11,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test a BLOB larger than Integer.MAX_VALUE
  */
-public class TestLargeBlob extends TestBase {
+public class TestLargeBlob extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestLinkedTable.java
+++ b/h2/src/test/org/h2/test/db/TestLinkedTable.java
@@ -17,12 +17,13 @@ import java.sql.Timestamp;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.value.DataType;
 
 /**
  * Tests the linked table feature (CREATE LINKED TABLE).
  */
-public class TestLinkedTable extends TestBase {
+public class TestLinkedTable extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestListener.java
+++ b/h2/src/test/org/h2/test/db/TestListener.java
@@ -14,11 +14,12 @@ import java.util.concurrent.TimeUnit;
 
 import org.h2.api.DatabaseEventListener;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the DatabaseEventListener.
  */
-public class TestListener extends TestBase implements DatabaseEventListener {
+public class TestListener extends TestDb implements DatabaseEventListener {
 
     private long last;
     private int lastState = -1;

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -31,6 +31,7 @@ import org.h2.jdbc.JdbcConnection;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Recover;
 import org.h2.util.IOUtils;
 import org.h2.util.JdbcUtils;
@@ -40,7 +41,7 @@ import org.h2.util.Task;
 /**
  * Tests LOB and CLOB data types.
  */
-public class TestLob extends TestBase {
+public class TestLob extends TestDb {
 
     private static final String MORE_THAN_128_CHARS =
             "12345678901234567890123456789012345678901234567890" +

--- a/h2/src/test/org/h2/test/db/TestMemoryUsage.java
+++ b/h2/src/test/org/h2/test/db/TestMemoryUsage.java
@@ -14,12 +14,13 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Utils;
 
 /**
  * Tests the memory usage of the cache.
  */
-public class TestMemoryUsage extends TestBase {
+public class TestMemoryUsage extends TestDb {
 
     private Connection conn;
 

--- a/h2/src/test/org/h2/test/db/TestMergeUsing.java
+++ b/h2/src/test/org/h2/test/db/TestMergeUsing.java
@@ -12,11 +12,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.Trigger;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test merge using syntax.
  */
-public class TestMergeUsing extends TestBase implements Trigger {
+public class TestMergeUsing extends TestDb implements Trigger {
 
     private static final String GATHER_ORDERED_RESULTS_SQL = "SELECT ID, NAME FROM PARENT ORDER BY ID ASC";
     private static int triggerTestingUpdateCount;

--- a/h2/src/test/org/h2/test/db/TestMultiConn.java
+++ b/h2/src/test/org/h2/test/db/TestMultiConn.java
@@ -11,12 +11,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.DatabaseEventListener;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Multi-connection tests.
  */
-public class TestMultiConn extends TestBase {
+public class TestMultiConn extends TestDb {
 
     /**
      * How long to wait in milliseconds.

--- a/h2/src/test/org/h2/test/db/TestMultiDimension.java
+++ b/h2/src/test/org/h2/test/db/TestMultiDimension.java
@@ -14,12 +14,13 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.MultiDimension;
 
 /**
  * Tests the multi-dimension index tool.
  */
-public class TestMultiDimension extends TestBase {
+public class TestMultiDimension extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestMultiThread.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThread.java
@@ -25,6 +25,7 @@ import org.h2.api.ErrorCode;
 import org.h2.jdbc.JdbcSQLException;
 import org.h2.test.TestAll;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.IOUtils;
 import org.h2.util.SmallLRUCache;
 import org.h2.util.SynchronizedVerifier;
@@ -33,7 +34,7 @@ import org.h2.util.Task;
 /**
  * Multi-threaded tests.
  */
-public class TestMultiThread extends TestBase implements Runnable {
+public class TestMultiThread extends TestDb implements Runnable {
 
     private boolean stop;
     private TestMultiThread parent;

--- a/h2/src/test/org/h2/test/db/TestMultiThreadedKernel.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThreadedKernel.java
@@ -14,13 +14,14 @@ import java.util.ArrayList;
 import java.util.Random;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.JdbcUtils;
 import org.h2.util.Task;
 
 /**
  * A multi-threaded test case.
  */
-public class TestMultiThreadedKernel extends TestBase {
+public class TestMultiThreadedKernel extends TestDb {
 
     /**
      * Stop the current thread.

--- a/h2/src/test/org/h2/test/db/TestOpenClose.java
+++ b/h2/src/test/org/h2/test/db/TestOpenClose.java
@@ -20,13 +20,14 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Restore;
 import org.h2.util.Task;
 
 /**
  * Tests opening and closing a database.
  */
-public class TestOpenClose extends TestBase {
+public class TestOpenClose extends TestDb {
 
     private int nextId = 10;
 

--- a/h2/src/test/org/h2/test/db/TestOptimizations.java
+++ b/h2/src/test/org/h2/test/db/TestOptimizations.java
@@ -18,6 +18,7 @@ import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.StringUtils;
 import org.h2.util.Task;
@@ -26,7 +27,7 @@ import org.h2.util.Task;
  * Test various optimizations (query cache, optimization for MIN(..), and
  * MAX(..)).
  */
-public class TestOptimizations extends TestBase {
+public class TestOptimizations extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestOptimizations.java
+++ b/h2/src/test/org/h2/test/db/TestOptimizations.java
@@ -1157,11 +1157,12 @@ public class TestOptimizations extends TestDb {
                 "FOREIGN KEY (table_a_id) REFERENCES TABLE_A(id) )");
         stat.execute("INSERT INTO TABLE_A (name)  SELECT 'package_' || CAST(X as VARCHAR) " +
                 "FROM SYSTEM_RANGE(1, 100)  WHERE X <= 100");
+        int count = config.memory ? 30_000 : 50_000;
         stat.execute("INSERT INTO TABLE_B (table_a_id, createDate)  SELECT " +
                 "CASE WHEN table_a_id = 0 THEN 1 ELSE table_a_id END, createDate " +
                 "FROM ( SELECT ROUND((RAND() * 100)) AS table_a_id, " +
-                "DATEADD('SECOND', X, NOW()) as createDate FROM SYSTEM_RANGE(1, 50000) " +
-                "WHERE X < 50000  )");
+                "DATEADD('SECOND', X, NOW()) as createDate FROM SYSTEM_RANGE(1, " + count + ") " +
+                "WHERE X < " + count + "  )");
         stat.execute("CREATE INDEX table_b_idx ON table_b(table_a_id, id)");
         stat.execute("ANALYZE");
 

--- a/h2/src/test/org/h2/test/db/TestOptimizerHints.java
+++ b/h2/src/test/org/h2/test/db/TestOptimizerHints.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.StatementBuilder;
 
 /**
@@ -18,7 +19,7 @@ import org.h2.util.StatementBuilder;
  *
  * @author Sergi Vladykin
  */
-public class TestOptimizerHints extends TestBase {
+public class TestOptimizerHints extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestOutOfMemory.java
+++ b/h2/src/test/org/h2/test/db/TestOutOfMemory.java
@@ -20,12 +20,13 @@ import org.h2.store.fs.FilePath;
 import org.h2.store.fs.FilePathMem;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests out of memory situations. The database must not get corrupted, and
  * transactions must stay atomic.
  */
-public class TestOutOfMemory extends TestBase {
+public class TestOutOfMemory extends TestDb {
 
     private static final String DB_NAME = "outOfMemory";
 
@@ -203,7 +204,7 @@ public class TestOutOfMemory extends TestBase {
         }
     }
 
-    public static final class MyChild extends TestBase.Child
+    public static final class MyChild extends TestDb.Child
     {
 
         /**

--- a/h2/src/test/org/h2/test/db/TestPowerOff.java
+++ b/h2/src/test/org/h2/test/db/TestPowerOff.java
@@ -16,12 +16,13 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Database;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.JdbcUtils;
 
 /**
  * Tests simulated power off conditions.
  */
-public class TestPowerOff extends TestBase {
+public class TestPowerOff extends TestDb {
 
     private static final String DB_NAME = "powerOff";
     private String dir, url;

--- a/h2/src/test/org/h2/test/db/TestQueryCache.java
+++ b/h2/src/test/org/h2/test/db/TestQueryCache.java
@@ -12,11 +12,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the query cache.
  */
-public class TestQueryCache extends TestBase {
+public class TestQueryCache extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestReadOnly.java
+++ b/h2/src/test/org/h2/test/db/TestReadOnly.java
@@ -18,13 +18,14 @@ import org.h2.dev.fs.FilePathZip2;
 import org.h2.store.FileLister;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Backup;
 import org.h2.tools.Server;
 
 /**
  * Test for the read-only database feature.
  */
-public class TestReadOnly extends TestBase {
+public class TestReadOnly extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestRecursiveQueries.java
+++ b/h2/src/test/org/h2/test/db/TestRecursiveQueries.java
@@ -11,11 +11,12 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.sql.Types;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test recursive queries using WITH.
  */
-public class TestRecursiveQueries extends TestBase {
+public class TestRecursiveQueries extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestReplace.java
+++ b/h2/src/test/org/h2/test/db/TestReplace.java
@@ -6,6 +6,7 @@
 package org.h2.test.db;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -17,7 +18,7 @@ import java.sql.Statement;
  *
  * @author Cemo
  */
-public class TestReplace extends TestBase {
+public class TestReplace extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestRights.java
+++ b/h2/src/test/org/h2/test/db/TestRights.java
@@ -15,11 +15,12 @@ import java.sql.Statement;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Access rights tests.
  */
-public class TestRights extends TestBase {
+public class TestRights extends TestDb {
 
     private Statement stat;
 

--- a/h2/src/test/org/h2/test/db/TestRowFactory.java
+++ b/h2/src/test/org/h2/test/db/TestRowFactory.java
@@ -12,6 +12,7 @@ import org.h2.result.Row;
 import org.h2.result.RowFactory;
 import org.h2.result.RowImpl;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.value.Value;
 
 /**
@@ -19,7 +20,7 @@ import org.h2.value.Value;
  *
  * @author Sergi Vladykin
  */
-public class TestRowFactory extends TestBase {
+public class TestRowFactory extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestRunscript.java
+++ b/h2/src/test/org/h2/test/db/TestRunscript.java
@@ -14,6 +14,7 @@ import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.ChangeFileEncryption;
 import org.h2.tools.Recover;
 import org.h2.util.Task;
@@ -21,7 +22,7 @@ import org.h2.util.Task;
 /**
  * Tests the RUNSCRIPT SQL statement.
  */
-public class TestRunscript extends TestBase implements Trigger {
+public class TestRunscript extends TestDb implements Trigger {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestSQLInjection.java
+++ b/h2/src/test/org/h2/test/db/TestSQLInjection.java
@@ -13,11 +13,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the ALLOW_LITERALS feature (protection against SQL injection).
  */
-public class TestSQLInjection extends TestBase {
+public class TestSQLInjection extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/db/TestSelectCountNonNullColumn.java
+++ b/h2/src/test/org/h2/test/db/TestSelectCountNonNullColumn.java
@@ -10,12 +10,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test that count(column) is converted to count(*) if the column is not
  * nullable.
  */
-public class TestSelectCountNonNullColumn extends TestBase {
+public class TestSelectCountNonNullColumn extends TestDb {
 
     private static final String DBNAME = "selectCountNonNullColumn";
     private Statement stat;

--- a/h2/src/test/org/h2/test/db/TestSequence.java
+++ b/h2/src/test/org/h2/test/db/TestSequence.java
@@ -15,12 +15,13 @@ import java.util.Collections;
 import java.util.List;
 import org.h2.api.Trigger;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Tests the sequence feature of this database.
  */
-public class TestSequence extends TestBase {
+public class TestSequence extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestSessionsLocks.java
+++ b/h2/src/test/org/h2/test/db/TestSessionsLocks.java
@@ -10,11 +10,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the meta data tables information_schema.locks and sessions.
  */
-public class TestSessionsLocks extends TestBase {
+public class TestSessionsLocks extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestSetCollation.java
+++ b/h2/src/test/org/h2/test/db/TestSetCollation.java
@@ -16,8 +16,9 @@ import java.util.Arrays;
 import java.util.List;
 import org.h2.jdbc.JdbcSQLException;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
-public class TestSetCollation extends TestBase {
+public class TestSetCollation extends TestDb {
     private static final String[] TEST_STRINGS = new String[]{"A", "\u00c4", "AA", "B", "$", "1A", null};
 
     private static final String DB_NAME = "collator";

--- a/h2/src/test/org/h2/test/db/TestShow.java
+++ b/h2/src/test/org/h2/test/db/TestShow.java
@@ -6,6 +6,7 @@
 package org.h2.test.db;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -15,7 +16,7 @@ import java.sql.Statement;
 /**
  * Test of compatibility for the SHOW statement.
  */
-public class TestShow extends TestBase {
+public class TestShow extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestSpaceReuse.java
+++ b/h2/src/test/org/h2/test/db/TestSpaceReuse.java
@@ -11,11 +11,12 @@ import java.sql.Statement;
 import org.h2.engine.Constants;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests if disk space is reused after deleting many rows.
  */
-public class TestSpaceReuse extends TestBase {
+public class TestSpaceReuse extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestSpatial.java
+++ b/h2/src/test/org/h2/test/db/TestSpatial.java
@@ -14,6 +14,7 @@ import java.sql.Types;
 import java.util.Random;
 import org.h2.api.Aggregate;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.SimpleResultSet;
 import org.h2.tools.SimpleRowSource;
 import org.h2.value.DataType;
@@ -38,7 +39,7 @@ import org.locationtech.jts.io.WKTReader;
  * @author Noel Grandin
  * @author Nicolas Fortin, Atelier SIG, IRSTV FR CNRS 24888
  */
-public class TestSpatial extends TestBase {
+public class TestSpatial extends TestDb {
 
     private static final String URL = "spatial";
 

--- a/h2/src/test/org/h2/test/db/TestSpeed.java
+++ b/h2/src/test/org/h2/test/db/TestSpeed.java
@@ -12,11 +12,12 @@ import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Various small performance tests.
  */
-public class TestSpeed extends TestBase {
+public class TestSpeed extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestSynonymForTable.java
+++ b/h2/src/test/org/h2/test/db/TestSynonymForTable.java
@@ -13,11 +13,12 @@ import java.sql.Statement;
 import org.h2.engine.Constants;
 import org.h2.jdbc.JdbcSQLException;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests for table synonyms.
  */
-public class TestSynonymForTable extends TestBase {
+public class TestSynonymForTable extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -50,6 +50,7 @@ import org.h2.table.TableBase;
 import org.h2.table.TableFilter;
 import org.h2.table.TableType;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.DoneFuture;
 import org.h2.value.Value;
 import org.h2.value.ValueInt;
@@ -61,7 +62,7 @@ import org.h2.value.ValueString;
  *
  * @author Sergi Vladykin
  */
-public class TestTableEngines extends TestBase {
+public class TestTableEngines extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestTempTables.java
+++ b/h2/src/test/org/h2/test/db/TestTempTables.java
@@ -14,11 +14,12 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Temporary table tests.
  */
-public class TestTempTables extends TestBase {
+public class TestTempTables extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestTransaction.java
+++ b/h2/src/test/org/h2/test/db/TestTransaction.java
@@ -17,12 +17,13 @@ import java.util.Random;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Transactional tests, including transaction isolation tests, and tests related
  * to savepoints.
  */
-public class TestTransaction extends TestBase {
+public class TestTransaction extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
+++ b/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
@@ -17,6 +17,7 @@ import org.h2.api.Trigger;
 import org.h2.engine.Session;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.TriggerAdapter;
 import org.h2.util.Task;
 import org.h2.value.ValueLong;
@@ -24,7 +25,7 @@ import org.h2.value.ValueLong;
 /**
  * Tests for trigger and constraints.
  */
-public class TestTriggersConstraints extends TestBase implements Trigger {
+public class TestTriggersConstraints extends TestDb implements Trigger {
 
     private static boolean mustNotCallTrigger;
     private String triggerName;

--- a/h2/src/test/org/h2/test/db/TestTwoPhaseCommit.java
+++ b/h2/src/test/org/h2/test/db/TestTwoPhaseCommit.java
@@ -11,11 +11,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests for the two-phase-commit feature.
  */
-public class TestTwoPhaseCommit extends TestBase {
+public class TestTwoPhaseCommit extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestUpgrade.java
+++ b/h2/src/test/org/h2/test/db/TestUpgrade.java
@@ -14,13 +14,14 @@ import java.sql.Statement;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.upgrade.DbUpgrade;
 import org.h2.util.Utils;
 
 /**
  * Automatic upgrade test cases.
  */
-public class TestUpgrade extends TestBase {
+public class TestUpgrade extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestUsingIndex.java
+++ b/h2/src/test/org/h2/test/db/TestUsingIndex.java
@@ -10,6 +10,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.value.DataType;
 
 /**
@@ -17,7 +18,7 @@ import org.h2.value.DataType;
  *
  * @author Erwan Bocher Atelier SIG, IRSTV FR CNRS 2488
  */
-public class TestUsingIndex extends TestBase {
+public class TestUsingIndex extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/db/TestView.java
+++ b/h2/src/test/org/h2/test/db/TestView.java
@@ -14,11 +14,12 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Session;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test for views.
  */
-public class TestView extends TestBase {
+public class TestView extends TestDb {
 
     private static int x;
 

--- a/h2/src/test/org/h2/test/db/TestViewAlterTable.java
+++ b/h2/src/test/org/h2/test/db/TestViewAlterTable.java
@@ -10,12 +10,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.api.ErrorCode;
 
 /**
  * Test the impact of ALTER TABLE statements on views.
  */
-public class TestViewAlterTable extends TestBase {
+public class TestViewAlterTable extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/db/TestViewDropView.java
+++ b/h2/src/test/org/h2/test/db/TestViewDropView.java
@@ -12,11 +12,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test the impact of DROP VIEW statements on dependent views.
  */
-public class TestViewDropView extends TestBase {
+public class TestViewDropView extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/jdbc/TestBatchUpdates.java
+++ b/h2/src/test/org/h2/test/jdbc/TestBatchUpdates.java
@@ -16,11 +16,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test for batch updates.
  */
-public class TestBatchUpdates extends TestBase {
+public class TestBatchUpdates extends TestDb {
 
     private static final String COFFEE_UPDATE =
             "UPDATE TEST SET PRICE=PRICE*20 WHERE TYPE_ID=?";

--- a/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.IOUtils;
 import org.h2.util.JdbcUtils;
@@ -35,7 +36,7 @@ import org.h2.util.Utils;
 /**
  * Tests for the CallableStatement class.
  */
-public class TestCallableStatement extends TestBase {
+public class TestCallableStatement extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestCancel.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCancel.java
@@ -14,11 +14,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests Statement.cancel
  */
-public class TestCancel extends TestBase {
+public class TestCancel extends TestDb {
 
     private static int lastVisited;
 

--- a/h2/src/test/org/h2/test/jdbc/TestConcurrentConnectionUsage.java
+++ b/h2/src/test/org/h2/test/jdbc/TestConcurrentConnectionUsage.java
@@ -11,12 +11,13 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Test concurrent usage of the same connection.
  */
-public class TestConcurrentConnectionUsage extends TestBase {
+public class TestConcurrentConnectionUsage extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestConnection.java
+++ b/h2/src/test/org/h2/test/jdbc/TestConnection.java
@@ -7,6 +7,8 @@ package org.h2.test.jdbc;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
+
 import java.sql.Connection;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
@@ -18,7 +20,7 @@ import java.util.Properties;
 /**
  * Tests the client info
  */
-public class TestConnection extends TestBase {
+public class TestConnection extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestCustomDataTypesHandler.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCustomDataTypesHandler.java
@@ -19,6 +19,7 @@ import org.h2.api.ErrorCode;
 import org.h2.message.DbException;
 import org.h2.store.DataHandler;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.JdbcUtils;
 import org.h2.util.StringUtils;
 import org.h2.value.CompareMode;
@@ -32,7 +33,7 @@ import org.h2.value.ValueString;
 /**
  * Tests {@link CustomDataTypesHandler}.
  */
-public class TestCustomDataTypesHandler extends TestBase {
+public class TestCustomDataTypesHandler extends TestDb {
 
     /**
      * The database name.

--- a/h2/src/test/org/h2/test/jdbc/TestDatabaseEventListener.java
+++ b/h2/src/test/org/h2/test/jdbc/TestDatabaseEventListener.java
@@ -15,11 +15,12 @@ import org.h2.Driver;
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the DatabaseEventListener interface.
  */
-public class TestDatabaseEventListener extends TestBase {
+public class TestDatabaseEventListener extends TestDb {
 
     /**
      * A flag to mark that the given method was called.

--- a/h2/src/test/org/h2/test/jdbc/TestDriver.java
+++ b/h2/src/test/org/h2/test/jdbc/TestDriver.java
@@ -13,11 +13,12 @@ import java.util.Properties;
 
 import org.h2.Driver;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the database driver.
  */
-public class TestDriver extends TestBase {
+public class TestDriver extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestGetGeneratedKeys.java
+++ b/h2/src/test/org/h2/test/jdbc/TestGetGeneratedKeys.java
@@ -17,11 +17,12 @@ import org.h2.api.Trigger;
 import org.h2.jdbc.JdbcPreparedStatement;
 import org.h2.jdbc.JdbcStatement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests for the {@link Statement#getGeneratedKeys()}.
  */
-public class TestGetGeneratedKeys extends TestBase {
+public class TestGetGeneratedKeys extends TestDb {
 
     public static class TestGetGeneratedKeysTrigger implements Trigger {
 

--- a/h2/src/test/org/h2/test/jdbc/TestJavaObject.java
+++ b/h2/src/test/org/h2/test/jdbc/TestJavaObject.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests java object values when SysProperties.SERIALIZE_JAVA_OBJECT property is
@@ -24,7 +25,7 @@ import org.h2.test.TestBase;
  *
  * @author Sergi Vladykin
  */
-public class TestJavaObject extends TestBase {
+public class TestJavaObject extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestJavaObjectSerializer.java
+++ b/h2/src/test/org/h2/test/jdbc/TestJavaObjectSerializer.java
@@ -12,6 +12,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import org.h2.api.JavaObjectSerializer;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.JdbcUtils;
 
 /**
@@ -20,7 +21,7 @@ import org.h2.util.JdbcUtils;
  * @author Sergi Vladykin
  * @author Davide Cavestro
  */
-public class TestJavaObjectSerializer extends TestBase {
+public class TestJavaObjectSerializer extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestLimitUpdates.java
+++ b/h2/src/test/org/h2/test/jdbc/TestLimitUpdates.java
@@ -10,11 +10,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test for limit updates.
  */
-public class TestLimitUpdates extends TestBase {
+public class TestLimitUpdates extends TestDb {
 
     private static final String DATABASE_NAME = "limitUpdates";
 

--- a/h2/src/test/org/h2/test/jdbc/TestLobApi.java
+++ b/h2/src/test/org/h2/test/jdbc/TestLobApi.java
@@ -25,12 +25,13 @@ import java.util.Random;
 import org.h2.api.ErrorCode;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.IOUtils;
 
 /**
  * Test the Blob, Clob, and NClob implementations.
  */
-public class TestLobApi extends TestBase {
+public class TestLobApi extends TestDb {
 
     private JdbcConnection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/jdbc/TestManyJdbcObjects.java
+++ b/h2/src/test/org/h2/test/jdbc/TestManyJdbcObjects.java
@@ -13,11 +13,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the server by creating many JDBC objects (result sets and so on).
  */
-public class TestManyJdbcObjects extends TestBase {
+public class TestManyJdbcObjects extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -20,12 +20,13 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.value.DataType;
 
 /**
  * Test for the DatabaseMetaData implementation.
  */
-public class TestMetaData extends TestBase {
+public class TestMetaData extends TestDb {
 
     private static final String CATALOG = "METADATA";
 

--- a/h2/src/test/org/h2/test/jdbc/TestNativeSQL.java
+++ b/h2/src/test/org/h2/test/jdbc/TestNativeSQL.java
@@ -13,11 +13,12 @@ import java.util.Random;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the Connection.nativeSQL method.
  */
-public class TestNativeSQL extends TestBase {
+public class TestNativeSQL extends TestDb {
 
     private static final String[] PAIRS = {
             "CREATE TABLE TEST(ID INT PRIMARY KEY)",

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -33,13 +33,14 @@ import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.LocalDateTimeUtils;
 import org.h2.util.Task;
 
 /**
  * Tests for the PreparedStatement implementation.
  */
-public class TestPreparedStatement extends TestBase {
+public class TestPreparedStatement extends TestDb {
 
     private static final int LOB_SIZE = 4000, LOB_SIZE_BIG = 512 * 1024;
 

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -40,6 +40,7 @@ import java.util.TimeZone;
 import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.DateTimeUtils;
 import org.h2.util.IOUtils;
 import org.h2.util.LocalDateTimeUtils;
@@ -49,7 +50,7 @@ import org.h2.util.StringUtils;
 /**
  * Tests for the ResultSet implementation.
  */
-public class TestResultSet extends TestBase {
+public class TestResultSet extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -21,11 +21,12 @@ import org.h2.jdbc.JdbcStatement;
 import org.h2.jdbc.JdbcStatementBackwardsCompat;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests for the Statement implementation.
  */
-public class TestStatement extends TestBase {
+public class TestStatement extends TestDb {
 
     private Connection conn;
 

--- a/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
+++ b/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
@@ -9,11 +9,12 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Transaction isolation level tests.
  */
-public class TestTransactionIsolation extends TestBase {
+public class TestTransactionIsolation extends TestDb {
 
     private Connection conn1, conn2;
 

--- a/h2/src/test/org/h2/test/jdbc/TestUpdatableResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestUpdatableResultSet.java
@@ -23,11 +23,12 @@ import java.sql.Types;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Updatable result set tests.
  */
-public class TestUpdatableResultSet extends TestBase {
+public class TestUpdatableResultSet extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestUrlJavaObjectSerializer.java
+++ b/h2/src/test/org/h2/test/jdbc/TestUrlJavaObjectSerializer.java
@@ -12,13 +12,14 @@ import java.sql.Statement;
 import java.sql.Types;
 import org.h2.api.JavaObjectSerializer;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests per-db {@link JavaObjectSerializer} when set through the JDBC URL.
  *
  * @author Davide Cavestro
  */
-public class TestUrlJavaObjectSerializer extends TestBase {
+public class TestUrlJavaObjectSerializer extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbc/TestZloty.java
+++ b/h2/src/test/org/h2/test/jdbc/TestZloty.java
@@ -13,12 +13,13 @@ import java.sql.SQLException;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests a custom BigDecimal implementation, as well
  * as direct modification of a byte in a byte array.
  */
-public class TestZloty extends TestBase {
+public class TestZloty extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbcx/TestConnectionPool.java
+++ b/h2/src/test/org/h2/test/jdbcx/TestConnectionPool.java
@@ -18,12 +18,13 @@ import javax.sql.DataSource;
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.h2.jdbcx.JdbcDataSource;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * This class tests the JdbcConnectionPool.
  */
-public class TestConnectionPool extends TestBase {
+public class TestConnectionPool extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbcx/TestDataSource.java
+++ b/h2/src/test/org/h2/test/jdbcx/TestDataSource.java
@@ -25,11 +25,12 @@ import org.h2.jdbcx.JdbcDataSourceFactory;
 import org.h2.jdbcx.JdbcXAConnection;
 import org.h2.message.TraceSystem;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests DataSource and XAConnection.
  */
-public class TestDataSource extends TestBase {
+public class TestDataSource extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/jdbcx/TestXA.java
+++ b/h2/src/test/org/h2/test/jdbcx/TestXA.java
@@ -16,12 +16,13 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import org.h2.jdbcx.JdbcDataSource;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.JdbcUtils;
 
 /**
  * Basic XA tests.
  */
-public class TestXA extends TestBase {
+public class TestXA extends TestDb {
 
     private static final String DB_NAME1 = "xadb1";
     private static final String DB_NAME2 = "xadb2";

--- a/h2/src/test/org/h2/test/jdbcx/TestXASimple.java
+++ b/h2/src/test/org/h2/test/jdbcx/TestXASimple.java
@@ -14,12 +14,13 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import org.h2.jdbcx.JdbcDataSource;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.JdbcUtils;
 
 /**
  * A simple XA test.
  */
-public class TestXASimple extends TestBase {
+public class TestXASimple extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
@@ -14,11 +14,12 @@ import java.util.Random;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Basic MVCC (multi version concurrency) test cases.
  */
-public class TestMvcc1 extends TestBase {
+public class TestMvcc1 extends TestDb {
 
     private Connection c1, c2;
     private Statement s1, s2;

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc2.java
@@ -11,12 +11,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Additional MVCC (multi version concurrency) test cases.
  */
-public class TestMvcc2 extends TestBase {
+public class TestMvcc2 extends TestDb {
 
     private static final String DROP_TABLE =
             "DROP TABLE IF EXISTS EMPLOYEE";

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc3.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc3.java
@@ -13,11 +13,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Additional MVCC (multi version concurrency) test cases.
  */
-public class TestMvcc3 extends TestBase {
+public class TestMvcc3 extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc4.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc4.java
@@ -13,11 +13,12 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.concurrent.CountDownLatch;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Additional MVCC (multi version concurrency) test cases.
  */
-public class TestMvcc4 extends TestBase {
+public class TestMvcc4 extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded.java
@@ -12,12 +12,13 @@ import java.util.ArrayList;
 import java.util.concurrent.CyclicBarrier;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Multi-threaded MVCC (multi version concurrency) test cases.
  */
-public class TestMvccMultiThreaded extends TestBase {
+public class TestMvccMultiThreaded extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
@@ -13,12 +13,13 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import org.h2.message.DbException;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.IOUtils;
 
 /**
  * Additional MVCC (multi version concurrency) test cases.
  */
-public class TestMvccMultiThreaded2 extends TestBase {
+public class TestMvccMultiThreaded2 extends TestDb {
 
     private static final int TEST_THREAD_COUNT = 100;
     private static final int TEST_TIME_SECONDS = 60;

--- a/h2/src/test/org/h2/test/recover/RecoverLobTest.java
+++ b/h2/src/test/org/h2/test/recover/RecoverLobTest.java
@@ -9,13 +9,14 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.DeleteDbFiles;
 import org.h2.tools.Recover;
 
 /**
  * Tests BLOB/CLOB recovery.
  */
-public class RecoverLobTest extends TestBase {
+public class RecoverLobTest extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/rowlock/TestRowLocks.java
+++ b/h2/src/test/org/h2/test/rowlock/TestRowLocks.java
@@ -12,12 +12,13 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Row level locking tests.
  */
-public class TestRowLocks extends TestBase {
+public class TestRowLocks extends TestDb {
 
     /**
      * The statements used in this test.

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -29,13 +29,14 @@ import org.h2.engine.SysProperties;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestAll;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.StringUtils;
 
 /**
  * This test runs a SQL script file and compares the output with the expected
  * output.
  */
-public class TestScript extends TestBase {
+public class TestScript extends TestDb {
 
     private static final String BASE_DIR = "org/h2/test/scripts/";
 

--- a/h2/src/test/org/h2/test/scripts/TestScriptSimple.java
+++ b/h2/src/test/org/h2/test/scripts/TestScriptSimple.java
@@ -12,13 +12,14 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.ScriptReader;
 
 /**
  * This test runs a simple SQL script file and compares the output with the
  * expected output.
  */
-public class TestScriptSimple extends TestBase {
+public class TestScriptSimple extends TestDb {
 
     private Connection conn;
 

--- a/h2/src/test/org/h2/test/server/TestAutoServer.java
+++ b/h2/src/test/org/h2/test/server/TestAutoServer.java
@@ -10,12 +10,13 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.SortedProperties;
 
 /**
  * Tests automatic embedded/server mode.
  */
-public class TestAutoServer extends TestBase {
+public class TestAutoServer extends TestDb {
 
     /**
      * The number of iterations.

--- a/h2/src/test/org/h2/test/server/TestInit.java
+++ b/h2/src/test/org/h2/test/server/TestInit.java
@@ -13,11 +13,12 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests INIT command within embedded/server mode.
  */
-public class TestInit extends TestBase {
+public class TestInit extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/server/TestNestedLoop.java
+++ b/h2/src/test/org/h2/test/server/TestNestedLoop.java
@@ -12,12 +12,13 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests remote JDBC access with nested loops.
  * This is not allowed in some databases.
  */
-public class TestNestedLoop extends TestBase {
+public class TestNestedLoop extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/server/TestWeb.java
+++ b/h2/src/test/org/h2/test/server/TestWeb.java
@@ -46,6 +46,7 @@ import org.h2.engine.SysProperties;
 import org.h2.server.web.WebServlet;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.AssertThrows;
 import org.h2.tools.Server;
 import org.h2.util.StringUtils;
@@ -54,7 +55,7 @@ import org.h2.util.Task;
 /**
  * Tests the H2 Console application.
  */
-public class TestWeb extends TestBase {
+public class TestWeb extends TestDb {
 
     private static volatile String lastUrl;
 

--- a/h2/src/test/org/h2/test/store/TestBenchmark.java
+++ b/h2/src/test/org/h2/test/store/TestBenchmark.java
@@ -18,12 +18,13 @@ import org.h2.mvstore.MVStore;
 import org.h2.store.FileLister;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * Tests performance and helps analyze bottlenecks.
  */
-public class TestBenchmark extends TestBase {
+public class TestBenchmark extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -29,6 +29,7 @@ import org.h2.mvstore.MVStore;
 import org.h2.mvstore.tx.TransactionStore;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Recover;
 import org.h2.tools.Restore;
 import org.h2.util.JdbcUtils;
@@ -37,7 +38,7 @@ import org.h2.util.Task;
 /**
  * Tests the MVStore in a database.
  */
-public class TestMVTableEngine extends TestBase {
+public class TestMVTableEngine extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/synth/TestBtreeIndex.java
+++ b/h2/src/test/org/h2/test/synth/TestBtreeIndex.java
@@ -12,12 +12,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Random;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.DeleteDbFiles;
 
 /**
  * A b-tree index test.
  */
-public class TestBtreeIndex extends TestBase {
+public class TestBtreeIndex extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/synth/TestConcurrentUpdate.java
+++ b/h2/src/test/org/h2/test/synth/TestConcurrentUpdate.java
@@ -11,12 +11,13 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Random;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Task;
 
 /**
  * A concurrent test.
  */
-public class TestConcurrentUpdate extends TestBase {
+public class TestConcurrentUpdate extends TestDb {
 
     private static final int THREADS = 3;
     private static final int ROW_COUNT = 10;

--- a/h2/src/test/org/h2/test/synth/TestCrashAPI.java
+++ b/h2/src/test/org/h2/test/synth/TestCrashAPI.java
@@ -39,6 +39,7 @@ import org.h2.store.FileLister;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestAll;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.scripts.TestScript;
 import org.h2.test.synth.sql.RandomGen;
 import org.h2.tools.Backup;
@@ -51,7 +52,7 @@ import org.h2.util.MathUtils;
  * A test that calls random methods with random parameters from JDBC objects.
  * This is sometimes called 'Fuzz Testing'.
  */
-public class TestCrashAPI extends TestBase implements Runnable {
+public class TestCrashAPI extends TestDb implements Runnable {
 
     private static final boolean RECOVER_ALL = false;
 

--- a/h2/src/test/org/h2/test/synth/TestDiskFull.java
+++ b/h2/src/test/org/h2/test/synth/TestDiskFull.java
@@ -12,12 +12,13 @@ import java.sql.Statement;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.FilePathUnstable;
 
 /**
  * Test simulated disk full problems.
  */
-public class TestDiskFull extends TestBase {
+public class TestDiskFull extends TestDb {
 
     private FilePathUnstable fs;
 

--- a/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
+++ b/h2/src/test/org/h2/test/synth/TestFuzzOptimizations.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Random;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.db.Db;
 import org.h2.test.db.Db.Prepared;
 
@@ -23,7 +24,7 @@ import org.h2.test.db.Db.Prepared;
  * This test executes random SQL statements to test if optimizations are working
  * correctly.
  */
-public class TestFuzzOptimizations extends TestBase {
+public class TestFuzzOptimizations extends TestDb {
 
     private Connection conn;
 

--- a/h2/src/test/org/h2/test/synth/TestJoin.java
+++ b/h2/src/test/org/h2/test/synth/TestJoin.java
@@ -18,13 +18,14 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.StringUtils;
 
 /**
  * A test that runs random join statements against two databases and compares
  * the results.
  */
-public class TestJoin extends TestBase {
+public class TestJoin extends TestDb {
 
     private final ArrayList<Connection> connections = new ArrayList<>();
     private Random random;

--- a/h2/src/test/org/h2/test/synth/TestKill.java
+++ b/h2/src/test/org/h2/test/synth/TestKill.java
@@ -13,6 +13,7 @@ import java.sql.Statement;
 import java.util.Random;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.SelfDestructor;
 
 /**
@@ -20,7 +21,7 @@ import org.h2.test.utils.SelfDestructor;
  * operations against a database, then kills this process. Afterwards recovery
  * is tested.
  */
-public class TestKill extends TestBase {
+public class TestKill extends TestDb {
 
     private static final String DIR = TestBase.getTestDir("kill");
 

--- a/h2/src/test/org/h2/test/synth/TestKillRestart.java
+++ b/h2/src/test/org/h2/test/synth/TestKillRestart.java
@@ -17,13 +17,14 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.SelfDestructor;
 
 /**
  * Standalone recovery test. A new process is started and then killed while it
  * executes random statements.
  */
-public class TestKillRestart extends TestBase {
+public class TestKillRestart extends TestDb {
 
     @Override
     public void test() throws Exception {

--- a/h2/src/test/org/h2/test/synth/TestKillRestartMulti.java
+++ b/h2/src/test/org/h2/test/synth/TestKillRestartMulti.java
@@ -18,6 +18,7 @@ import java.util.Random;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.SelfDestructor;
 import org.h2.tools.Backup;
 
@@ -25,7 +26,7 @@ import org.h2.tools.Backup;
  * Standalone recovery test. A new process is started and then killed while it
  * executes random statements using multiple connection.
  */
-public class TestKillRestartMulti extends TestBase {
+public class TestKillRestartMulti extends TestDb {
 
     /**
      * We want self-destruct to occur before the read times out and we kill the

--- a/h2/src/test/org/h2/test/synth/TestLimit.java
+++ b/h2/src/test/org/h2/test/synth/TestLimit.java
@@ -9,11 +9,12 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * The LIMIT, OFFSET, maxRows.
  */
-public class TestLimit extends TestBase {
+public class TestLimit extends TestDb {
 
     private Statement stat;
 

--- a/h2/src/test/org/h2/test/synth/TestMultiThreaded.java
+++ b/h2/src/test/org/h2/test/synth/TestMultiThreaded.java
@@ -12,11 +12,12 @@ import java.sql.Statement;
 import java.util.Random;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the multi-threaded mode.
  */
-public class TestMultiThreaded extends TestBase {
+public class TestMultiThreaded extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/synth/TestNestedJoins.java
+++ b/h2/src/test/org/h2/test/synth/TestNestedJoins.java
@@ -19,12 +19,13 @@ import java.util.Random;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.ScriptReader;
 
 /**
  * Tests nested joins and right outer joins.
  */
-public class TestNestedJoins extends TestBase {
+public class TestNestedJoins extends TestDb {
 
     private final ArrayList<Statement> dbs = new ArrayList<>();
 

--- a/h2/src/test/org/h2/test/synth/TestOuterJoins.java
+++ b/h2/src/test/org/h2/test/synth/TestOuterJoins.java
@@ -18,12 +18,13 @@ import java.util.Random;
 
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.ScriptReader;
 
 /**
  * Tests nested joins and right outer joins.
  */
-public class TestOuterJoins extends TestBase {
+public class TestOuterJoins extends TestDb {
 
     private final ArrayList<Statement> dbs = new ArrayList<>();
 

--- a/h2/src/test/org/h2/test/synth/TestPowerOffFs.java
+++ b/h2/src/test/org/h2/test/synth/TestPowerOffFs.java
@@ -12,12 +12,13 @@ import java.sql.Statement;
 import org.h2.api.ErrorCode;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.FilePathDebug;
 
 /**
  * Tests that use the debug file system to simulate power failure.
  */
-public class TestPowerOffFs extends TestBase {
+public class TestPowerOffFs extends TestDb {
 
     private FilePathDebug fs;
 

--- a/h2/src/test/org/h2/test/synth/TestPowerOffFs2.java
+++ b/h2/src/test/org/h2/test/synth/TestPowerOffFs2.java
@@ -15,13 +15,14 @@ import java.util.Random;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.FilePathDebug;
 
 /**
  * Tests that use the debug file system to simulate power failure.
  * This test runs many random operations and stops after some time.
  */
-public class TestPowerOffFs2 extends TestBase {
+public class TestPowerOffFs2 extends TestDb {
 
     private static final String USER = "sa";
     private static final String PASSWORD = "sa";

--- a/h2/src/test/org/h2/test/synth/TestRandomCompare.java
+++ b/h2/src/test/org/h2/test/synth/TestRandomCompare.java
@@ -15,11 +15,12 @@ import java.util.Collections;
 import java.util.Random;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests random compare operations.
  */
-public class TestRandomCompare extends TestBase {
+public class TestRandomCompare extends TestDb {
 
     private final ArrayList<Statement> dbs = new ArrayList<>();
     private int aliasId;

--- a/h2/src/test/org/h2/test/synth/TestRandomSQL.java
+++ b/h2/src/test/org/h2/test/synth/TestRandomSQL.java
@@ -11,12 +11,13 @@ import java.sql.Statement;
 import org.h2.engine.SysProperties;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.MathUtils;
 
 /**
  * This test executes random SQL statements generated using the BNF tool.
  */
-public class TestRandomSQL extends TestBase {
+public class TestRandomSQL extends TestDb {
 
     private int success, total;
 

--- a/h2/src/test/org/h2/test/synth/TestReleaseSelectLock.java
+++ b/h2/src/test/org/h2/test/synth/TestReleaseSelectLock.java
@@ -11,11 +11,12 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.concurrent.CountDownLatch;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests lock releasing for concurrent select statements
  */
-public class TestReleaseSelectLock extends TestBase {
+public class TestReleaseSelectLock extends TestDb {
 
     private static final String TEST_DB_NAME = "releaseSelectLock";
 

--- a/h2/src/test/org/h2/test/synth/TestSimpleIndex.java
+++ b/h2/src/test/org/h2/test/synth/TestSimpleIndex.java
@@ -11,13 +11,14 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.synth.sql.RandomGen;
 
 /**
  * A test that runs random operations against a table to test the various index
  * implementations.
  */
-public class TestSimpleIndex extends TestBase {
+public class TestSimpleIndex extends TestDb {
 
     private Connection conn;
     private Statement stat;

--- a/h2/src/test/org/h2/test/synth/TestStringAggCompatibility.java
+++ b/h2/src/test/org/h2/test/synth/TestStringAggCompatibility.java
@@ -10,11 +10,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test for check compatibility with PostgreSQL function string_agg()
  */
-public class TestStringAggCompatibility extends TestBase {
+public class TestStringAggCompatibility extends TestDb {
 
     private Connection conn;
 

--- a/h2/src/test/org/h2/test/synth/TestThreads.java
+++ b/h2/src/test/org/h2/test/synth/TestThreads.java
@@ -13,12 +13,13 @@ import java.sql.Statement;
 import java.util.Random;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * This test starts multiple threads and executes random operations in each
  * thread.
  */
-public class TestThreads extends TestBase implements Runnable {
+public class TestThreads extends TestDb implements Runnable {
 
     private static final int INSERT = 0, UPDATE = 1, DELETE = 2;
     private static final int SELECT_ONE = 3, SELECT_ALL = 4;

--- a/h2/src/test/org/h2/test/synth/TestTimer.java
+++ b/h2/src/test/org/h2/test/synth/TestTimer.java
@@ -14,6 +14,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Backup;
 import org.h2.tools.DeleteDbFiles;
 
@@ -22,7 +23,7 @@ import org.h2.tools.DeleteDbFiles;
  * then deletes everything and runs in an endless loop executing random
  * operations. This loop is usually stopped by switching off the computer.
  */
-public class TestTimer extends TestBase {
+public class TestTimer extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/synth/sql/TestSynth.java
+++ b/h2/src/test/org/h2/test/synth/sql/TestSynth.java
@@ -9,13 +9,14 @@ import java.util.ArrayList;
 
 import org.h2.test.TestAll;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.MathUtils;
 
 /**
  * A test that generates random SQL statements against a number of databases
  * and compares the results.
  */
-public class TestSynth extends TestBase {
+public class TestSynth extends TestDb {
 
     //  TODO hsqldb: call 1||null should return 1 but returns null
     //  TODO hsqldb: call mod(1) should return invalid parameter count

--- a/h2/src/test/org/h2/test/synth/thread/TestMulti.java
+++ b/h2/src/test/org/h2/test/synth/thread/TestMulti.java
@@ -10,11 +10,12 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Starts multiple threads and performs random operations on each thread.
  */
-public class TestMulti extends TestBase {
+public class TestMulti extends TestDb {
 
     /**
      * If set, the test should stop.

--- a/h2/src/test/org/h2/test/unit/TestAutoReconnect.java
+++ b/h2/src/test/org/h2/test/unit/TestAutoReconnect.java
@@ -13,12 +13,13 @@ import java.sql.Statement;
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Server;
 
 /**
  * Tests automatic embedded/server mode.
  */
-public class TestAutoReconnect extends TestBase {
+public class TestAutoReconnect extends TestDb {
 
     private String url;
     private boolean autoServer;

--- a/h2/src/test/org/h2/test/unit/TestBnf.java
+++ b/h2/src/test/org/h2/test/unit/TestBnf.java
@@ -15,12 +15,13 @@ import org.h2.bnf.context.DbContextRule;
 import org.h2.bnf.context.DbProcedure;
 import org.h2.bnf.context.DbSchema;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test Bnf Sql parser
  * @author Nicolas Fortin
  */
-public class TestBnf extends TestBase {
+public class TestBnf extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestCache.java
+++ b/h2/src/test/org/h2/test/unit/TestCache.java
@@ -16,6 +16,7 @@ import java.util.Random;
 
 import org.h2.message.Trace;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Cache;
 import org.h2.util.CacheLRU;
 import org.h2.util.CacheObject;
@@ -27,7 +28,7 @@ import org.h2.value.Value;
 /**
  * Tests the cache.
  */
-public class TestCache extends TestBase implements CacheWriter {
+public class TestCache extends TestDb implements CacheWriter {
 
     private String out;
 

--- a/h2/src/test/org/h2/test/unit/TestCollation.java
+++ b/h2/src/test/org/h2/test/unit/TestCollation.java
@@ -10,11 +10,12 @@ import java.sql.Statement;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Test the ICU4J collator.
  */
-public class TestCollation extends TestBase {
+public class TestCollation extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestCompress.java
+++ b/h2/src/test/org/h2/test/unit/TestCompress.java
@@ -24,6 +24,7 @@ import org.h2.compress.Compressor;
 import org.h2.engine.Constants;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.CompressTool;
 import org.h2.util.IOUtils;
 import org.h2.util.Task;
@@ -31,7 +32,7 @@ import org.h2.util.Task;
 /**
  * Data compression tests.
  */
-public class TestCompress extends TestBase {
+public class TestCompress extends TestDb {
 
     private boolean testPerformance;
     private final byte[] buff = new byte[10];

--- a/h2/src/test/org/h2/test/unit/TestConnectionInfo.java
+++ b/h2/src/test/org/h2/test/unit/TestConnectionInfo.java
@@ -12,6 +12,7 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.ConnectionInfo;
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.DeleteDbFiles;
 
 /**
@@ -20,7 +21,7 @@ import org.h2.tools.DeleteDbFiles;
  * @author Kerry Sainsbury
  * @author Thomas Mueller Graf
  */
-public class TestConnectionInfo extends TestBase {
+public class TestConnectionInfo extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestExit.java
+++ b/h2/src/test/org/h2/test/unit/TestExit.java
@@ -13,12 +13,13 @@ import java.sql.SQLException;
 
 import org.h2.api.DatabaseEventListener;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.SelfDestructor;
 
 /**
  * Tests the flag db_close_on_exit. A new process is started.
  */
-public class TestExit extends TestBase {
+public class TestExit extends TestDb {
 
     private static Connection conn;
 

--- a/h2/src/test/org/h2/test/unit/TestFileLock.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLock.java
@@ -13,12 +13,13 @@ import org.h2.message.TraceSystem;
 import org.h2.store.FileLock;
 import org.h2.store.FileLockMethod;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the database file locking facility. Both lock files and sockets locking
  * is tested.
  */
-public class TestFileLock extends TestBase implements Runnable {
+public class TestFileLock extends TestDb implements Runnable {
 
     private static volatile int locks;
     private static volatile boolean stop;

--- a/h2/src/test/org/h2/test/unit/TestFileLockProcess.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLockProcess.java
@@ -10,13 +10,14 @@ import java.sql.DriverManager;
 import java.util.ArrayList;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.SelfDestructor;
 
 /**
  * Tests database file locking.
  * A new process is started.
  */
-public class TestFileLockProcess extends TestBase {
+public class TestFileLockProcess extends TestDb {
 
     /**
      * This method is called when executing this application from the command

--- a/h2/src/test/org/h2/test/unit/TestFileLockSerialized.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLockSerialized.java
@@ -19,13 +19,14 @@ import org.h2.api.ErrorCode;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.SortedProperties;
 import org.h2.util.Task;
 
 /**
  * Test the serialized (server-less) mode.
  */
-public class TestFileLockSerialized extends TestBase {
+public class TestFileLockSerialized extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestFileSystem.java
+++ b/h2/src/test/org/h2/test/unit/TestFileSystem.java
@@ -32,6 +32,7 @@ import org.h2.store.fs.FilePathEncrypt;
 import org.h2.store.fs.FilePathRec;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.AssertThrows;
 import org.h2.test.utils.FilePathDebug;
 import org.h2.tools.Backup;
@@ -42,7 +43,7 @@ import org.h2.util.Task;
 /**
  * Tests various file system.
  */
-public class TestFileSystem extends TestBase {
+public class TestFileSystem extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestJmx.java
+++ b/h2/src/test/org/h2/test/unit/TestJmx.java
@@ -18,12 +18,13 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import org.h2.engine.Constants;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.Utils;
 
 /**
  * Tests the JMX feature.
  */
-public class TestJmx extends TestBase {
+public class TestJmx extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestLocale.java
+++ b/h2/src/test/org/h2/test/unit/TestLocale.java
@@ -11,11 +11,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Locale;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests that change the default locale.
  */
-public class TestLocale extends TestBase {
+public class TestLocale extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestModifyOnWrite.java
+++ b/h2/src/test/org/h2/test/unit/TestModifyOnWrite.java
@@ -12,13 +12,14 @@ import java.sql.Statement;
 import org.h2.engine.SysProperties;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.IOUtils;
 import org.h2.util.Utils;
 
 /**
  * Test that the database file is only modified when writing to the database.
  */
-public class TestModifyOnWrite extends TestBase {
+public class TestModifyOnWrite extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestMultiThreadedKernel.java
+++ b/h2/src/test/org/h2/test/unit/TestMultiThreadedKernel.java
@@ -11,11 +11,12 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the multi-threaded kernel feature.
  */
-public class TestMultiThreadedKernel extends TestBase implements Runnable {
+public class TestMultiThreadedKernel extends TestDb implements Runnable {
 
     private String url, user, password;
     private int id;

--- a/h2/src/test/org/h2/test/unit/TestOldVersion.java
+++ b/h2/src/test/org/h2/test/unit/TestOldVersion.java
@@ -19,12 +19,13 @@ import java.sql.Types;
 import java.util.Properties;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Server;
 
 /**
  * Tests the compatibility with older versions
  */
-public class TestOldVersion extends TestBase {
+public class TestOldVersion extends TestDb {
 
     private ClassLoader cl;
     private Driver driver;

--- a/h2/src/test/org/h2/test/unit/TestPageStore.java
+++ b/h2/src/test/org/h2/test/unit/TestPageStore.java
@@ -26,13 +26,14 @@ import org.h2.result.RowImpl;
 import org.h2.store.Page;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.IOUtils;
 import org.h2.util.JdbcUtils;
 
 /**
  * Test the page store.
  */
-public class TestPageStore extends TestBase {
+public class TestPageStore extends TestDb {
 
     /**
      * The events log.

--- a/h2/src/test/org/h2/test/unit/TestPageStoreCoverage.java
+++ b/h2/src/test/org/h2/test/unit/TestPageStoreCoverage.java
@@ -15,12 +15,13 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Restore;
 
 /**
  * Test the page store.
  */
-public class TestPageStoreCoverage extends TestBase {
+public class TestPageStoreCoverage extends TestDb {
 
     private static final String URL = "pageStoreCoverage;" +
             "PAGE_SIZE=64;CACHE_SIZE=16;MAX_LOG_SIZE=1";

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -27,12 +27,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.Server;
 
 /**
  * Tests the PostgreSQL server protocol compliant implementation.
  */
-public class TestPgServer extends TestBase {
+public class TestPgServer extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestRecovery.java
+++ b/h2/src/test/org/h2/test/unit/TestRecovery.java
@@ -17,6 +17,7 @@ import java.sql.Statement;
 import org.h2.engine.Constants;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.DeleteDbFiles;
 import org.h2.tools.Recover;
 import org.h2.util.IOUtils;
@@ -24,7 +25,7 @@ import org.h2.util.IOUtils;
 /**
  * Tests database recovery.
  */
-public class TestRecovery extends TestBase {
+public class TestRecovery extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestSampleApps.java
+++ b/h2/src/test/org/h2/test/unit/TestSampleApps.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.tools.DeleteDbFiles;
 import org.h2.util.IOUtils;
 import org.h2.util.StringUtils;
@@ -22,7 +23,7 @@ import org.h2.util.StringUtils;
 /**
  * Tests the sample apps.
  */
-public class TestSampleApps extends TestBase {
+public class TestSampleApps extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestServlet.java
+++ b/h2/src/test/org/h2/test/unit/TestServlet.java
@@ -32,12 +32,13 @@ import javax.servlet.descriptor.JspConfigDescriptor;
 import org.h2.api.ErrorCode;
 import org.h2.server.web.DbStarter;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 
 /**
  * Tests the DbStarter servlet.
  * This test simulates a minimum servlet container environment.
  */
-public class TestServlet extends TestBase {
+public class TestServlet extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
+++ b/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
@@ -15,6 +15,7 @@ import java.util.TimeZone;
 
 import org.h2.api.TimestampWithTimeZone;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.util.DateTimeUtils;
 import org.h2.util.LocalDateTimeUtils;
 import org.h2.value.Value;
@@ -25,7 +26,7 @@ import org.h2.value.ValueTimestampTimeZone;
 
 /**
  */
-public class TestTimeStampWithTimeZone extends TestBase {
+public class TestTimeStampWithTimeZone extends TestDb {
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -43,6 +43,7 @@ import org.h2.engine.SysProperties;
 import org.h2.store.FileLister;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.trace.Player;
 import org.h2.test.utils.AssertThrows;
 import org.h2.tools.Backup;
@@ -65,7 +66,7 @@ import org.h2.value.ValueUuid;
 /**
  * Tests the database tools.
  */
-public class TestTools extends TestBase {
+public class TestTools extends TestDb {
 
     private static String lastUrl;
     private Server server;

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import org.h2.api.ErrorCode;
 import org.h2.message.DbException;
 import org.h2.test.TestBase;
+import org.h2.test.TestDb;
 import org.h2.test.utils.AssertThrows;
 import org.h2.tools.SimpleResultSet;
 import org.h2.util.Bits;
@@ -43,7 +44,7 @@ import org.h2.value.ValueUuid;
 /**
  * Tests features of values.
  */
-public class TestValue extends TestBase {
+public class TestValue extends TestDb {
 
     /**
      * Run just this test.


### PR DESCRIPTION
Issue #1215.

1. A new abstract `TestDb` class is extracted from the `TestBase` to be used as a base class for all tests that use connections to database. With this change it's easier to see whether some test case uses connections or not.

2. `testUnit()` is replaced with `testAdditional()` and `testUtils()`. `testAdditional()` contains tests that use connections to database and `testUtils()` contains tests that do not use them and can be safely tested only once.