### PR TITLE
Enable Java 10 testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ matrix:
       dist: trusty
       group: edge
       sudo: required
-      addons:
-        apt:
-          packages:
-            - oracle-java10-installer
       before_script:
         - "cd h2"
         - "echo $JAVA_OPTS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ matrix:
       dist: trusty
       group: edge
       sudo: required
-      addons:
-        apt:
-          packages:
-            - oracle-java8-installer
       before_script:
         - "cd h2"
         - "echo $JAVA_OPTS"
@@ -32,9 +28,5 @@ matrix:
       dist: trusty
       group: edge
       sudo: required
-      addons:
-        apt:
-          packages:
-            - openjdk-7-jdk
       before_script:
         - "cd h2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,19 @@ cache:
 
 matrix:
   include:
-    - jdk: oraclejdk8 
+    - jdk: oraclejdk10
+      dist: trusty
+      group: edge
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - oracle-java10-installer
+      before_script:
+        - "cd h2"
+        - "echo $JAVA_OPTS"
+        - "export JAVA_OPTS=-Xmx512m"
+    - jdk: oraclejdk8
       dist: trusty
       group: edge
       sudo: required
@@ -16,11 +28,11 @@ matrix:
         apt:
           packages:
             - oracle-java8-installer
-      before_script: 
+      before_script:
         - "cd h2"
         - "echo $JAVA_OPTS"
         - "export JAVA_OPTS=-Xmx512m"
-    - jdk: openjdk7 
+    - jdk: openjdk7
       dist: trusty
       group: edge
       sudo: required
@@ -28,5 +40,5 @@ matrix:
         apt:
           packages:
             - openjdk-7-jdk
-      before_script: 
+      before_script:
         - "cd h2"


### PR DESCRIPTION
An attempt to enable testing on Java 10 too in automated builds on Travis.

Motivation:

1. Test Java9+ code that is included in multi-release jars. It is not tested currently at all.
2. Detect possible problems with the latest released Java version (that's why I chose Java 10 instead of Java 9).