### PR TITLE
Fix JdbcPreparedStatement.set*() methods with null Calendar argument

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -734,7 +734,8 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (x == null) {
                 setParameter(parameterIndex, ValueNull.INSTANCE);
             } else {
-                setParameter(parameterIndex, DateTimeUtils.convertDate(x, calendar));
+                setParameter(parameterIndex,
+                        calendar != null ? DateTimeUtils.convertDate(x, calendar) : ValueDate.get(x));
             }
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -760,7 +761,8 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (x == null) {
                 setParameter(parameterIndex, ValueNull.INSTANCE);
             } else {
-                setParameter(parameterIndex, DateTimeUtils.convertTime(x, calendar));
+                setParameter(parameterIndex,
+                        calendar != null ? DateTimeUtils.convertTime(x, calendar) : ValueTime.get(x));
             }
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -787,7 +789,8 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (x == null) {
                 setParameter(parameterIndex, ValueNull.INSTANCE);
             } else {
-                setParameter(parameterIndex, DateTimeUtils.convertTimestamp(x, calendar));
+                setParameter(parameterIndex,
+                        calendar != null ? DateTimeUtils.convertTimestamp(x, calendar) : ValueTimestamp.get(x));
             }
         } catch (Exception e) {
             throw logAndConvert(e);

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -13,7 +13,6 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import org.h2.engine.Mode;
-import org.h2.message.DbException;
 import org.h2.value.Value;
 import org.h2.value.ValueDate;
 import org.h2.value.ValueNull;
@@ -278,9 +277,6 @@ public class DateTimeUtils {
      * @return the date
      */
     public static ValueDate convertDate(Date x, Calendar calendar) {
-        if (calendar == null) {
-            throw DbException.getInvalidValueException("calendar", null);
-        }
         Calendar cal = (Calendar) calendar.clone();
         cal.setTimeInMillis(x.getTime());
         long dateValue = dateValueFromCalendar(cal);
@@ -295,9 +291,6 @@ public class DateTimeUtils {
      * @return the time
      */
     public static ValueTime convertTime(Time x, Calendar calendar) {
-        if (calendar == null) {
-            throw DbException.getInvalidValueException("calendar", null);
-        }
         Calendar cal = (Calendar) calendar.clone();
         cal.setTimeInMillis(x.getTime());
         long nanos = nanosFromCalendar(cal);
@@ -313,9 +306,6 @@ public class DateTimeUtils {
      */
     public static ValueTimestamp convertTimestamp(Timestamp x,
             Calendar calendar) {
-        if (calendar == null) {
-            throw DbException.getInvalidValueException("calendar", null);
-        }
         Calendar cal = (Calendar) calendar.clone();
         cal.setTimeInMillis(x.getTime());
         long dateValue = dateValueFromCalendar(cal);

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -1497,6 +1497,12 @@ public class TestResultSet extends TestDb {
                 java.sql.Timestamp.valueOf("2107-08-09 10:11:12.131415"));
         prep.execute();
 
+        prep.setInt(1, 5);
+        prep.setDate(2, java.sql.Date.valueOf("2101-02-03"), null);
+        prep.setTime(3, java.sql.Time.valueOf("14:05:06"), null);
+        prep.setTimestamp(4, java.sql.Timestamp.valueOf("2107-08-09 10:11:12.131415"), null);
+        prep.execute();
+
         rs = stat.executeQuery("SELECT * FROM TEST ORDER BY ID");
         assertResultSetMeta(rs, 4,
                 new String[] { "ID", "D", "T", "TS" },
@@ -1540,6 +1546,13 @@ public class TestResultSet extends TestDb {
 
         rs.next();
         assertEquals(4, rs.getInt("ID"));
+        assertEquals("2107-08-09 10:11:12.131415",
+                rs.getTimestamp("TS").toString());
+        assertEquals("14:05:06", rs.getTime("T").toString());
+        assertEquals("2101-02-03", rs.getDate("D").toString());
+
+        rs.next();
+        assertEquals(5, rs.getInt("ID"));
         assertEquals("2107-08-09 10:11:12.131415",
                 rs.getTimestamp("TS").toString());
         assertEquals("14:05:06", rs.getTime("T").toString());


### PR DESCRIPTION
A fix for issue #1307.

Calendar may be not specified according to `java.sql.PreparedStatement` javadoc.