### PR TITLE
Handle distinct results properly

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2535,7 +2535,7 @@ public class Parser {
         }
         currentSelect = temp;
         if (readIf(DISTINCT)) {
-            command.setDistinct(true);
+            command.setDistinct();
         } else {
             readIf(ALL);
         }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2749,6 +2749,8 @@ public class Parser {
                 } else {
                     if (isSelect()) {
                         Query query = parseSelect();
+                        // TODO lazy result causes timeout in TestFuzzOptimizations
+                        query.setNeverLazy(true);
                         r = new ConditionInSelect(database, r, query, false,
                                 Comparison.EQUAL);
                     } else {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2749,10 +2749,6 @@ public class Parser {
                 } else {
                     if (isSelect()) {
                         Query query = parseSelect();
-                        // can not be lazy because we have to call
-                        // method ResultInterface.containsDistinct
-                        // which is not supported for lazy execution
-                        query.setNeverLazy(true);
                         r = new ConditionInSelect(database, r, query, false,
                                 Comparison.EQUAL);
                     } else {

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -255,12 +255,16 @@ public abstract class Query extends Prepared {
 
     /**
      * Set the distinct flag.
-     *
-     * @param b the new value
      */
-    public void setDistinct(boolean b) {
-        distinct = b;
+    public void setDistinct() {
+        distinct = true;
     }
+
+    /**
+     * Set the distinct flag only if it is possible, may be used as a possible
+     * optimization only.
+     */
+    public abstract void setDistinctIfPossible();
 
     public boolean isDistinct() {
         return distinct;

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -219,9 +219,6 @@ public class SelectUnion extends Query {
             right.setDistinctIfPossible();
             result.setDistinct();
         }
-        if (randomAccessResult) {
-            result.setRandomAccess();
-        }
         switch (unionType) {
         case UNION:
         case EXCEPT:
@@ -265,7 +262,6 @@ public class SelectUnion extends Query {
         case INTERSECT: {
             LocalResult temp = new LocalResult(session, expressionArray, columnCount);
             temp.setDistinct();
-            temp.setRandomAccess();
             while (l.next()) {
                 temp.addRow(convert(l.currentRow(), columnCount));
             }

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -125,6 +125,11 @@ public class SelectUnion extends Query {
         return orderList != null || sort != null;
     }
 
+    @Override
+    public void setDistinctIfPossible() {
+        setDistinct();
+    }
+
     private Value[] convert(Value[] values, int columnCount) {
         Value[] newValues;
         if (columnCount == values.length) {
@@ -210,8 +215,8 @@ public class SelectUnion extends Query {
             result.setSortOrder(sort);
         }
         if (distinct) {
-            left.setDistinct(true);
-            right.setDistinct(true);
+            left.setDistinctIfPossible();
+            right.setDistinctIfPossible();
             result.setDistinct();
         }
         if (randomAccessResult) {
@@ -220,15 +225,15 @@ public class SelectUnion extends Query {
         switch (unionType) {
         case UNION:
         case EXCEPT:
-            left.setDistinct(true);
-            right.setDistinct(true);
+            left.setDistinctIfPossible();
+            right.setDistinctIfPossible();
             result.setDistinct();
             break;
         case UNION_ALL:
             break;
         case INTERSECT:
-            left.setDistinct(true);
-            right.setDistinct(true);
+            left.setDistinctIfPossible();
+            right.setDistinctIfPossible();
             break;
         default:
             DbException.throwInternalError("type=" + unionType);

--- a/h2/src/main/org/h2/expression/ConditionInSelect.java
+++ b/h2/src/main/org/h2/expression/ConditionInSelect.java
@@ -43,9 +43,7 @@ public class ConditionInSelect extends Condition {
     @Override
     public Value getValue(Session session) {
         query.setSession(session);
-        if (!query.hasOrder()) {
-            query.setDistinct(true);
-        }
+        query.setDistinctIfPossible();
         ResultInterface rows = query.query(0);
         Value l = left.getValue(session);
         if (!rows.hasNext()) {

--- a/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
@@ -5,8 +5,6 @@
  */
 package org.h2.mvstore.db;
 
-import java.util.Arrays;
-
 import org.h2.engine.Database;
 import org.h2.expression.Expression;
 import org.h2.message.DbException;
@@ -23,11 +21,6 @@ import org.h2.value.ValueArray;
 class MVPlainTempResult extends MVTempResult {
 
     /**
-     * The type of the distinct values.
-     */
-    private final ValueDataType distinctType;
-
-    /**
      * Map with identities of rows as keys rows as values.
      */
     private final MVMap<Long, ValueArray> map;
@@ -38,12 +31,6 @@ class MVPlainTempResult extends MVTempResult {
      * method to ensure that each row will have an own identity.
      */
     private long counter;
-
-    /**
-     * Optional index. This index is created only if {@link #contains(Value[])}
-     * method is invoked. Only the root result should have an index if required.
-     */
-    private MVMap<ValueArray, Boolean> index;
 
     /**
      * Cursor for the {@link #next()} method.
@@ -58,7 +45,6 @@ class MVPlainTempResult extends MVTempResult {
      */
     private MVPlainTempResult(MVPlainTempResult parent) {
         super(parent);
-        this.distinctType = null;
         this.map = parent.map;
     }
 
@@ -75,46 +61,20 @@ class MVPlainTempResult extends MVTempResult {
     MVPlainTempResult(Database database, Expression[] expressions, int visibleColumnCount) {
         super(database, expressions.length, visibleColumnCount);
         ValueDataType valueType = new ValueDataType(database.getCompareMode(), database, new int[columnCount]);
-        if (columnCount == visibleColumnCount) {
-            distinctType = valueType;
-        } else {
-            distinctType = new ValueDataType(database.getCompareMode(), database, new int[visibleColumnCount]);
-        }
         Builder<Long, ValueArray> builder = new MVMap.Builder<Long, ValueArray>().valueType(valueType);
         map = store.openMap("tmp", builder);
     }
 
     @Override
     public int addRow(Value[] values) {
-        assert parent == null && index == null;
+        assert parent == null;
         map.put(counter++, ValueArray.get(values));
         return ++rowCount;
     }
 
     @Override
     public boolean contains(Value[] values) {
-        // Only parent result maintains the index
-        if (parent != null) {
-            return parent.contains(values);
-        }
-        if (index == null) {
-            createIndex();
-        }
-        return index.containsKey(ValueArray.get(values));
-    }
-
-    private void createIndex() {
-        Builder<ValueArray, Boolean> builder = new MVMap.Builder<ValueArray, Boolean>().keyType(distinctType);
-        index = store.openMap("idx", builder);
-        Cursor<Long, ValueArray> c = map.cursor(null);
-        while (c.hasNext()) {
-            c.next();
-            ValueArray row = c.getValue();
-            if (columnCount != visibleColumnCount) {
-                row = ValueArray.get(Arrays.copyOf(row.getList(), visibleColumnCount));
-            }
-            index.putIfAbsent(row, true);
-        }
+        throw DbException.getUnsupportedException("contains()");
     }
 
     @Override

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -43,7 +43,6 @@ public class LocalResult implements ResultInterface, ResultTarget {
     private int limit = -1;
     private ResultExternal external;
     private boolean distinct;
-    private boolean randomAccess;
     private boolean closed;
     private boolean containsLobs;
 
@@ -151,7 +150,6 @@ public class LocalResult implements ResultInterface, ResultTarget {
         copy.sort = this.sort;
         copy.distinctRows = this.distinctRows;
         copy.distinct = distinct;
-        copy.randomAccess = randomAccess;
         copy.currentRow = null;
         copy.offset = 0;
         copy.limit = -1;
@@ -174,13 +172,6 @@ public class LocalResult implements ResultInterface, ResultTarget {
     public void setDistinct() {
         distinct = true;
         distinctRows = ValueHashMap.newInstance();
-    }
-
-    /**
-     * Random access is required (containsDistinct).
-     */
-    public void setRandomAccess() {
-        this.randomAccess = true;
     }
 
     /**

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -279,6 +279,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
     private void createExternalResult() {
         Database database = session.getDatabase();
         external = database.isMVStore()
+                || /* not supported by ResultTempTable */ distinct && expressions.length != visibleColumnCount
                 ? MVTempResult.of(database, expressions, distinct, visibleColumnCount, sort)
                         : new ResultTempTable(session, expressions, distinct, sort);
     }


### PR DESCRIPTION
An attempt to fix issue #1295.

1. `SelectUnion` and `ConditionInSelect` now try to set results to distinct mode in a safe way with `setDistinctIfPossible()` method that checks whether result can be set to distinct without side effects. (Please review.) It should work even if results will not be distinct because rows are copied into own `LocalResult` with distinct flag in `SelectUnion` and for `ConditionInSelect` distinct result will be returned even if this soft way fails due to changes in `randomAccessResult` handling (see 2).

2. `Select.queryWithoutCache()` with `randomAccessResult` flag now generates a normal result first (possibly distinct, possibly lazy, it does not matter). If this flag is set content of this result is copied into into new `LocalResult` with distinct flag. This copy is returned. If result is already a distinct `LocalResult` copying is not performed. This way should not break optimizations and caching of results for `ConditionInSelect`, but I didn't test it in debugger.

3. Lazy result is not forced for some `ConditionInSelect` subqueries because `randomAccessResult` should handle situation with lazy results anyway. Only 1 of 4 invocations of `new ConditionInSelect()` used never lazy flag for unknown reason so setup of this flag is removed only in one place.

4. `LocalResult.setRandomAccess()` is removed, it did not affect anything. Similar flag is handled only in selects.

5. All tricks with support of `containsDistinct()` in not distinct results are removed from external results.

6. Implementations of `MVTempResult` are now used also in PageStore mode if external result is distinct and has invisible columns. This combination is not supported by `ResultTempTable` that leads to incorrect results. Such queries (especially with a lot of rows, otherwise external results are not used) are rare enough, but it's better to avoid this bug anyway. Without this fix such problems can be easily reproduced by `TestScript` in PageStore mode with forced usage of external results.