### PR TITLE
Do not add rows before OFFSET to result if possible

### DIFF
--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -639,7 +639,7 @@ public class Select extends Query {
 
     private LazyResult queryFlat(int columnCount, ResultTarget result, long offset, long limitRows, boolean withTies,
             boolean quickOffset) {
-        if (limitRows > 0 && offset > 0) {
+        if (limitRows > 0 && offset > 0 && !quickOffset) {
             limitRows += offset;
             if (limitRows < 0) {
                 // Overflow
@@ -654,7 +654,7 @@ public class Select extends Query {
         if (result == null) {
             return lazyResult;
         }
-        if (sort != null && !sortUsingIndex || limitRows <= 0 || withTies) {
+        if (sort != null && !sortUsingIndex || limitRows < 0 || withTies) {
             limitRows = Long.MAX_VALUE;
         }
         while (result.getRowCount() < limitRows && lazyResult.next()) {
@@ -726,6 +726,7 @@ public class Select extends Query {
                 !session.getDatabase().getSettings().optimizeInsertFromSelect)) {
             result = createLocalResult(result);
         }
+        // Do not add rows before OFFSET to result if possible
         boolean quickOffset = true;
         if (sort != null && (!sortUsingIndex || isAnyDistinct() || withTies)) {
             result = createLocalResult(result);

--- a/h2/src/test/org/h2/test/scripts/dml/select.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/select.sql
@@ -148,3 +148,18 @@ SELECT A, B FROM TEST ORDER  BY A FETCH FIRST 1 ROW WITH TIES;
 
 DROP TABLE TEST;
 > ok
+
+CREATE TABLE TEST(A INT, B INT);
+> ok
+
+INSERT INTO TEST VALUES (1, 1), (1, 2), (2, 1), (2, 2), (2, 3);
+> update count: 5
+
+SELECT A, COUNT(B) FROM TEST GROUP BY A OFFSET 1;
+> A COUNT(B)
+> - --------
+> 2 3
+> rows: 1
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
If query [is not sorted or sorted by index] and [not distinct or distinct by index] there is no reason to add rows before `OFFSET` to `LocalResult`. This improves speed of some queries with large offsets.

With these changes 64-bit offsets are also supported in such queries. I tested it with 5,000,000,000 rows. It took 10 minutes on my system, but at least it works.