### PR TITLE
Do not quote other lower case characters

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3911,18 +3911,18 @@ public class Parser {
         }
         case CHAR_SPECIAL_2:
             if (types[i] == CHAR_SPECIAL_2) {
-                i++;
+                char c1 = chars[i++];
                 currentToken = sqlCommand.substring(start, i);
-                currentTokenType = getSpecialType2(currentToken);
+                currentTokenType = getSpecialType2(c, c1);
             } else {
                 currentToken = sqlCommand.substring(start, i);
-                currentTokenType = getSpecialType1(currentToken);
+                currentTokenType = getSpecialType1(c);
             }
             parseIndex = i;
             return;
         case CHAR_SPECIAL_1:
             currentToken = sqlCommand.substring(start, i);
-            currentTokenType = getSpecialType1(currentToken);
+            currentTokenType = getSpecialType1(c);
             parseIndex = i;
             return;
         case CHAR_VALUE:
@@ -4352,8 +4352,8 @@ public class Parser {
         }
     }
 
-    private int getSpecialType1(String s) {
-        switch (s.charAt(0)) {
+    private int getSpecialType1(char c0) {
+        switch (c0) {
         case '?':
         case '$':
             return PARAMETER;
@@ -4392,9 +4392,8 @@ public class Parser {
         }
     }
 
-    private int getSpecialType2(String s) {
-        char c1 = s.charAt(1);
-        switch (s.charAt(0)) {
+    private int getSpecialType2(char c0, char c1) {
+        switch (c0) {
         case ':':
             if (c1 == ':' || c1 == '=') {
                 return KEYWORD;

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -279,7 +279,10 @@ public class ParserUtil {
          */
         switch (s.charAt(0)) {
         case 'A':
-            return getKeywordOrIdentifier(s, "ALL", ALL);
+            if ("ALL".equals(s)) {
+                return ALL;
+            }
+            return IDENTIFIER;
         case 'C':
             if ("CHECK".equals(s)) {
                 return CHECK;
@@ -295,12 +298,17 @@ public class ParserUtil {
             }
             return IDENTIFIER;
         case 'D':
-            return getKeywordOrIdentifier(s, "DISTINCT", DISTINCT);
+            if ("DISTINCT".equals(s)) {
+                return DISTINCT;
+            }
+            return IDENTIFIER;
         case 'E':
             if ("EXCEPT".equals(s)) {
                 return EXCEPT;
+            } else if ("EXISTS".equals(s)) {
+                return EXISTS;
             }
-            return getKeywordOrIdentifier(s, "EXISTS", EXISTS);
+            return IDENTIFIER;
         case 'F':
             if ("FETCH".equals(s)) {
                 return FETCH;
@@ -312,12 +320,20 @@ public class ParserUtil {
                 return FOREIGN;
             } else if ("FULL".equals(s)) {
                 return FULL;
+            } else if ("FALSE".equals(s)) {
+                return FALSE;
             }
-            return getKeywordOrIdentifier(s, "FALSE", FALSE);
+            return IDENTIFIER;
         case 'G':
-            return getKeywordOrIdentifier(s, "GROUP", GROUP);
+            if ("GROUP".equals(s)) {
+                return GROUP;
+            }
+            return IDENTIFIER;
         case 'H':
-            return getKeywordOrIdentifier(s, "HAVING", HAVING);
+            if ("HAVING".equals(s)) {
+                return HAVING;
+            }
+            return IDENTIFIER;
         case 'I':
             if ("INNER".equals(s)) {
                 return INNER;
@@ -333,7 +349,10 @@ public class ParserUtil {
             }
             return IDENTIFIER;
         case 'J':
-            return getKeywordOrIdentifier(s, "JOIN", JOIN);
+            if ("JOIN".equals(s)) {
+                return JOIN;
+            }
+            return IDENTIFIER;
         case 'L':
             if ("LIMIT".equals(s)) {
                 return LIMIT;
@@ -347,25 +366,38 @@ public class ParserUtil {
             }
             return IDENTIFIER;
         case 'M':
-            return getKeywordOrIdentifier(s, "MINUS", MINUS);
+            if ("MINUS".equals(s)) {
+                return MINUS;
+            }
+            return IDENTIFIER;
         case 'N':
             if ("NOT".equals(s)) {
                 return NOT;
             } else if ("NATURAL".equals(s)) {
                 return NATURAL;
+            } else if ("NULL".equals(s)) {
+                return NULL;
             }
-            return getKeywordOrIdentifier(s, "NULL", NULL);
+            return IDENTIFIER;
         case 'O':
             if ("OFFSET".equals(s)) {
                 return OFFSET;
             } else if ("ON".equals(s)) {
                 return ON;
+            } else if ("ORDER".equals(s)) {
+                return ORDER;
             }
-            return getKeywordOrIdentifier(s, "ORDER", ORDER);
+            return IDENTIFIER;
         case 'P':
-            return getKeywordOrIdentifier(s, "PRIMARY", PRIMARY);
+            if ("PRIMARY".equals(s)) {
+                return PRIMARY;
+            }
+            return IDENTIFIER;
         case 'R':
-            return getKeywordOrIdentifier(s, "ROWNUM", ROWNUM);
+            if ("ROWNUM".equals(s)) {
+                return ROWNUM;
+            }
+            return IDENTIFIER;
         case 'S':
             if ("SELECT".equals(s)) {
                 return SELECT;
@@ -389,24 +421,20 @@ public class ParserUtil {
         case 'U':
             if ("UNIQUE".equals(s)) {
                 return UNIQUE;
+            } else if ("UNION".equals(s)) {
+                return UNION;
             }
-            return getKeywordOrIdentifier(s, "UNION", UNION);
+            return IDENTIFIER;
         case 'W':
             if ("WITH".equals(s)) {
                 return WITH;
+            } else if ("WHERE".equals(s)) {
+                return WHERE;
             }
-            return getKeywordOrIdentifier(s, "WHERE", WHERE);
+            return IDENTIFIER;
         default:
             return IDENTIFIER;
         }
-    }
-
-    private static int getKeywordOrIdentifier(String s1, String s2,
-            int keywordType) {
-        if (s1.equals(s2)) {
-            return keywordType;
-        }
-        return IDENTIFIER;
     }
 
 }

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -212,6 +212,16 @@ public class ParserUtil {
      */
     public static final int WITH = WHERE + 1;
 
+    private static final int UPPER_OR_OTHER_LETTER =
+            1 << Character.UPPERCASE_LETTER
+            | 1 << Character.TITLECASE_LETTER
+            | 1 << Character.MODIFIER_LETTER
+            | 1 << Character.OTHER_LETTER;
+
+    private static final int UPPER_OR_OTHER_LETTER_OR_DIGIT =
+            UPPER_OR_OTHER_LETTER
+            | 1 << Character.DECIMAL_DIGIT_NUMBER;
+
     private ParserUtil() {
         // utility class
     }
@@ -242,13 +252,12 @@ public class ParserUtil {
         }
         char c = s.charAt(0);
         // lowercase a-z is quoted as well
-        if ((!Character.isLetter(c) && c != '_') || Character.isLowerCase(c)) {
+        if ((UPPER_OR_OTHER_LETTER >>> Character.getType(c) & 1) == 0 && c != '_') {
             return false;
         }
         for (int i = 1, length = s.length(); i < length; i++) {
             c = s.charAt(i);
-            if ((!Character.isLetterOrDigit(c) && c != '_') ||
-                    Character.isLowerCase(c)) {
+            if ((UPPER_OR_OTHER_LETTER_OR_DIGIT >>> Character.getType(c) & 1) == 0 && c != '_') {
                 return false;
             }
         }

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -233,7 +233,7 @@ public class ParserUtil {
      * @return true if it is a keyword
      */
     public static boolean isKeyword(String s) {
-        if (s == null || s.length() == 0) {
+        if (s.length() == 0) {
             return false;
         }
         return getSaveTokenType(s, false) != IDENTIFIER;

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -336,12 +336,16 @@ public class TestStatement extends TestDb {
         assertEquals("\"FROM\"", statBC.enquoteIdentifier("FROM", false));
         assertEquals("\"Test\"", statBC.enquoteIdentifier("Test", false));
         assertEquals("\"TODAY\"", statBC.enquoteIdentifier("TODAY", false));
+        // Other lower case characters don't have upper case mappings
+        assertEquals("\u00AA", statBC.enquoteIdentifier("\u00AA", false));
 
         assertTrue(statBC.isSimpleIdentifier("SOME_ID"));
         assertFalse(statBC.isSimpleIdentifier("SOME ID"));
         assertFalse(statBC.isSimpleIdentifier("FROM"));
         assertFalse(statBC.isSimpleIdentifier("Test"));
         assertFalse(statBC.isSimpleIdentifier("TODAY"));
+        // Other lower case characters don't have upper case mappings
+        assertTrue(statBC.isSimpleIdentifier("\u00AA"));
 
         stat.close();
     }

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -337,7 +337,7 @@ public class TestStatement extends TestDb {
         assertEquals("\"Test\"", statBC.enquoteIdentifier("Test", false));
         assertEquals("\"TODAY\"", statBC.enquoteIdentifier("TODAY", false));
         // Other lower case characters don't have upper case mappings
-        assertEquals("\u00AA", statBC.enquoteIdentifier("\u00AA", false));
+        assertEquals("\u02B0", statBC.enquoteIdentifier("\u02B0", false));
 
         assertTrue(statBC.isSimpleIdentifier("SOME_ID"));
         assertFalse(statBC.isSimpleIdentifier("SOME ID"));
@@ -345,7 +345,7 @@ public class TestStatement extends TestDb {
         assertFalse(statBC.isSimpleIdentifier("Test"));
         assertFalse(statBC.isSimpleIdentifier("TODAY"));
         // Other lower case characters don't have upper case mappings
-        assertTrue(statBC.isSimpleIdentifier("\u00AA"));
+        assertTrue(statBC.isSimpleIdentifier("\u02B0"));
 
         stat.close();
     }


### PR DESCRIPTION
There are some “other lower case” characters in Unicode. They all do not have upper case equivalents and `Character.toUpperCase()` returns the same character for them. There is no reason to quote them in identifiers.

Checks for character types are also optimized. Now only one lookup of character type is performed for each character instead of three lookups before (check for any letter/digit character, check for normal lowercase character, check for other lowercase character).

Other changes:

1. Characters are passed to `Parser.getSpecialType*()` instead of combined string.
2. `Parser.getKeywordOrIdentifier()` is inlined, this makes code more readable and also reduces size of compiled .class file slightly.
3. `null` is not passed to `ParserUtil.isKeyword()` so null check is removed.
