### PR TITLE
Assorted minor changes

### DIFF
--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -61,7 +61,7 @@ public class SelectUnion extends Query {
         INTERSECT
     }
 
-    private UnionType unionType;
+    private final UnionType unionType;
 
     /**
      * The left hand side of the union (the first subquery).
@@ -71,7 +71,7 @@ public class SelectUnion extends Query {
     /**
      * The right hand side of the union (the second subquery).
      */
-    Query right;
+    final Query right;
 
     private ArrayList<Expression> expressions;
     private Expression[] expressionArray;
@@ -80,9 +80,11 @@ public class SelectUnion extends Query {
     private boolean isPrepared, checkInit;
     private boolean isForUpdate;
 
-    public SelectUnion(Session session, Query query) {
+    public SelectUnion(Session session, UnionType unionType, Query query, Query right) {
         super(session);
+        this.unionType = unionType;
         this.left = query;
+        this.right = right;
     }
 
     @Override
@@ -96,16 +98,8 @@ public class SelectUnion extends Query {
         right.prepareJoinBatch();
     }
 
-    public void setUnionType(UnionType type) {
-        this.unionType = type;
-    }
-
     public UnionType getUnionType() {
         return unionType;
-    }
-
-    public void setRight(Query select) {
-        right = select;
     }
 
     public Query getLeft() {

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -252,7 +252,7 @@ public class Function extends Expression implements FunctionCall {
         addFunction("OCTET_LENGTH", OCTET_LENGTH, 1, Value.LONG);
         addFunction("RAWTOHEX", RAWTOHEX, 1, Value.STRING);
         addFunction("REPEAT", REPEAT, 2, Value.STRING);
-        addFunction("REPLACE", REPLACE, VAR_ARGS, Value.STRING, false, true,true);
+        addFunctionWithNull("REPLACE", REPLACE, VAR_ARGS, Value.STRING);
         addFunction("RIGHT", RIGHT, 2, Value.STRING);
         addFunction("RTRIM", RTRIM, VAR_ARGS, Value.STRING);
         addFunction("SOUNDEX", SOUNDEX, 1, Value.STRING);
@@ -421,8 +421,7 @@ public class Function extends Expression implements FunctionCall {
                 VAR_ARGS, Value.LONG);
         addFunction("ARRAY_GET", ARRAY_GET,
                 2, Value.NULL);
-        addFunction("ARRAY_CONTAINS", ARRAY_CONTAINS,
-                2, Value.BOOLEAN, false, true, true);
+        addFunctionWithNull("ARRAY_CONTAINS", ARRAY_CONTAINS, 2, Value.BOOLEAN);
         addFunction("CSVREAD", CSVREAD,
                 VAR_ARGS, Value.RESULT_SET, false, false, false);
         addFunction("CSVWRITE", CSVWRITE,
@@ -515,17 +514,6 @@ public class Function extends Expression implements FunctionCall {
     }
 
     /**
-     * Get the function info object for this function, or null if there is no
-     * such function.
-     *
-     * @param name the function name
-     * @return the function info
-     */
-    private static FunctionInfo getFunctionInfo(String name) {
-        return FUNCTIONS.get(name);
-    }
-
-    /**
      * Get an instance of the given function for this database.
      * If no function with this name is found, null is returned.
      *
@@ -538,7 +526,7 @@ public class Function extends Expression implements FunctionCall {
             // if not yet converted to uppercase, do it now
             name = StringUtils.toUpperEnglish(name);
         }
-        FunctionInfo info = getFunctionInfo(name);
+        FunctionInfo info = FUNCTIONS.get(name);
         if (info == null) {
             return null;
         }
@@ -914,7 +902,7 @@ public class Function extends Expression implements FunctionCall {
             if (v0 == ValueNull.INSTANCE) {
                 result = getNullOrValue(session, args, values, 1);
             }
-            result = convertResult(result);
+            result = result.convertTo(dataType, -1, database.getMode());
             break;
         }
         case CASEWHEN: {
@@ -1077,10 +1065,6 @@ public class Function extends Expression implements FunctionCall {
             result = null;
         }
         return result;
-    }
-
-    private Value convertResult(Value v) {
-        return v.convertTo(dataType, -1, database.getMode());
     }
 
     private static boolean cancelStatement(Session session, int targetSessionId) {

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -80,10 +80,6 @@ public class LocalDateTimeUtils {
      */
     private static final Method LOCAL_DATE_OF_YEAR_MONTH_DAY;
     /**
-     * {@code java.time.LocalDate#parse(CharSequence)} or {@code null}.
-     */
-    private static final Method LOCAL_DATE_PARSE;
-    /**
      * {@code java.time.LocalDate#getYear()} or {@code null}.
      */
     private static final Method LOCAL_DATE_GET_YEAR;
@@ -114,11 +110,6 @@ public class LocalDateTimeUtils {
     private static final Method TIMESTAMP_TO_INSTANT;
 
     /**
-     * {@code java.time.LocalTime#parse(CharSequence)} or {@code null}.
-     */
-    private static final Method LOCAL_TIME_PARSE;
-
-    /**
      * {@code java.time.LocalDateTime#plusNanos(long)} or {@code null}.
      */
     private static final Method LOCAL_DATE_TIME_PLUS_NANOS;
@@ -130,10 +121,6 @@ public class LocalDateTimeUtils {
      * {@code java.time.LocalDateTime#toLocalTime()} or {@code null}.
      */
     private static final Method LOCAL_DATE_TIME_TO_LOCAL_TIME;
-    /**
-     * {@code java.time.LocalDateTime#parse(CharSequence)} or {@code null}.
-     */
-    private static final Method LOCAL_DATE_TIME_PARSE;
 
     /**
      * {@code java.time.ZoneOffset#ofTotalSeconds(int)} or {@code null}.
@@ -145,10 +132,6 @@ public class LocalDateTimeUtils {
      * {@code null}.
      */
     private static final Method OFFSET_DATE_TIME_OF_LOCAL_DATE_TIME_ZONE_OFFSET;
-    /**
-     * {@code java.time.OffsetDateTime#parse(CharSequence)} or {@code null}.
-     */
-    private static final Method OFFSET_DATE_TIME_PARSE;
     /**
      * {@code java.time.OffsetDateTime#toLocalDateTime()} or {@code null}.
      */
@@ -183,8 +166,6 @@ public class LocalDateTimeUtils {
 
             LOCAL_DATE_OF_YEAR_MONTH_DAY = getMethod(LOCAL_DATE, "of",
                     int.class, int.class, int.class);
-            LOCAL_DATE_PARSE = getMethod(LOCAL_DATE, "parse",
-                    CharSequence.class);
             LOCAL_DATE_GET_YEAR = getMethod(LOCAL_DATE, "getYear");
             LOCAL_DATE_GET_MONTH_VALUE = getMethod(LOCAL_DATE, "getMonthValue");
             LOCAL_DATE_GET_DAY_OF_MONTH = getMethod(LOCAL_DATE, "getDayOfMonth");
@@ -194,12 +175,9 @@ public class LocalDateTimeUtils {
             INSTANT_GET_NANO = getMethod(INSTANT, "getNano");
             TIMESTAMP_TO_INSTANT = getMethod(Timestamp.class, "toInstant");
 
-            LOCAL_TIME_PARSE = getMethod(LOCAL_TIME, "parse", CharSequence.class);
-
             LOCAL_DATE_TIME_PLUS_NANOS = getMethod(LOCAL_DATE_TIME, "plusNanos", long.class);
             LOCAL_DATE_TIME_TO_LOCAL_DATE = getMethod(LOCAL_DATE_TIME, "toLocalDate");
             LOCAL_DATE_TIME_TO_LOCAL_TIME = getMethod(LOCAL_DATE_TIME, "toLocalTime");
-            LOCAL_DATE_TIME_PARSE = getMethod(LOCAL_DATE_TIME, "parse", CharSequence.class);
 
             ZONE_OFFSET_OF_TOTAL_SECONDS = getMethod(ZONE_OFFSET, "ofTotalSeconds", int.class);
 
@@ -207,14 +185,12 @@ public class LocalDateTimeUtils {
             OFFSET_DATE_TIME_GET_OFFSET = getMethod(OFFSET_DATE_TIME, "getOffset");
             OFFSET_DATE_TIME_OF_LOCAL_DATE_TIME_ZONE_OFFSET = getMethod(
                     OFFSET_DATE_TIME, "of", LOCAL_DATE_TIME, ZONE_OFFSET);
-            OFFSET_DATE_TIME_PARSE = getMethod(OFFSET_DATE_TIME, "parse", CharSequence.class);
 
             ZONE_OFFSET_GET_TOTAL_SECONDS = getMethod(ZONE_OFFSET, "getTotalSeconds");
         } else {
             LOCAL_TIME_OF_NANO = null;
             LOCAL_TIME_TO_NANO = null;
             LOCAL_DATE_OF_YEAR_MONTH_DAY = null;
-            LOCAL_DATE_PARSE = null;
             LOCAL_DATE_GET_YEAR = null;
             LOCAL_DATE_GET_MONTH_VALUE = null;
             LOCAL_DATE_GET_DAY_OF_MONTH = null;
@@ -222,16 +198,13 @@ public class LocalDateTimeUtils {
             INSTANT_GET_EPOCH_SECOND = null;
             INSTANT_GET_NANO = null;
             TIMESTAMP_TO_INSTANT = null;
-            LOCAL_TIME_PARSE = null;
             LOCAL_DATE_TIME_PLUS_NANOS = null;
             LOCAL_DATE_TIME_TO_LOCAL_DATE = null;
             LOCAL_DATE_TIME_TO_LOCAL_TIME = null;
-            LOCAL_DATE_TIME_PARSE = null;
             ZONE_OFFSET_OF_TOTAL_SECONDS = null;
             OFFSET_DATE_TIME_TO_LOCAL_DATE_TIME = null;
             OFFSET_DATE_TIME_GET_OFFSET = null;
             OFFSET_DATE_TIME_OF_LOCAL_DATE_TIME_ZONE_OFFSET = null;
-            OFFSET_DATE_TIME_PARSE = null;
             ZONE_OFFSET_GET_TOTAL_SECONDS = null;
         }
     }
@@ -250,62 +223,6 @@ public class LocalDateTimeUtils {
      */
     public static boolean isJava8DateApiPresent() {
         return IS_JAVA8_DATE_API_PRESENT;
-    }
-
-    /**
-     * Parses an ISO date string into a java.time.LocalDate.
-     *
-     * @param text the ISO date string
-     * @return the java.time.LocalDate instance
-     */
-    public static Object parseLocalDate(CharSequence text) {
-        try {
-            return LOCAL_DATE_PARSE.invoke(null, text);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalArgumentException("error when parsing text '" + text + "'", e);
-        }
-    }
-
-    /**
-     * Parses an ISO time string into a java.time.LocalTime.
-     *
-     * @param text the ISO time string
-     * @return the java.time.LocalTime instance
-     */
-    public static Object parseLocalTime(CharSequence text) {
-        try {
-            return LOCAL_TIME_PARSE.invoke(null, text);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalArgumentException("error when parsing text '" + text + "'", e);
-        }
-    }
-
-    /**
-     * Parses an ISO date string into a java.time.LocalDateTime.
-     *
-     * @param text the ISO date string
-     * @return the java.time.LocalDateTime instance
-     */
-    public static Object parseLocalDateTime(CharSequence text) {
-        try {
-            return LOCAL_DATE_TIME_PARSE.invoke(null, text);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalArgumentException("error when parsing text '" + text + "'", e);
-        }
-    }
-
-    /**
-     * Parses an ISO date string into a java.time.OffsetDateTime.
-     *
-     * @param text the ISO date string
-     * @return the java.time.OffsetDateTime instance
-     */
-    public static Object parseOffsetDateTime(CharSequence text) {
-        try {
-            return OFFSET_DATE_TIME_PARSE.invoke(null, text);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalArgumentException("error when parsing text '" + text + "'", e);
-        }
     }
 
     private static Class<?> tryGetClass(String className) {


### PR DESCRIPTION
1. Four methods that are useful only for testing are moved from `LocalDateTimeUtils` into testing unit.

2. Two very short methods in `Function` are inlined. Both of them were used only once.

3. `Function.addFunctionWithNull()` is used in two more places instead of generic method with hardly readable flags.

4. `Parser.parseSelectUnionExtension()` is inlined into `parseSelectUnion()` and slightly optimized.