### PR TITLE
Use OpenJDK instead of OracleJDK 10 in Travis builds due to Travis problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 matrix:
   include:
-    - jdk: openjdk11
+    - jdk: openjdk10
       dist: trusty
       group: edge
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 matrix:
   include:
-    - jdk: oraclejdk10
+    - jdk: openjdk11
       dist: trusty
       group: edge
       sudo: required


### PR DESCRIPTION
An attempt to fix Travis builds.

Travis cannot install OracleJDK 10 due to some network problem that is not yet resolved.