### PR TITLE
Force SYS_ID.ID index always to be a MVDelegateIndex

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -845,12 +845,9 @@ public class Database implements DataHandler {
     }
 
     private void handleUpgradeIssues() {
-        if (mvStore != null) {
+        if (mvStore != null && !isReadOnly()) {
             MVStore store = mvStore.getStore();
             if (store.hasMap("index.0")) {
-                if (isReadOnly()) {
-                    throw DbException.get(ErrorCode.GENERAL_ERROR_1, "Upgrade can not be performed while database is in R/O mode");
-                }
                 Index scanIndex = meta.getScanIndex(systemSession);
                 Cursor curs = scanIndex.find(systemSession, null, null);
                 List<Row> allMetaRows = new ArrayList<>();

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -844,9 +844,15 @@ public class Database implements DataHandler {
         }
     }
 
+
     private void handleUpgradeIssues() {
         if (mvStore != null && !isReadOnly()) {
             MVStore store = mvStore.getStore();
+            // Version 1.4.197 erroneously handles index on SYS_ID.ID as secondary
+            // and does not delegate to scan index as it should.
+            // This code will try to fix that by converging ROW_ID and ID,
+            // since they may have got out of sync, and by removing map "index.0",
+            // which corresponds to a secondary index.
             if (store.hasMap("index.0")) {
                 Index scanIndex = meta.getScanIndex(systemSession);
                 Cursor curs = scanIndex.find(systemSession, null, null);

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -506,12 +506,15 @@ public class MVTable extends TableBase {
         int mainIndexColumn = primaryIndex.getMainIndexColumn() != SearchRow.ROWID_INDEX
                 ? SearchRow.ROWID_INDEX : getMainIndexColumn(indexType, cols);
         if (database.isStarting()) {
-            if (transactionStore.hasMap("index." + indexId)) {
+            // if this is not "SYS_ID" table and index does exists as a separate map
+            if (indexId != 0 && transactionStore.hasMap("index." + indexId)) {
+                // we can not reuse primary index
                 mainIndexColumn = SearchRow.ROWID_INDEX;
             }
         } else if (primaryIndex.getRowCountMax() != 0) {
             mainIndexColumn = SearchRow.ROWID_INDEX;
         }
+
         if (mainIndexColumn != SearchRow.ROWID_INDEX) {
             primaryIndex.setMainIndexColumn(mainIndexColumn);
             index = new MVDelegateIndex(this, indexId, indexName, primaryIndex,

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -507,7 +507,7 @@ public class MVTable extends TableBase {
                 ? SearchRow.ROWID_INDEX : getMainIndexColumn(indexType, cols);
         if (database.isStarting()) {
             // if this is not "SYS_ID" table and index does exists as a separate map
-            if (indexId != 0 && transactionStore.hasMap("index." + indexId)) {
+            if (transactionStore.hasMap("index." + indexId)) {
                 // we can not reuse primary index
                 mainIndexColumn = SearchRow.ROWID_INDEX;
             }

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -507,7 +507,7 @@ public class MVTable extends TableBase {
                 ? SearchRow.ROWID_INDEX : getMainIndexColumn(indexType, cols);
         if (database.isStarting()) {
             // if this is not "SYS_ID" table and index does exists as a separate map
-            if (transactionStore.hasMap("index." + indexId)) {
+            if (indexId != 0 && transactionStore.hasMap("index." + indexId)) {
                 // we can not reuse primary index
                 mainIndexColumn = SearchRow.ROWID_INDEX;
             }

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -506,8 +506,8 @@ public class MVTable extends TableBase {
         int mainIndexColumn = primaryIndex.getMainIndexColumn() != SearchRow.ROWID_INDEX
                 ? SearchRow.ROWID_INDEX : getMainIndexColumn(indexType, cols);
         if (database.isStarting()) {
-            // if this is not "SYS_ID" table and index does exists as a separate map
-            if (indexId != 0 && transactionStore.hasMap("index." + indexId)) {
+            // if index does exists as a separate map it can't be a delegate
+            if (transactionStore.hasMap("index." + indexId)) {
                 // we can not reuse primary index
                 mainIndexColumn = SearchRow.ROWID_INDEX;
             }


### PR DESCRIPTION
This PR fixes issue#1331
Attempt to create primary index SYS_ID.ID should be treated as a special case, because in version 1.4.197 this index is mistakenly created as a secondary index and therefore map "index.0" will be there after upgrade. Normally, this would indicate secondary index, not delegation to scan index.
This is also the case with other tables as well, where scan index could have been re-used as primary, but it's hard to discern such cases from plain unique secondary indexes.