### PR TITLE
Optimize WITH TIES in some queries and specify data types for KEY_COLUMN_USAGE

### DIFF
--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -268,6 +268,11 @@ public class Insert extends Prepared implements ResultTarget {
     }
 
     @Override
+    public void limitsWereApplied() {
+        // Nothing to do
+    }
+
+    @Override
     public String getPlanSQL() {
         StatementBuilder buff = new StatementBuilder("INSERT INTO ");
         buff.append(table.getSQL()).append('(');

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -677,6 +677,7 @@ public class Select extends Query {
                 }
                 result.addRow(row);
             }
+            result.limitsWereApplied();
         }
         if (forUpdateRows != null) {
             topTableFilter.lockRows(forUpdateRows);

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -42,6 +42,7 @@ public class LocalResult implements ResultInterface, ResultTarget {
     private int offset;
     private int limit = -1;
     private boolean withTies;
+    private boolean limitsWereApplied;
     private ResultExternal external;
     private boolean distinct;
     private int[] distinctIndexes;
@@ -381,6 +382,9 @@ public class LocalResult implements ResultInterface, ResultTarget {
     }
 
     private void applyOffsetAndLimit() {
+        if (limitsWereApplied) {
+            return;
+        }
         int offset = Math.max(this.offset, 0);
         int limit = this.limit;
         if (offset == 0 && limit < 0 || rowCount == 0) {
@@ -459,6 +463,11 @@ public class LocalResult implements ResultInterface, ResultTarget {
     @Override
     public int getRowCount() {
         return rowCount;
+    }
+
+    @Override
+    public void limitsWereApplied() {
+        this.limitsWereApplied = true;
     }
 
     @Override

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -411,8 +411,10 @@ public class LocalResult implements ResultInterface, ResultTarget {
                     rowCount++;
                 }
             }
-            // avoid copying the whole array for each row
-            rows = new ArrayList<>(rows.subList(offset, to));
+            if (offset != 0 || to != rows.size()) {
+                // avoid copying the whole array for each row
+                rows = new ArrayList<>(rows.subList(offset, to));
+            }
         } else {
             if (clearAll) {
                 external.close();

--- a/h2/src/main/org/h2/result/ResultTarget.java
+++ b/h2/src/main/org/h2/result/ResultTarget.java
@@ -26,4 +26,11 @@ public interface ResultTarget {
      */
     int getRowCount();
 
+    /**
+     * A hint that offset and limit may be ignored by this result because they
+     * were applied during the query. This is useful for WITH TIES clause
+     * because result may contain tied rows above limit.
+     */
+    void limitsWereApplied();
+
 }

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -590,8 +590,8 @@ public class MetaTable extends Table {
                     "TABLE_SCHEMA",
                     "TABLE_NAME",
                     "COLUMN_NAME",
-                    "ORDINAL_POSITION",
-                    "POSITION_IN_UNIQUE_CONSTRAINT"
+                    "ORDINAL_POSITION INT",
+                    "POSITION_IN_UNIQUE_CONSTRAINT INT"
             );
             indexColumnName = "TABLE_NAME";
             break;


### PR DESCRIPTION
1. Integer columns in `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` now have proper data type.
2. Optimize `Select.queryFlat()` for `WITH TIES` when select is compatible with “quick offset”. Read only tied rows after limit and stop when the next row is not tied.