### PR TITLE
Add Java 9+ support to NIO_CLEANER_HACK

### DIFF
--- a/h2/src/main/org/h2/store/fs/FilePathNioMapped.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNioMapped.java
@@ -9,7 +9,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Method;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
@@ -19,6 +18,7 @@ import java.nio.channels.NonWritableChannelException;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.engine.SysProperties;
+import org.h2.util.MemoryUnmapper;
 
 /**
  * This file system stores files on disk and uses java.nio to access the files.
@@ -78,36 +78,22 @@ class FileNioMapped extends FileBase {
         // need to dispose old direct buffer, see bug
         // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4724038
 
-        boolean useSystemGc = true;
         if (SysProperties.NIO_CLEANER_HACK) {
-            try {
-                Method cleanerMethod = mapped.getClass().getMethod("cleaner");
-                cleanerMethod.setAccessible(true);
-                Object cleaner = cleanerMethod.invoke(mapped);
-                if (cleaner != null) {
-                    Method clearMethod = cleaner.getClass().getMethod("clean");
-                    clearMethod.invoke(cleaner);
-                }
-                useSystemGc = false;
-            } catch (Throwable e) {
-                // useSystemGc is already true
-            } finally {
+            if (MemoryUnmapper.unmap(mapped)) {
                 mapped = null;
+                return;
             }
         }
-        if (useSystemGc) {
-            WeakReference<MappedByteBuffer> bufferWeakRef =
-                    new WeakReference<>(mapped);
-            mapped = null;
-            long start = System.nanoTime();
-            while (bufferWeakRef.get() != null) {
-                if (System.nanoTime() - start > TimeUnit.MILLISECONDS.toNanos(GC_TIMEOUT_MS)) {
-                    throw new IOException("Timeout (" + GC_TIMEOUT_MS
-                            + " ms) reached while trying to GC mapped buffer");
-                }
-                System.gc();
-                Thread.yield();
+        WeakReference<MappedByteBuffer> bufferWeakRef = new WeakReference<>(mapped);
+        mapped = null;
+        long start = System.nanoTime();
+        while (bufferWeakRef.get() != null) {
+            if (System.nanoTime() - start > TimeUnit.MILLISECONDS.toNanos(GC_TIMEOUT_MS)) {
+                throw new IOException("Timeout (" + GC_TIMEOUT_MS
+                        + " ms) reached while trying to GC mapped buffer");
             }
+            System.gc();
+            Thread.yield();
         }
     }
 

--- a/h2/src/main/org/h2/util/MemoryUnmapper.java
+++ b/h2/src/main/org/h2/util/MemoryUnmapper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+import org.h2.engine.SysProperties;
+
+/**
+ * Unsafe memory unmapper.
+ *
+ * @see SysProperties#NIO_CLEANER_HACK
+ */
+public final class MemoryUnmapper {
+
+    private static final boolean ENABLED;
+
+    private static final Object UNSAFE;
+
+    private static final Method INVOKE_CLEANER;
+
+    static {
+        boolean enabled = SysProperties.NIO_CLEANER_HACK;
+        Object unsafe = null;
+        Method invokeCleaner = null;
+        if (enabled) {
+            try {
+                Class<?> clazz = Class.forName("sun.misc.Unsafe");
+                Field field = clazz.getDeclaredField("theUnsafe");
+                field.setAccessible(true);
+                unsafe = field.get(null);
+                // This method exists only on Java 9 and later versions
+                invokeCleaner = clazz.getMethod("invokeCleaner", ByteBuffer.class);
+            } catch (ReflectiveOperationException e) {
+                // Java 7 or 8
+                unsafe = null;
+                // invokeCleaner can be only null here
+            } catch (Throwable e) {
+                // Should be a SecurityException, but catch everything to be
+                // safe
+                enabled = false;
+                unsafe = null;
+                // invokeCleaner can be only null here
+            }
+        }
+        ENABLED = enabled;
+        UNSAFE = unsafe;
+        INVOKE_CLEANER = invokeCleaner;
+    }
+
+    /**
+     * Tries to unmap memory for the specified byte buffer using Java internals
+     * in unsafe way if {@link SysProperties#NIO_CLEANER_HACK} is enabled and
+     * access is not denied by a security manager.
+     *
+     * @param buffer
+     *            mapped byte buffer
+     * @return whether operation was successful
+     */
+    public static boolean unmap(ByteBuffer buffer) {
+        if (!ENABLED) {
+            return false;
+        }
+        try {
+            if (INVOKE_CLEANER != null) {
+                // Java 9 or later
+                INVOKE_CLEANER.invoke(UNSAFE, buffer);
+                return true;
+            }
+            // Java 7 or 8
+            Method cleanerMethod = buffer.getClass().getMethod("cleaner");
+            cleanerMethod.setAccessible(true);
+            Object cleaner = cleanerMethod.invoke(buffer);
+            if (cleaner != null) {
+                Method clearMethod = cleaner.getClass().getMethod("clean");
+                clearMethod.invoke(cleaner);
+            }
+            return true;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
+    private MemoryUnmapper() {
+    }
+
+}

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -193,6 +193,7 @@ import org.h2.test.unit.TestIntPerfectHash;
 import org.h2.test.unit.TestJmx;
 import org.h2.test.unit.TestLocale;
 import org.h2.test.unit.TestMathUtils;
+import org.h2.test.unit.TestMemoryUnmapper;
 import org.h2.test.unit.TestMode;
 import org.h2.test.unit.TestModifyOnWrite;
 import org.h2.test.unit.TestNetUtils;
@@ -960,6 +961,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestIntIntHashMap());
         addTest(new TestIntPerfectHash());
         addTest(new TestMathUtils());
+        addTest(new TestMemoryUnmapper());
         addTest(new TestMode());
         addTest(new TestObjectDeserialization());
         addTest(new TestOverflow());

--- a/h2/src/test/org/h2/test/unit/TestMemoryUnmapper.java
+++ b/h2/src/test/org/h2/test/unit/TestMemoryUnmapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.test.unit;
+
+import java.lang.ProcessBuilder.Redirect;
+import java.nio.ByteBuffer;
+
+import org.h2.test.TestBase;
+import org.h2.util.MemoryUnmapper;
+
+/**
+ * Tests memory unmapper.
+ */
+public class TestMemoryUnmapper extends TestBase {
+    private static final int OK = 0, /* EXCEPTION = 1, */ UNAVAILABLE = 2;
+
+    /**
+     * May be used to run only this test and may be launched by this test in a
+     * subprocess.
+     *
+     * @param a
+     *            if empty run this test only
+     */
+    public static void main(String... a) throws Exception {
+        if (a.length == 0) {
+            TestBase.createCaller().init().test();
+        } else {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(10);
+            System.exit(MemoryUnmapper.unmap(buffer) ? OK : UNAVAILABLE);
+        }
+    }
+
+    @Override
+    public void test() throws Exception {
+        ProcessBuilder pb = new ProcessBuilder().redirectError(Redirect.INHERIT);
+        // Test that unsafe unmapping is disabled by default
+        pb.command(getJVM(), "-cp", getClassPath(), "-ea", getClass().getName(), "dummy");
+        assertEquals(UNAVAILABLE, pb.start().waitFor());
+        // Test that it can be enabled
+        pb.command(getJVM(), "-cp", getClassPath(), "-ea", "-Dh2.nioCleanerHack=true", getClass().getName(), "dummy");
+        assertEquals(OK, pb.start().waitFor());
+        // Test that it will not be enabled with a security manager
+        pb.command(getJVM(), "-cp", getClassPath(), "-ea", "-Djava.security.manager", "-Dh2.nioCleanerHack=true",
+                getClass().getName(), "dummy");
+        assertEquals(UNAVAILABLE, pb.start().waitFor());
+    }
+
+}


### PR DESCRIPTION
Since Java 9 old unsafe way to free `MappedByteBuffer` memory does not work anymore. An alternative was added in [JDK-8171377](https://bugs.openjdk.java.net/browse/JDK-8171377) that also requires unsafe access because such unmapping is dangerous.

Availability of special method from Java 9/10/11/… is checked once, if it is available it will be used later. If this method is not available an old way for Java 7/8 is used.

@andreitokar
Please adjust code in your branch too to make it usable on modern Java versions.

I did not introduce complete cleaner here because way with garbage collection relies too much on reachability of variables. Usually Java allows garbage collection of objects stored in local variables that are not read in remaining part of the method, but I'm not sure that it works with parameters too.