### PR TITLE
Improve support of ARRAY and SQLXML in JDBC layer

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcCallableStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcCallableStatement.java
@@ -872,21 +872,30 @@ public class JdbcCallableStatement extends JdbcPreparedStatement implements
     }
 
     /**
-     * [Not supported] Returns the value of the specified column as a SQLXML
-     * object.
+     * Returns the value of the specified column as a SQLXML object.
+     *
+     * @param parameterIndex the parameter index (1, 2, ...)
+     * @return the value
+     * @throws SQLException if the column is not found or if this object is
+     *             closed
      */
     @Override
     public SQLXML getSQLXML(int parameterIndex) throws SQLException {
-        throw unsupported("SQLXML");
+        checkRegistered(parameterIndex);
+        return getOpenResultSet().getSQLXML(parameterIndex);
     }
 
     /**
-     * [Not supported] Returns the value of the specified column as a SQLXML
-     * object.
+     * Returns the value of the specified column as a SQLXML object.
+     *
+     * @param parameterName the parameter name
+     * @return the value
+     * @throws SQLException if the column is not found or if this object is
+     *             closed
      */
     @Override
     public SQLXML getSQLXML(String parameterName) throws SQLException {
-        throw unsupported("SQLXML");
+        return getSQLXML(getIndexForName(parameterName));
     }
 
     /**
@@ -1584,12 +1593,16 @@ public class JdbcCallableStatement extends JdbcPreparedStatement implements
     }
 
     /**
-     * [Not supported] Sets the value of a parameter as a SQLXML object.
+     * Sets the value of a parameter as a SQLXML object.
+     *
+     * @param parameterName the parameter name
+     * @param x the value
+     * @throws SQLException if this object is closed
      */
     @Override
     public void setSQLXML(String parameterName, SQLXML x)
             throws SQLException {
-        throw unsupported("SQLXML");
+        setSQLXML(getIndexForName(parameterName), x);
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -2489,19 +2489,57 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     }
 
     /**
-     * [Not supported]
+     * Updates a column in the current or insert row.
+     *
+     * @param columnIndex (1,2,...)
+     * @param x the value
+     * @param length the length
+     * @throws SQLException if the result set is closed or not updatable
      */
     @Override
     public void updateArray(int columnIndex, Array x) throws SQLException {
-        throw unsupported("setArray");
+        try {
+            if (isDebugEnabled()) {
+                debugCode("updateArray(" + columnIndex + ", x);");
+            }
+            checkClosed();
+            Value v;
+            if (x == null) {
+                v = ValueNull.INSTANCE;
+            } else {
+                v = DataType.convertToValue(stat.session, x.getArray(), Value.ARRAY);
+            }
+            update(columnIndex, v);
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
     }
 
     /**
-     * [Not supported]
+     * Updates a column in the current or insert row.
+     *
+     * @param columnLabel the column label
+     * @param x the value
+     * @param length the length
+     * @throws SQLException if the result set is closed or not updatable
      */
     @Override
     public void updateArray(String columnLabel, Array x) throws SQLException {
-        throw unsupported("setArray");
+        try {
+            if (isDebugEnabled()) {
+                debugCode("updateArray(" + quote(columnLabel) + ", x);");
+            }
+            checkClosed();
+            Value v;
+            if (x == null) {
+                v = ValueNull.INSTANCE;
+            } else {
+                v = DataType.convertToValue(stat.session, x.getArray(), Value.ARRAY);
+            }
+            update(columnLabel, v);
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueArray.java
+++ b/h2/src/main/org/h2/value/ValueArray.java
@@ -7,6 +7,7 @@ package org.h2.value;
 
 import java.lang.reflect.Array;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Arrays;
 
 import org.h2.engine.Constants;
@@ -135,8 +136,8 @@ public class ValueArray extends Value {
     }
 
     @Override
-    public void set(PreparedStatement prep, int parameterIndex) {
-        throw throwUnsupportedExceptionForType("PreparedStatement.set");
+    public void set(PreparedStatement prep, int parameterIndex) throws SQLException {
+        prep.setArray(parameterIndex, prep.getConnection().createArrayOf("NULL", (Object[]) getObject()));
     }
 
     @Override

--- a/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCallableStatement.java
@@ -91,8 +91,6 @@ public class TestCallableStatement extends TestDb {
                 getRef(1);
         assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, call).
                 getRowId(1);
-        assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, call).
-                getSQLXML(1);
 
         assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, call).
                 getURL("a");
@@ -102,8 +100,6 @@ public class TestCallableStatement extends TestDb {
                 getRef("a");
         assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, call).
                 getRowId("a");
-        assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, call).
-                getSQLXML("a");
 
         assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, call).
                 setURL(1, (URL) null);
@@ -116,9 +112,6 @@ public class TestCallableStatement extends TestDb {
                 setURL("a", (URL) null);
         assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, call).
                 setRowId("a", (RowId) null);
-        assertThrows(ErrorCode.FEATURE_NOT_SUPPORTED_1, call).
-                setSQLXML("a", (SQLXML) null);
-
     }
 
     private void testCallWithResultSet(Connection conn) throws SQLException {
@@ -332,6 +325,8 @@ public class TestCallableStatement extends TestDb {
         assertEquals("ABC", call.getClob("B").getSubString(1, 3));
         assertEquals("ABC", call.getNClob(2).getSubString(1, 3));
         assertEquals("ABC", call.getNClob("B").getSubString(1, 3));
+        assertEquals("ABC", call.getSQLXML(2).getString());
+        assertEquals("ABC", call.getSQLXML("B").getString());
 
         try {
             call.getString(100);
@@ -397,6 +392,11 @@ public class TestCallableStatement extends TestDb {
         call.setNString("B", "xyz");
         call.executeUpdate();
         assertEquals("XYZ", call.getString("B"));
+        SQLXML xml = conn.createSQLXML();
+        xml.setString("<x>xyz</x>");
+        call.setSQLXML("B", xml);
+        call.executeUpdate();
+        assertEquals("<X>XYZ</X>", call.getString("B"));
 
         // test for exceptions after closing
         call.close();


### PR DESCRIPTION
1. All three SQLXML-related methods in `JdbcCallableStatement` are implemented.

2. Both `JdbcResultSet.updateArray()` methods are implemented.