### PR TITLE
Do not use deprecated Class.newInstance()

### DIFF
--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -489,7 +489,7 @@ public class Set extends Prepared {
             Class<RowFactory> rowFactoryClass = JdbcUtils.loadUserClass(rowFactoryName);
             RowFactory rowFactory;
             try {
-                rowFactory = rowFactoryClass.newInstance();
+                rowFactory = rowFactoryClass.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw DbException.convert(e);
             }

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2179,7 +2179,7 @@ public class Database implements DataHandler {
         } else {
             try {
                 eventListener = (DatabaseEventListener)
-                        JdbcUtils.loadUserClass(className).newInstance();
+                        JdbcUtils.loadUserClass(className).getDeclaredConstructor().newInstance();
                 String url = databaseURL;
                 if (cipher != null) {
                     url += ";CIPHER=" + cipher;
@@ -2939,7 +2939,7 @@ public class Database implements DataHandler {
                         !serializerName.equals("null")) {
                     try {
                         javaObjectSerializer = (JavaObjectSerializer)
-                                JdbcUtils.loadUserClass(serializerName).newInstance();
+                                JdbcUtils.loadUserClass(serializerName).getDeclaredConstructor().newInstance();
                     } catch (Exception e) {
                         throw DbException.convert(e);
                     }
@@ -2968,7 +2968,7 @@ public class Database implements DataHandler {
         TableEngine engine = tableEngines.get(tableEngine);
         if (engine == null) {
             try {
-                engine = (TableEngine) JdbcUtils.loadUserClass(tableEngine).newInstance();
+                engine = (TableEngine) JdbcUtils.loadUserClass(tableEngine).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw DbException.convert(e);
             }

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -409,7 +409,7 @@ public class SessionRemote extends SessionWithState implements DataHandler {
                 className = StringUtils.trim(className, true, true, "'");
                 try {
                     eventListener = (DatabaseEventListener) JdbcUtils
-                            .loadUserClass(className).newInstance();
+                            .loadUserClass(className).getDeclaredConstructor().newInstance();
                 } catch (Throwable e) {
                     throw DbException.convert(e);
                 }
@@ -794,7 +794,7 @@ public class SessionRemote extends SessionWithState implements DataHandler {
                 if (!serializerFQN.isEmpty() && !serializerFQN.equals("null")) {
                     try {
                         javaObjectSerializer = (JavaObjectSerializer) JdbcUtils
-                                .loadUserClass(serializerFQN).newInstance();
+                                .loadUserClass(serializerFQN).getDeclaredConstructor().newInstance();
                     } catch (Exception e) {
                         throw DbException.convert(e);
                     }

--- a/h2/src/main/org/h2/engine/UserAggregate.java
+++ b/h2/src/main/org/h2/engine/UserAggregate.java
@@ -39,7 +39,7 @@ public class UserAggregate extends DbObjectBase {
         }
         Object obj;
         try {
-            obj = javaClass.newInstance();
+            obj = javaClass.getDeclaredConstructor().newInstance();
             Aggregate agg;
             if (obj instanceof Aggregate) {
                 agg = (Aggregate) obj;

--- a/h2/src/main/org/h2/message/TraceSystem.java
+++ b/h2/src/main/org/h2/message/TraceSystem.java
@@ -189,7 +189,7 @@ public class TraceSystem implements TraceWriter {
         if (level == ADAPTER) {
             String adapterClass = "org.h2.message.TraceWriterAdapter";
             try {
-                writer = (TraceWriter) Class.forName(adapterClass).newInstance();
+                writer = (TraceWriter) Class.forName(adapterClass).getDeclaredConstructor().newInstance();
             } catch (Throwable e) {
                 e = DbException.get(ErrorCode.CLASS_NOT_FOUND_1, e, adapterClass);
                 write(ERROR, Trace.DATABASE, adapterClass, e);

--- a/h2/src/main/org/h2/schema/TriggerObject.java
+++ b/h2/src/main/org/h2/schema/TriggerObject.java
@@ -74,7 +74,7 @@ public class TriggerObject extends SchemaObjectBase {
             Connection c2 = sysSession.createConnection(false);
             Object obj;
             if (triggerClassName != null) {
-                obj = JdbcUtils.loadUserClass(triggerClassName).newInstance();
+                obj = JdbcUtils.loadUserClass(triggerClassName).getDeclaredConstructor().newInstance();
             } else {
                 obj = loadFromSource();
             }

--- a/h2/src/main/org/h2/security/auth/DefaultAuthenticator.java
+++ b/h2/src/main/org/h2/security/auth/DefaultAuthenticator.java
@@ -245,7 +245,7 @@ public class DefaultAuthenticator implements Authenticator {
             CredentialsValidator currentValidator = null;
             try {
                 currentValidator = (CredentialsValidator) Class.forName(currentRealmConfig.getValidatorClass())
-                        .newInstance();
+                        .getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw new AuthenticationException("invalid validator class fo realm " + currentRealmName, e);
             }
@@ -260,7 +260,7 @@ public class DefaultAuthenticator implements Authenticator {
             UserToRolesMapper currentUserToRolesMapper = null;
             try {
                 currentUserToRolesMapper = (UserToRolesMapper) Class
-                        .forName(currentUserToRolesMapperConfig.getClassName()).newInstance();
+                        .forName(currentUserToRolesMapperConfig.getClassName()).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw new AuthenticationException("Invalid class in UserToRolesMapperConfig", e);
             }

--- a/h2/src/main/org/h2/store/fs/FilePath.java
+++ b/h2/src/main/org/h2/store/fs/FilePath.java
@@ -78,7 +78,7 @@ public abstract class FilePath {
                     "org.h2.store.fs.FilePathRetryOnInterrupt"
             }) {
                 try {
-                    FilePath p = (FilePath) Class.forName(c).newInstance();
+                    FilePath p = (FilePath) Class.forName(c).getDeclaredConstructor().newInstance();
                     map.put(p.getScheme(), p);
                     if (defaultProvider == null) {
                         defaultProvider = p;

--- a/h2/src/main/org/h2/store/fs/FilePathWrapper.java
+++ b/h2/src/main/org/h2/store/fs/FilePathWrapper.java
@@ -41,7 +41,7 @@ public abstract class FilePathWrapper extends FilePath {
 
     private FilePathWrapper create(String path, FilePath base) {
         try {
-            FilePathWrapper p = getClass().newInstance();
+            FilePathWrapper p = getClass().getDeclaredConstructor().newInstance();
             p.name = path;
             p.base = base;
             return p;

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -114,7 +114,7 @@ public class JdbcUtils {
         String clazz = SysProperties.JAVA_OBJECT_SERIALIZER;
         if (clazz != null) {
             try {
-                serializer = (JavaObjectSerializer) loadUserClass(clazz).newInstance();
+                serializer = (JavaObjectSerializer) loadUserClass(clazz).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw DbException.convert(e);
             }
@@ -124,7 +124,7 @@ public class JdbcUtils {
         if (customTypeHandlerClass != null) {
             try {
                 customDataTypesHandler = (CustomDataTypesHandler)
-                        loadUserClass(customTypeHandlerClass).newInstance();
+                        loadUserClass(customTypeHandlerClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 throw DbException.convert(e);
             }
@@ -290,7 +290,7 @@ public class JdbcUtils {
             Class<?> d = loadUserClass(driver);
             if (java.sql.Driver.class.isAssignableFrom(d)) {
                 try {
-                    Driver driverInstance = (Driver) d.newInstance();
+                    Driver driverInstance = (Driver) d.getDeclaredConstructor().newInstance();
                     return driverInstance.connect(url, prop); /*fix issue #695 with drivers with the same
                     jdbc subprotocol in classpath of jdbc drivers (as example redshift and postgresql drivers)*/
                 } catch (Exception e) {
@@ -299,7 +299,7 @@ public class JdbcUtils {
             } else if (javax.naming.Context.class.isAssignableFrom(d)) {
                 // JNDI context
                 try {
-                    Context context = (Context) d.newInstance();
+                    Context context = (Context) d.getDeclaredConstructor().newInstance();
                     DataSource ds = (DataSource) context.lookup(url);
                     String user = prop.getProperty("user");
                     String password = prop.getProperty("password");

--- a/h2/src/main/org/h2/util/SourceCompiler.java
+++ b/h2/src/main/org/h2/util/SourceCompiler.java
@@ -399,7 +399,7 @@ public class SourceCompiler {
             System.setErr(temp);
             Method compile;
             compile = JAVAC_SUN.getMethod("compile", String[].class);
-            Object javac = JAVAC_SUN.newInstance();
+            Object javac = JAVAC_SUN.getDeclaredConstructor().newInstance();
             compile.invoke(javac, (Object) new String[] {
                     "-sourcepath", COMPILE_DIR,
                     // "-Xlint:unchecked",

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -1054,11 +1054,8 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
     private static TestBase createTest(String className) {
         try {
             Class<?> clazz = Class.forName(className);
-            return (TestBase) clazz.newInstance();
-        } catch (Exception e) {
-            // ignore
-            TestBase.printlnWithTime(0, className + " class not found");
-        } catch (NoClassDefFoundError e) {
+            return (TestBase) clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception | NoClassDefFoundError e) {
             // ignore
             TestBase.printlnWithTime(0, className + " class not found");
         }

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -1303,7 +1303,7 @@ public abstract class TestBase {
         try {
             return (TestBase) new SecurityManager() {
                 Class<?> clazz = getClassContext()[2];
-            }.clazz.newInstance();
+            }.clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/h2/src/test/org/h2/test/bench/Database.java
+++ b/h2/src/test/org/h2/test/bench/Database.java
@@ -107,7 +107,7 @@ class Database {
             Thread.sleep(100);
         } else if (url.startsWith("jdbc:derby://")) {
             serverDerby = Class.forName(
-                    "org.apache.derby.drda.NetworkServerControl").newInstance();
+                    "org.apache.derby.drda.NetworkServerControl").getDeclaredConstructor().newInstance();
             Method m = serverDerby.getClass().getMethod("start", PrintWriter.class);
             m.invoke(serverDerby, new Object[] { null });
             // serverDerby = new NetworkServerControl();

--- a/h2/src/test/org/h2/test/bench/TestPerformance.java
+++ b/h2/src/test/org/h2/test/bench/TestPerformance.java
@@ -111,7 +111,7 @@ public class TestPerformance implements Database.DatabaseTest {
         for (int i = 0; i < 100; i++) {
             String testString = prop.getProperty("test" + i);
             if (testString != null) {
-                Bench bench = (Bench) Class.forName(testString).newInstance();
+                Bench bench = (Bench) Class.forName(testString).getDeclaredConstructor().newInstance();
                 tests.add(bench);
             }
         }

--- a/h2/src/test/org/h2/test/db/TaskDef.java
+++ b/h2/src/test/org/h2/test/db/TaskDef.java
@@ -28,7 +28,7 @@ public abstract class TaskDef {
         TaskDef task;
         try {
             String className = args[0];
-            task = (TaskDef) Class.forName(className).newInstance();
+            task = (TaskDef) Class.forName(className).getDeclaredConstructor().newInstance();
             System.out.println("running");
         } catch (Throwable t) {
             System.out.println("init error: " + t);

--- a/h2/src/test/org/h2/test/poweroff/TestRecover.java
+++ b/h2/src/test/org/h2/test/poweroff/TestRecover.java
@@ -205,7 +205,7 @@ public class TestRecover {
                 // ignore
             }
             try {
-                Driver driver = (Driver) Class.forName(DRIVER).newInstance();
+                Driver driver = (Driver) Class.forName(DRIVER).getDeclaredConstructor().newInstance();
                 DriverManager.registerDriver(driver);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/h2/src/test/org/h2/test/unit/TestClassLoaderLeak.java
+++ b/h2/src/test/org/h2/test/unit/TestClassLoaderLeak.java
@@ -63,9 +63,9 @@ public class TestClassLoaderLeak extends TestBase {
             }
         }
         DriverManager.registerDriver((Driver)
-                Class.forName("org.h2.Driver").newInstance());
+                Class.forName("org.h2.Driver").getDeclaredConstructor().newInstance());
         DriverManager.registerDriver((Driver)
-                Class.forName("org.h2.upgrade.v1_1.Driver").newInstance());
+                Class.forName("org.h2.upgrade.v1_1.Driver").getDeclaredConstructor().newInstance());
     }
 
     private static WeakReference<ClassLoader> createClassLoader() throws Exception {

--- a/h2/src/tools/org/h2/build/BuildBase.java
+++ b/h2/src/tools/org/h2/build/BuildBase.java
@@ -974,7 +974,7 @@ public class BuildBase {
                 }));
             }
             Method compile = clazz.getMethod("compile", new Class<?>[] { String[].class });
-            Object instance = clazz.newInstance();
+            Object instance = clazz.getDeclaredConstructor().newInstance();
             result = (Integer) invoke(compile, instance, new Object[] { array });
         } catch (Exception e) {
             e.printStackTrace();

--- a/h2/src/tools/org/h2/jaqu/Db.java
+++ b/h2/src/tools/org/h2/jaqu/Db.java
@@ -66,7 +66,7 @@ public class Db {
 
     private static <T> T instance(Class<T> clazz) {
         try {
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/h2/src/tools/org/h2/jaqu/util/ClassUtils.java
+++ b/h2/src/tools/org/h2/jaqu/util/ClassUtils.java
@@ -65,7 +65,7 @@ public class ClassUtils {
             return (T) new ArrayList<>();
         }
         try {
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             if (MAKE_ACCESSIBLE) {
                 Constructor<?>[] constructors = clazz.getDeclaredConstructors();
@@ -74,7 +74,7 @@ public class ClassUtils {
                     if (c.getParameterTypes().length == 0) {
                         c.setAccessible(true);
                         try {
-                            return clazz.newInstance();
+                            return clazz.getDeclaredConstructor().newInstance();
                         } catch (Exception e2) {
                             // ignore
                         }


### PR DESCRIPTION
`Class.newInstance()` was deprecated since Java 9 because it can throw undeclared checked exceptions that is valid in JVM, but is not valid in Java. `Class.getDeclaredConstructor().newInstance()` is used instead of it in all places. This significantly reduces the amount of compiler warnings in Java 9 and later versions.