### PR TITLE
Detect disabled tests

### DIFF
--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -8,6 +8,8 @@ package org.h2.test;
 import java.lang.management.ManagementFactory;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
@@ -430,6 +432,7 @@ java org.h2.test.TestAll timer
 
     private Server server;
 
+    HashMap<Class<? extends TestBase>, Boolean> executedTests = new HashMap<>();
 
     /**
      * Run all tests.
@@ -688,6 +691,12 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
             test();
             cipher = null;
             test();
+        }
+
+        for (Entry<Class<? extends TestBase>, Boolean> entry : executedTests.entrySet()) {
+            if (!entry.getValue()) {
+                System.out.println("Warning: test " + entry.getKey().getName() + " was not executed.");
+            }
         }
     }
 

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -127,6 +127,9 @@ public abstract class TestBase {
         }
         try {
             init(conf);
+            if (!isEnabled()) {
+                return;
+            }
             start = System.nanoTime();
             test();
             println("");
@@ -428,6 +431,13 @@ public abstract class TestBase {
             s = s.substring(3);
         }
         return s;
+    }
+
+    /**
+     * @return whether this test is enabled in the current configuration
+     */
+    public boolean isEnabled() {
+        return true;
     }
 
     /**

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -128,8 +128,12 @@ public abstract class TestBase {
         try {
             init(conf);
             if (!isEnabled()) {
+                if (!conf.executedTests.containsKey(getClass())) {
+                    conf.executedTests.put(getClass(), false);
+                }
                 return;
             }
+            conf.executedTests.put(getClass(), true);
             start = System.nanoTime();
             test();
             println("");

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -41,7 +41,6 @@ import org.h2.store.fs.FilePath;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.utils.ProxyCodeGenerator;
 import org.h2.test.utils.ResultVerifier;
-import org.h2.util.Utils;
 
 /**
  * The base class for all tests.
@@ -130,14 +129,7 @@ public abstract class TestBase {
             init(conf);
             start = System.nanoTime();
             test();
-            if (!config.mvStore) {
-                /*
-                 * This code is here to debug memory issues with PageStore testing on Travis.
-                 */
-                println("(" + (Utils.getMemoryUsed() >> 10) + " MiB used after)");
-            } else {
-                println("");
-            }
+            println("");
         } catch (Throwable e) {
             println("FAIL " + e.toString());
             logError("FAIL ("+conf+") " + e.toString(), e);

--- a/h2/src/test/org/h2/test/db/TestBackup.java
+++ b/h2/src/test/org/h2/test/db/TestBackup.java
@@ -35,10 +35,15 @@ public class TestBackup extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         testConcurrentBackup();
         testBackupRestoreLobStatement();
         testBackupRestoreLob();

--- a/h2/src/test/org/h2/test/db/TestBigDb.java
+++ b/h2/src/test/org/h2/test/db/TestBigDb.java
@@ -31,13 +31,18 @@ public class TestBigDb extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.memory) {
-            return;
+            return false;
         }
         if (config.networked && config.big) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         testLargeTable();
         testInsert();
         testLeftSummary();

--- a/h2/src/test/org/h2/test/db/TestBigResult.java
+++ b/h2/src/test/org/h2/test/db/TestBigResult.java
@@ -38,10 +38,15 @@ public class TestBigResult extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         testLargeSubquery();
         testSortingAndDistinct();
         testLOB();

--- a/h2/src/test/org/h2/test/db/TestCluster.java
+++ b/h2/src/test/org/h2/test/db/TestCluster.java
@@ -36,6 +36,14 @@ public class TestCluster extends TestDb {
     }
 
     @Override
+    public boolean isEnabled() {
+        if (config.memory || config.networked || config.cipher != null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public void test() throws Exception {
         testClob();
         testRecover();
@@ -47,9 +55,6 @@ public class TestCluster extends TestDb {
     }
 
     private void testClob() throws SQLException {
-        if (config.memory || config.networked || config.cipher != null) {
-            return;
-        }
         deleteFiles();
 
         org.h2.Driver.load();
@@ -86,9 +91,6 @@ public class TestCluster extends TestDb {
     }
 
     private void testRecover() throws SQLException {
-        if (config.memory || config.networked || config.cipher != null) {
-            return;
-        }
         deleteFiles();
 
         org.h2.Driver.load();
@@ -149,9 +151,6 @@ public class TestCluster extends TestDb {
     }
 
     private void testRollback() throws SQLException {
-        if (config.memory || config.networked || config.cipher != null) {
-            return;
-        }
         deleteFiles();
 
         org.h2.Driver.load();
@@ -196,9 +195,6 @@ public class TestCluster extends TestDb {
     }
 
     private void testCase() throws SQLException {
-        if (config.memory || config.networked || config.cipher != null) {
-            return;
-        }
         deleteFiles();
 
         org.h2.Driver.load();
@@ -252,9 +248,6 @@ public class TestCluster extends TestDb {
     }
 
     private void testClientInfo() throws SQLException {
-        if (config.memory || config.networked || config.cipher != null) {
-            return;
-        }
         deleteFiles();
 
         org.h2.Driver.load();
@@ -304,9 +297,6 @@ public class TestCluster extends TestDb {
     }
 
     private void testCreateClusterAtRuntime() throws SQLException {
-        if (config.memory || config.networked || config.cipher != null) {
-            return;
-        }
         deleteFiles();
 
         org.h2.Driver.load();
@@ -396,9 +386,6 @@ public class TestCluster extends TestDb {
     }
 
     private void testStartStopCluster() throws SQLException {
-        if (config.memory || config.networked || config.cipher != null) {
-            return;
-        }
         int port1 = 9193, port2 = 9194;
         String serverList = "localhost:" + port1 + ",localhost:" + port2;
         deleteFiles();

--- a/h2/src/test/org/h2/test/db/TestEncryptedDb.java
+++ b/h2/src/test/org/h2/test/db/TestEncryptedDb.java
@@ -29,10 +29,15 @@ public class TestEncryptedDb extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.memory || config.cipher != null) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         deleteDb("encrypted");
         Connection conn = getConnection("encrypted;CIPHER=AES", "sa", "123 123");
         Statement stat = conn.createStatement();

--- a/h2/src/test/org/h2/test/db/TestLargeBlob.java
+++ b/h2/src/test/org/h2/test/db/TestLargeBlob.java
@@ -28,11 +28,15 @@ public class TestLargeBlob extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!config.big || config.memory || config.mvStore || config.networked) {
-            return;
+            return false;
         }
+        return true;
+    }
 
+    @Override
+    public void test() throws Exception {
         deleteDb("largeBlob");
         String url = getURL("largeBlob;TRACE_LEVEL_FILE=0", true);
         Connection conn = getConnection(url);

--- a/h2/src/test/org/h2/test/db/TestListener.java
+++ b/h2/src/test/org/h2/test/db/TestListener.java
@@ -39,10 +39,15 @@ public class TestListener extends TestDb implements DatabaseEventListener {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.networked || config.cipher != null) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         deleteDb("listener");
         Connection conn;
         conn = getConnection("listener");

--- a/h2/src/test/org/h2/test/db/TestMergeUsing.java
+++ b/h2/src/test/org/h2/test/db/TestMergeUsing.java
@@ -34,12 +34,16 @@ public class TestMergeUsing extends TestDb implements Trigger {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         // TODO breaks in pagestore case
         if (!config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
 
+    @Override
+    public void test() throws Exception {
         // Simple ID,NAME inserts, target table with PK initially empty
         testMergeUsing(
                 "CREATE TABLE PARENT(ID INT, NAME VARCHAR, PRIMARY KEY(ID) );",

--- a/h2/src/test/org/h2/test/db/TestMultiThread.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThread.java
@@ -60,11 +60,16 @@ public class TestMultiThread extends TestDb implements Runnable {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         // pagestore and multithreaded was always experimental, we're not going to fix that
         if (!config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         testConcurrentSchemaChange();
         testConcurrentLobAdd();
         testConcurrentView();

--- a/h2/src/test/org/h2/test/db/TestMultiThreadedKernel.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThreadedKernel.java
@@ -43,10 +43,15 @@ public class TestMultiThreadedKernel extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.mvStore) { // FIXME can't see why test should not work in MVStore mode
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("multiThreadedKernel");
         testConcurrentRead();
         testCache();

--- a/h2/src/test/org/h2/test/db/TestOutOfMemory.java
+++ b/h2/src/test/org/h2/test/db/TestOutOfMemory.java
@@ -40,11 +40,16 @@ public class TestOutOfMemory extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.vmlens) {
             // running out of memory will cause the vmlens agent to stop working
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         try {
             if (!config.travis) {
                 System.gc();

--- a/h2/src/test/org/h2/test/db/TestPowerOff.java
+++ b/h2/src/test/org/h2/test/db/TestPowerOff.java
@@ -39,10 +39,15 @@ public class TestPowerOff extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         if (config.big || config.googleAppEngine) {
             dir = getBaseDir();
             url = DB_NAME;

--- a/h2/src/test/org/h2/test/db/TestReadOnly.java
+++ b/h2/src/test/org/h2/test/db/TestReadOnly.java
@@ -37,10 +37,15 @@ public class TestReadOnly extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         testReadOnlyInZip();
         testReadOnlyTempTableResult();
         testReadOnlyConnect();

--- a/h2/src/test/org/h2/test/db/TestSQLInjection.java
+++ b/h2/src/test/org/h2/test/db/TestSQLInjection.java
@@ -33,10 +33,15 @@ public class TestSQLInjection extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.reopen) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         deleteDb("sqlInjection");
         reconnect("sqlInjection");
         stat.execute("DROP TABLE IF EXISTS USERS");

--- a/h2/src/test/org/h2/test/db/TestSessionsLocks.java
+++ b/h2/src/test/org/h2/test/db/TestSessionsLocks.java
@@ -27,10 +27,15 @@ public class TestSessionsLocks extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!config.multiThreaded) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         testCancelStatement();
         if (!config.mvStore) {
             testLocks();

--- a/h2/src/test/org/h2/test/db/TestSpaceReuse.java
+++ b/h2/src/test/org/h2/test/db/TestSpaceReuse.java
@@ -28,10 +28,15 @@ public class TestSpaceReuse extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         deleteDb("spaceReuse");
         long max = 0, now = 0, min = Long.MAX_VALUE;
         for (int i = 0; i < 20; i++) {

--- a/h2/src/test/org/h2/test/db/TestSpatial.java
+++ b/h2/src/test/org/h2/test/db/TestSpatial.java
@@ -53,15 +53,21 @@ public class TestSpatial extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.memory && config.mvStore) {
-            return;
+            return false;
         }
-        if (DataType.GEOMETRY_CLASS != null) {
-            deleteDb("spatial");
-            testSpatial();
-            deleteDb("spatial");
+        if (DataType.GEOMETRY_CLASS == null) {
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
+        deleteDb("spatial");
+        testSpatial();
+        deleteDb("spatial");
     }
 
     private void testSpatial() throws SQLException {

--- a/h2/src/test/org/h2/test/db/TestTwoPhaseCommit.java
+++ b/h2/src/test/org/h2/test/db/TestTwoPhaseCommit.java
@@ -28,11 +28,15 @@ public class TestTwoPhaseCommit extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.memory || config.networked) {
-            return;
+            return false;
         }
+        return true;
+    }
 
+    @Override
+    public void test() throws SQLException {
         deleteDb("twoPhaseCommit");
 
         prepare();

--- a/h2/src/test/org/h2/test/db/TestUpgrade.java
+++ b/h2/src/test/org/h2/test/db/TestUpgrade.java
@@ -35,13 +35,18 @@ public class TestUpgrade extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.mvStore) {
-            return;
+            return false;
         }
         if (!Utils.isClassPresent("org.h2.upgrade.v1_1.Driver")) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         testLobs();
         testErrorUpgrading();
         testNoDb();

--- a/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
+++ b/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
@@ -28,12 +28,17 @@ public class TestTransactionIsolation extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.mvStore) {
             // no tests yet
-        } else {
-            testTableLevelLocking();
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
+        testTableLevelLocking();
     }
 
     private void testTableLevelLocking() throws SQLException {

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc1.java
@@ -35,15 +35,20 @@ public class TestMvcc1 extends TestDb {
     }
 
     @Override
+    public boolean isEnabled() {
+        if (!config.mvStore) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public void test() throws SQLException {
         testCases();
         deleteDb("mvcc1");
     }
 
     private void testCases() throws SQLException {
-        if (!config.mvStore) {
-            return;
-        }
         ResultSet rs;
 
         // TODO Prio 1: document: exclusive table lock still used when altering

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc2.java
@@ -39,10 +39,15 @@ public class TestMvcc2 extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("mvcc2");
         testConcurrentInsert();
         testConcurrentUpdate();

--- a/h2/src/test/org/h2/test/mvcc/TestMvcc4.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvcc4.java
@@ -33,10 +33,15 @@ public class TestMvcc4 extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.networked || !config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         testSelectForUpdateAndUpdateConcurrency();
     }
 

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded.java
@@ -30,10 +30,15 @@ public class TestMvccMultiThreaded extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         testConcurrentSelectForUpdate();
         testMergeWithUniqueKeyViolation();
         testConcurrentMerge();

--- a/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
+++ b/h2/src/test/org/h2/test/mvcc/TestMvccMultiThreaded2.java
@@ -46,10 +46,15 @@ public class TestMvccMultiThreaded2 extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException, InterruptedException {
+    public boolean isEnabled() {
         if (!config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException, InterruptedException {
         testSelectForUpdateConcurrency();
     }
 

--- a/h2/src/test/org/h2/test/recover/RecoverLobTest.java
+++ b/h2/src/test/org/h2/test/recover/RecoverLobTest.java
@@ -28,10 +28,15 @@ public class RecoverLobTest extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.mvStore || config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         testRecoverClob();
     }
 

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -85,10 +85,15 @@ public class TestScript extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.networked && config.big) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         reconnectOften = !config.memory && config.big;
 
         testScript("testScript.sql");

--- a/h2/src/test/org/h2/test/scripts/TestScriptSimple.java
+++ b/h2/src/test/org/h2/test/scripts/TestScriptSimple.java
@@ -33,10 +33,15 @@ public class TestScriptSimple extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.memory || config.big || config.networked) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("scriptSimple");
         reconnect();
         String inFile = "org/h2/test/scripts/testSimple.in.txt";

--- a/h2/src/test/org/h2/test/store/TestMVStoreBenchmark.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreBenchmark.java
@@ -34,17 +34,21 @@ public class TestMVStoreBenchmark extends TestBase {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!config.big) {
-            return;
+            return false;
         }
         if (config.codeCoverage) {
             // run only when _not_ using a code coverage tool,
             // because the tool might instrument our code but not
             // java.util.*
-            return;
+            return false;
         }
+        return true;
+    }
 
+    @Override
+    public void test() throws Exception {
         testPerformanceComparison();
         testMemoryUsageComparison();
     }

--- a/h2/src/test/org/h2/test/store/TestMVStoreStopCompact.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreStopCompact.java
@@ -29,10 +29,15 @@ public class TestMVStoreStopCompact extends TestBase {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!config.big) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         for(int retentionTime = 10; retentionTime < 1000; retentionTime *= 10) {
             for(int timeout = 100; timeout <= 1000; timeout *= 10) {
                 testStopCompact(retentionTime, timeout);

--- a/h2/src/test/org/h2/test/store/TestMVStoreTool.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreTool.java
@@ -34,14 +34,19 @@ public class TestMVStoreTool extends TestBase {
     }
 
     @Override
+    public boolean isEnabled() {
+        if (config.memory) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public void test() throws Exception {
         testCompact();
     }
 
     private void testCompact() {
-        if (config.memory) {
-            return;
-        }
         String fileName = getBaseDir() + "/testCompact.h3";
         String fileNameNew = fileName + ".new";
         String fileNameCompressed = fileNameNew + ".compress";

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -50,10 +50,15 @@ public class TestMVTableEngine extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         testLobCopy();
         testLobReuse();
         testShutdownDuringLobCreation();

--- a/h2/src/test/org/h2/test/synth/TestCrashAPI.java
+++ b/h2/src/test/org/h2/test/synth/TestCrashAPI.java
@@ -149,6 +149,14 @@ public class TestCrashAPI extends TestDb implements Runnable {
     }
 
     @Override
+    public boolean isEnabled() {
+        if (config.networked) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public void test() throws Exception {
         if (RECOVER_ALL) {
             recoverAll();

--- a/h2/src/test/org/h2/test/synth/TestKillRestart.java
+++ b/h2/src/test/org/h2/test/synth/TestKillRestart.java
@@ -26,13 +26,18 @@ import org.h2.test.utils.SelfDestructor;
 public class TestKillRestart extends TestDb {
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.networked) {
-            return;
+            return false;
         }
         if (getBaseDir().indexOf(':') > 0) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("killRestart");
         String url = getURL("killRestart", true);
         // String url = getURL(

--- a/h2/src/test/org/h2/test/synth/TestKillRestartMulti.java
+++ b/h2/src/test/org/h2/test/synth/TestKillRestartMulti.java
@@ -68,13 +68,18 @@ public class TestKillRestartMulti extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.networked) {
-            return;
+            return false;
         }
         if (getBaseDir().indexOf(':') > 0) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("killRestartMulti");
         url = getURL("killRestartMulti", true);
         user = getUser();

--- a/h2/src/test/org/h2/test/synth/TestMultiThreaded.java
+++ b/h2/src/test/org/h2/test/synth/TestMultiThreaded.java
@@ -123,10 +123,15 @@ public class TestMultiThreaded extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("multiThreaded");
         int size = getSize(2, 4);
         Connection[] connList = new Connection[size];

--- a/h2/src/test/org/h2/test/synth/TestRandomSQL.java
+++ b/h2/src/test/org/h2/test/synth/TestRandomSQL.java
@@ -31,10 +31,15 @@ public class TestRandomSQL extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.networked) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         int len = getSize(2, 6);
         for (int a = 0; a < len; a++) {
             int s = MathUtils.randomInt(Integer.MAX_VALUE);

--- a/h2/src/test/org/h2/test/unit/TestExit.java
+++ b/h2/src/test/org/h2/test/unit/TestExit.java
@@ -27,13 +27,18 @@ public class TestExit extends TestDb {
             OPEN_WITHOUT_CLOSE_ON_EXIT = 2;
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.codeCoverage || config.networked) {
-            return;
+            return false;
         }
         if (getBaseDir().indexOf(':') > 0) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("exit");
         String url = getURL(OPEN_WITH_CLOSE_ON_EXIT);
         String selfDestruct = SelfDestructor.getPropertyString(60);

--- a/h2/src/test/org/h2/test/unit/TestFileLock.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLock.java
@@ -50,10 +50,15 @@ public class TestFileLock extends TestDb implements Runnable {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!getFile().startsWith(TestBase.BASE_TEST_DIR)) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         testFsFileLock();
         testFutureModificationDate();
         testSimple();

--- a/h2/src/test/org/h2/test/unit/TestFileLockProcess.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLockProcess.java
@@ -48,13 +48,18 @@ public class TestFileLockProcess extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.codeCoverage || config.networked) {
-            return;
+            return false;
         }
         if (getBaseDir().indexOf(':') > 0) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("lock");
         String url = "jdbc:h2:"+getBaseDir()+"/lock";
 

--- a/h2/src/test/org/h2/test/unit/TestFileLockSerialized.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLockSerialized.java
@@ -38,10 +38,15 @@ public class TestFileLockSerialized extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         println("testSequence");
         testSequence();
         println("testAutoIncrement");

--- a/h2/src/test/org/h2/test/unit/TestFtp.java
+++ b/h2/src/test/org/h2/test/unit/TestFtp.java
@@ -30,10 +30,15 @@ public class TestFtp extends TestBase implements FtpEventListener {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (getBaseDir().indexOf(':') > 0) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         FileUtils.delete(getBaseDir() + "/ftp");
         test(getBaseDir());
         FileUtils.delete(getBaseDir() + "/ftp");

--- a/h2/src/test/org/h2/test/unit/TestModifyOnWrite.java
+++ b/h2/src/test/org/h2/test/unit/TestModifyOnWrite.java
@@ -32,10 +32,15 @@ public class TestModifyOnWrite extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!SysProperties.MODIFY_ON_WRITE) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("modifyOnWrite");
         String dbFile = getBaseDir() + "/modifyOnWrite.h2.db";
         assertFalse(FileUtils.exists(dbFile));

--- a/h2/src/test/org/h2/test/unit/TestMultiThreadedKernel.java
+++ b/h2/src/test/org/h2/test/unit/TestMultiThreadedKernel.java
@@ -33,10 +33,15 @@ public class TestMultiThreadedKernel extends TestDb implements Runnable {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.networked || config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb("multiThreadedKernel");
         int count = getSize(2, 5);
         Thread[] list = new Thread[count];

--- a/h2/src/test/org/h2/test/unit/TestOldVersion.java
+++ b/h2/src/test/org/h2/test/unit/TestOldVersion.java
@@ -40,10 +40,15 @@ public class TestOldVersion extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.mvStore) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         cl = getClassLoader("file:ext/h2-1.2.127.jar");
         driver = getDriver(cl);
         if (driver == null) {

--- a/h2/src/test/org/h2/test/unit/TestPageStore.java
+++ b/h2/src/test/org/h2/test/unit/TestPageStore.java
@@ -50,10 +50,15 @@ public class TestPageStore extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb(null);
         testDropTempTable();
         testLogLimitFalsePositive();

--- a/h2/src/test/org/h2/test/unit/TestPageStoreCoverage.java
+++ b/h2/src/test/org/h2/test/unit/TestPageStoreCoverage.java
@@ -36,11 +36,16 @@ public class TestPageStoreCoverage extends TestDb {
     }
 
     @Override
+    public boolean isEnabled() {
+        if (config.memory) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public void test() throws Exception {
         // TODO mvcc, 2-phase commit
-        if (config.memory) {
-            return;
-        }
         deleteDb("pageStoreCoverage");
         testMoveRoot();
         testBasic();

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -47,10 +47,15 @@ public class TestPgServer extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         // testPgAdapter() starts server by itself without a wait so run it first
         testPgAdapter();
         testLowerCaseIdentifiers();

--- a/h2/src/test/org/h2/test/unit/TestRecovery.java
+++ b/h2/src/test/org/h2/test/unit/TestRecovery.java
@@ -37,10 +37,15 @@ public class TestRecovery extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         if (!config.mvStore) {
             testRecoverTestMode();
         }

--- a/h2/src/test/org/h2/test/unit/TestSampleApps.java
+++ b/h2/src/test/org/h2/test/unit/TestSampleApps.java
@@ -35,10 +35,15 @@ public class TestSampleApps extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (!getBaseDir().startsWith(TestBase.BASE_TEST_DIR)) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         deleteDb(getTestName());
         InputStream in = getClass().getClassLoader().getResourceAsStream(
                 "org/h2/samples/optimizations.sql");

--- a/h2/src/test/org/h2/test/unit/TestServlet.java
+++ b/h2/src/test/org/h2/test/unit/TestServlet.java
@@ -345,10 +345,15 @@ public class TestServlet extends TestDb {
     }
 
     @Override
-    public void test() throws SQLException {
+    public boolean isEnabled() {
         if (config.networked || config.memory) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws SQLException {
         DbStarter listener = new DbStarter();
 
         TestServletContext context = new TestServletContext();

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -82,10 +82,15 @@ public class TestTools extends TestDb {
     }
 
     @Override
-    public void test() throws Exception {
+    public boolean isEnabled() {
         if (config.networked) {
-            return;
+            return false;
         }
+        return true;
+    }
+
+    @Override
+    public void test() throws Exception {
         DeleteDbFiles.execute(getBaseDir(), null, true);
         org.h2.Driver.load();
         testSimpleResultSet();


### PR DESCRIPTION
1. Explicit garbage collection after each test in PageStore mode is removed, PageStore-specific memory-related issues were fixed.
2. A new method `TestBase.isEnabled()` is used instead of `return` from `test()` to detect whether test executed in the current mode or not.
3. Tests that are not executed in some modes are not printed in these modes to reduce size of output.
4. Tests that are not executed at all are printed in the end.