### PR TITLE
Fix inconsistencies in checks for transaction isolation level

### DIFF
--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -229,7 +229,7 @@ Transaction isolation is provided for all data manipulation language (DML) state
 <p>
 Please note that with default MVStore storage engine table level locking is not used.
 Instead, rows are locked for update, and read committed is used in all cases
-(changing the isolation level has no effect).
+except for explicitly selected read uncommitted transaction isolation level.
 </p>
 <p>
 This database supports the following transaction isolation levels:
@@ -247,7 +247,9 @@ This database supports the following transaction isolation levels:
     To enable, execute the SQL statement <code>SET LOCK_MODE 1</code><br />
     or append <code>;LOCK_MODE=1</code> to the database URL: <code>jdbc:h2:~/test;LOCK_MODE=1</code>
 </li><li><b>Read Uncommitted</b><br />
-    This level means that transaction isolation is disabled.<br />
+    This level means that transaction isolation is disabled.
+    This level is not supported by PageStore engine if multi-threaded mode is enabled.
+    <br />
     To enable, execute the SQL statement <code>SET LOCK_MODE 0</code><br />
     or append <code>;LOCK_MODE=0</code> to the database URL: <code>jdbc:h2:~/test;LOCK_MODE=0</code>
 </li>

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2265,12 +2265,12 @@ public class Database implements DataHandler {
         switch (lockMode) {
         case Constants.LOCK_MODE_OFF:
             if (multiThreaded && !isMVStore()) {
-                // currently the combination of MVCC=FALSE, LOCK_MODE=0 and MULTI_THREADED
-                // is not supported. also see code in
+                // Currently the combination of MV_STORE=FALSE, LOCK_MODE=0 and
+                // MULTI_THREADED=TRUE is not supported. Also see code in
                 // JdbcDatabaseMetaData#supportsTransactionIsolationLevel(int)
                 throw DbException.get(
                         ErrorCode.UNSUPPORTED_SETTING_COMBINATION,
-                        "MVCC=FALSE & LOCK_MODE=0 & MULTI_THREADED");
+                        "MV_STORE=FALSE & LOCK_MODE=0 & MULTI_THREADED=TRUE");
             }
             break;
         case Constants.LOCK_MODE_READ_COMMITTED:
@@ -2457,12 +2457,12 @@ public class Database implements DataHandler {
 
     public void setMultiThreaded(boolean multiThreaded) {
         if (multiThreaded && this.multiThreaded != multiThreaded) {
-            if (lockMode == 0) {
-                // currently the combination of LOCK_MODE=0 and MULTI_THREADED
-                // is not supported
+            if (lockMode == Constants.LOCK_MODE_OFF && !isMVStore()) {
+                // Currently the combination of MV_STORE=FALSE, LOCK_MODE=0 and
+                // MULTI_THREADED=TRUE is not supported.
                 throw DbException.get(
                         ErrorCode.UNSUPPORTED_SETTING_COMBINATION,
-                        "LOCK_MODE=0 & MULTI_THREADED");
+                        "MV_STORE=FALSE & LOCK_MODE=0 & MULTI_THREADED=TRUE");
             }
         }
         this.multiThreaded = multiThreaded;

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -2315,7 +2315,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     @Override
     public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
         debugCodeCall("supportsTransactionIsolationLevel");
-        if (level == Connection.TRANSACTION_READ_UNCOMMITTED) {
+        switch (level) {
+        case Connection.TRANSACTION_READ_UNCOMMITTED: {
             // Currently the combination of MV_STORE=FALSE, LOCK_MODE=0 and
             // MULTI_THREADED=TRUE is not supported. Also see code in
             // Database#setLockMode(int)
@@ -2332,7 +2333,13 @@ public class JdbcDatabaseMetaData extends TraceObject implements
                 return !rs.next() || !rs.getString(1).equals("1");
             }
         }
-        return true;
+        case Connection.TRANSACTION_READ_COMMITTED:
+        case Connection.TRANSACTION_REPEATABLE_READ:
+        case Connection.TRANSACTION_SERIALIZABLE:
+            return true;
+        default:
+            return false;
+        }
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -2316,13 +2316,21 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
         debugCodeCall("supportsTransactionIsolationLevel");
         if (level == Connection.TRANSACTION_READ_UNCOMMITTED) {
-            // currently the combination of LOCK_MODE=0 and MULTI_THREADED
-            // is not supported, also see code in Database#setLockMode(int)
-            PreparedStatement prep = conn.prepareAutoCloseStatement(
-                    "SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME=?");
-            prep.setString(1, "MULTI_THREADED");
-            ResultSet rs = prep.executeQuery();
-            return !rs.next() || !rs.getString(1).equals("1");
+            // Currently the combination of MV_STORE=FALSE, LOCK_MODE=0 and
+            // MULTI_THREADED=TRUE is not supported. Also see code in
+            // Database#setLockMode(int)
+            try (PreparedStatement prep = conn.prepareStatement(
+                    "SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME=?")) {
+                // TODO skip MV_STORE check for H2 <= 1.4.197
+                prep.setString(1, "MV_STORE");
+                ResultSet rs = prep.executeQuery();
+                if (rs.next() && Boolean.parseBoolean(rs.getString(1))) {
+                    return true;
+                }
+                prep.setString(1, "MULTI_THREADED");
+                rs = prep.executeQuery();
+                return !rs.next() || !rs.getString(1).equals("1");
+            }
         }
         return true;
     }

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -292,7 +292,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
 
     private void createExternalResult() {
         Database database = session.getDatabase();
-        external = database.getMvStore() != null
+        external = database.isMVStore()
                 ? MVTempResult.of(database, expressions, distinct, sort)
                         : new ResultTempTable(session, expressions, distinct, sort);
     }

--- a/h2/src/test/org/h2/test/db/TestMultiThread.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThread.java
@@ -288,13 +288,12 @@ public class TestMultiThread extends TestDb implements Runnable {
     }
 
     private void testLockModeWithMultiThreaded() throws Exception {
-        // currently the combination of LOCK_MODE=0 and MULTI_THREADED
-        // is not supported
         deleteDb("lockMode");
         final String url = getURL("lockMode;MULTI_THREADED=1", true);
         try (Connection conn = getConnection(url)) {
             DatabaseMetaData meta = conn.getMetaData();
-            assertFalse(meta.supportsTransactionIsolationLevel(
+            // LOCK_MODE=0 with MULTI_THREADED=TRUE is supported only by MVStore
+            assertEquals(config.mvStore, meta.supportsTransactionIsolationLevel(
                     Connection.TRANSACTION_READ_UNCOMMITTED));
         }
         deleteDb("lockMode");

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -611,14 +611,13 @@ public class TestMetaData extends TestDb {
         assertTrue(meta.supportsSubqueriesInQuantifieds());
         assertTrue(meta.supportsTableCorrelationNames());
         assertTrue(meta.supportsTransactions());
-        assertTrue(meta.supportsTransactionIsolationLevel(
+        assertFalse(meta.supportsTransactionIsolationLevel(
                 Connection.TRANSACTION_NONE));
         assertTrue(meta.supportsTransactionIsolationLevel(
                 Connection.TRANSACTION_READ_COMMITTED));
-        if (!config.multiThreaded) {
-            assertTrue(meta.supportsTransactionIsolationLevel(
-                    Connection.TRANSACTION_READ_UNCOMMITTED));
-        }
+        assertEquals(config.mvStore || !config.multiThreaded,
+                meta.supportsTransactionIsolationLevel(
+                        Connection.TRANSACTION_READ_UNCOMMITTED));
         assertTrue(meta.supportsTransactionIsolationLevel(
                 Connection.TRANSACTION_REPEATABLE_READ));
         assertTrue(meta.supportsTransactionIsolationLevel(


### PR DESCRIPTION
1. `Database.setMultiThreaded()` now has the same checks as `Database.setLockMode()`.
2. `JdbcDatabaseMetaData.supportsTransactionIsolationLevel()` now returns correct result for `TRANSACTION_READ_UNCOMMITTED` and also returns `false` for all unknown modes (including illegal for this method `TRANSACTION_NONE`) as expected.