### PR TITLE
Remove some PageStore+MVCC leftovers

### DIFF
--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -928,11 +928,6 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
             undoLog.add(log);
         } else {
             if (database.isMVStore()) {
-                // see also UndoLogRecord.commit
-                ArrayList<Index> indexes = table.getIndexes();
-                for (Index index : indexes) {
-                    index.commit(operation, row);
-                }
                 row.commit();
             }
         }

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -698,7 +698,6 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
                     ArrayList<Row> rows = new ArrayList<>(undoLog.size());
                     while (undoLog.size() > 0) {
                         UndoLogRecord entry = undoLog.getLast();
-                        entry.commit();
                         rows.add(entry.getRow());
                         undoLog.removeLast(false);
                     }

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -692,20 +692,6 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         }
         removeTemporaryLobs(true);
         if (undoLog.size() > 0) {
-            // commit the rows when using MVCC
-            if (database.isMVStore()) {
-                synchronized (database) {
-                    ArrayList<Row> rows = new ArrayList<>(undoLog.size());
-                    while (undoLog.size() > 0) {
-                        UndoLogRecord entry = undoLog.getLast();
-                        rows.add(entry.getRow());
-                        undoLog.removeLast(false);
-                    }
-                    for (Row r : rows) {
-                        r.commit();
-                    }
-                }
-            }
             undoLog.clear();
         }
         if (!ddl) {
@@ -925,10 +911,6 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
                 }
             }
             undoLog.add(log);
-        } else {
-            if (database.isMVStore()) {
-                row.commit();
-            }
         }
     }
 

--- a/h2/src/main/org/h2/engine/UndoLogRecord.java
+++ b/h2/src/main/org/h2/engine/UndoLogRecord.java
@@ -244,14 +244,6 @@ public class UndoLogRecord {
     }
 
     /**
-     * This method is called after the operation was committed.
-     * It commits the change to the indexes.
-     */
-    void commit() {
-        table.commit(operation, row);
-    }
-
-    /**
      * Get the row that was deleted or inserted.
      *
      * @return the row

--- a/h2/src/main/org/h2/engine/UndoLogRecord.java
+++ b/h2/src/main/org/h2/engine/UndoLogRecord.java
@@ -106,9 +106,6 @@ public class UndoLogRecord {
             try {
                 table.addRow(session, row);
                 table.fireAfterRow(session, null, row, true);
-                // reset session id, otherwise other sessions think
-                // that this row was inserted by this session
-                row.commit();
             } catch (DbException e) {
                 if (session.getDatabase().getLockMode() == Constants.LOCK_MODE_OFF
                         && e.getSQLException().getErrorCode() == ErrorCode.DUPLICATE_KEY_1) {
@@ -137,7 +134,6 @@ public class UndoLogRecord {
         buff.writeByte(row.isDeleted() ? (byte) 1 : (byte) 0);
         buff.writeInt(log.getTableId(table));
         buff.writeLong(row.getKey());
-        buff.writeInt(row.getSessionId());
         int count = row.getColumnCount();
         buff.writeInt(count);
         for (int i = 0; i < count; i++) {
@@ -212,7 +208,6 @@ public class UndoLogRecord {
         boolean deleted = buff.readByte() == 1;
         table = log.getTable(buff.readInt());
         long key = buff.readLong();
-        int sessionId = buff.readInt();
         int columnCount = buff.readInt();
         Value[] values = new Value[columnCount];
         for (int i = 0; i < columnCount; i++) {
@@ -221,7 +216,6 @@ public class UndoLogRecord {
         row = getTable().getDatabase().createRow(values, Row.MEMORY_CALCULATE);
         row.setKey(key);
         row.setDeleted(deleted);
-        row.setSessionId(sessionId);
         state = IN_MEMORY_INVALID;
     }
 

--- a/h2/src/main/org/h2/index/BaseIndex.java
+++ b/h2/src/main/org/h2/index/BaseIndex.java
@@ -447,11 +447,6 @@ public abstract class BaseIndex extends SchemaObjectBase implements Index {
     }
 
     @Override
-    public void commit(int operation, Row row) {
-        // nothing to do
-    }
-
-    @Override
     public Row getRow(Session session, long key) {
         throw DbException.getUnsupportedException(toString());
     }

--- a/h2/src/main/org/h2/index/Index.java
+++ b/h2/src/main/org/h2/index/Index.java
@@ -245,15 +245,6 @@ public interface Index extends SchemaObject {
     Table getTable();
 
     /**
-     * Commit the operation for a row. This is only important for multi-version
-     * indexes. The method is only called if multi-version is enabled.
-     *
-     * @param operation the operation type
-     * @param row the row
-     */
-    void commit(int operation, Row row);
-
-    /**
      * Get the row with the given key.
      *
      * @param session the session

--- a/h2/src/main/org/h2/result/Row.java
+++ b/h2/src/main/org/h2/result/Row.java
@@ -54,25 +54,6 @@ public interface Row extends SearchRow {
     void setDeleted(boolean deleted);
 
     /**
-     * Set session id.
-     *
-     * @param sessionId the session id
-     */
-    void setSessionId(int sessionId);
-
-    /**
-     * Get session id.
-     *
-     * @return the session id
-     */
-    int getSessionId();
-
-    /**
-     * This record has been committed. The session id is reset.
-     */
-    void commit();
-
-    /**
      * Check if the row is deleted.
      *
      * @return {@code true} if the row is deleted

--- a/h2/src/main/org/h2/result/RowImpl.java
+++ b/h2/src/main/org/h2/result/RowImpl.java
@@ -22,7 +22,6 @@ public class RowImpl implements Row {
     private int memory;
     private int version;
     private boolean deleted;
-    private int sessionId;
 
     public RowImpl(Value[] data, int memory) {
         this.data = data;
@@ -41,7 +40,6 @@ public class RowImpl implements Row {
         RowImpl r2 = new RowImpl(d2, memory);
         r2.key = key;
         r2.version = version + 1;
-        r2.sessionId = sessionId;
         return r2;
     }
 
@@ -152,24 +150,6 @@ public class RowImpl implements Row {
     @Override
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
-    }
-
-    @Override
-    public void setSessionId(int sessionId) {
-        this.sessionId = sessionId;
-    }
-
-    @Override
-    public int getSessionId() {
-        return sessionId;
-    }
-
-    /**
-     * This record has been committed. The session id is reset.
-     */
-    @Override
-    public void commit() {
-        this.sessionId = 0;
     }
 
     @Override

--- a/h2/src/main/org/h2/result/RowList.java
+++ b/h2/src/main/org/h2/result/RowList.java
@@ -56,7 +56,6 @@ public class RowList {
         buff.writeLong(r.getKey());
         buff.writeInt(r.getVersion());
         buff.writeInt(r.isDeleted() ? 1 : 0);
-        buff.writeInt(r.getSessionId());
         for (int i = 0; i < columnCount; i++) {
             Value v = r.getValue(i);
             buff.checkCapacity(1);
@@ -174,7 +173,6 @@ public class RowList {
             key = 0;
         }
         boolean deleted = buff.readInt() == 1;
-        int sessionId = buff.readInt();
         Value[] values = new Value[columnCount];
         for (int i = 0; i < columnCount; i++) {
             Value v;
@@ -196,7 +194,6 @@ public class RowList {
         row.setKey(key);
         row.setVersion(version);
         row.setDeleted(deleted);
-        row.setSessionId(sessionId);
         return row;
     }
 

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -145,9 +145,6 @@ public class RegularTable extends TableBase {
     @Override
     public void commit(short operation, Row row) {
         lastModificationId = database.getNextModificationDataId();
-        for (Index index : indexes) {
-            index.commit(operation, row);
-        }
     }
 
     private void checkRowCount(Session session, Index index, int offset) {

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -142,11 +142,6 @@ public class RegularTable extends TableBase {
         analyzeIfRequired(session);
     }
 
-    @Override
-    public void commit(short operation, Row row) {
-        lastModificationId = database.getNextModificationDataId();
-    }
-
     private void checkRowCount(Session session, Index index, int offset) {
         if (SysProperties.CHECK) {
             if (!(index instanceof PageDelegateIndex)) {

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -225,17 +225,6 @@ public abstract class Table extends SchemaObjectBase {
     }
 
     /**
-     * Commit an operation (when using multi-version concurrency).
-     *
-     * @param operation the operation
-     * @param row the row
-     */
-    @SuppressWarnings("unused")
-    public void commit(short operation, Row row) {
-        // nothing to do
-    }
-
-    /**
      * Check if this table supports ALTER TABLE.
      *
      * @throws DbException if it is not supported


### PR DESCRIPTION
1. All remaining indexes have no-op `Index.commit()`.
2. `Table.commit()` was used only by PageStore+MVCC.
3. Session ID from `Row` is not used anymore, there is no need to remember it.