### PR TITLE
Don't try to find tools.jar on Java 9+

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -131,20 +131,18 @@
       <scope>test</scope>
     </dependency>
     <!-- END TEST DEPENDENCIES !-->
-
-    <!--  JDK dependencies  -->
-    <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>1.7</version>
-      <scope>system</scope>
-      <systemPath>${tools.jar}</systemPath>
-    </dependency>
   </dependencies>
 
   <!-- The test code creates proxy files using javac or tools.jar. Through maven we need to tell it
        where to possibly find tools.jar and annoyingly its called classes.jar on OSX -->
   <profiles>
+    <profile>
+      <id>jigsaw-jdk</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <dependencies/>
+    </profile>
     <profile>
       <id>default-tools.jar</id>
       <activation>
@@ -152,9 +150,15 @@
           <exists>${java.home}/../lib/tools.jar</exists>
         </file>
       </activation>
-      <properties>
-        <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
-      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <scope>system</scope>
+          <version>1.7</version>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>default-tools.jar-mac</id>
@@ -163,9 +167,15 @@
           <exists>${java.home}/../Classes/classes.jar</exists>
         </file>
       </activation>
-      <properties>
-        <tools.jar>${java.home}/../Classes/classes.jar</tools.jar>
-      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <scope>system</scope>
+          <version>1.7</version>
+          <systemPath>${java.home}/../Classes/classes.jar</systemPath>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 


### PR DESCRIPTION
There is no `tools.jar` since Java 9. `pom.xml` is modified to declare this dependency only on older versions. This resolves noisy (but harmless) errors during the build on Java 9 and later versions.