### PR TITLE
Change MVSecondaryIndex uniqueness check

### DIFF
--- a/h2/src/main/org/h2/expression/Comparison.java
+++ b/h2/src/main/org/h2/expression/Comparison.java
@@ -465,12 +465,16 @@ public class Comparison extends Condition {
         }
         if (addIndex) {
             if (l != null) {
-                filter.addIndexCondition(
-                        IndexCondition.get(compareType, l, right));
+                if (l.getType() == right.getType() || right.getType() != Value.STRING_IGNORECASE) {
+                    filter.addIndexCondition(
+                            IndexCondition.get(compareType, l, right));
+                }
             } else if (r != null) {
-                int compareRev = getReversedCompareType(compareType);
-                filter.addIndexCondition(
-                        IndexCondition.get(compareRev, r, left));
+                if (r.getType() == left.getType() || left.getType() != Value.STRING_IGNORECASE) {
+                    int compareRev = getReversedCompareType(compareType);
+                    filter.addIndexCondition(
+                            IndexCondition.get(compareRev, r, left));
+                }
             }
         }
     }

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -199,7 +199,7 @@ public class ExpressionColumn extends Expression {
 
     @Override
     public int getType() {
-        return column.getType();
+        return column == null ? Value.UNKNOWN : column.getType();
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
@@ -60,7 +60,7 @@ class MVPlainTempResult extends MVTempResult {
      */
     MVPlainTempResult(Database database, Expression[] expressions, int visibleColumnCount) {
         super(database, expressions.length, visibleColumnCount);
-        ValueDataType valueType = new ValueDataType(database.getCompareMode(), database, new int[columnCount]);
+        ValueDataType valueType = new ValueDataType(database, new int[columnCount]);
         Builder<Long, ValueArray> builder = new MVMap.Builder<Long, ValueArray>()
                                                 .valueType(valueType).singleWriter();
         map = store.openMap("tmp", builder);

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -51,9 +51,8 @@ public class MVPrimaryIndex extends BaseIndex {
         for (int i = 0; i < columns.length; i++) {
             sortTypes[i] = SortOrder.ASCENDING;
         }
-        ValueDataType keyType = new ValueDataType(null, null, null);
-        ValueDataType valueType = new ValueDataType(db.getCompareMode(), db,
-                sortTypes);
+        ValueDataType keyType = ValueDataType.INSTANCE;
+        ValueDataType valueType = new ValueDataType(db, sortTypes);
         mapName = "table." + getId();
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(mapName, keyType, valueType);

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -51,7 +51,7 @@ public class MVPrimaryIndex extends BaseIndex {
         for (int i = 0; i < columns.length; i++) {
             sortTypes[i] = SortOrder.ASCENDING;
         }
-        ValueDataType keyType = ValueDataType.INSTANCE;
+        ValueDataType keyType = new ValueDataType();
         ValueDataType valueType = new ValueDataType(db, sortTypes);
         mapName = "table." + getId();
         Transaction t = mvTable.getTransactionBegin();

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -267,7 +267,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         return new MVStoreCursor(session, map.keyIterator(min, max, false));
     }
 
-    private ValueArray convertToKey(ValueArray r, Boolean minmax) {
+    private static ValueArray convertToKey(ValueArray r, Boolean minmax) {
         if (r == null) {
             return null;
         }

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -63,7 +63,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         }
         sortTypes[keyColumns - 1] = SortOrder.ASCENDING;
         ValueDataType keyType = new ValueDataType(db, sortTypes);
-        ValueDataType valueType = ValueDataType.INSTANCE;
+        ValueDataType valueType = new ValueDataType();
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(mapName, keyType, valueType);
         dataMap.map.setVolatile(!indexType.isPersistent());
@@ -162,7 +162,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         }
         sortTypes[keyColumns - 1] = SortOrder.ASCENDING;
         ValueDataType keyType = new ValueDataType(database, sortTypes);
-        ValueDataType valueType = ValueDataType.INSTANCE;
+        ValueDataType valueType = new ValueDataType();
         MVMap.Builder<ValueArray, Value> builder =
                 new MVMap.Builder<ValueArray, Value>()
                         .singleWriter()

--- a/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSortedTempResult.java
@@ -166,12 +166,12 @@ class MVSortedTempResult extends MVTempResult {
             indexes = null;
         }
         this.indexes = indexes;
-        ValueDataType keyType = new ValueDataType(database.getCompareMode(), database, sortTypes);
+        ValueDataType keyType = new ValueDataType(database, sortTypes);
         Builder<ValueArray, Long> builder = new MVMap.Builder<ValueArray, Long>().keyType(keyType);
         map = store.openMap("tmp", builder);
         if (distinct && length != visibleColumnCount || distinctIndexes != null) {
             int count = distinctIndexes != null ? distinctIndexes.length : visibleColumnCount;
-            ValueDataType distinctType = new ValueDataType(database.getCompareMode(), database, new int[count]);
+            ValueDataType distinctType = new ValueDataType(database, new int[count]);
             Builder<ValueArray, Boolean> indexBuilder = new MVMap.Builder<ValueArray, Boolean>().keyType(distinctType);
             index = store.openMap("idx", indexBuilder);
         }

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -93,7 +93,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
             checkIndexColumnTypes(columns);
         }
         String mapName = "index." + getId();
-        ValueDataType vt = new ValueDataType(null, null, null);
+        ValueDataType vt = new ValueDataType(db, null);
         VersionedValue.Type valueType = new VersionedValue.Type(vt);
         MVRTreeMap.Builder<VersionedValue> mapBuilder =
                 new MVRTreeMap.Builder<VersionedValue>().

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -160,9 +160,8 @@ public class MVTableEngine implements TableEngine {
                 if (!db.getSettings().reuseSpace) {
                     store.setReuseSpace(false);
                 }
-                this.transactionStore = new TransactionStore(
-                        store,
-                        new ValueDataType(db.getCompareMode(), db, null), db.getLockTimeout());
+                this.transactionStore = new TransactionStore(store,
+                        new ValueDataType(db, null), db.getLockTimeout());
             } catch (IllegalStateException e) {
                 throw convertIllegalStateException(e);
             }

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -158,9 +158,15 @@ public class ValueDataType implements DataType {
         }
 
         int t2 = Value.getHigherOrder(a.getType(), b.getType());
-        String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(a, b);
-        int comp = a.convertTo(t2, -1, mode, null, enumerators)
-                .compareTypeSafe(b.convertTo(t2, -1, mode, null, enumerators), compareMode);
+        if (t2 == Value.ENUM) {
+            String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(a, b);
+            a = a.convertToEnum(enumerators);
+            b = b.convertToEnum(enumerators);
+        } else {
+            a = a.convertTo(t2, -1, mode);
+            b = b.convertTo(t2, -1, mode);
+        }
+        int comp = a.compareTypeSafe(b, compareMode);
 
         if ((sortType & SortOrder.DESCENDING) != 0) {
             comp = -comp;

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -81,8 +81,9 @@ public class ValueDataType implements DataType {
     final int[] sortTypes;
     SpatialDataType spatialType;
 
-    public static ValueDataType INSTANCE =
-                new ValueDataType(CompareMode.getInstance(null, 0), Mode.getRegular(), null, null);
+    public ValueDataType() {
+        this(CompareMode.getInstance(null, 0), Mode.getRegular(), null, null);
+    }
 
     public ValueDataType(Database database, int[] sortTypes) {
         this(database.getCompareMode(), database.getMode(), database, sortTypes);

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -12,6 +12,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Objects;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Database;
 import org.h2.engine.Mode;
@@ -80,7 +81,8 @@ public class ValueDataType implements DataType {
     final int[] sortTypes;
     SpatialDataType spatialType;
 
-    public static ValueDataType INSTANCE = new ValueDataType(null, Mode.getRegular(), null, null);
+    public static ValueDataType INSTANCE =
+                new ValueDataType(CompareMode.getInstance(null, 0), Mode.getRegular(), null, null);
 
     public ValueDataType(Database database, int[] sortTypes) {
         this(database.getCompareMode(), database.getMode(), database, sortTypes);

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -622,12 +622,8 @@ public class Recover extends Tool implements DataHandler {
                 }
                 String tableId = mapName.substring("table.".length());
                 if (Integer.parseInt(tableId) == 0) {
-                    ValueDataType keyType = new ValueDataType(
-                            null, this, null);
-                    ValueDataType valueType = new ValueDataType(
-                            null, this, null);
                     TransactionMap<Value, Value> dataMap = store.begin().openMap(
-                            mapName, keyType, valueType);
+                            mapName, ValueDataType.INSTANCE, ValueDataType.INSTANCE);
                     Iterator<Value> dataIt = dataMap.keyIterator(null);
                     while (dataIt.hasNext()) {
                         Value rowId = dataIt.next();
@@ -660,12 +656,8 @@ public class Recover extends Tool implements DataHandler {
                 if (Integer.parseInt(tableId) == 0) {
                     continue;
                 }
-                ValueDataType keyType = new ValueDataType(
-                        null, this, null);
-                ValueDataType valueType = new ValueDataType(
-                        null, this, null);
                 TransactionMap<Value, Value> dataMap = store.begin().openMap(
-                        mapName, keyType, valueType);
+                        mapName, ValueDataType.INSTANCE, ValueDataType.INSTANCE);
                 Iterator<Value> dataIt = dataMap.keyIterator(null);
                 boolean init = false;
                 while (dataIt.hasNext()) {

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -616,14 +616,14 @@ public class Recover extends Tool implements DataHandler {
         }
         try {
             // extract the metadata so we can dump the settings
+            ValueDataType type = new ValueDataType();
             for (String mapName : mv.getMapNames()) {
                 if (!mapName.startsWith("table.")) {
                     continue;
                 }
                 String tableId = mapName.substring("table.".length());
                 if (Integer.parseInt(tableId) == 0) {
-                    TransactionMap<Value, Value> dataMap = store.begin().openMap(
-                            mapName, ValueDataType.INSTANCE, ValueDataType.INSTANCE);
+                    TransactionMap<Value, Value> dataMap = store.begin().openMap(mapName, type, type);
                     Iterator<Value> dataIt = dataMap.keyIterator(null);
                     while (dataIt.hasNext()) {
                         Value rowId = dataIt.next();
@@ -656,8 +656,7 @@ public class Recover extends Tool implements DataHandler {
                 if (Integer.parseInt(tableId) == 0) {
                     continue;
                 }
-                TransactionMap<Value, Value> dataMap = store.begin().openMap(
-                        mapName, ValueDataType.INSTANCE, ValueDataType.INSTANCE);
+                TransactionMap<Value, Value> dataMap = store.begin().openMap(mapName, type, type);
                 Iterator<Value> dataIt = dataMap.keyIterator(null);
                 boolean init = false;
                 while (dataIt.hasNext()) {

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -2866,7 +2866,7 @@ CREATE TABLE TEST2(ID INT PRIMARY KEY, NAME VARCHAR(255));
 create unique index idx_test2_name on test2(name);
 > ok
 
-INSERT INTO TEST2 VALUES(1, 'HElLo');
+INSERT INTO TEST2 VALUES(1, 'hElLo');
 > update count: 1
 
 INSERT INTO TEST2 VALUES(2, 'World');
@@ -2886,7 +2886,7 @@ select * from test where name='HELLO';
 select * from test2 where name='HELLO';
 > ID NAME
 > -- -----
-> 1  HElLo
+> 1  hElLo
 > rows: 1
 
 select * from test where name like 'HELLO';
@@ -2897,26 +2897,26 @@ select * from test where name like 'HELLO';
 select * from test2 where name like 'HELLO';
 > ID NAME
 > -- -----
-> 1  HElLo
+> 1  hElLo
 > rows: 1
 
 explain plan for select * from test2, test where test2.name = test.name;
->> SELECT TEST2.ID, TEST2.NAME, TEST.ID, TEST.NAME FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ INNER JOIN PUBLIC.TEST /* PUBLIC.IDX_TEST_NAME: NAME = TEST2.NAME */ ON 1=1 WHERE TEST2.NAME = TEST.NAME
+>> SELECT TEST2.ID, TEST2.NAME, TEST.ID, TEST.NAME FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ INNER JOIN PUBLIC.TEST /* PUBLIC.TEST.tableScan */ ON 1=1 WHERE TEST2.NAME = TEST.NAME
 
 select * from test2, test where test2.name = test.name;
 > ID NAME  ID NAME
 > -- ----- -- -----
-> 1  HElLo 1  Hello
+> 1  hElLo 1  Hello
 > 2  World 2  World
 > rows: 2
 
 explain plan for select * from test, test2 where test2.name = test.name;
->> SELECT TEST.ID, TEST.NAME, TEST2.ID, TEST2.NAME FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ INNER JOIN PUBLIC.TEST /* PUBLIC.IDX_TEST_NAME: NAME = TEST2.NAME */ ON 1=1 WHERE TEST2.NAME = TEST.NAME
+>> SELECT TEST.ID, TEST.NAME, TEST2.ID, TEST2.NAME FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ INNER JOIN PUBLIC.TEST /* PUBLIC.TEST.tableScan */ ON 1=1 WHERE TEST2.NAME = TEST.NAME
 
 select * from test, test2 where test2.name = test.name;
 > ID NAME  ID NAME
 > -- ----- -- -----
-> 1  Hello 1  HElLo
+> 1  Hello 1  hElLo
 > 2  World 2  World
 > rows: 2
 
@@ -2924,12 +2924,12 @@ create index idx_test2_name on test2(name);
 > ok
 
 explain plan for select * from test2, test where test2.name = test.name;
->> SELECT TEST2.ID, TEST2.NAME, TEST.ID, TEST.NAME FROM PUBLIC.TEST2 /* PUBLIC.TEST2.tableScan */ INNER JOIN PUBLIC.TEST /* PUBLIC.IDX_TEST_NAME: NAME = TEST2.NAME */ ON 1=1 WHERE TEST2.NAME = TEST.NAME
+>> SELECT TEST2.ID, TEST2.NAME, TEST.ID, TEST.NAME FROM PUBLIC.TEST /* PUBLIC.TEST.tableScan */ INNER JOIN PUBLIC.TEST2 /* PUBLIC.IDX_TEST2_NAME: NAME = TEST.NAME */ ON 1=1 WHERE TEST2.NAME = TEST.NAME
 
 select * from test2, test where test2.name = test.name;
 > ID NAME  ID NAME
 > -- ----- -- -----
-> 1  HElLo 1  Hello
+> 1  hElLo 1  Hello
 > 2  World 2  World
 > rows: 2
 
@@ -2939,7 +2939,7 @@ explain plan for select * from test, test2 where test2.name = test.name;
 select * from test, test2 where test2.name = test.name;
 > ID NAME  ID NAME
 > -- ----- -- -----
-> 1  Hello 1  HElLo
+> 1  Hello 1  hElLo
 > 2  World 2  World
 > rows: 2
 


### PR DESCRIPTION
Fix for issue #1323 
Modify uniqueness check in MVSecondaryIndex to use upper-bounded cursor
Push upper bound check from MVStoreCursor down to underlying map cursor
Propagate database compatibility mode down to Value comparison operation
Disable index lookups in join optimization if index is case sensitive, but argument is not.
Modified test script to avoid coincidental success ('HElLo' < 'Hello')
