### PR TITLE
misc tiny refactorings

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1045,7 +1045,8 @@ public class MVMap<K, V> extends AbstractMap<K, V>
     public final long getVersion() {
         RootReference rootReference = getRoot();
         RootReference previous = rootReference.previous;
-        return previous == null || previous.root != rootReference.root ?
+        return previous == null || previous.root != rootReference.root ||
+                previous.appendCounter != rootReference.appendCounter ?
                     rootReference.version : previous.version;
     }
 

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1177,10 +1177,6 @@ public class MVStore {
         c.mapId = lastMapId.get();
         c.next = Long.MAX_VALUE;
         chunks.put(c.id, c);
-        // force a metadata update
-        meta.put(Chunk.getMetaKey(c.id), c.asString());
-        meta.remove(Chunk.getMetaKey(c.id));
-        markMetaChanged();
         ArrayList<Page> changed = new ArrayList<>();
         for (Iterator<MVMap<?, ?>> iter = maps.values().iterator(); iter.hasNext(); ) {
             MVMap<?, ?> map = iter.next();

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -57,6 +57,7 @@ public class MVPrimaryIndex extends BaseIndex {
         mapName = "table." + getId();
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(mapName, keyType, valueType);
+        dataMap.map.setVolatile(!indexType.isPersistent());
         t.commit();
         if (!table.isPersistData() || !indexType.isPersistent()) {
             dataMap.map.setVolatile(true);

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -67,6 +67,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         ValueDataType valueType = new ValueDataType(null, null, null);
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(mapName, keyType, valueType);
+        dataMap.map.setVolatile(!indexType.isPersistent());
         t.commit();
         if (!keyType.equals(dataMap.getKeyType())) {
             throw DbException.throwInternalError(

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -101,6 +101,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
         spatialMap = db.getMvStore().getStore().openMap(mapName, mapBuilder);
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(spatialMap);
+        dataMap.map.setVolatile(!indexType.isPersistent());
         t.commit();
     }
 


### PR DESCRIPTION
1. Replace dataType field in transactionStore with mapBiulder to avoid repetitive builder creation
2. Remove duplicate access to tx status in endLeftoverTransactions()
3. Set map to volatile for non-persistent indexes
4. Fix MVMap.getVersion() to account for append mode
5. Eliminate no-op meta manipulations in MVStore.storeNow()