### PR TITLE
Optimize MVSecondaryIndex.convertToKey()

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -203,7 +203,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
     }
 
     private void checkUnique(TransactionMap<Value, Value> map, ValueArray row, long newKey) {
-        Iterator<Value> it = map.keyIterator(convertToKey(row, Boolean.FALSE), convertToKey(row, Boolean.TRUE), true);
+        Iterator<Value> it = map.keyIterator(convertToKey(row, false), convertToKey(row, true), true);
         while (it.hasNext()) {
             ValueArray rowData = (ValueArray)it.next();
             Value[] array = rowData.getList();
@@ -262,21 +262,18 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
 
     private Cursor find(Session session, SearchRow first, boolean bigger, SearchRow last) {
         ValueArray min = convertToKey(convertToKey(first), bigger);
-        ValueArray max = convertToKey(convertToKey(last), Boolean.TRUE);
+        ValueArray max = convertToKey(convertToKey(last), true);
         TransactionMap<Value,Value> map = getMap(session);
         return new MVStoreCursor(session, map.keyIterator(min, max, false));
     }
 
-    private static ValueArray convertToKey(ValueArray r, Boolean minmax) {
+    private static ValueArray convertToKey(ValueArray r, boolean minmax) {
         if (r == null) {
             return null;
         }
-
         Value[] values = r.getList().clone();
         ValueArray row = ValueArray.get(values);
-        if (minmax != null) {
-            values[values.length - 1] = ValueLong.get(minmax ? Long.MAX_VALUE : Long.MIN_VALUE);
-        }
+        values[values.length - 1] = minmax ? ValueLong.MAX : ValueLong.MIN;
         return row;
     }
 


### PR DESCRIPTION
Double conversion of rows in `MVSecondaryIndex.find()` is fixed. Before this change `SearchRow` was converted to `ValueArray` with real key that was immediately converted to another `ValueArray` with smallest or largest possible key. Now it is converted to `ValueArray` with required min/max key in one step.

`convertToKey()` methods are reorganized. Obscure `Boolean minmax` (that was never `null`) parameter is replaced with required key.