### PR TITLE
Treat NEXTVAL as an auto-generated key

### DIFF
--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -23,7 +23,6 @@ import org.h2.expression.ConditionAndOr;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.expression.Parameter;
-import org.h2.expression.SequenceValue;
 import org.h2.expression.ValueExpression;
 import org.h2.index.Index;
 import org.h2.index.PageDataIndex;
@@ -170,7 +169,7 @@ public class Insert extends Prepared implements ResultTarget {
                         try {
                             Value v = c.convert(e.getValue(session), mode);
                             newRow.setValue(index, v);
-                            if (e instanceof SequenceValue) {
+                            if (e.isGeneratedKey()) {
                                 generatedKeys.add(c);
                             }
                         } catch (DbException ex) {

--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -19,7 +19,6 @@ import org.h2.engine.Session;
 import org.h2.engine.UndoLogRecord;
 import org.h2.expression.Expression;
 import org.h2.expression.Parameter;
-import org.h2.expression.SequenceValue;
 import org.h2.index.Index;
 import org.h2.message.DbException;
 import org.h2.result.ResultInterface;
@@ -108,7 +107,7 @@ public class Merge extends Prepared {
                         try {
                             Value v = c.convert(e.getValue(session), mode);
                             newRow.setValue(index, v);
-                            if (e instanceof SequenceValue) {
+                            if (e.isGeneratedKey()) {
                                 generatedKeys.add(c);
                             }
                         } catch (DbException ex) {

--- a/h2/src/main/org/h2/expression/Expression.java
+++ b/h2/src/main/org/h2/expression/Expression.java
@@ -167,6 +167,16 @@ public abstract class Expression {
     }
 
     /**
+     * Check if this expression is an auto-generated key expression such as next
+     * value from a sequence.
+     *
+     * @return whether this expression is an auto-generated key expression
+     */
+    public boolean isGeneratedKey() {
+        return false;
+    }
+
+    /**
      * Get the value in form of a boolean expression.
      * Returns true or false.
      * In this database, everything can be a condition.

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -2692,4 +2692,9 @@ public class Function extends Expression implements FunctionCall {
         return info.bufferResultSetToLocalTemp;
     }
 
+    @Override
+    public boolean isGeneratedKey() {
+        return info.type == NEXTVAL;
+    }
+
 }

--- a/h2/src/main/org/h2/expression/SequenceValue.java
+++ b/h2/src/main/org/h2/expression/SequenceValue.java
@@ -106,4 +106,9 @@ public class SequenceValue extends Expression {
         return 1;
     }
 
+    @Override
+    public boolean isGeneratedKey() {
+        return true;
+    }
+
 }


### PR DESCRIPTION
A fix for additional issue reported in https://github.com/h2database/h2database/issues/1052#issuecomment-406851590

There is also a `CURRVAL()` function that does not increment a sequence but only uses its current value. I have no idea should result of this function be treated as an auto-generated key or not. @grandinj, may be you have some opinion about it?