### PR TITLE
Minor refactorings

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -56,11 +56,8 @@ public class MVPrimaryIndex extends BaseIndex {
         mapName = "table." + getId();
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(mapName, keyType, valueType);
-        dataMap.map.setVolatile(!indexType.isPersistent());
+        dataMap.map.setVolatile(!table.isPersistData() || !indexType.isPersistent());
         t.commit();
-        if (!table.isPersistData() || !indexType.isPersistent()) {
-            dataMap.map.setVolatile(true);
-        }
         Value k = dataMap.map.lastKey();    // include uncommitted keys as well
         lastKey.set(k == null ? 0 : k.getLong());
     }

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -66,7 +66,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         ValueDataType valueType = new ValueDataType();
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(mapName, keyType, valueType);
-        dataMap.map.setVolatile(!indexType.isPersistent());
+        dataMap.map.setVolatile(!table.isPersistData() || !indexType.isPersistent());
         t.commit();
         if (!keyType.equals(dataMap.getKeyType())) {
             throw DbException.throwInternalError(

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -142,15 +142,8 @@ public class MVTable extends TableBase {
         }
         containsLargeObject = b;
         traceLock = database.getTrace(Trace.LOCK);
-    }
 
-    /**
-     * Initialize the table.
-     *
-     * @param session the session
-     */
-    void init(Session session) {
-        primaryIndex = new MVPrimaryIndex(session.getDatabase(), this, getId(),
+        primaryIndex = new MVPrimaryIndex(database, this, getId(),
                 IndexColumn.wrap(getColumns()), IndexType.createScan(true));
         indexes.add(primaryIndex);
     }

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -221,7 +221,6 @@ public class MVTableEngine implements TableEngine {
          */
         public MVTable createTable(CreateTableData data) {
             MVTable table = new MVTable(data, this);
-            table.init(data.session);
             tableMap.put(table.getMapName(), table);
             return table;
         }


### PR DESCRIPTION
consistently set volatile on all indexes
move to MVSpartial.MVStoreCursor and inline getRow(), make inner class static
inline MVTable.init()
remove unused relativeKey()
move to TMIterator and inline getValue()