### PR TITLE
Assorted minor changes

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -651,10 +651,9 @@ public class Parser {
             for (int i = 0;; i++) {
                 Column column = parseColumnForTable("C" + i, true);
                 list.add(column);
-                if (readIf(")")) {
+                if (!readIfMore(true)) {
                     break;
                 }
-                read(",");
             }
         }
         read("AS");
@@ -3302,20 +3301,17 @@ public class Parser {
                 r = new ExpressionList(new Expression[0]);
             } else {
                 r = readExpression();
-                if (readIf(",")) {
+                if (readIfMore(true)) {
                     ArrayList<Expression> list = Utils.newSmallArrayList();
                     list.add(r);
                     while (!readIf(")")) {
                         r = readExpression();
                         list.add(r);
-                        if (!readIf(",")) {
-                            read(")");
+                        if (!readIfMore(true)) {
                             break;
                         }
                     }
                     r = new ExpressionList(list.toArray(new Expression[0]));
-                } else {
-                    read(")");
                 }
             }
             break;
@@ -5770,10 +5766,9 @@ public class Parser {
             readIfEqualOrTo();
             Set command = new Set(session, SetTypes.SCHEMA_SEARCH_PATH);
             ArrayList<String> list = Utils.newSmallArrayList();
-            list.add(readAliasIdentifier());
-            while (readIf(",")) {
+            do {
                 list.add(readAliasIdentifier());
-            }
+            } while (readIf(","));
             command.setStringArray(list.toArray(new String[0]));
             return command;
         } else if (readIf("JAVA_OBJECT_SERIALIZER")) {
@@ -5836,11 +5831,10 @@ public class Parser {
     }
 
     private Set parseSetBinaryCollation() {
-        Set command = new Set(session, SetTypes.BINARY_COLLATION);
         String name = readAliasIdentifier();
-        command.setString(name);
-        if (equalsToken(name, CompareMode.UNSIGNED) ||
-                equalsToken(name, CompareMode.SIGNED)) {
+        if (equalsToken(name, CompareMode.UNSIGNED) || equalsToken(name, CompareMode.SIGNED)) {
+            Set command = new Set(session, SetTypes.BINARY_COLLATION);
+            command.setString(name);
             return command;
         }
         throw DbException.getInvalidValueException("BINARY_COLLATION", name);

--- a/h2/src/main/org/h2/command/ddl/Analyze.java
+++ b/h2/src/main/org/h2/command/ddl/Analyze.java
@@ -17,6 +17,7 @@ import org.h2.table.Column;
 import org.h2.table.Table;
 import org.h2.table.TableType;
 import org.h2.util.StatementBuilder;
+import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueInt;
 import org.h2.value.ValueNull;
@@ -104,8 +105,7 @@ public class Analyze extends DefineCommand {
         StatementBuilder buff = new StatementBuilder("SELECT ");
         for (Column col : columns) {
             buff.appendExceptFirst(", ");
-            int type = col.getType();
-            if (type == Value.BLOB || type == Value.CLOB) {
+            if (DataType.isLargeObject(col.getType())) {
                 // can not index LOB columns, so calculating
                 // the selectivity is not required
                 buff.append("MAX(NULL)");

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -50,6 +50,7 @@ import org.h2.util.ColumnNamerConfiguration;
 import org.h2.util.CurrentTimestamp;
 import org.h2.util.SmallLRUCache;
 import org.h2.util.Utils;
+import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
 import org.h2.value.ValueLong;
@@ -1701,7 +1702,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
 
     @Override
     public void addTemporaryLob(Value v) {
-        if (v.getType() != Value.CLOB && v.getType() != Value.BLOB) {
+        if (!DataType.isLargeObject(v.getType())) {
             return;
         }
         if (v.getTableId() == LobStorageFrontend.TABLE_RESULT

--- a/h2/src/main/org/h2/expression/CompareLike.java
+++ b/h2/src/main/org/h2/expression/CompareLike.java
@@ -15,6 +15,7 @@ import org.h2.message.DbException;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.value.CompareMode;
+import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueBoolean;
 import org.h2.value.ValueNull;
@@ -198,9 +199,7 @@ public class CompareLike extends Condition {
             // can't use an index
             return;
         }
-        int dataType = l.getColumn().getType();
-        if (dataType != Value.STRING && dataType != Value.STRING_IGNORECASE &&
-                dataType != Value.STRING_FIXED) {
+        if (!DataType.isStringType(l.getColumn().getType())) {
             // column is not a varchar - can't use the index
             return;
         }

--- a/h2/src/main/org/h2/index/BaseIndex.java
+++ b/h2/src/main/org/h2/index/BaseIndex.java
@@ -23,6 +23,7 @@ import org.h2.table.Table;
 import org.h2.table.TableFilter;
 import org.h2.util.StatementBuilder;
 import org.h2.util.StringUtils;
+import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueNull;
 
@@ -72,8 +73,7 @@ public abstract class BaseIndex extends SchemaObjectBase implements Index {
      */
     protected static void checkIndexColumnTypes(IndexColumn[] columns) {
         for (IndexColumn c : columns) {
-            int type = c.column.getType();
-            if (type == Value.CLOB || type == Value.BLOB) {
+            if (DataType.isLargeObject(c.column.getType())) {
                 throw DbException.getUnsupportedException(
                         "Index on BLOB or CLOB column: " + c.column.getCreateSQL());
             }

--- a/h2/src/main/org/h2/result/ResultTempTable.java
+++ b/h2/src/main/org/h2/result/ResultTempTable.java
@@ -23,6 +23,7 @@ import org.h2.table.Column;
 import org.h2.table.IndexColumn;
 import org.h2.table.Table;
 import org.h2.util.TempFileDeleter;
+import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueNull;
 
@@ -118,7 +119,7 @@ public class ResultTempTable implements ResultExternal {
         for (int i = 0; i < expressions.length; i++) {
             int type = expressions[i].getType();
             Column col = new Column(COLUMN_NAME + i, type);
-            if (type == Value.CLOB || type == Value.BLOB) {
+            if (DataType.isLargeObject(type)) {
                 containsLob = true;
             }
             data.columns.add(col);

--- a/h2/src/main/org/h2/result/RowList.java
+++ b/h2/src/main/org/h2/result/RowList.java
@@ -13,6 +13,7 @@ import org.h2.engine.Session;
 import org.h2.store.Data;
 import org.h2.store.FileStore;
 import org.h2.util.Utils;
+import org.h2.value.DataType;
 import org.h2.value.Value;
 
 /**
@@ -63,7 +64,7 @@ public class RowList {
                 buff.writeByte((byte) 0);
             } else {
                 buff.writeByte((byte) 1);
-                if (v.getType() == Value.CLOB || v.getType() == Value.BLOB) {
+                if (DataType.isLargeObject(v.getType())) {
                     // need to keep a reference to temporary lobs,
                     // otherwise the temp file is deleted
                     if (v.getSmall() == null && v.getTableId() == 0) {

--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -37,6 +37,7 @@ import org.h2.store.LobStorageInterface;
 import org.h2.util.IOUtils;
 import org.h2.util.SmallLRUCache;
 import org.h2.util.SmallMap;
+import org.h2.value.DataType;
 import org.h2.value.Transfer;
 import org.h2.value.Value;
 import org.h2.value.ValueLobDb;
@@ -572,7 +573,7 @@ public class TcpServerThread implements Runnable {
     }
 
     private void writeValue(Value v) throws IOException {
-        if (v.getType() == Value.CLOB || v.getType() == Value.BLOB) {
+        if (DataType.isLargeObject(v.getType())) {
             if (v instanceof ValueLobDb) {
                 ValueLobDb lob = (ValueLobDb) v;
                 if (lob.isStored()) {


### PR DESCRIPTION
1. `DataType.isLargeObject()` and `DataType.isStringType()` are used in more places instead of manual checks for all possible types. This mostly a preparation work for introduction of LOB-based `XML` data type. I searched where BLOB or CLOB values are treated in a special way and found that there is a common method for such checks that is not always used.

2. `Session.getParsingCreateViewName()`, `Session.setParsingCreateView()`, and `Session.isParsingCreateView()` are slightly optimized. `Session.parsingView` counter is removed, `Session.viewNameStack` is allocated only when necessary (in the most cases it is not used) and initial capacity is reduced from 15 to 3, usually 1 is enough.

3. `Parser.readIfMore()` is used in more places.

4. Some other code in `Parser` is slightly changed. `do` loop is used instead of duplicated call, `Set` for binary collation is created after checks for correctness.