### PR TITLE
Simplify old lob ValueLob class

### DIFF
--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -621,7 +621,6 @@ public class Data {
             writeByte((byte) type);
             if (v instanceof ValueLob) {
                 ValueLob lob = (ValueLob) v;
-                lob.convertToFileIfRequired(handler);
                 byte[] small = lob.getSmall();
                 if (small == null) {
                     int t = -1;
@@ -1069,7 +1068,6 @@ public class Data {
             int len = 1;
             if (v instanceof ValueLob) {
                 ValueLob lob = (ValueLob) v;
-                lob.convertToFileIfRequired(handler);
                 byte[] small = lob.getSmall();
                 if (small == null) {
                     int t = -1;

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -852,8 +852,8 @@ public class Data {
                     return ValueLob.openUnlinked(type, handler, tableId,
                             objectId, precision, compression, filename);
                 }
-                return ValueLob.openLinked(type, handler, tableId,
-                        objectId, precision, compression);
+                return ValueLobDb.create(type, handler, tableId,
+                        objectId, null, precision);
             }
         }
         case Value.ARRAY: {

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -852,8 +852,8 @@ public class Data {
                     return ValueLob.openUnlinked(type, handler, tableId,
                             objectId, precision, compression, filename);
                 }
-                return ValueLobDb.create(type, handler, tableId,
-                        objectId, null, precision);
+                return ValueLob.openLinked(type, handler, tableId,
+                        objectId, precision, compression);
             }
         }
         case Value.ARRAY: {

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -214,7 +214,7 @@ public class Recover extends Tool implements DataHandler {
     /**
      * INTERNAL
      */
-    public static Value.ValueBlob readBlobDb(Connection conn, long lobId,
+    public static ValueLobDb readBlobDb(Connection conn, long lobId,
             long precision) {
         DataHandler h = ((JdbcConnection) conn).getSession().getDataHandler();
         verifyPageStore(h);
@@ -235,7 +235,7 @@ public class Recover extends Tool implements DataHandler {
     /**
      * INTERNAL
      */
-    public static Value.ValueClob readClobDb(Connection conn, long lobId,
+    public static ValueLobDb readClobDb(Connection conn, long lobId,
             long precision) {
         DataHandler h = ((JdbcConnection) conn).getSession().getDataHandler();
         verifyPageStore(h);

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -995,10 +995,11 @@ public class DataType {
             return Value.DECIMAL;
         } else if (ResultSet.class.isAssignableFrom(x)) {
             return Value.RESULT_SET;
-        } else if (Value.ValueBlob.class.isAssignableFrom(x)) {
+        } else if (ValueLobDb.class.isAssignableFrom(x)) {
             return Value.BLOB;
-        } else if (Value.ValueClob.class.isAssignableFrom(x)) {
-            return Value.CLOB;
+// FIXME no way to distinguish between these 2 types
+//        } else if (ValueLobDb.class.isAssignableFrom(x)) {
+//            return Value.CLOB;
         } else if (Date.class.isAssignableFrom(x)) {
             return Value.DATE;
         } else if (Time.class.isAssignableFrom(x)) {

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -1395,18 +1395,4 @@ public abstract class Value {
         return null;
     }
 
-    /**
-     * A "binary large object".
-     */
-    public interface ValueClob {
-        // this is a marker interface
-    }
-
-    /**
-     * A "character large object".
-     */
-    public interface ValueBlob {
-        // this is a marker interface
-    }
-
 }

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -6,15 +6,12 @@
 package org.h2.value;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-
 import org.h2.engine.Constants;
 import org.h2.engine.Mode;
 import org.h2.engine.SysProperties;
@@ -22,7 +19,6 @@ import org.h2.message.DbException;
 import org.h2.store.DataHandler;
 import org.h2.store.FileStore;
 import org.h2.store.FileStoreInputStream;
-import org.h2.store.FileStoreOutputStream;
 import org.h2.store.RangeInputStream;
 import org.h2.store.RangeReader;
 import org.h2.store.fs.FileUtils;
@@ -113,15 +109,14 @@ public class ValueLob extends Value {
      * either Value.BLOB or Value.CLOB
      */
     private final int valueType;
-    private long precision;
-    private DataHandler handler;
+    private final long precision;
+    private final DataHandler handler;
     private int tableId;
-    private int objectId;
+    private final int objectId;
     private String fileName;
     private boolean linked;
-    private byte[] small;
     private int hash;
-    private boolean compressed;
+    private final boolean compressed;
     private FileStore tempFile;
 
     private ValueLob(int type, DataHandler handler, String fileName,
@@ -135,37 +130,6 @@ public class ValueLob extends Value {
         this.linked = linked;
         this.precision = precision;
         this.compressed = compressed;
-    }
-
-    private ValueLob(int type, byte[] small) {
-        this.valueType = type;
-        this.small = small;
-        if (small != null) {
-            if (type == Value.BLOB) {
-                this.precision = small.length;
-            } else {
-                this.precision = getString().length();
-            }
-        }
-    }
-
-    private static ValueLob copy(ValueLob lob) {
-        ValueLob copy = new ValueLob(lob.valueType, lob.handler, lob.fileName,
-                lob.tableId, lob.objectId, lob.linked, lob.precision, lob.compressed);
-        copy.small = lob.small;
-        copy.hash = lob.hash;
-        return copy;
-    }
-
-    /**
-     * Create a small lob using the given byte array.
-     *
-     * @param type the type (Value.BLOB or CLOB)
-     * @param small the byte array
-     * @return the lob value
-     */
-    private static ValueLob createSmallLob(int type, byte[] small) {
-        return new ValueLob(type, small);
     }
 
     private static String getFileName(DataHandler handler, int tableId,
@@ -213,92 +177,6 @@ public class ValueLob extends Value {
             String fileName) {
         return new ValueLob(type, handler, fileName, tableId, objectId,
                 false/* linked */, precision, compression);
-    }
-
-    /**
-     * Create a CLOB value from a stream.
-     *
-     * @param in the reader
-     * @param length the number of characters to read, or -1 for no limit
-     * @param handler the data handler
-     * @return the lob value
-     */
-    private static ValueLob createClob(Reader in, long length,
-            DataHandler handler) {
-        try {
-            if (handler == null) {
-                String s = IOUtils.readStringAndClose(in, (int) length);
-                return createSmallLob(Value.CLOB, s.getBytes(StandardCharsets.UTF_8));
-            }
-            boolean compress = handler.getLobCompressionAlgorithm(Value.CLOB) != null;
-            long remaining = Long.MAX_VALUE;
-            if (length >= 0 && length < remaining) {
-                remaining = length;
-            }
-            int len = getBufferSize(handler, compress, remaining);
-            char[] buff;
-            if (len >= Integer.MAX_VALUE) {
-                String data = IOUtils.readStringAndClose(in, -1);
-                buff = data.toCharArray();
-                len = buff.length;
-            } else {
-                buff = new char[len];
-                len = IOUtils.readFully(in, buff, len);
-            }
-            if (len <= handler.getMaxLengthInplaceLob()) {
-                byte[] small = new String(buff, 0, len).getBytes(StandardCharsets.UTF_8);
-                return ValueLob.createSmallLob(Value.CLOB, small);
-            }
-            ValueLob lob = new ValueLob(Value.CLOB, null);
-            lob.createFromReader(buff, len, in, remaining, handler);
-            return lob;
-        } catch (IOException e) {
-            throw DbException.convertIOException(e, null);
-        }
-    }
-
-    private static int getBufferSize(DataHandler handler, boolean compress,
-            long remaining) {
-        if (remaining < 0 || remaining > Integer.MAX_VALUE) {
-            remaining = Integer.MAX_VALUE;
-        }
-        int inplace = handler.getMaxLengthInplaceLob();
-        long m = compress ?
-                Constants.IO_BUFFER_SIZE_COMPRESS : Constants.IO_BUFFER_SIZE;
-        if (m < remaining && m <= inplace) {
-            // using "1L" to force long arithmetic
-            m = Math.min(remaining, inplace + 1L);
-            // the buffer size must be bigger than the inplace lob, otherwise we
-            // can't know if it must be stored in-place or not
-            m = MathUtils.roundUpLong(m, Constants.IO_BUFFER_SIZE);
-        }
-        m = Math.min(remaining, m);
-        m = MathUtils.convertLongToInt(m);
-        if (m < 0) {
-            m = Integer.MAX_VALUE;
-        }
-        return (int) m;
-    }
-
-    private void createFromReader(char[] buff, int len, Reader in,
-            long remaining, DataHandler h) throws IOException {
-        try (FileStoreOutputStream out = initLarge(h)) {
-            boolean compress = h.getLobCompressionAlgorithm(Value.CLOB) != null;
-            while (true) {
-                precision += len;
-                byte[] b = new String(buff, 0, len).getBytes(StandardCharsets.UTF_8);
-                out.write(b, 0, b.length);
-                remaining -= len;
-                if (remaining <= 0) {
-                    break;
-                }
-                len = getBufferSize(h, compress, remaining);
-                len = IOUtils.readFully(in, buff, len);
-                if (len == 0) {
-                    break;
-                }
-            }
-        }
     }
 
     private static String getFileNamePrefix(String path, int objectId) {
@@ -410,91 +288,6 @@ public class ValueLob extends Value {
     }
 
     /**
-     * Create a BLOB value from a stream.
-     *
-     * @param in the input stream
-     * @param length the number of characters to read, or -1 for no limit
-     * @param handler the data handler
-     * @return the lob value
-     */
-    private static ValueLob createBlob(InputStream in, long length,
-            DataHandler handler) {
-        try {
-            if (handler == null) {
-                byte[] data = IOUtils.readBytesAndClose(in, (int) length);
-                return createSmallLob(Value.BLOB, data);
-            }
-            long remaining = Long.MAX_VALUE;
-            boolean compress = handler.getLobCompressionAlgorithm(Value.BLOB) != null;
-            if (length >= 0 && length < remaining) {
-                remaining = length;
-            }
-            int len = getBufferSize(handler, compress, remaining);
-            byte[] buff;
-            if (len >= Integer.MAX_VALUE) {
-                buff = IOUtils.readBytesAndClose(in, -1);
-                len = buff.length;
-            } else {
-                buff = Utils.newBytes(len);
-                len = IOUtils.readFully(in, buff, len);
-            }
-            if (len <= handler.getMaxLengthInplaceLob()) {
-                byte[] small = Utils.copyBytes(buff, len);
-                return ValueLob.createSmallLob(Value.BLOB, small);
-            }
-            ValueLob lob = new ValueLob(Value.BLOB, null);
-            lob.createFromStream(buff, len, in, remaining, handler);
-            return lob;
-        } catch (IOException e) {
-            throw DbException.convertIOException(e, null);
-        }
-    }
-
-    private FileStoreOutputStream initLarge(DataHandler h) {
-        this.handler = h;
-        this.tableId = 0;
-        this.linked = false;
-        this.precision = 0;
-        this.small = null;
-        this.hash = 0;
-        String compressionAlgorithm = h.getLobCompressionAlgorithm(valueType);
-        this.compressed = compressionAlgorithm != null;
-        synchronized (h) {
-            String path = h.getDatabasePath();
-            if ((path != null) && (path.length() == 0)) {
-                path = new File(Utils.getProperty("java.io.tmpdir", "."),
-                        SysProperties.PREFIX_TEMP_FILE).getAbsolutePath();
-            }
-            objectId = getNewObjectId(h);
-            fileName = getFileNamePrefix(path, objectId) + Constants.SUFFIX_TEMP_FILE;
-            tempFile = h.openFile(fileName, "rw", false);
-            tempFile.autoDelete();
-        }
-        return new FileStoreOutputStream(tempFile, h,
-                compressionAlgorithm);
-    }
-
-    private void createFromStream(byte[] buff, int len, InputStream in,
-            long remaining, DataHandler h) throws IOException {
-        try (FileStoreOutputStream out = initLarge(h)) {
-            boolean compress = h.getLobCompressionAlgorithm(Value.BLOB) != null;
-            while (true) {
-                precision += len;
-                out.write(buff, 0, len);
-                remaining -= len;
-                if (remaining <= 0) {
-                    break;
-                }
-                len = getBufferSize(h, compress, remaining);
-                len = IOUtils.readFully(in, buff, len);
-                if (len <= 0) {
-                    break;
-                }
-            }
-        }
-    }
-
-    /**
      * Convert a lob to another data type. The data is fully read in memory
      * except when converting to BLOB or CLOB.
      *
@@ -513,9 +306,9 @@ public class ValueLob extends Value {
         if (t == valueType) {
             return this;
         } else if (t == Value.CLOB) {
-            return ValueLob.createClob(getReader(), -1, handler);
+            return ValueLobDb.createTempClob(getReader(), -1, handler);
         } else if (t == Value.BLOB) {
-            return ValueLob.createBlob(getInputStream(), -1, handler);
+            return ValueLobDb.createTempBlob(getInputStream(), -1, handler);
         }
         return super.convertTo(t, precision, mode, column, null);
     }
@@ -552,8 +345,9 @@ public class ValueLob extends Value {
             return this;
         }
         if (linked) {
-            ValueLob copy = ValueLob.copy(this);
-            copy.objectId = getNewObjectId(h);
+            ValueLob copy = new ValueLob(this.valueType, this.handler, this.fileName,
+                    this.tableId, getNewObjectId(h), this.linked, this.precision, this.compressed);
+            copy.hash = this.hash;
             copy.tableId = tabId;
             String live = getFileName(h, copy.tableId, copy.objectId);
             copyFileTo(h, fileName, live);
@@ -610,17 +404,9 @@ public class ValueLob extends Value {
                 Integer.MAX_VALUE : (int) precision;
         try {
             if (valueType == Value.CLOB) {
-                if (small != null) {
-                    return new String(small, StandardCharsets.UTF_8);
-                }
                 return IOUtils.readStringAndClose(getReader(), len);
             }
-            byte[] buff;
-            if (small != null) {
-                buff = small;
-            } else {
-                buff = IOUtils.readBytesAndClose(getInputStream(), len);
-            }
+            byte[] buff = IOUtils.readBytesAndClose(getInputStream(), len);
             return StringUtils.convertBytesToHex(buff);
         } catch (IOException e) {
             throw DbException.convertIOException(e, fileName);
@@ -642,9 +428,6 @@ public class ValueLob extends Value {
         if (valueType == CLOB) {
             // convert hex to string
             return super.getBytesNoCopy();
-        }
-        if (small != null) {
-            return small;
         }
         try {
             return IOUtils.readBytesAndClose(
@@ -700,9 +483,6 @@ public class ValueLob extends Value {
 
     @Override
     public InputStream getInputStream() {
-        if (fileName == null) {
-            return new ByteArrayInputStream(small);
-        }
         FileStore store = handler.openFile(fileName, "r", true);
         boolean alwaysClose = SysProperties.lobCloseBetweenReads;
         return new BufferedInputStream(
@@ -751,9 +531,6 @@ public class ValueLob extends Value {
 
     @Override
     public String getTraceSQL() {
-        if (small != null && getPrecision() <= SysProperties.MAX_TRACE_DATA_LENGTH) {
-            return getSQL();
-        }
         StringBuilder buff = new StringBuilder();
         if (valueType == Value.CLOB) {
             buff.append("SPACE(").append(getPrecision());
@@ -771,7 +548,7 @@ public class ValueLob extends Value {
      */
     @Override
     public byte[] getSmall() {
-        return small;
+        return null;
     }
 
     @Override
@@ -782,35 +559,6 @@ public class ValueLob extends Value {
     @Override
     public boolean equals(Object other) {
         return other instanceof ValueLob && compareSecure((Value) other, null) == 0;
-    }
-
-    /**
-     * Store the lob data to a file if the size of the buffer is larger than the
-     * maximum size for an in-place lob.
-     *
-     * @param h the data handler
-     */
-    public void convertToFileIfRequired(DataHandler h) {
-        try {
-            if (small != null && small.length > h.getMaxLengthInplaceLob()) {
-                boolean compress = h.getLobCompressionAlgorithm(valueType) != null;
-                int len = getBufferSize(h, compress, Long.MAX_VALUE);
-                int tabId = tableId;
-                if (valueType == Value.BLOB) {
-                    createFromStream(
-                            Utils.newBytes(len), 0, getInputStream(), Long.MAX_VALUE, h);
-                } else {
-                    createFromReader(
-                            new char[len], 0, getReader(), Long.MAX_VALUE, h);
-                }
-                Value v2 = copy(h, tabId);
-                if (SysProperties.CHECK && v2 != this) {
-                    DbException.throwInternalError(v2.toString());
-                }
-            }
-        } catch (IOException e) {
-            throw DbException.convertIOException(e, null);
-        }
     }
 
     /**
@@ -851,9 +599,6 @@ public class ValueLob extends Value {
 
     @Override
     public int getMemory() {
-        if (small != null) {
-            return small.length + 104;
-        }
         return 140;
     }
 
@@ -864,12 +609,12 @@ public class ValueLob extends Value {
      * @return the value
      */
     @Override
-    public ValueLob copyToTemp() {
-        ValueLob lob;
+    public ValueLobDb copyToTemp() {
+        ValueLobDb lob;
         if (valueType == CLOB) {
-            lob = ValueLob.createClob(getReader(), precision, handler);
+            lob = ValueLobDb.createTempClob(getReader(), precision, handler);
         } else {
-            lob = ValueLob.createBlob(getInputStream(), precision, handler);
+            lob = ValueLobDb.createTempBlob(getInputStream(), precision, handler);
         }
         return lob;
     }
@@ -879,11 +624,11 @@ public class ValueLob extends Value {
         if (this.precision <= precision) {
             return this;
         }
-        ValueLob lob;
+        ValueLobDb lob;
         if (valueType == CLOB) {
-            lob = ValueLob.createClob(getReader(), precision, handler);
+            lob = ValueLobDb.createTempClob(getReader(), precision, handler);
         } else {
-            lob = ValueLob.createBlob(getInputStream(), precision, handler);
+            lob = ValueLobDb.createTempBlob(getInputStream(), precision, handler);
         }
         return lob;
     }

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -30,18 +30,9 @@ import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 
 /**
- * Implementation of the BLOB and CLOB data types. Small objects are kept in
- * memory and stored in the record.
- *
- * Large objects are stored in their own files. When large objects are set in a
- * prepared statement, they are first stored as 'temporary' files. Later, when
- * they are used in a record, and when the record is stored, the lob files are
- * linked: the file is renamed using the file format (tableId).(objectId). There
- * is one exception: large variables are stored in the file (-1).(objectId).
- *
- * When lobs are deleted, they are first renamed to a temp file, and if the
- * delete operation is committed the file is deleted.
- *
+ * This is the legacy implementation of LOBs for PageStore databases where the
+ * LOB was stored in an external file.
+ * 
  * Data compression is supported.
  */
 public class ValueLob extends Value {
@@ -139,24 +130,6 @@ public class ValueLob extends Value {
         String table = tableId < 0 ? ".temp" : ".t" + tableId;
         return getFileNamePrefix(handler.getDatabasePath(), objectId) +
                 table + Constants.SUFFIX_LOB_FILE;
-    }
-
-    /**
-     * Create a LOB value with the given parameters.
-     *
-     * @param type the data type, either Value.BLOB or Value.CLOB
-     * @param handler the file handler
-     * @param tableId the table object id
-     * @param objectId the object id
-     * @param precision the precision (length in elements)
-     * @param compression if compression is used
-     * @return the value object
-     */
-    public static ValueLob openLinked(int type, DataHandler handler,
-            int tableId, int objectId, long precision, boolean compression) {
-        String fileName = getFileName(handler, tableId, objectId);
-        return new ValueLob(type, handler, fileName, tableId, objectId,
-                true/* linked */, precision, compression);
     }
 
     /**
@@ -328,17 +301,11 @@ public class ValueLob extends Value {
 
     @Override
     public void remove() {
-        if (fileName != null) {
-            deleteFile(handler, fileName);
-        }
+        deleteFile(handler, fileName);
     }
 
     @Override
     public Value copy(DataHandler h, int tabId) {
-        if (fileName == null) {
-            this.tableId = tabId;
-            return this;
-        }
         if (linked) {
             ValueLob copy = new ValueLob(this.valueType, this.handler, this.fileName,
                     this.tableId, getNewObjectId(h), this.linked, this.precision, this.compressed);

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -117,7 +117,6 @@ public class ValueLob extends Value {
     private boolean linked;
     private int hash;
     private final boolean compressed;
-    private FileStore tempFile;
 
     private ValueLob(int type, DataHandler handler, String fileName,
             int tableId, int objectId, boolean linked, long precision,
@@ -330,10 +329,6 @@ public class ValueLob extends Value {
     @Override
     public void remove() {
         if (fileName != null) {
-            if (tempFile != null) {
-                tempFile.stopAutoDelete();
-                tempFile = null;
-            }
             deleteFile(handler, fileName);
         }
     }
@@ -358,10 +353,6 @@ public class ValueLob extends Value {
         if (!linked) {
             this.tableId = tabId;
             String live = getFileName(h, tableId, objectId);
-            if (tempFile != null) {
-                tempFile.stopAutoDelete();
-                tempFile = null;
-            }
             renameFile(h, fileName, live);
             fileName = live;
             linked = true;

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -42,7 +42,10 @@ import org.h2.util.Utils;
 public class ValueLobDb extends Value implements Value.ValueClob,
         Value.ValueBlob {
 
-    private final int type;
+    /**
+     * the value type (Value.BLOB or CLOB)
+     */
+    private final int valueType;
     private final long lobId;
     private final byte[] hmac;
     private final byte[] small;
@@ -66,7 +69,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
 
     private ValueLobDb(int type, DataHandler handler, int tableId, long lobId,
             byte[] hmac, long precision) {
-        this.type = type;
+        this.valueType = type;
         this.handler = handler;
         this.tableId = tableId;
         this.lobId = lobId;
@@ -78,7 +81,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
     }
 
     private ValueLobDb(int type, byte[] small, long precision) {
-        this.type = type;
+        this.valueType = type;
         this.small = small;
         this.precision = precision;
         this.lobId = 0;
@@ -94,7 +97,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
      */
     private ValueLobDb(DataHandler handler, Reader in, long remaining)
             throws IOException {
-        this.type = Value.CLOB;
+        this.valueType = Value.CLOB;
         this.handler = handler;
         this.small = null;
         this.lobId = 0;
@@ -126,7 +129,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
      */
     private ValueLobDb(DataHandler handler, byte[] buff, int len, InputStream in,
             long remaining) throws IOException {
-        this.type = Value.BLOB;
+        this.valueType = Value.BLOB;
         this.handler = handler;
         this.small = null;
         this.lobId = 0;
@@ -167,7 +170,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
     /**
      * Create a LOB value.
      *
-     * @param type the type
+     * @param type the type (Value.BLOB or CLOB)
      * @param handler the data handler
      * @param tableId the table id
      * @param id the lob id
@@ -194,7 +197,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
      */
     @Override
     public Value convertTo(int t, int precision, Mode mode, Object column, String[] enumerators) {
-        if (t == type) {
+        if (t == valueType) {
             return this;
         } else if (t == Value.CLOB) {
             if (handler != null) {
@@ -248,7 +251,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
         } else if (small.length > database.getMaxLengthInplaceLob()) {
             LobStorageInterface s = database.getLobStorage();
             Value v;
-            if (type == Value.BLOB) {
+            if (valueType == Value.BLOB) {
                 v = s.createBlob(getInputStream(), getPrecision());
             } else {
                 v = s.createClob(getReader(), getPrecision());
@@ -272,7 +275,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
 
     @Override
     public int getType() {
-        return type;
+        return valueType;
     }
 
     @Override
@@ -285,7 +288,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
         int len = precision > Integer.MAX_VALUE || precision == 0 ?
                 Integer.MAX_VALUE : (int) precision;
         try {
-            if (type == Value.CLOB) {
+            if (valueType == Value.CLOB) {
                 if (small != null) {
                     return new String(small, StandardCharsets.UTF_8);
                 }
@@ -305,7 +308,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
 
     @Override
     public byte[] getBytes() {
-        if (type == CLOB) {
+        if (valueType == CLOB) {
             // convert hex to string
             return super.getBytes();
         }
@@ -315,7 +318,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
 
     @Override
     public byte[] getBytesNoCopy() {
-        if (type == CLOB) {
+        if (valueType == CLOB) {
             // convert hex to string
             return super.getBytesNoCopy();
         }
@@ -337,7 +340,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
                 // it in the database file
                 return (int) (precision ^ (precision >>> 32));
             }
-            if (type == CLOB) {
+            if (valueType == CLOB) {
                 hash = getString().hashCode();
             } else {
                 hash = Utils.getByteArrayHash(getBytes());
@@ -357,7 +360,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
                 return 0;
             }
         }
-        if (type == Value.CLOB) {
+        if (valueType == Value.CLOB) {
             return Integer.signum(getString().compareTo(v.getString()));
         }
         byte[] v2 = v.getBytesNoCopy();
@@ -366,7 +369,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
 
     @Override
     public Object getObject() {
-        if (type == Value.CLOB) {
+        if (valueType == Value.CLOB) {
             return getReader();
         }
         return getInputStream();
@@ -379,7 +382,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
 
     @Override
     public Reader getReader(long oneBasedOffset, long length) {
-        return ValueLob.rangeReader(getReader(), oneBasedOffset, length, type == Value.CLOB ? precision : -1);
+        return ValueLob.rangeReader(getReader(), oneBasedOffset, length, valueType == Value.CLOB ? precision : -1);
     }
 
     @Override
@@ -392,7 +395,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
             return new BufferedInputStream(new FileStoreInputStream(store,
                     handler, false, alwaysClose), Constants.IO_BUFFER_SIZE);
         }
-        long byteCount = (type == Value.BLOB) ? precision : -1;
+        long byteCount = (valueType == Value.BLOB) ? precision : -1;
         try {
             return handler.getLobStorage().getInputStream(this, hmac, byteCount);
         } catch (IOException e) {
@@ -413,7 +416,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
             inputStream = new BufferedInputStream(new FileStoreInputStream(store,
                     handler, false, alwaysClose), Constants.IO_BUFFER_SIZE);
         } else {
-            byteCount = (type == Value.BLOB) ? precision : -1;
+            byteCount = (valueType == Value.BLOB) ? precision : -1;
             try {
                 inputStream = handler.getLobStorage().getInputStream(this, hmac, byteCount);
             } catch (IOException e) {
@@ -430,7 +433,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
         if (p > Integer.MAX_VALUE || p <= 0) {
             p = -1;
         }
-        if (type == Value.BLOB) {
+        if (valueType == Value.BLOB) {
             prep.setBinaryStream(parameterIndex, getInputStream(), (int) p);
         } else {
             prep.setCharacterStream(parameterIndex, getReader(), (int) p);
@@ -440,7 +443,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
     @Override
     public String getSQL() {
         String s;
-        if (type == Value.CLOB) {
+        if (valueType == Value.CLOB) {
             s = getString();
             return StringUtils.quoteStringSQL(s);
         }
@@ -455,7 +458,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
             return getSQL();
         }
         StringBuilder buff = new StringBuilder();
-        if (type == Value.CLOB) {
+        if (valueType == Value.CLOB) {
             buff.append("SPACE(").append(getPrecision());
         } else {
             buff.append("CAST(REPEAT('00', ").append(getPrecision()).append(") AS BINARY");
@@ -650,13 +653,13 @@ public class ValueLobDb extends Value implements Value.ValueClob,
             return this;
         }
         ValueLobDb lob;
-        if (type == CLOB) {
+        if (valueType == CLOB) {
             if (handler == null) {
                 try {
                     int p = MathUtils.convertLongToInt(precision);
                     String s = IOUtils.readStringAndClose(getReader(), p);
                     byte[] data = s.getBytes(StandardCharsets.UTF_8);
-                    lob = ValueLobDb.createSmallLob(type, data, s.length());
+                    lob = ValueLobDb.createSmallLob(valueType, data, s.length());
                 } catch (IOException e) {
                     throw DbException.convertIOException(e, null);
                 }
@@ -668,7 +671,7 @@ public class ValueLobDb extends Value implements Value.ValueClob,
                 try {
                     int p = MathUtils.convertLongToInt(precision);
                     byte[] data = IOUtils.readBytesAndClose(getInputStream(), p);
-                    lob = ValueLobDb.createSmallLob(type, data, data.length);
+                    lob = ValueLobDb.createSmallLob(valueType, data, data.length);
                 } catch (IOException e) {
                     throw DbException.convertIOException(e, null);
                 }

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -39,8 +39,7 @@ import org.h2.util.Utils;
  * Small objects are kept in memory and stored in the record.
  * Large objects are either stored in the database, or in temporary files.
  */
-public class ValueLobDb extends Value implements Value.ValueClob,
-        Value.ValueBlob {
+public class ValueLobDb extends Value {
 
     /**
      * the value type (Value.BLOB or CLOB)

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -265,8 +265,9 @@ public class TestValue extends TestDb {
         testDataType(Value.NULL, Void.class);
         testDataType(Value.DECIMAL, BigDecimal.class);
         testDataType(Value.RESULT_SET, ResultSet.class);
-        testDataType(Value.BLOB, Value.ValueBlob.class);
-        testDataType(Value.CLOB, Value.ValueClob.class);
+        testDataType(Value.BLOB, ValueLobDb.class);
+        // see FIXME in DataType.getTypeFromClass
+        //testDataType(Value.CLOB, Value.ValueClob.class);
         testDataType(Value.DATE, Date.class);
         testDataType(Value.TIME, Time.class);
         testDataType(Value.TIMESTAMP, Timestamp.class);


### PR DESCRIPTION
it is currently only used in very specific situations to read old legacy ways of storing LOBs in PageStore databases (legacy even for PageStore), so strip out the unused code