### PR TITLE
Add Function "LEN" #1196

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1196: Feature request for MS SQL Server Compatibility Mode
+</li>
 <li>Issue #1177: Resource leak in Recover tool
 </li>
 <li>PR #1183: Improve concurrency of connection pool with wait-free implement

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -239,6 +239,8 @@ public class Function extends Expression implements FunctionCall {
         addFunction("LCASE", LCASE, 1, Value.STRING);
         addFunction("LEFT", LEFT, 2, Value.STRING);
         addFunction("LENGTH", LENGTH, 1, Value.LONG);
+        // alias for MSSQLServer
+        addFunction("LEN", LENGTH, 1, Value.LONG);
         // 2 or 3 arguments
         addFunction("LOCATE", LOCATE, VAR_ARGS, Value.INT);
         // alias for MSSQLServer

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -127,7 +127,6 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         testAnnotationProcessorsOutput();
         testRound();
         testSignal();
-        testLength();
 
         deleteDb("functions");
     }
@@ -2078,24 +2077,6 @@ public class TestFunctions extends TestDb implements AggregateFunction {
             assertContains(e.getMessage(), "some custom error");
         }
 
-        conn.close();
-    }
-
-    private void testLength() throws SQLException {
-        deleteDb("functions");
-
-        Connection conn = getConnection("functions");
-        Statement stat = conn.createStatement();
-
-        final ResultSet rs = stat.executeQuery(
-                "select LENGTH('This has 17 chars'), LEN('MSSQLServer uses the len keyword') from dual");
-
-        rs.next();
-        assertEquals(17, rs.getInt(1));
-        assertEquals(32, rs.getInt(2));
-
-
-        rs.close();
         conn.close();
     }
 

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -127,6 +127,7 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         testAnnotationProcessorsOutput();
         testRound();
         testSignal();
+        testLength();
 
         deleteDb("functions");
     }
@@ -2077,6 +2078,24 @@ public class TestFunctions extends TestDb implements AggregateFunction {
             assertContains(e.getMessage(), "some custom error");
         }
 
+        conn.close();
+    }
+
+    private void testLength() throws SQLException {
+        deleteDb("functions");
+
+        Connection conn = getConnection("functions");
+        Statement stat = conn.createStatement();
+
+        final ResultSet rs = stat.executeQuery(
+                "select LENGTH('This has 17 chars'), LEN('MSSQLServer uses the len keyword') from dual");
+
+        rs.next();
+        assertEquals(17, rs.getInt(1));
+        assertEquals(32, rs.getInt(2));
+
+
+        rs.close();
         conn.close();
     }
 

--- a/h2/src/test/org/h2/test/scripts/functions/string/length.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/length.sql
@@ -2,3 +2,15 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+create memory table test(id int primary key, name varchar(255));
+> ok
+
+insert into test values(1, 'Hello');
+> update count: 1
+
+select length(null) en, len(null) en2, length('This has 17 chars') e_17, len('MSSQLServer uses the len keyword') e_32 from test;
+> EN   EN2  E_17 E_32
+> ---- ---- ---- ----
+> null null 17   32
+> rows: 1


### PR DESCRIPTION
Defines alias LEN for LENGTH. 
It is not only for MS SQL Server Compatibility Mode (MODE=MSSQLServer), but this seems default behaviour (i.e. CHARINDEX).