### PR TITLE
Minor memory leak

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1038,7 +1038,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
 
     /**
      * Get version of the map, which is the version of the store,
-     * at which map was modified last time.
+     * at the moment when map was modified last time.
      *
      * @return version
      */
@@ -1136,10 +1136,10 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      */
     final void copyFrom(MVMap<K, V> sourceMap) {
         // We are going to cheat a little bit in the copy()
-        // by setting map's root to an arbitrary nodes
-        // to allow for just created ones to be saved.
+        // by temporary setting map's root to some arbitrary nodes.
+        // This will allow for newly created ones to be saved.
         // That's why it's important to preserve all chunks
-        // created in the process, especially it retention time
+        // created in the process, especially if retention time
         // is set to a lower value, or even 0.
         MVStore.TxCounter txCounter = store.registerVersionUsage();
         try {
@@ -1170,6 +1170,11 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         return target;
     }
 
+    /**
+     * If map was used in append mode, this method will ensure that append buffer
+     * is flushed - emptied with all entries inserted into map as a new leaf.
+     * @return potentially updated RootReference
+     */
     public RootReference flushAppendBuffer() {
         return flushAppendBuffer(null);
     }
@@ -1216,9 +1221,9 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                     p = split;
                 } else {
                     Object keys[] = new Object[] { key };
-                    Page.PageReference children[] = new Page.PageReference[store.getKeysPerPage() + 1];
-                    children[0] = new Page.PageReference(p);
-                    children[1] = new Page.PageReference(split);
+                    Page.PageReference children[] = new Page.PageReference[] {
+                                                        new Page.PageReference(p),
+                                                        new Page.PageReference(split)};
                     p = Page.create(this, keys, null, children, p.getTotalCount() + split.getTotalCount(), 0);
                 }
                 break;
@@ -1231,7 +1236,8 @@ public class MVMap<K, V> extends AbstractMap<K, V>
             p.setChild(index, split);
             p.insertNode(index, key, c);
             int keyCount;
-            if ((keyCount = p.getKeyCount()) <= store.getKeysPerPage() && (p.getMemory() < store.getMaxPageSize() || keyCount <= (p.isLeaf() ? 1 : 2))) {
+            if ((keyCount = p.getKeyCount()) <= store.getKeysPerPage() &&
+                    (p.getMemory() < store.getMaxPageSize() || keyCount <= (p.isLeaf() ? 1 : 2))) {
                 break;
             }
             int at = keyCount - 2;

--- a/h2/src/test/org/h2/test/store/TestMVStoreBenchmark.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreBenchmark.java
@@ -7,10 +7,10 @@ package org.h2.test.store;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.mvstore.MVStore;
@@ -84,7 +84,7 @@ public class TestMVStoreBenchmark extends TestBase {
         mapList = new ArrayList<>(count);
         mem = getMemory();
         for (int i = 0; i < count; i++) {
-            mapList.add(new HashMap<Integer, String>(size));
+            mapList.add(new ConcurrentHashMap<Integer, String>(size));
         }
         addEntries(mapList, size);
         hash = getMemory() - mem;
@@ -93,7 +93,7 @@ public class TestMVStoreBenchmark extends TestBase {
         mapList.clear();
         mem = getMemory();
         for (int i = 0; i < count; i++) {
-            mapList.add(new TreeMap<Integer, String>());
+            mapList.add(new ConcurrentSkipListMap<Integer, String>());
         }
         addEntries(mapList, size);
         tree = getMemory() - mem;
@@ -150,11 +150,10 @@ public class TestMVStoreBenchmark extends TestBase {
             MVStore store = MVStore.open(null);
             map = store.openMap("test");
             mv = testPerformance(map, size);
-            map = new HashMap<>(size);
-            // map = new ConcurrentHashMap<Integer, String>(size);
+            store.close();
+            map = new ConcurrentHashMap<>(size);
             hash = testPerformance(map, size);
-            map = new TreeMap<>();
-            // map = new ConcurrentSkipListMap<Integer, String>();
+            map = new ConcurrentSkipListMap<>();
             tree = testPerformance(map, size);
             if (hash < tree && mv < tree * 1.5) {
                 break;


### PR DESCRIPTION
My intention of making class PageReference immutable fall flat upon realization, that this might cause references to already saved pages to remain in the MVTree (in-memory).
If any non-leaf page is modified, while MVStore is in commit, specifically after MVMap root was fetched for save, but before actual save operation has finished, references to child pages won't be cleared, because modified (and therefore cloned) page is still holding original immutable PageReference instances.
This situation will remain only until next MVStore commit and only will be noticeable in tight memory conditions.