### PR TITLE
Add initial DISTINCT ON (expression, ...) implementation

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3,7 +3,8 @@
 # Initial Developer: H2 Group
 "SECTION","TOPIC","SYNTAX","TEXT","EXAMPLE"
 "Commands (DML)","SELECT","
-SELECT [ TOP term ] [ DISTINCT | ALL ] selectExpression [,...]
+SELECT [ TOP term ] [ DISTINCT [ ON ( expression [,...] ) ] | ALL ]
+selectExpression [,...]
 FROM tableExpression [,...] [ WHERE expression ]
 [ GROUP BY expression [,...] ] [ HAVING expression ]
 [ { UNION [ ALL ] | MINUS | EXCEPT | INTERSECT } select ]
@@ -42,6 +43,8 @@ SELECT * FROM TEST LIMIT 1000;
 SELECT * FROM (SELECT ID, COUNT(*) FROM TEST
     GROUP BY ID UNION SELECT NULL, COUNT(*) FROM TEST)
     ORDER BY 1 NULLS LAST;
+SELECT DISTINCT C1, C2 FROM TEST;
+SELECT DISTINCT ON(C1) C1, C2 FROM TEST ORDER BY C1;
 "
 
 "Commands (DML)","INSERT","

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2535,7 +2535,16 @@ public class Parser {
         }
         currentSelect = temp;
         if (readIf(DISTINCT)) {
-            command.setDistinct();
+            if (readIf(ON)) {
+                read(OPEN_PAREN);
+                ArrayList<Expression> distinctExpressions = Utils.newSmallArrayList();
+                do {
+                    distinctExpressions.add(readExpression());
+                } while (readIfMore(true));
+                command.setDistinct(distinctExpressions.toArray(new Expression[0]));
+            } else {
+                command.setDistinct();
+            }
         } else {
             readIf(ALL);
         }

--- a/h2/src/main/org/h2/mvstore/db/MVTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTempResult.java
@@ -66,6 +66,8 @@ public abstract class MVTempResult implements ResultExternal {
      *            expressions
      * @param distinct
      *            is output distinct
+     * @param distinctIndexes
+     *            indexes of distinct columns for DISINCT ON results
      * @param visibleColumnCount
      *            count of visible columns
      * @param sort
@@ -73,9 +75,9 @@ public abstract class MVTempResult implements ResultExternal {
      * @return temporary result
      */
     public static ResultExternal of(Database database, Expression[] expressions, boolean distinct,
-            int visibleColumnCount, SortOrder sort) {
-        return distinct || sort != null
-                ? new MVSortedTempResult(database, expressions, distinct, visibleColumnCount, sort)
+            int[] distinctIndexes, int visibleColumnCount, SortOrder sort) {
+        return distinct || distinctIndexes != null || sort != null
+                ? new MVSortedTempResult(database, expressions, distinct, distinctIndexes, visibleColumnCount, sort)
                 : new MVPlainTempResult(database, expressions, visibleColumnCount);
     }
 

--- a/h2/src/main/org/h2/util/ValueHashMap.java
+++ b/h2/src/main/org/h2/util/ValueHashMap.java
@@ -66,7 +66,7 @@ public class ValueHashMap<V> extends HashBase {
             if (k != null && k != ValueNull.DELETED) {
                 // skip the checkSizePut so we don't end up
                 // accidentally recursing
-                internalPut(k, oldValues[i]);
+                internalPut(k, oldValues[i], false);
             }
         }
     }
@@ -88,10 +88,21 @@ public class ValueHashMap<V> extends HashBase {
      */
     public void put(Value key, V value) {
         checkSizePut();
-        internalPut(key, value);
+        internalPut(key, value, false);
     }
 
-    private void internalPut(Value key, V value) {
+    /**
+     * Add a key value pair, values for existing keys are not replaced.
+     *
+     * @param key the key
+     * @param value the new value
+     */
+    public void putIfAbsent(Value key, V value) {
+        checkSizePut();
+        internalPut(key, value, true);
+    }
+
+    private void internalPut(Value key, V value, boolean ifAbsent) {
         int index = getIndex(key);
         int plus = 1;
         int deleted = -1;
@@ -113,6 +124,9 @@ public class ValueHashMap<V> extends HashBase {
                     deleted = index;
                 }
             } else if (k.equals(key)) {
+                if (ifAbsent) {
+                    return;
+                }
                 // update existing
                 values[index] = value;
                 return;

--- a/h2/src/test/org/h2/test/scripts/distinct.sql
+++ b/h2/src/test/org/h2/test/scripts/distinct.sql
@@ -103,3 +103,49 @@ DROP TABLE TEST;
 
 DROP TABLE TEST2;
 > ok
+
+CREATE TABLE TEST(C1 INT, C2 INT, C3 INT, C4 INT, C5 INT);
+> ok
+
+INSERT INTO TEST VALUES(1, 2, 3, 4, 5), (1, 2, 3, 6, 7), (2, 1, 4, 8, 9), (3, 4, 5, 1, 1);
+> update count: 4
+
+SELECT DISTINCT ON(C1, C2) C1, C2, C3, C4, C5 FROM TEST;
+> C1 C2 C3 C4 C5
+> -- -- -- -- --
+> 1  2  3  4  5
+> 2  1  4  8  9
+> 3  4  5  1  1
+> rows: 3
+
+SELECT DISTINCT ON(C1 + C2) C1, C2, C3, C4, C5 FROM TEST;
+> C1 C2 C3 C4 C5
+> -- -- -- -- --
+> 1  2  3  4  5
+> 3  4  5  1  1
+> rows: 2
+
+SELECT DISTINCT ON(C1 + C2, C3) C1, C2, C3, C4, C5 FROM TEST;
+> C1 C2 C3 C4 C5
+> -- -- -- -- --
+> 1  2  3  4  5
+> 2  1  4  8  9
+> 3  4  5  1  1
+> rows: 3
+
+SELECT DISTINCT ON(C1) C2 FROM TEST ORDER BY C1;
+> C2
+> --
+> 2
+> 1
+> 4
+> rows (ordered): 3
+
+EXPLAIN SELECT DISTINCT ON(C1) C2 FROM TEST ORDER BY C1;
+>> SELECT DISTINCT ON(C1) C2 FROM PUBLIC.TEST /* PUBLIC.TEST.tableScan */ ORDER BY =C1
+
+SELECT DISTINCT ON(C1) C2 FROM TEST ORDER BY C3;
+> exception ORDER_BY_NOT_IN_RESULT
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
An implementation of feature request #1032.

Limitatitons / incompatibilities:
1. Such query
```SQL
SELECT DISTINCT ON(C1) C2 from TEST ORDER BY C2
```
is not valid in PostgreSQL because `C2` requested in `ORDER BY` is not in `DISTINCT ON` list. This is currently not checked and such query is accepted. I'm not sure that this requirement is really necessary. However, queries like
```SQL
SELECT DISTINCT ON(C1) C2 FROM TEST ORDER BY C3;
```
are rejected in this implementation (and in PostgreSQL too).
2. There is no support of such queries in PageStore implementation of external results, so if external result is needed MVStore-based implementation will be used instead.