### PR TITLE
Preserve domain name in columns and add CASCADE | RESTRICT to DROP DOMAIN

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -884,9 +884,11 @@ DROP CONSTANT ONE
 "
 
 "Commands (DDL)","DROP DOMAIN","
-DROP DOMAIN [ IF EXISTS ] domainName
+DROP DOMAIN [ IF EXISTS ] domainName [ RESTRICT | CASCADE ]
 ","
 Drops a data type (domain).
+The command will fail if it is referenced by a column (the default).
+Column descriptors are replaced with original definition of specified domain if the CASCADE clause is used.
 This command commits an open transaction in this connection.
 ","
 DROP DOMAIN EMAIL

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -99,8 +99,8 @@ public class DbSettings extends SettingsBase {
 
     /**
      * Database setting <code>DROP_RESTRICT</code> (default: true).<br />
-     * Whether the default action for DROP TABLE, DROP VIEW, and DROP SCHEMA
-     * is RESTRICT.
+     * Whether the default action for DROP TABLE, DROP VIEW, DROP SCHEMA, and
+     * DROP DOMAIN is RESTRICT.
      */
     public final boolean dropRestrict = get("DROP_RESTRICT", true);
 

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -12,6 +12,7 @@ import org.h2.command.Parser;
 import org.h2.engine.Constants;
 import org.h2.engine.Mode;
 import org.h2.engine.Session;
+import org.h2.engine.UserDataType;
 import org.h2.expression.ConditionAndOr;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionVisitor;
@@ -87,6 +88,7 @@ public class Column {
     private String comment;
     private boolean primaryKey;
     private boolean visible = true;
+    private UserDataType userDataType;
 
     public Column(String name, int type) {
         this(name, type, -1, -1, -1, null);
@@ -312,6 +314,14 @@ public class Column {
 
     public void setVisible(boolean b) {
         visible = b;
+    }
+
+    public UserDataType getUserDataType() {
+        return userDataType;
+    }
+
+    public void setUserDataType(UserDataType userDataType) {
+        this.userDataType = userDataType;
     }
 
     /**

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -576,6 +576,8 @@ public class Column {
         }
         if (!nullable) {
             buff.append(" NOT NULL");
+        } else if (userDataType != null && !userDataType.getColumn().isNullable()) {
+            buff.append(" NULL");
         }
         if (convertNullToDefault) {
             buff.append(" NULL_TO_DEFAULT");

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -124,7 +124,7 @@ public class TestScript extends TestDb {
         }
         for (String s : new String[] { "alterTableAdd", "alterTableDropColumn",
                 "createAlias", "createSynonym", "createView", "createTable", "createTrigger",
-                "dropIndex", "dropSchema", "truncateTable" }) {
+                "dropDomain", "dropIndex", "dropSchema", "truncateTable" }) {
             testScript("ddl/" + s + ".sql");
         }
         for (String s : new String[] { "error_reporting", "insertIgnore",

--- a/h2/src/test/org/h2/test/scripts/ddl/dropDomain.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/dropDomain.sql
@@ -6,24 +6,32 @@
 CREATE DOMAIN E AS ENUM('A', 'B');
 > ok
 
-CREATE TABLE TEST(I INT PRIMARY KEY, E1 E, E2 E NOT NULL);
+CREATE DOMAIN E_NN AS ENUM('A', 'B') NOT NULL;
 > ok
 
-INSERT INTO TEST VALUES (1, 'A', 'B');
+CREATE TABLE TEST(I INT PRIMARY KEY, E1 E, E2 E NOT NULL, E3 E_NN, E4 E_NN NULL);
+> ok
+
+INSERT INTO TEST VALUES (1, 'A', 'B', 'A', 'B');
 > update count: 1
 
 SELECT COLUMN_NAME, NULLABLE, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
 > COLUMN_NAME NULLABLE COLUMN_TYPE
-> ----------- -------- ------------
+> ----------- -------- -------------
 > I           0        INT NOT NULL
 > E1          1        E
 > E2          0        E NOT NULL
-> rows (ordered): 3
+> E3          0        E_NN NOT NULL
+> E4          1        E_NN NULL
+> rows (ordered): 5
 
 DROP DOMAIN E RESTRICT;
 > exception CANNOT_DROP_2
 
 DROP DOMAIN E CASCADE;
+> ok
+
+DROP DOMAIN E_NN CASCADE;
 > ok
 
 SELECT COLUMN_NAME, NULLABLE, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
@@ -32,7 +40,9 @@ SELECT COLUMN_NAME, NULLABLE, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE 
 > I           0        INT NOT NULL
 > E1          1        ENUM('A','B')
 > E2          0        ENUM('A','B') NOT NULL
-> rows (ordered): 3
+> E3          0        ENUM('A','B') NOT NULL
+> E4          1        ENUM('A','B')
+> rows (ordered): 5
 
 DROP TABLE TEST;
 > ok

--- a/h2/src/test/org/h2/test/scripts/ddl/dropDomain.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/dropDomain.sql
@@ -1,0 +1,38 @@
+-- Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+CREATE DOMAIN E AS ENUM('A', 'B');
+> ok
+
+CREATE TABLE TEST(I INT PRIMARY KEY, E1 E, E2 E NOT NULL);
+> ok
+
+INSERT INTO TEST VALUES (1, 'A', 'B');
+> update count: 1
+
+SELECT COLUMN_NAME, NULLABLE, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME NULLABLE COLUMN_TYPE
+> ----------- -------- ------------
+> I           0        INT NOT NULL
+> E1          1        E
+> E2          0        E NOT NULL
+> rows (ordered): 3
+
+DROP DOMAIN E RESTRICT;
+> exception CANNOT_DROP_2
+
+DROP DOMAIN E CASCADE;
+> ok
+
+SELECT COLUMN_NAME, NULLABLE, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME NULLABLE COLUMN_TYPE
+> ----------- -------- ----------------------
+> I           0        INT NOT NULL
+> E1          1        ENUM('A','B')
+> E2          0        ENUM('A','B') NOT NULL
+> rows (ordered): 3
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -840,9 +840,12 @@ script nodata nopasswords nosettings;
 > -----------------------------------------------
 > -- 0 +/- SELECT COUNT(*) FROM PUBLIC.TEST;
 > CREATE DOMAIN INT AS VARCHAR;
-> CREATE MEMORY TABLE PUBLIC.TEST( ID VARCHAR );
+> CREATE MEMORY TABLE PUBLIC.TEST( ID INT );
 > CREATE USER IF NOT EXISTS SA PASSWORD '' ADMIN;
 > rows: 4
+
+SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'TEST';
+>> 12
 
 drop table test;
 > ok
@@ -2674,7 +2677,7 @@ select DOMAIN_NAME, COLUMN_DEFAULT, IS_NULLABLE, DATA_TYPE, PRECISION, SCALE, TY
 
 script nodata nopasswords nosettings;
 > SCRIPT
-> ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+> ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 > -- 1 +/- SELECT COUNT(*) FROM PUBLIC.ADDRESS;
 > -- 1 +/- SELECT COUNT(*) FROM PUBLIC.TEST;
 > ALTER TABLE PUBLIC.ADDRESS ADD CONSTRAINT PUBLIC.CONSTRAINT_E PRIMARY KEY(ID);
@@ -2685,8 +2688,8 @@ script nodata nopasswords nosettings;
 > CREATE DOMAIN STRING2 AS VARCHAR NOT NULL;
 > CREATE DOMAIN STRING3 AS VARCHAR DEFAULT '<empty>';
 > CREATE DOMAIN STRING_X AS VARCHAR DEFAULT '<empty>';
-> CREATE MEMORY TABLE PUBLIC.ADDRESS( ID INT NOT NULL, NAME VARCHAR(200) CHECK (POSITION('@', NAME) > 1), NAME2 VARCHAR(200) DEFAULT '@gmail.com' CHECK ((POSITION('@', NAME2) > 1) AND (POSITION('gmail', NAME2) > 1)) );
-> CREATE MEMORY TABLE PUBLIC.TEST( A VARCHAR(255) DEFAULT '' NOT NULL, B VARCHAR, C VARCHAR NOT NULL, D VARCHAR DEFAULT '<empty>' );
+> CREATE MEMORY TABLE PUBLIC.ADDRESS( ID INT NOT NULL, NAME EMAIL CHECK (POSITION('@', NAME) > 1), NAME2 GMAIL DEFAULT '@gmail.com' CHECK ((POSITION('@', NAME2) > 1) AND (POSITION('gmail', NAME2) > 1)) );
+> CREATE MEMORY TABLE PUBLIC.TEST( A STRING DEFAULT '' NOT NULL, B STRING1, C STRING2 NOT NULL, D STRING3 DEFAULT '<empty>' );
 > CREATE USER IF NOT EXISTS SA PASSWORD '' ADMIN;
 > rows: 13
 


### PR DESCRIPTION
1. Domain name is preserved in original SQL in data types of columns. It is not preserved in other possible places, because it's not easy to find such references later.

2. `DROP DOMAIN` statement now supports `CASCADE` and `RESTRICT` clauses as required by the SQL standard. With `CASCADE` data types of columns are changed to original SQL of domain, with `RESTRICT` domains that have references to them cannot be dropped. `RESTRICT` is default for compatibility with PostgreSQL, this default can be changed by configuration parameter. There is no default in the SQL standard, either `CASCADE` or `RESTRICT` should be specified in compliant scripts.

This should also fix issue #1261.