### PR TITLE
Add support of TIMESTAMP WITH TIME ZONE to addition and subtraction operators

### DIFF
--- a/h2/src/main/org/h2/expression/Operation.java
+++ b/h2/src/main/org/h2/expression/Operation.java
@@ -216,9 +216,7 @@ public class Operation extends Expression {
                 } else {
                     dataType = Value.DECIMAL;
                 }
-            } else if (l == Value.DATE || l == Value.TIMESTAMP ||
-                    l == Value.TIME || r == Value.DATE ||
-                    r == Value.TIMESTAMP || r == Value.TIME) {
+            } else if (DataType.isDateTimeType(l) || DataType.isDateTimeType(r)) {
                 switch (opType) {
                 case PLUS:
                     if (r != Value.getHigherOrder(l, r)) {
@@ -252,10 +250,10 @@ public class Operation extends Expression {
                         return f.optimize(session);
                     }
                     case Value.TIME:
-                        if (r == Value.TIME) {
-                            dataType = Value.TIME;
+                        if (r == Value.TIME || r == Value.TIMESTAMP_TZ) {
+                            dataType = r;
                             return this;
-                        } else {
+                        } else { // DATE, TIMESTAMP
                             dataType = Value.TIMESTAMP;
                             return this;
                         }
@@ -265,6 +263,7 @@ public class Operation extends Expression {
                     switch (l) {
                     case Value.DATE:
                     case Value.TIMESTAMP:
+                    case Value.TIMESTAMP_TZ:
                         switch (r) {
                         case Value.INT: {
                             // Oracle date subtract
@@ -296,7 +295,8 @@ public class Operation extends Expression {
                             dataType = Value.TIMESTAMP;
                             return this;
                         case Value.DATE:
-                        case Value.TIMESTAMP: {
+                        case Value.TIMESTAMP:
+                        case Value.TIMESTAMP_TZ: {
                             // Oracle date subtract
                             Function f = Function.getFunction(session.getDatabase(), "DATEDIFF");
                             f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));

--- a/h2/src/main/org/h2/expression/Operation.java
+++ b/h2/src/main/org/h2/expression/Operation.java
@@ -217,129 +217,7 @@ public class Operation extends Expression {
                     dataType = Value.DECIMAL;
                 }
             } else if (DataType.isDateTimeType(l) || DataType.isDateTimeType(r)) {
-                switch (opType) {
-                case PLUS:
-                    if (r != Value.getHigherOrder(l, r)) {
-                        // order left and right: INT < TIME < DATE < TIMESTAMP
-                        swap();
-                        int t = l;
-                        l = r;
-                        r = t;
-                    }
-                    switch (l) {
-                    case Value.INT: {
-                        // Oracle date add
-                        Function f = Function.getFunction(session.getDatabase(), "DATEADD");
-                        f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));
-                        f.setParameter(1, left);
-                        f.setParameter(2, right);
-                        f.doneWithParameters();
-                        return f.optimize(session);
-                    }
-                    case Value.DECIMAL:
-                    case Value.FLOAT:
-                    case Value.DOUBLE: {
-                        // Oracle date add
-                        Function f = Function.getFunction(session.getDatabase(), "DATEADD");
-                        f.setParameter(0, ValueExpression.get(ValueString.get("SECOND")));
-                        left = new Operation(OpType.MULTIPLY, ValueExpression.get(ValueInt
-                                .get(60 * 60 * 24)), left);
-                        f.setParameter(1, left);
-                        f.setParameter(2, right);
-                        f.doneWithParameters();
-                        return f.optimize(session);
-                    }
-                    case Value.TIME:
-                        if (r == Value.TIME || r == Value.TIMESTAMP_TZ) {
-                            dataType = r;
-                            return this;
-                        } else { // DATE, TIMESTAMP
-                            dataType = Value.TIMESTAMP;
-                            return this;
-                        }
-                    }
-                    break;
-                case MINUS:
-                    switch (l) {
-                    case Value.DATE:
-                    case Value.TIMESTAMP:
-                    case Value.TIMESTAMP_TZ:
-                        switch (r) {
-                        case Value.INT: {
-                            // Oracle date subtract
-                            Function f = Function.getFunction(session.getDatabase(), "DATEADD");
-                            f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));
-                            right = new Operation(OpType.NEGATE, right, null);
-                            right = right.optimize(session);
-                            f.setParameter(1, right);
-                            f.setParameter(2, left);
-                            f.doneWithParameters();
-                            return f.optimize(session);
-                        }
-                        case Value.DECIMAL:
-                        case Value.FLOAT:
-                        case Value.DOUBLE: {
-                            // Oracle date subtract
-                            Function f = Function.getFunction(session.getDatabase(), "DATEADD");
-                            f.setParameter(0, ValueExpression.get(ValueString.get("SECOND")));
-                            right = new Operation(OpType.MULTIPLY, ValueExpression.get(ValueInt
-                                    .get(60 * 60 * 24)), right);
-                            right = new Operation(OpType.NEGATE, right, null);
-                            right = right.optimize(session);
-                            f.setParameter(1, right);
-                            f.setParameter(2, left);
-                            f.doneWithParameters();
-                            return f.optimize(session);
-                        }
-                        case Value.TIME:
-                            dataType = Value.TIMESTAMP;
-                            return this;
-                        case Value.DATE:
-                        case Value.TIMESTAMP:
-                        case Value.TIMESTAMP_TZ: {
-                            // Oracle date subtract
-                            Function f = Function.getFunction(session.getDatabase(), "DATEDIFF");
-                            f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));
-                            f.setParameter(1, right);
-                            f.setParameter(2, left);
-                            f.doneWithParameters();
-                            return f.optimize(session);
-                        }
-                        }
-                        break;
-                    case Value.TIME:
-                        if (r == Value.TIME) {
-                            dataType = Value.TIME;
-                            return this;
-                        }
-                        break;
-                    }
-                    break;
-                case MULTIPLY:
-                    if (l == Value.TIME) {
-                        dataType = Value.TIME;
-                        convertRight = false;
-                        return this;
-                    } else if (r == Value.TIME) {
-                        swap();
-                        dataType = Value.TIME;
-                        convertRight = false;
-                        return this;
-                    }
-                    break;
-                case DIVIDE:
-                    if (l == Value.TIME) {
-                        dataType = Value.TIME;
-                        convertRight = false;
-                        return this;
-                    }
-                    break;
-                default:
-                }
-                throw DbException.getUnsupportedException(
-                        DataType.getDataType(l).name + " " +
-                        getOperationToken() + " " +
-                        DataType.getDataType(r).name);
+                return optimizeDateTime(session, l, r);
             } else {
                 dataType = Value.getHigherOrder(l, r);
                 if (dataType == Value.ENUM) {
@@ -357,6 +235,132 @@ public class Operation extends Expression {
             return ValueExpression.get(getValue(session));
         }
         return this;
+    }
+
+    private Expression optimizeDateTime(Session session, int l, int r) {
+        switch (opType) {
+        case PLUS:
+            if (r != Value.getHigherOrder(l, r)) {
+                // order left and right: INT < TIME < DATE < TIMESTAMP
+                swap();
+                int t = l;
+                l = r;
+                r = t;
+            }
+            switch (l) {
+            case Value.INT: {
+                // Oracle date add
+                Function f = Function.getFunction(session.getDatabase(), "DATEADD");
+                f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));
+                f.setParameter(1, left);
+                f.setParameter(2, right);
+                f.doneWithParameters();
+                return f.optimize(session);
+            }
+            case Value.DECIMAL:
+            case Value.FLOAT:
+            case Value.DOUBLE: {
+                // Oracle date add
+                Function f = Function.getFunction(session.getDatabase(), "DATEADD");
+                f.setParameter(0, ValueExpression.get(ValueString.get("SECOND")));
+                left = new Operation(OpType.MULTIPLY, ValueExpression.get(ValueInt
+                        .get(60 * 60 * 24)), left);
+                f.setParameter(1, left);
+                f.setParameter(2, right);
+                f.doneWithParameters();
+                return f.optimize(session);
+            }
+            case Value.TIME:
+                if (r == Value.TIME || r == Value.TIMESTAMP_TZ) {
+                    dataType = r;
+                    return this;
+                } else { // DATE, TIMESTAMP
+                    dataType = Value.TIMESTAMP;
+                    return this;
+                }
+            }
+            break;
+        case MINUS:
+            switch (l) {
+            case Value.DATE:
+            case Value.TIMESTAMP:
+            case Value.TIMESTAMP_TZ:
+                switch (r) {
+                case Value.INT: {
+                    // Oracle date subtract
+                    Function f = Function.getFunction(session.getDatabase(), "DATEADD");
+                    f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));
+                    right = new Operation(OpType.NEGATE, right, null);
+                    right = right.optimize(session);
+                    f.setParameter(1, right);
+                    f.setParameter(2, left);
+                    f.doneWithParameters();
+                    return f.optimize(session);
+                }
+                case Value.DECIMAL:
+                case Value.FLOAT:
+                case Value.DOUBLE: {
+                    // Oracle date subtract
+                    Function f = Function.getFunction(session.getDatabase(), "DATEADD");
+                    f.setParameter(0, ValueExpression.get(ValueString.get("SECOND")));
+                    right = new Operation(OpType.MULTIPLY, ValueExpression.get(ValueInt
+                            .get(60 * 60 * 24)), right);
+                    right = new Operation(OpType.NEGATE, right, null);
+                    right = right.optimize(session);
+                    f.setParameter(1, right);
+                    f.setParameter(2, left);
+                    f.doneWithParameters();
+                    return f.optimize(session);
+                }
+                case Value.TIME:
+                    dataType = Value.TIMESTAMP;
+                    return this;
+                case Value.DATE:
+                case Value.TIMESTAMP:
+                case Value.TIMESTAMP_TZ: {
+                    // Oracle date subtract
+                    Function f = Function.getFunction(session.getDatabase(), "DATEDIFF");
+                    f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));
+                    f.setParameter(1, right);
+                    f.setParameter(2, left);
+                    f.doneWithParameters();
+                    return f.optimize(session);
+                }
+                }
+                break;
+            case Value.TIME:
+                if (r == Value.TIME) {
+                    dataType = Value.TIME;
+                    return this;
+                }
+                break;
+            }
+            break;
+        case MULTIPLY:
+            if (l == Value.TIME) {
+                dataType = Value.TIME;
+                convertRight = false;
+                return this;
+            } else if (r == Value.TIME) {
+                swap();
+                dataType = Value.TIME;
+                convertRight = false;
+                return this;
+            }
+            break;
+        case DIVIDE:
+            if (l == Value.TIME) {
+                dataType = Value.TIME;
+                convertRight = false;
+                return this;
+            }
+            break;
+        default:
+        }
+        throw DbException.getUnsupportedException(
+                DataType.getDataType(l).name + " " +
+                getOperationToken() + " " +
+                DataType.getDataType(r).name);
     }
 
     private void swap() {

--- a/h2/src/test/org/h2/test/scripts/datatypes/timestamp-with-timezone.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/timestamp-with-timezone.sql
@@ -93,3 +93,22 @@ SELECT T0 FROM TEST;
 
 DROP TABLE TEST;
 > ok
+
+SELECT (LOCALTIMESTAMP + 1) = (CURRENT_TIMESTAMP + 1);
+>> TRUE
+
+SELECT (TIMESTAMP WITH TIME ZONE '2010-01-01 10:00:00+01' + 1) A,
+    (1 + TIMESTAMP WITH TIME ZONE '2010-01-01 10:00:00+01') B;
+> A                      B
+> ---------------------- ----------------------
+> 2010-01-02 10:00:00+01 2010-01-02 10:00:00+01
+> rows: 1
+
+SELECT (LOCALTIMESTAMP - 1) = (CURRENT_TIMESTAMP - 1);
+>> TRUE
+
+SELECT (TIMESTAMP WITH TIME ZONE '2010-01-01 10:00:00+01' - 1) A;
+> A
+> ----------------------
+> 2009-12-31 10:00:00+01
+> rows: 1


### PR DESCRIPTION
1. Conditions in `Operation.optimize()` are reorganized without functionality changes. Chained `if`– `else if` operators are converted into `switch` operators, some conditions are extracted into upper level.

2. Support for addition and subtraction operations with `TIMESTAMP WITH TIME ZONE` is introduced. This fixes regression with expressions like `CURRENT_TIMESTAMP - 1` that did not work because `CURRENT_TIMESTAMP` returns `TIMESTAMP WITH TIME ZONE` for compatibility with SQL standard and other standard-compliant databases.