### PR TITLE
Fix MVTempResult implementations for results with invisible columns

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
@@ -5,10 +5,12 @@
  */
 package org.h2.mvstore.db;
 
+import java.util.Arrays;
 import java.util.BitSet;
 
 import org.h2.engine.Database;
 import org.h2.expression.Expression;
+import org.h2.message.DbException;
 import org.h2.mvstore.Cursor;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVMap.Builder;
@@ -44,6 +46,19 @@ class MVSortedTempResult extends MVTempResult {
     private final MVMap<ValueArray, Long> map;
 
     /**
+     * The type of the distinct values.
+     */
+    private final ValueDataType distinctType;
+
+    /**
+     * Optional index. This index is created only if result is distinct and
+     * {@code columnCount != distinctColumnCount} or if
+     * {@link #contains(Value[])} method is invoked. Only the root result should
+     * have an index if required.
+     */
+    private MVMap<ValueArray, Boolean> index;
+
+    /**
      * Cursor for the {@link #next()} method.
      */
     private Cursor<ValueArray, Long> cursor;
@@ -71,6 +86,7 @@ class MVSortedTempResult extends MVTempResult {
         this.distinct = parent.distinct;
         this.indexes = parent.indexes;
         this.map = parent.map;
+        this.distinctType = null;
         this.rowCount = parent.rowCount;
     }
 
@@ -78,19 +94,22 @@ class MVSortedTempResult extends MVTempResult {
      * Creates a new sorted temporary result.
      *
      * @param database
-     *                        database
+     *            database
      * @param expressions
-     *                        column expressions
+     *            column expressions
      * @param distinct
-     *                        whether this result should be distinct
+     *            whether this result should be distinct
+     * @param visibleColumnCount
+     *            count of visible columns
      * @param sort
-     *                        sort order, or {@code null} if this result does not
-     *                        need any sorting
+     *            sort order, or {@code null} if this result does not need any
+     *            sorting
      */
-    MVSortedTempResult(Database database, Expression[] expressions, boolean distinct, SortOrder sort) {
-        super(database);
+    MVSortedTempResult(Database database, Expression[] expressions, boolean distinct, int visibleColumnCount,
+            SortOrder sort) {
+        super(database, expressions.length, visibleColumnCount);
         this.distinct = distinct;
-        int length = expressions.length;
+        int length = columnCount;
         int[] sortTypes = new int[length];
         int[] indexes;
         if (sort != null) {
@@ -147,6 +166,14 @@ class MVSortedTempResult extends MVTempResult {
         ValueDataType keyType = new ValueDataType(database.getCompareMode(), database, sortTypes);
         Builder<ValueArray, Long> builder = new MVMap.Builder<ValueArray, Long>().keyType(keyType);
         map = store.openMap("tmp", builder);
+        if (length == visibleColumnCount) {
+            distinctType = null;
+        } else {
+            distinctType = new ValueDataType(database.getCompareMode(), database, new int[visibleColumnCount]);
+            if (distinct) {
+                createIndex(false);
+            }
+        }
     }
 
     @Override
@@ -154,6 +181,12 @@ class MVSortedTempResult extends MVTempResult {
         assert parent == null;
         ValueArray key = getKey(values);
         if (distinct) {
+            if (columnCount != visibleColumnCount) {
+                ValueArray distinctRow = ValueArray.get(Arrays.copyOf(values, visibleColumnCount));
+                if (index.putIfAbsent(distinctRow, true) != null) {
+                    return rowCount;
+                }
+            }
             // Add a row and increment the counter only if row does not exist
             if (map.putIfAbsent(key, 1L) == null) {
                 rowCount++;
@@ -172,7 +205,31 @@ class MVSortedTempResult extends MVTempResult {
 
     @Override
     public boolean contains(Value[] values) {
+        // Only parent result maintains the index
+        if (parent != null) {
+            return parent.contains(values);
+        }
+        if (columnCount != visibleColumnCount) {
+            if (index == null) {
+                createIndex(true);
+            }
+            return index.containsKey(ValueArray.get(values));
+        }
         return map.containsKey(getKey(values));
+    }
+
+    private void createIndex(boolean fill) {
+        Builder<ValueArray, Boolean> indexBuilder = new MVMap.Builder<ValueArray, Boolean>()
+                .keyType(distinctType);
+        index = store.openMap("idx", indexBuilder);
+        if (fill) {
+            Cursor<ValueArray, Long> c = map.cursor(null);
+            while (c.hasNext()) {
+                Value[] v = getValue(c.next().getList());
+                ValueArray distinctRow = ValueArray.get(Arrays.copyOf(v, visibleColumnCount));
+                index.putIfAbsent(distinctRow, true);
+            }
+        }
     }
 
     @Override
@@ -198,7 +255,7 @@ class MVSortedTempResult extends MVTempResult {
         if (indexes != null) {
             Value[] r = new Value[indexes.length];
             for (int i = 0; i < indexes.length; i++) {
-                r[indexes[i]] = values[i];
+                r[i] = values[indexes[i]];
             }
             values = r;
         }
@@ -216,7 +273,7 @@ class MVSortedTempResult extends MVTempResult {
         if (indexes != null) {
             Value[] r = new Value[indexes.length];
             for (int i = 0; i < indexes.length; i++) {
-                r[i] = key[indexes[i]];
+                r[indexes[i]] = key[i];
             }
             key = r;
         }
@@ -256,6 +313,9 @@ class MVSortedTempResult extends MVTempResult {
     @Override
     public int removeRow(Value[] values) {
         assert parent == null && distinct;
+        if (columnCount != visibleColumnCount) {
+            throw DbException.getUnsupportedException("removeRow()");
+        }
         // If an entry was removed decrement the counter
         if (map.remove(getKey(values)) != null) {
             rowCount--;

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -192,6 +192,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
         if (!distinct) {
             DbException.throwInternalError();
         }
+        assert values.length == visibleColumnCount;
         if (distinctRows != null) {
             ValueArray array = ValueArray.get(values);
             distinctRows.remove(array);
@@ -209,6 +210,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
      */
     @Override
     public boolean containsDistinct(Value[] values) {
+        assert values.length == visibleColumnCount;
         if (external != null) {
             return external.contains(values);
         }
@@ -286,7 +288,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
     private void createExternalResult() {
         Database database = session.getDatabase();
         external = database.isMVStore()
-                ? MVTempResult.of(database, expressions, distinct, sort)
+                ? MVTempResult.of(database, expressions, distinct, visibleColumnCount, sort)
                         : new ResultTempTable(session, expressions, distinct, sort);
     }
 

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -3077,17 +3077,17 @@ SELECT t.f1, t.f2 FROM test t ORDER BY t.f2;
 > abc 333
 > rows (ordered): 3
 
-SELECT t1.f1, t1.f2, t2.f1, t2.f2 FROM test t1, test t2 ORDER BY t2.f2;
+SELECT t1.f1, t1.f2, t2.f1, t2.f2 FROM test t1, test t2 ORDER BY t2.f2, t1.f2;
 > F1  F2  F1  F2
 > --- --- --- ---
-> abc 222 abc 111
 > abc 111 abc 111
+> abc 222 abc 111
 > abc 333 abc 111
-> abc 222 abc 222
 > abc 111 abc 222
+> abc 222 abc 222
 > abc 333 abc 222
-> abc 222 abc 333
 > abc 111 abc 333
+> abc 222 abc 333
 > abc 333 abc 333
 > rows (ordered): 9
 


### PR DESCRIPTION
There are fixes for all `TestScript` failures with `maxMemoryRows = 0` in MVStore mode.

1. `visibleColumnCount` is passed and handed in all MVStore temporary results.

2. A bug with column ordering in `MVSortedTempResult` is fixed.

I'm not sure how to test this mode on Travis properly. Very low values of `maxMemoryRows` may slow down the testing process.