### PR TITLE
Clean up interaction between LocalResult and ResultExternal

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTempResult.java
@@ -186,9 +186,4 @@ public abstract class MVTempResult implements ResultExternal {
         tempFileDeleter.deleteFile(fileRef, closeable);
     }
 
-    @Override
-    public void done() {
-        // Do nothing
-    }
-
 }

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -377,7 +377,6 @@ public class LocalResult implements ResultInterface, ResultTarget {
         }
         if (external != null) {
             addRowsToDisk();
-            external.done();
         } else {
             if (sort != null) {
                 if (offset > 0 || limit > 0) {

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -315,15 +315,15 @@ public class LocalResult implements ResultInterface, ResultTarget {
             rows.add(values);
             rowCount++;
             if (rows.size() > maxMemoryRows) {
-                if (external == null) {
-                    createExternalResult();
-                }
                 addRowsToDisk();
             }
         }
     }
 
     private void addRowsToDisk() {
+        if (external == null) {
+            createExternalResult();
+        }
         rowCount = external.addRows(rows);
         rows.clear();
     }
@@ -400,9 +400,6 @@ public class LocalResult implements ResultInterface, ResultTarget {
         while (--limit >= 0) {
             rows.add(temp.next());
             if (rows.size() > maxMemoryRows) {
-                if (external == null) {
-                    createExternalResult();
-                }
                 addRowsToDisk();
             }
         }

--- a/h2/src/main/org/h2/result/ResultExternal.java
+++ b/h2/src/main/org/h2/result/ResultExternal.java
@@ -43,11 +43,6 @@ public interface ResultExternal {
     int addRows(ArrayList<Value[]> rows);
 
     /**
-     * This method is called after all rows have been added.
-     */
-    void done();
-
-    /**
      * Close this object and delete the temporary file.
      */
     void close();

--- a/h2/src/main/org/h2/result/ResultTempTable.java
+++ b/h2/src/main/org/h2/result/ResultTempTable.java
@@ -310,11 +310,6 @@ public class ResultTempTable implements ResultExternal {
     }
 
     @Override
-    public void done() {
-        // nothing to do
-    }
-
-    @Override
     public Value[] next() {
         if (resultCursor == null) {
             Index idx;


### PR DESCRIPTION
1. Unnecessary copying of sorted external results is avoided.

2. External results are copied if and only if some rows should be excluded due to `OFFSET` or `LIMIT`. Copy may be in-memory if limit is not very large (typical case), this allows us to free disk space immediately. This also fixes issues for `IN` conditions with very large subquieries.

3. `LocalResult` now creates only one copy of own list if both `OFFSET` and `LIMIT` are specified.

4. Unused `ResultExternal.done()` is removed.

This is a preparation work for issues with distinct results. There is a serious bug with all implementations of `ResultExternal` if `LocalResult` is created with `expressions.length != visibleColumnCount`. I have a draft implementation of fixed external result for MVStore that is not yet ready to be merged. I extracted not directly related changes in this pull request.