### PR TITLE
Fix issues with testing on latest Java versions

### DIFF
--- a/h2/src/main/org/h2/engine/MetaRecord.java
+++ b/h2/src/main/org/h2/engine/MetaRecord.java
@@ -24,6 +24,14 @@ public class MetaRecord implements Comparable<MetaRecord> {
     private final int objectType;
     private final String sql;
 
+    /**
+     * Copy metadata from the specified object into specified search row.
+     *
+     * @param obj
+     *            database object
+     * @param r
+     *            search row
+     */
     public static void populateRowFromDBObject(DbObject obj, SearchRow r) {
         r.setValue(0, ValueInt.get(obj.getId()));
         r.setValue(1, ValueInt.get(0));

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -311,7 +311,8 @@ public class DbException extends RuntimeException {
             return get(ErrorCode.GENERAL_ERROR_1, e, e.toString());
         } catch (Throwable ex) {
             try {
-                DbException dbException = new DbException(new SQLException("GeneralError", "HY000", ErrorCode.GENERAL_ERROR_1, e));
+                DbException dbException = new DbException(
+                        new SQLException("GeneralError", "HY000", ErrorCode.GENERAL_ERROR_1, e));
                 dbException.addSuppressed(ex);
                 return dbException;
             } catch (OutOfMemoryError ignore) {

--- a/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
@@ -49,16 +49,19 @@ public abstract class TxDecisionMaker extends MVMap.DecisionMaker<VersionedValue
             // because a tree root has definitely been changed.
             logIt(existingValue.value == null ? null : VersionedValue.getInstance(existingValue.value));
             decision = MVMap.Decision.PUT;
-        } else if(fetchTransaction(blockingId) != null) {
-            // this entry comes from a different transaction, and this transaction is not committed yet
+        } else if (fetchTransaction(blockingId) != null) {
+            // this entry comes from a different transaction, and this
+            // transaction is not committed yet
             // should wait on blockingTransaction that was determined earlier
             decision = MVMap.Decision.ABORT;
-        } else if(id == lastOperationId) {
-            // There is no transaction with that id, so we've retried it just before,
-            // but map root has not changed (which must be the case if we just missed a closed transaction),
-            // therefore we came back here again.
-            // Now we assume it's a leftover after unclean shutdown (map update was written but not undo log),
-            // and will effectively roll it back (just overwrite).
+        } else if (id == lastOperationId) {
+            // There is no transaction with that id, so we've retried it just
+            // before, but map root has not changed (which must be the case if
+            // we just missed a closed transaction), therefore we came back here
+            // again.
+            // Now we assume it's a leftover after unclean shutdown (map update
+            // was written but not undo log), and will effectively roll it back
+            // (just overwrite).
             Object committedValue = existingValue.getCommittedValue();
             logIt(committedValue == null ? null : VersionedValue.getInstance(committedValue));
             decision = MVMap.Decision.PUT;

--- a/h2/src/main/org/h2/security/auth/H2AuthConfig.java
+++ b/h2/src/main/org/h2/security/auth/H2AuthConfig.java
@@ -22,7 +22,7 @@ public class H2AuthConfig {
     public void setAllowUserRegistration(boolean allowUserRegistration) {
         this.allowUserRegistration = allowUserRegistration;
     }
-    
+
     boolean createMissingRoles=true;
 
     public boolean isCreateMissingRoles() {

--- a/h2/src/main/org/h2/security/auth/H2AuthConfigXml.java
+++ b/h2/src/main/org/h2/security/auth/H2AuthConfigXml.java
@@ -58,7 +58,7 @@ public class H2AuthConfigXml extends DefaultHandler{
         default:
             throw new SAXException("unexpected element "+qName);
         }
-        
+
     }
 
     @Override
@@ -74,7 +74,7 @@ public class H2AuthConfigXml extends DefaultHandler{
             throw new SAXException("missing attribute "+attributeName);
         }
         return attributeValue;
-        
+
     }
 
     static String getAttributeValueOr(String attributeName, Attributes attributes, String defaultValue) {
@@ -90,7 +90,7 @@ public class H2AuthConfigXml extends DefaultHandler{
     }
 
     /**
-     * Parse the xml 
+     * Parse the xml
      * @param url
      * @return
      * @throws Exception
@@ -102,7 +102,7 @@ public class H2AuthConfigXml extends DefaultHandler{
     }
 
     public static H2AuthConfig parseFrom(InputStream inputStream) throws Exception{
-        SAXParser saxParser = SAXParserFactory.newInstance().newSAXParser();        
+        SAXParser saxParser = SAXParserFactory.newInstance().newSAXParser();
         H2AuthConfigXml xmlHandler = new H2AuthConfigXml();
         saxParser.parse(inputStream,xmlHandler);
         return xmlHandler.getResult();

--- a/h2/src/main/org/h2/security/auth/HasConfigProperties.java
+++ b/h2/src/main/org/h2/security/auth/HasConfigProperties.java
@@ -7,6 +7,9 @@ package org.h2.security.auth;
 
 import java.util.List;
 
+/**
+ * Interface for objects with configuration properties.
+ */
 public interface HasConfigProperties {
     List<PropertyConfig> getProperties();
 }

--- a/h2/src/main/org/h2/security/auth/RealmConfig.java
+++ b/h2/src/main/org/h2/security/auth/RealmConfig.java
@@ -8,7 +8,10 @@ package org.h2.security.auth;
 import java.util.ArrayList;
 import java.util.List;
 
-public class RealmConfig implements HasConfigProperties{
+/**
+ * Configuration for authentication realm.
+ */
+public class RealmConfig implements HasConfigProperties {
 
     private String name;
 
@@ -32,6 +35,7 @@ public class RealmConfig implements HasConfigProperties{
 
     List<PropertyConfig> properties;
 
+    @Override
     public List<PropertyConfig> getProperties() {
         if (properties == null) {
             properties = new ArrayList<>();

--- a/h2/src/main/org/h2/security/auth/UserToRolesMapperConfig.java
+++ b/h2/src/main/org/h2/security/auth/UserToRolesMapperConfig.java
@@ -8,7 +8,10 @@ package org.h2.security.auth;
 import java.util.ArrayList;
 import java.util.List;
 
-public class UserToRolesMapperConfig implements HasConfigProperties{
+/**
+ * Configuration for class that maps users to their roles.
+ */
+public class UserToRolesMapperConfig implements HasConfigProperties {
 
     private String className;
 
@@ -22,6 +25,7 @@ public class UserToRolesMapperConfig implements HasConfigProperties{
         this.className = className;
     }
 
+    @Override
     public List<PropertyConfig> getProperties() {
         if (properties == null) {
             properties = new ArrayList<>();

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -889,7 +889,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
      */
     private void testAdditional() {
         if (networked) {
-            throw new RuntimeException("testAditional() is not allowed in networked mode");
+            throw new RuntimeException("testAdditional() is not allowed in networked mode");
         }
 
         addTest(new TestMVTableEngine());

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -6,6 +6,7 @@
 package org.h2.test;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1315,6 +1316,16 @@ public abstract class TestBase {
      */
     protected String getClassPath() {
         return System.getProperty("java.class.path");
+    }
+
+    /**
+     * Get the path to a java executable of the current process
+     *
+     * @return the path to java
+     */
+    public static String getJVM() {
+        return System.getProperty("java.home") + File.separatorChar + "bin"
+                + File.separator + "java";
     }
 
     /**

--- a/h2/src/test/org/h2/test/TestDb.java
+++ b/h2/src/test/org/h2/test/TestDb.java
@@ -5,7 +5,6 @@
  */
 package org.h2.test;
 
-import java.io.File;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -189,16 +188,6 @@ public abstract class TestDb extends TestBase {
         // if (list.size() >  0) {
         //    System.out.println("Not deleted: " + list);
         // }
-    }
-
-    /**
-     * Get the path to a java executable of the current process
-     *
-     * @return the path to java
-     */
-    private static String getJVM() {
-        return System.getProperty("java.home") + File.separatorChar + "bin"
-                + File.separator + "java";
     }
 
     /**

--- a/h2/src/test/org/h2/test/auth/TestAuthentication.java
+++ b/h2/src/test/org/h2/test/auth/TestAuthentication.java
@@ -278,7 +278,7 @@ public class TestAuthentication extends TestBase {
         }
         testExternalUser();
     }
-    
+
     static final String TESTXML="<h2Auth allowUserRegistration=\"true\" createMissingRoles=\"false\">"
             + "<realm name=\"ciao\" validatorClass=\"myclass\"/>"
             + "<realm name=\"miao\" validatorClass=\"myclass1\">"
@@ -288,7 +288,7 @@ public class TestAuthentication extends TestBase {
             + "</userToRolesMapper>"
             + "</realm>"
             + "</h2Auth>";
-    
+
     protected void testXmlConfig() throws Exception {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(TESTXML.getBytes());
         H2AuthConfig config = H2AuthConfigXml.parseFrom(inputStream);

--- a/h2/src/test/org/h2/test/db/TaskProcess.java
+++ b/h2/src/test/org/h2/test/db/TaskProcess.java
@@ -15,6 +15,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import org.h2.test.TestBase;
 import org.h2.test.utils.SelfDestructor;
 import org.h2.util.StringUtils;
 import org.h2.util.Task;
@@ -48,7 +50,7 @@ public class TaskProcess {
         try {
             String selfDestruct = SelfDestructor.getPropertyString(60);
             ArrayList<String> list = new ArrayList<>();
-            list.add("java");
+            list.add(TestBase.getJVM());
             list.add(selfDestruct);
             list.add("-cp");
             list.add("bin" + File.pathSeparator + ".");

--- a/h2/src/test/org/h2/test/poweroff/TestRecoverKillLoop.java
+++ b/h2/src/test/org/h2/test/poweroff/TestRecoverKillLoop.java
@@ -37,7 +37,7 @@ public class TestRecoverKillLoop extends TestBase {
         Random random = new Random(1);
         for (int i = 0; i < count; i++) {
             String[] procDef = {
-                    "java", "-cp", getClassPath(),
+                    getJVM(), "-cp", getClassPath(),
                     "-Dtest.dir=data/db",
                     TestRecover.class.getName()
             };

--- a/h2/src/test/org/h2/test/store/TestTransactionStore.java
+++ b/h2/src/test/org/h2/test/store/TestTransactionStore.java
@@ -421,9 +421,9 @@ public class TestTransactionStore extends TestBase {
         }
     }
 
-    private boolean hasDataUndoLog(MVStore s) {
+    private static boolean hasDataUndoLog(MVStore s) {
         for (int i = 0; i < 255; i++) {
-            if(s.hasData(TransactionStore.getUndoLogName(true, 1))) {
+            if (s.hasData(TransactionStore.getUndoLogName(true, 1))) {
                 return true;
             }
         }

--- a/h2/src/test/org/h2/test/synth/TestHalt.java
+++ b/h2/src/test/org/h2/test/synth/TestHalt.java
@@ -226,7 +226,7 @@ public abstract class TestHalt extends TestBase {
             // String classPath = "-cp
             // .;D:/data/java/hsqldb.jar;D:/data/java/derby.jar";
             String selfDestruct = SelfDestructor.getPropertyString(60);
-            String[] procDef = { "java", selfDestruct,
+            String[] procDef = { getJVM(), selfDestruct,
                     "-cp", getClassPath(),
                     getClass().getName(), "" + operations, "" + flags, "" + testValue};
             traceOperation("start: " + StringUtils.arrayCombine(procDef, ' '));

--- a/h2/src/test/org/h2/test/synth/TestKill.java
+++ b/h2/src/test/org/h2/test/synth/TestKill.java
@@ -50,7 +50,7 @@ public class TestKill extends TestDb {
         String password = getPassword();
         String selfDestruct = SelfDestructor.getPropertyString(60);
         String[] procDef = {
-                "java", selfDestruct,
+                getJVM(), selfDestruct,
                 "-cp", getClassPath(),
                 "org.h2.test.synth.TestKillProcess", url, user,
                 password, getBaseDir(), "" + ACCOUNTS };

--- a/h2/src/test/org/h2/test/synth/TestKillRestart.java
+++ b/h2/src/test/org/h2/test/synth/TestKillRestart.java
@@ -16,7 +16,6 @@ import java.sql.Statement;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.test.utils.SelfDestructor;
 
@@ -40,7 +39,7 @@ public class TestKillRestart extends TestDb {
         //        "killRestart;CACHE_SIZE=2048;WRITE_DELAY=0", true);
         String user = getUser(), password = getPassword();
         String selfDestruct = SelfDestructor.getPropertyString(60);
-        String[] procDef = { "java", selfDestruct,
+        String[] procDef = { getJVM(), selfDestruct,
                 "-cp", getClassPath(),
                 getClass().getName(), "-url", url, "-user", user,
                 "-password", password };

--- a/h2/src/test/org/h2/test/synth/TestKillRestartMulti.java
+++ b/h2/src/test/org/h2/test/synth/TestKillRestartMulti.java
@@ -83,7 +83,7 @@ public class TestKillRestartMulti extends TestDb {
         // Inherit error so that the stacktraces reported from SelfDestructor
         // show up in our log.
         ProcessBuilder pb = new ProcessBuilder().redirectError(Redirect.INHERIT)
-                .command("java", selfDestruct, "-cp", getClassPath(),
+                .command(getJVM(), selfDestruct, "-cp", getClassPath(),
                         "-ea",
                         getClass().getName(), "-url", url, "-user", user,
                         "-password", password);

--- a/h2/src/test/org/h2/test/unit/TestExit.java
+++ b/h2/src/test/org/h2/test/unit/TestExit.java
@@ -37,7 +37,7 @@ public class TestExit extends TestDb {
         deleteDb("exit");
         String url = getURL(OPEN_WITH_CLOSE_ON_EXIT);
         String selfDestruct = SelfDestructor.getPropertyString(60);
-        String[] procDef = { "java", selfDestruct, "-cp", getClassPath(),
+        String[] procDef = { getJVM(), selfDestruct, "-cp", getClassPath(),
                 getClass().getName(), url };
         Process proc = Runtime.getRuntime().exec(procDef);
         while (true) {
@@ -60,7 +60,7 @@ public class TestExit extends TestDb {
             fail("did not close database");
         }
         url = getURL(OPEN_WITHOUT_CLOSE_ON_EXIT);
-        procDef = new String[] { "java", "-cp", getClassPath(),
+        procDef = new String[] { getJVM(), "-cp", getClassPath(),
                 getClass().getName(), url };
         proc = Runtime.getRuntime().exec(procDef);
         proc.waitFor();

--- a/h2/src/test/org/h2/test/unit/TestFileLockProcess.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLockProcess.java
@@ -74,7 +74,7 @@ public class TestFileLockProcess extends TestDb {
         url = getURL(url, true);
         Connection conn = getConnection(url);
         String selfDestruct = SelfDestructor.getPropertyString(60);
-        String[] procDef = { "java", selfDestruct,
+        String[] procDef = { getJVM(), selfDestruct,
                 "-cp", getClassPath(),
                 getClass().getName(), url };
         ArrayList<Process> processes = new ArrayList<>(count);

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -1013,6 +1013,10 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
                 File.pathSeparator + "ext/slf4j-nop-1.6.0.jar" +
                 File.pathSeparator + javaToolsJar;
+        int version = getJavaVersion();
+        if (version >= 9) {
+            cp = "src/java9/precompiled" + File.pathSeparator + cp;
+        }
         int ret;
         if (travis) {
             ret = execJava(args(

--- a/h2/src/tools/org/h2/build/BuildBase.java
+++ b/h2/src/tools/org/h2/build/BuildBase.java
@@ -925,6 +925,25 @@ public class BuildBase {
         return System.getProperty("java.specification.version");
     }
 
+    /**
+     * Get the current Java version as integer value.
+     *
+     * @return the Java version (7, 8, 9, 10, 11, etc)
+     */
+    protected static int getJavaVersion() {
+        int version = 7;
+        String v = getJavaSpecVersion();
+        if (v != null) {
+            int idx = v.indexOf('.');
+            if (idx >= 0) {
+                // 1.7, 1.8
+                v = v.substring(idx + 1);
+            }
+            version = Integer.parseInt(v);
+        }
+        return version;
+    }
+
     private static List<String> getPaths(FileList files) {
         StringList list = new StringList();
         for (File f : files) {

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -783,3 +783,4 @@ intentionally authenticator authrealm ventura credentials alessandro validator a
 ewkt ewkb informations authzpwd realms mappers jaxb realmname configurationfile unmarshal jaas externals customize
 authenticators appname interrogate metatable barrier preliminary staticuser staticpassword unregistered inquiry
 ldapexample remoteuser assignments djava validators mock relate mapid tighten
+retried helpers unclean missed parsers sax myclass suppose mandatory testxml miao ciao


### PR DESCRIPTION
1. Current JVM is used in all tests. If current JVM is more recent than system default some tests failed due to unsupported class format version.

2. Java 9 and later versions are now detected and multi-release code for Java 9 is included into classpath for tests to test this code too.

3. Usual minor issues with formatting, spelling, etc are fixed.