### PR TITLE
Streamline Value comparison

### DIFF
--- a/h2/src/main/org/h2/expression/Comparison.java
+++ b/h2/src/main/org/h2/expression/Comparison.java
@@ -271,15 +271,19 @@ public class Comparison extends Condition {
                 return ValueNull.INSTANCE;
             }
         }
-        int dataType = Value.getHigherOrder(left.getType(), right.getType());
-        if (dataType == Value.ENUM) {
-            String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(l, r);
-            l = l.convertToEnum(enumerators);
-            r = r.convertToEnum(enumerators);
-        } else {
-            Mode mode = database.getMode();
-            l = l.convertTo(dataType, -1, mode);
-            r = r.convertTo(dataType, -1, mode);
+        int leftType = left.getType();
+        int rightType = right.getType();
+        if (leftType != rightType || leftType == Value.ENUM) {
+            int dataType = Value.getHigherOrder(leftType, rightType);
+            if (dataType == Value.ENUM) {
+                String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(l, r);
+                l = l.convertToEnum(enumerators);
+                r = r.convertToEnum(enumerators);
+            } else {
+                Mode mode = database.getMode();
+                l = l.convertTo(dataType, -1, mode);
+                r = r.convertTo(dataType, -1, mode);
+            }
         }
         boolean result = compareNotNull(database, l, r, compareType);
         return ValueBoolean.get(result);

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -142,29 +142,23 @@ public class ValueDataType implements DataType {
         if (a == b) {
             return 0;
         }
-        // null is never stored;
-        // comparison with null is used to retrieve all entries
-        // in which case null is always lower than all entries
-        // (even for descending ordered indexes)
-        if (a == null) {
-            return -1;
-        } else if (b == null) {
-            return 1;
-        }
         boolean aNull = a == ValueNull.INSTANCE;
-        boolean bNull = b == ValueNull.INSTANCE;
-        if (aNull || bNull) {
+        if (aNull || b == ValueNull.INSTANCE) {
             return SortOrder.compareNull(aNull, sortType);
         }
 
-        int t2 = Value.getHigherOrder(a.getType(), b.getType());
-        if (t2 == Value.ENUM) {
-            String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(a, b);
-            a = a.convertToEnum(enumerators);
-            b = b.convertToEnum(enumerators);
-        } else {
-            a = a.convertTo(t2, -1, mode);
-            b = b.convertTo(t2, -1, mode);
+        int aType = a.getType();
+        int bType = b.getType();
+        if (aType != bType || aType == Value.ENUM) {
+            int t2 = Value.getHigherOrder(aType, bType);
+            if (t2 == Value.ENUM) {
+                String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(a, b);
+                a = a.convertToEnum(enumerators);
+                b = b.convertToEnum(enumerators);
+            } else {
+                a = a.convertTo(t2, -1, mode);
+                b = b.convertTo(t2, -1, mode);
+            }
         }
         int comp = a.compareTypeSafe(b, compareMode);
 

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -1213,15 +1213,19 @@ public abstract class Table extends SchemaObjectBase {
         if (a == b) {
             return 0;
         }
-        int dataType = Value.getHigherOrder(a.getType(), b.getType());
-        if (dataType == Value.ENUM) {
-            String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(a, b);
-            a = a.convertToEnum(enumerators);
-            b = b.convertToEnum(enumerators);
-        } else {
-            Mode mode = database.getMode();
-            a = a.convertTo(dataType, -1, mode);
-            b = b.convertTo(dataType, -1, mode);
+        int aType = a.getType();
+        int bType = b.getType();
+        if (aType != bType || aType == Value.ENUM) {
+            int dataType = Value.getHigherOrder(aType, bType);
+            if (dataType == Value.ENUM) {
+                String[] enumerators = ValueEnum.getEnumeratorsForBinaryOperation(a, b);
+                a = a.convertToEnum(enumerators);
+                b = b.convertToEnum(enumerators);
+            } else {
+                Mode mode = database.getMode();
+                a = a.convertTo(dataType, -1, mode);
+                b = b.convertTo(dataType, -1, mode);
+            }
         }
         return a.compareTypeSafe(b, compareMode);
     }

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -1161,13 +1161,6 @@ public abstract class Value {
      *         1 otherwise
      */
     public final int compareTypeSafe(Value v, CompareMode mode) {
-        if (this == v) {
-            return 0;
-        } else if (this == ValueNull.INSTANCE) {
-            return -1;
-        } else if (v == ValueNull.INSTANCE) {
-            return 1;
-        }
         return compareSecure(v, mode);
     }
 


### PR DESCRIPTION
Eliminate redundant attempts for type conversions.
Avoid null and ValueNull.INSTANCE handling at lower levels when it's been already taken care of by the caller.