### PR TITLE
Assorted changes in Parser

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3174,9 +3174,6 @@ public class Parser {
     }
 
     private Expression readFunctionWithoutParameters(String name) {
-        if (readIf(OPEN_PAREN)) {
-            read(CLOSE_PAREN);
-        }
         if (database.isAllowBuiltinAliasOverride()) {
             FunctionAlias functionAlias = database.getSchema(session.getCurrentSchemaName()).findFunction(name);
             if (functionAlias != null) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3990,16 +3990,13 @@ public class Parser {
         case CHAR_SPECIAL_2:
             if (types[i] == CHAR_SPECIAL_2) {
                 char c1 = chars[i++];
-                currentToken = sqlCommand.substring(start, i);
                 currentTokenType = getSpecialType2(c, c1);
             } else {
-                currentToken = sqlCommand.substring(start, i);
                 currentTokenType = getSpecialType1(c);
             }
             parseIndex = i;
             return;
         case CHAR_SPECIAL_1:
-            currentToken = sqlCommand.substring(start, i);
             currentTokenType = getSpecialType1(c);
             parseIndex = i;
             return;
@@ -4101,7 +4098,6 @@ public class Parser {
             return;
         }
         case CHAR_END:
-            currentToken = "";
             currentTokenType = END;
             parseIndex = i;
             return;

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -697,6 +697,9 @@ public class Parser {
             c = parseWithStatementOrQuery();
             break;
         case IDENTIFIER:
+            if (currentTokenQuoted) {
+                break;
+            }
             switch (currentToken.charAt(0)) {
             case 'a':
             case 'A':

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -561,6 +561,19 @@ public class TestCompatibility extends TestDb {
                 "select date from test where date = '2014-04-05-09.48.28.020005'");
         assertResult("2014-04-05 09:48:28.020005", stat,
                 "select date from test where date = '2014-04-05 09:48:28.020005'");
+
+        // Test limited support for DB2's special registers
+
+        // Standard SQL functions like LOCALTIMESTAMP, CURRENT_TIMESTAMP and
+        // others are used to compare values, their implementation in H2 is
+        // compatible with standard, but may be not really compatible with DB2.
+        assertResult("TRUE", stat, "SELECT LOCALTIMESTAMP = CURRENT TIMESTAMP");
+        assertResult("TRUE", stat, "SELECT CAST(LOCALTIMESTAMP AS VARCHAR) = CAST(CURRENT TIMESTAMP AS VARCHAR)");
+        assertResult("TRUE", stat, "SELECT CURRENT_TIMESTAMP = CURRENT TIMESTAMP WITH TIME ZONE");
+        assertResult("TRUE", stat,
+                "SELECT CAST(CURRENT_TIMESTAMP AS VARCHAR) = CAST(CURRENT TIMESTAMP WITH TIME ZONE AS VARCHAR)");
+        assertResult("TRUE", stat, "SELECT CURRENT_TIME = CURRENT TIME");
+        assertResult("TRUE", stat, "SELECT CURRENT_DATE = CURRENT DATE");
     }
 
     private void testDerby() throws SQLException {


### PR DESCRIPTION
1. Parse DB2's special registers only in DB2 compatibility mode and add test for them. Also restore parsing of `CURRENT TIMESTAMP` as function of `TIMESTAMP` type (remap it to `LOCALTIMESTAMP`) and add `CURRENT TIMESTAMP WITH TIME ZONE` special register mapped to `CURRENT_TIMESTAMP` that returns `TIMESTAMP WITH TIME ZONE` as required by SQL standard). I don't see a reason to support them in other modes, such support is only a source of possible accidental incorrect usage.

2. `Parser.readFunctionWithoutParameters()` should not try to parse `()`, presence of parentheses is already checked before invocations if this method.

3. Remaining operators like `::` got separate token types to remove usages of common `KEYWORD` token type in `Parser`.

4. Token type is used in `Parser.parsePrepared()` to avoid re-parsing of keywords and operators.

5. Do not fill `currentToken` for operators, this field is not used for them any more. This reduces allocation of temporary strings.