### PR TITLE
Read nanoseconds of timestamps from old H2 versions properly and remove some dead code

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
@@ -255,26 +255,10 @@ class MVSortedTempResult extends MVTempResult {
 
     @Override
     public int removeRow(Value[] values) {
-        assert parent == null;
-        ValueArray key = getKey(values);
-        if (distinct) {
-            // If an entry was removed decrement the counter
-            if (map.remove(key) != null) {
-                rowCount--;
-            }
-        } else {
-            Long old = map.remove(key);
-            if (old != null) {
-                long l = old;
-                if (l > 1) {
-                    /*
-                     * We have more than one such row. Decrement its counter by 1 and put this row
-                     * back into map.
-                     */
-                    map.put(key, l - 1);
-                }
-                rowCount--;
-            }
+        assert parent == null && distinct;
+        // If an entry was removed decrement the counter
+        if (map.remove(getKey(values)) != null) {
+            rowCount--;
         }
         return rowCount;
     }

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -738,7 +738,7 @@ public class Data {
         case Value.TIMESTAMP: {
             return ValueTimestamp.fromMillisNanos(
                     DateTimeUtils.getTimeUTCWithoutDst(readVarLong()),
-                    readVarInt());
+                    readVarInt() % 1_000_000);
         }
         case Value.TIMESTAMP_TZ: {
             long dateValue = readVarLong();


### PR DESCRIPTION
1. A fix for issue #1284.

2. Dead code (that was actually never used) is removed from `MVSortedTempResult.removeRow()`. This method is used only in distinct results, there is no need to have code for non-distinct case.