### PR TITLE
Fix MySQL compatibility ALTER TABLE DROP INDEX with schema

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6093,7 +6093,7 @@ public class Parser {
                 return commandIfTableExists(schema, tableName, ifTableExists, command);
             } else if (readIf("INDEX")) {
                 // MySQL compatibility
-                String indexOrConstraintName = readIdentifierWithSchema();
+                String indexOrConstraintName = readIdentifierWithSchema(schema.getName());
                 final SchemaCommand command;
                 if (schema.findIndex(session, indexOrConstraintName) != null) {
                     DropIndex dropIndexCommand = new DropIndex(session, getSchema());

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -124,7 +124,7 @@ public class TestScript extends TestDb {
         }
         for (String s : new String[] { "alterTableAdd", "alterTableDropColumn",
                 "createAlias", "createSynonym", "createView", "createTable", "createTrigger",
-                "dropSchema", "truncateTable" }) {
+                "dropIndex", "dropSchema", "truncateTable" }) {
             testScript("ddl/" + s + ".sql");
         }
         for (String s : new String[] { "error_reporting", "insertIgnore",

--- a/h2/src/test/org/h2/test/scripts/ddl/dropIndex.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/dropIndex.sql
@@ -1,0 +1,43 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+CREATE SCHEMA TEST;
+> ok
+
+CREATE TABLE TEST.TBL (
+    NAME VARCHAR
+);
+> ok
+
+CREATE UNIQUE INDEX NAME_INDEX ON TEST.TBL(NAME);
+> ok
+
+-- MySQL compatibility syntax
+ALTER TABLE TEST.TBL DROP INDEX NAME_INDEX;
+> ok
+
+CREATE UNIQUE INDEX NAME_INDEX ON TEST.TBL(NAME);
+> ok
+
+-- MySQL compatibility syntax
+ALTER TABLE TEST.TBL DROP INDEX TEST.NAME_INDEX;
+> ok
+
+ALTER TABLE TEST.TBL ADD CONSTRAINT NAME_INDEX UNIQUE (NAME);
+> ok
+
+-- MySQL compatibility syntax
+ALTER TABLE TEST.TBL DROP INDEX NAME_INDEX;
+> ok
+
+ALTER TABLE TEST.TBL ADD CONSTRAINT NAME_INDEX UNIQUE (NAME);
+> ok
+
+-- MySQL compatibility syntax
+ALTER TABLE TEST.TBL DROP INDEX TEST.NAME_INDEX;
+> ok
+
+DROP SCHEMA TEST CASCADE;
+> ok


### PR DESCRIPTION
A fix for issue #1258.

Name of the schema was not used only in one place in `Parser.parseAlterTable()` method.