### PR TITLE
Fix for issue #1298

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -183,7 +183,7 @@ public class TransactionStore {
                         }
                     }
 
-                    if (!store.hasData(mapName) && !store.isReadOnly()) {
+                    if (!store.isReadOnly()) {
                         store.removeMap(mapName);
                     }
                 }


### PR DESCRIPTION
Fix for issue #1298:
If database was killed in the middle of commit, specifically when undo log gets renamed to signify committed status, undo log map can get two names. One that corresponds to uncommitted is removed by this PR.
At some point I would redo the whole "committed" marker implementation, so instead of (or in addition to) renaming the map, we append special closing record to it. This should also reduce possibility of marking transaction as committed without fully persisting it's undo log.