### PR TITLE
Replace some init methods with constructors

### DIFF
--- a/h2/src/main/org/h2/constraint/Constraint.java
+++ b/h2/src/main/org/h2/constraint/Constraint.java
@@ -64,7 +64,7 @@ public abstract class Constraint extends SchemaObjectBase implements
     protected Table table;
 
     Constraint(Schema schema, int id, String name, Table table) {
-        initSchemaObjectBase(schema, id, name, Trace.CONSTRAINT);
+        super(schema, id, name, Trace.CONSTRAINT);
         this.table = table;
         this.setTemporary(table.isTemporary());
     }

--- a/h2/src/main/org/h2/engine/Comment.java
+++ b/h2/src/main/org/h2/engine/Comment.java
@@ -20,7 +20,7 @@ public class Comment extends DbObjectBase {
     private String commentText;
 
     public Comment(Database database, int id, DbObject obj) {
-        initDbObjectBase(database, id,  getKey(obj), Trace.DATABASE);
+        super(database, id,  getKey(obj), Trace.DATABASE);
         this.objectType = obj.getType();
         this.objectName = obj.getSQL();
     }

--- a/h2/src/main/org/h2/engine/DbObjectBase.java
+++ b/h2/src/main/org/h2/engine/DbObjectBase.java
@@ -43,7 +43,7 @@ public abstract class DbObjectBase implements DbObject {
      * @param name the name
      * @param traceModuleId the trace module id
      */
-    protected void initDbObjectBase(Database db, int objectId, String name,
+    protected DbObjectBase(Database db, int objectId, String name,
             int traceModuleId) {
         this.database = db;
         this.trace = db.getTrace(traceModuleId);

--- a/h2/src/main/org/h2/engine/FunctionAlias.java
+++ b/h2/src/main/org/h2/engine/FunctionAlias.java
@@ -47,7 +47,7 @@ public class FunctionAlias extends SchemaObjectBase {
     private boolean bufferResultSetToLocalTemp = true;
 
     private FunctionAlias(Schema schema, int id, String name) {
-        initSchemaObjectBase(schema, id, name, Trace.FUNCTION);
+        super(schema, id, name, Trace.FUNCTION);
     }
 
     /**

--- a/h2/src/main/org/h2/engine/Right.java
+++ b/h2/src/main/org/h2/engine/Right.java
@@ -68,14 +68,14 @@ public class Right extends DbObjectBase {
     private DbObject grantedObject;
 
     public Right(Database db, int id, RightOwner grantee, Role grantedRole) {
-        initDbObjectBase(db, id, "RIGHT_" + id, Trace.USER);
+        super(db, id, "RIGHT_" + id, Trace.USER);
         this.grantee = grantee;
         this.grantedRole = grantedRole;
     }
 
     public Right(Database db, int id, RightOwner grantee, int grantedRight,
             DbObject grantedObject) {
-        initDbObjectBase(db, id, Integer.toString(id), Trace.USER);
+        super(db, id, Integer.toString(id), Trace.USER);
         this.grantee = grantee;
         this.grantedRight = grantedRight;
         this.grantedObject = grantedObject;

--- a/h2/src/main/org/h2/engine/RightOwner.java
+++ b/h2/src/main/org/h2/engine/RightOwner.java
@@ -29,7 +29,7 @@ public abstract class RightOwner extends DbObjectBase {
 
     protected RightOwner(Database database, int id, String name,
             int traceModuleId) {
-        initDbObjectBase(database, id, name, traceModuleId);
+        super(database, id, name, traceModuleId);
     }
 
     /**

--- a/h2/src/main/org/h2/engine/Setting.java
+++ b/h2/src/main/org/h2/engine/Setting.java
@@ -18,7 +18,7 @@ public class Setting extends DbObjectBase {
     private String stringValue;
 
     public Setting(Database database, int id, String settingName) {
-        initDbObjectBase(database, id, settingName, Trace.SETTING);
+        super(database, id, settingName, Trace.SETTING);
     }
 
     public void setIntValue(int value) {

--- a/h2/src/main/org/h2/engine/UserAggregate.java
+++ b/h2/src/main/org/h2/engine/UserAggregate.java
@@ -26,7 +26,7 @@ public class UserAggregate extends DbObjectBase {
 
     public UserAggregate(Database db, int id, String name, String className,
             boolean force) {
-        initDbObjectBase(db, id, name, Trace.FUNCTION);
+        super(db, id, name, Trace.FUNCTION);
         this.className = className;
         if (!force) {
             getInstance();

--- a/h2/src/main/org/h2/engine/UserDataType.java
+++ b/h2/src/main/org/h2/engine/UserDataType.java
@@ -18,7 +18,7 @@ public class UserDataType extends DbObjectBase {
     private Column column;
 
     public UserDataType(Database database, int id, String name) {
-        initDbObjectBase(database, id, name, Trace.DATABASE);
+        super(database, id, name, Trace.DATABASE);
     }
 
     @Override

--- a/h2/src/main/org/h2/index/BaseIndex.java
+++ b/h2/src/main/org/h2/index/BaseIndex.java
@@ -35,8 +35,8 @@ public abstract class BaseIndex extends SchemaObjectBase implements Index {
     protected IndexColumn[] indexColumns;
     protected Column[] columns;
     protected int[] columnIds;
-    protected Table table;
-    protected IndexType indexType;
+    protected final Table table;
+    protected final IndexType indexType;
 
     /**
      * Initialize the base index.
@@ -48,9 +48,9 @@ public abstract class BaseIndex extends SchemaObjectBase implements Index {
      *            not yet known
      * @param newIndexType the index type
      */
-    protected void initBaseIndex(Table newTable, int id, String name,
+    protected BaseIndex(Table newTable, int id, String name,
             IndexColumn[] newIndexColumns, IndexType newIndexType) {
-        initSchemaObjectBase(newTable.getSchema(), id, name, Trace.INDEX);
+        super(newTable.getSchema(), id, name, Trace.INDEX);
         this.indexType = newIndexType;
         this.table = newTable;
         if (newIndexColumns != null) {

--- a/h2/src/main/org/h2/index/FunctionIndex.java
+++ b/h2/src/main/org/h2/index/FunctionIndex.java
@@ -24,7 +24,7 @@ public class FunctionIndex extends BaseIndex {
     private final FunctionTable functionTable;
 
     public FunctionIndex(FunctionTable functionTable, IndexColumn[] columns) {
-        initBaseIndex(functionTable, 0, null, columns, IndexType.createNonUnique(true));
+        super(functionTable, 0, null, columns, IndexType.createNonUnique(true));
         this.functionTable = functionTable;
     }
 

--- a/h2/src/main/org/h2/index/HashIndex.java
+++ b/h2/src/main/org/h2/index/HashIndex.java
@@ -33,7 +33,7 @@ public class HashIndex extends BaseIndex {
 
     public HashIndex(RegularTable table, int id, String indexName,
             IndexColumn[] columns, IndexType indexType) {
-        initBaseIndex(table, id, indexName, columns, indexType);
+        super(table, id, indexName, columns, indexType);
         this.indexColumn = columns[0].column.getColumnId();
         this.tableData = table;
         reset();

--- a/h2/src/main/org/h2/index/LinkedIndex.java
+++ b/h2/src/main/org/h2/index/LinkedIndex.java
@@ -37,7 +37,7 @@ public class LinkedIndex extends BaseIndex {
 
     public LinkedIndex(TableLink table, int id, IndexColumn[] columns,
             IndexType indexType) {
-        initBaseIndex(table, id, null, columns, indexType);
+        super(table, id, null, columns, indexType);
         link = table;
         targetTableName = link.getQualifiedTable();
     }

--- a/h2/src/main/org/h2/index/MetaIndex.java
+++ b/h2/src/main/org/h2/index/MetaIndex.java
@@ -26,7 +26,7 @@ public class MetaIndex extends BaseIndex {
     private final boolean scan;
 
     public MetaIndex(MetaTable meta, IndexColumn[] columns, boolean scan) {
-        initBaseIndex(meta, 0, null, columns, IndexType.createNonUnique(true));
+        super(meta, 0, null, columns, IndexType.createNonUnique(true));
         this.meta = meta;
         this.scan = scan;
     }

--- a/h2/src/main/org/h2/index/NonUniqueHashIndex.java
+++ b/h2/src/main/org/h2/index/NonUniqueHashIndex.java
@@ -38,7 +38,7 @@ public class NonUniqueHashIndex extends BaseIndex {
 
     public NonUniqueHashIndex(RegularTable table, int id, String indexName,
             IndexColumn[] columns, IndexType indexType) {
-        initBaseIndex(table, id, indexName, columns, indexType);
+        super(table, id, indexName, columns, indexType);
         this.indexColumn = columns[0].column.getColumnId();
         this.tableData = table;
         reset();

--- a/h2/src/main/org/h2/index/PageBtreeIndex.java
+++ b/h2/src/main/org/h2/index/PageBtreeIndex.java
@@ -43,7 +43,7 @@ public class PageBtreeIndex extends PageIndex {
     public PageBtreeIndex(RegularTable table, int id, String indexName,
             IndexColumn[] columns,
             IndexType indexType, boolean create, Session session) {
-        initBaseIndex(table, id, indexName, columns, indexType);
+        super(table, id, indexName, columns, indexType);
         if (!database.isStarting() && create) {
             checkIndexColumnTypes(columns);
         }

--- a/h2/src/main/org/h2/index/PageDataIndex.java
+++ b/h2/src/main/org/h2/index/PageDataIndex.java
@@ -47,7 +47,7 @@ public class PageDataIndex extends PageIndex {
 
     public PageDataIndex(RegularTable table, int id, IndexColumn[] columns,
             IndexType indexType, boolean create, Session session) {
-        initBaseIndex(table, id, table.getName() + "_DATA", columns, indexType);
+        super(table, id, table.getName() + "_DATA", columns, indexType);
 
         // trace = database.getTrace(Trace.PAGE_STORE + "_di");
         // trace.setLevel(TraceSystem.DEBUG);

--- a/h2/src/main/org/h2/index/PageDelegateIndex.java
+++ b/h2/src/main/org/h2/index/PageDelegateIndex.java
@@ -27,9 +27,9 @@ public class PageDelegateIndex extends PageIndex {
     public PageDelegateIndex(RegularTable table, int id, String name,
             IndexType indexType, PageDataIndex mainIndex, boolean create,
             Session session) {
-        IndexColumn[] cols = IndexColumn.wrap(
-                new Column[] { table.getColumn(mainIndex.getMainIndexColumn())});
-        this.initBaseIndex(table, id, name, cols, indexType);
+        super(table, id, name,
+                IndexColumn.wrap(new Column[] { table.getColumn(mainIndex.getMainIndexColumn()) }),
+                indexType);
         this.mainIndex = mainIndex;
         if (!database.isPersistent() || id < 0) {
             throw DbException.throwInternalError(name);

--- a/h2/src/main/org/h2/index/PageIndex.java
+++ b/h2/src/main/org/h2/index/PageIndex.java
@@ -5,6 +5,8 @@
  */
 package org.h2.index;
 
+import org.h2.table.IndexColumn;
+import org.h2.table.Table;
 
 /**
  * A page store index.
@@ -17,6 +19,20 @@ public abstract class PageIndex extends BaseIndex {
     protected int rootPageId;
 
     private boolean sortedInsertMode;
+
+    /**
+     * Initialize the page store index.
+     *
+     * @param newTable the table
+     * @param id the object id
+     * @param name the index name
+     * @param newIndexColumns the columns that are indexed or null if this is
+     *            not yet known
+     * @param newIndexType the index type
+     */
+    protected PageIndex(Table newTable, int id, String name, IndexColumn[] newIndexColumns, IndexType newIndexType) {
+        super(newTable, id, name, newIndexColumns, newIndexType);
+    }
 
     /**
      * Get the root page of this index.

--- a/h2/src/main/org/h2/index/RangeIndex.java
+++ b/h2/src/main/org/h2/index/RangeIndex.java
@@ -24,7 +24,7 @@ public class RangeIndex extends BaseIndex {
     private final RangeTable rangeTable;
 
     public RangeIndex(RangeTable table, IndexColumn[] columns) {
-        initBaseIndex(table, 0, "RANGE_INDEX", columns,
+        super(table, 0, "RANGE_INDEX", columns,
                 IndexType.createNonUnique(true));
         this.rangeTable = table;
     }

--- a/h2/src/main/org/h2/index/ScanIndex.java
+++ b/h2/src/main/org/h2/index/ScanIndex.java
@@ -35,7 +35,7 @@ public class ScanIndex extends BaseIndex {
 
     public ScanIndex(RegularTable table, int id, IndexColumn[] columns,
             IndexType indexType) {
-        initBaseIndex(table, id, table.getName() + "_DATA", columns, indexType);
+        super(table, id, table.getName() + "_DATA", columns, indexType);
         tableData = table;
     }
 

--- a/h2/src/main/org/h2/index/SpatialTreeIndex.java
+++ b/h2/src/main/org/h2/index/SpatialTreeIndex.java
@@ -58,6 +58,7 @@ public class SpatialTreeIndex extends BaseIndex implements SpatialIndex {
     public SpatialTreeIndex(Table table, int id, String indexName,
             IndexColumn[] columns, IndexType indexType, boolean persistent,
             boolean create, Session session) {
+        super(table, id, indexName, columns, indexType);
         if (indexType.isUnique()) {
             throw DbException.getUnsupportedException("not unique");
         }
@@ -81,9 +82,7 @@ public class SpatialTreeIndex extends BaseIndex implements SpatialIndex {
             throw DbException.getUnsupportedException(
                     "cannot do nulls last");
         }
-        initBaseIndex(table, id, indexName, columns, indexType);
         this.needRebuild = create;
-        this.table = table;
         if (!database.isStarting()) {
             if (columns[0].column.getType() != Value.GEOMETRY) {
                 throw DbException.getUnsupportedException(

--- a/h2/src/main/org/h2/index/TreeIndex.java
+++ b/h2/src/main/org/h2/index/TreeIndex.java
@@ -30,7 +30,7 @@ public class TreeIndex extends BaseIndex {
 
     public TreeIndex(RegularTable table, int id, String indexName,
             IndexColumn[] columns, IndexType indexType) {
-        initBaseIndex(table, id, indexName, columns, indexType);
+        super(table, id, indexName, columns, indexType);
         tableData = table;
         if (!database.isStarting()) {
             checkIndexColumnTypes(columns);

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -64,7 +64,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
      */
     public ViewIndex(TableView view, String querySQL,
             ArrayList<Parameter> originalParameters, boolean recursive) {
-        initBaseIndex(view, 0, null, null, IndexType.createNonUnique(false));
+        super(view, 0, null, null, IndexType.createNonUnique(false));
         this.view = view;
         this.querySQL = querySQL;
         this.originalParameters = originalParameters;
@@ -91,7 +91,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
      */
     public ViewIndex(TableView view, ViewIndex index, Session session,
             int[] masks, TableFilter[] filters, int filter, SortOrder sortOrder) {
-        initBaseIndex(view, 0, null, null, IndexType.createNonUnique(false));
+        super(view, 0, null, null, IndexType.createNonUnique(false));
         this.view = view;
         this.querySQL = index.querySQL;
         this.originalParameters = index.originalParameters;

--- a/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
@@ -30,9 +30,9 @@ public class MVDelegateIndex extends BaseIndex implements MVIndex {
     public MVDelegateIndex(MVTable table, int id, String name,
             MVPrimaryIndex mainIndex,
             IndexType indexType) {
-        IndexColumn[] cols = IndexColumn.wrap(new Column[] { table
-                .getColumn(mainIndex.getMainIndexColumn()) });
-        this.initBaseIndex(table, id, name, cols, indexType);
+        super(table, id, name,
+                IndexColumn.wrap(new Column[] { table.getColumn(mainIndex.getMainIndexColumn()) }),
+                indexType);
         this.mainIndex = mainIndex;
         if (id < 0) {
             throw DbException.throwInternalError(name);

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -45,8 +45,8 @@ public class MVPrimaryIndex extends BaseIndex {
 
     public MVPrimaryIndex(Database db, MVTable table, int id,
             IndexColumn[] columns, IndexType indexType) {
+        super(table, id, table.getName() + "_DATA", columns, indexType);
         this.mvTable = table;
-        initBaseIndex(table, id, table.getName() + "_DATA", columns, indexType);
         int[] sortTypes = new int[columns.length];
         for (int i = 0; i < columns.length; i++) {
             sortTypes[i] = SortOrder.ASCENDING;

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -48,8 +48,8 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
 
     public MVSecondaryIndex(Database db, MVTable table, int id, String indexName,
                 IndexColumn[] columns, IndexType indexType) {
+        super(table, id, indexName, columns, indexType);
         this.mvTable = table;
-        initBaseIndex(table, id, indexName, columns, indexType);
         if (!database.isStarting()) {
             checkIndexColumnTypes(columns);
         }

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -65,6 +65,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
     public MVSpatialIndex(
             Database db, MVTable table, int id, String indexName,
             IndexColumn[] columns, IndexType indexType) {
+        super(table, id, indexName, columns, indexType);
         if (columns.length != 1) {
             throw DbException.getUnsupportedException(
                     "Can only index one column");
@@ -88,7 +89,6 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
                     + col.column.getCreateSQL());
         }
         this.mvTable = table;
-        initBaseIndex(table, id, indexName, columns, indexType);
         if (!database.isStarting()) {
             checkIndexColumnTypes(columns);
         }

--- a/h2/src/main/org/h2/schema/Constant.java
+++ b/h2/src/main/org/h2/schema/Constant.java
@@ -23,7 +23,7 @@ public class Constant extends SchemaObjectBase {
     private ValueExpression expression;
 
     public Constant(Schema schema, int id, String name) {
-        initSchemaObjectBase(schema, id, name, Trace.SCHEMA);
+        super(schema, id, name, Trace.SCHEMA);
     }
 
     @Override

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -73,6 +73,7 @@ public class Schema extends DbObjectBase {
      */
     public Schema(Database database, int id, String schemaName, User owner,
             boolean system) {
+        super(database, id, schemaName, Trace.SCHEMA);
         tablesAndViews = database.newConcurrentStringMap();
         synonyms = database.newConcurrentStringMap();
         indexes = database.newConcurrentStringMap();
@@ -81,7 +82,6 @@ public class Schema extends DbObjectBase {
         constraints = database.newConcurrentStringMap();
         constants = database.newConcurrentStringMap();
         functions = database.newConcurrentStringMap();
-        initDbObjectBase(database, id, schemaName, Trace.SCHEMA);
         this.owner = owner;
         this.system = system;
     }

--- a/h2/src/main/org/h2/schema/SchemaObjectBase.java
+++ b/h2/src/main/org/h2/schema/SchemaObjectBase.java
@@ -13,7 +13,7 @@ import org.h2.engine.DbObjectBase;
 public abstract class SchemaObjectBase extends DbObjectBase implements
         SchemaObject {
 
-    private Schema schema;
+    private final Schema schema;
 
     /**
      * Initialize some attributes of this object.
@@ -23,9 +23,9 @@ public abstract class SchemaObjectBase extends DbObjectBase implements
      * @param name the name
      * @param traceModuleId the trace module id
      */
-    protected void initSchemaObjectBase(Schema newSchema, int id, String name,
+    protected SchemaObjectBase(Schema newSchema, int id, String name,
             int traceModuleId) {
-        initDbObjectBase(newSchema.getDatabase(), id, name, traceModuleId);
+        super(newSchema.getDatabase(), id, name, traceModuleId);
         this.schema = newSchema;
     }
 

--- a/h2/src/main/org/h2/schema/Sequence.java
+++ b/h2/src/main/org/h2/schema/Sequence.java
@@ -67,7 +67,7 @@ public class Sequence extends SchemaObjectBase {
     public Sequence(Schema schema, int id, String name, Long startValue,
             Long increment, Long cacheSize, Long minValue, Long maxValue,
             boolean cycle, boolean belongsToTable) {
-        initSchemaObjectBase(schema, id, name, Trace.SEQUENCE);
+        super(schema, id, name, Trace.SEQUENCE);
         this.increment = increment != null ?
                 increment : 1;
         this.minValue = minValue != null ?

--- a/h2/src/main/org/h2/schema/TriggerObject.java
+++ b/h2/src/main/org/h2/schema/TriggerObject.java
@@ -52,7 +52,7 @@ public class TriggerObject extends SchemaObjectBase {
     private Trigger triggerCallback;
 
     public TriggerObject(Schema schema, int id, String name, Table table) {
-        initSchemaObjectBase(schema, id, name, Trace.TRIGGER);
+        super(schema, id, name, Trace.TRIGGER);
         this.table = table;
         setTemporary(table.isTemporary());
     }

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -95,8 +95,8 @@ public abstract class Table extends SchemaObjectBase {
 
     public Table(Schema schema, int id, String name, boolean persistIndexes,
             boolean persistData) {
+        super(schema, id, name, Trace.TABLE);
         columnMap = schema.getDatabase().newStringMap();
-        initSchemaObjectBase(schema, id, name, Trace.TABLE);
         this.persistIndexes = persistIndexes;
         this.persistData = persistData;
         compareMode = schema.getDatabase().getCompareMode();

--- a/h2/src/main/org/h2/table/TableSynonym.java
+++ b/h2/src/main/org/h2/table/TableSynonym.java
@@ -26,7 +26,7 @@ public class TableSynonym extends SchemaObjectBase {
     private Table synonymFor;
 
     public TableSynonym(CreateSynonymData data) {
-        initSchemaObjectBase(data.schema, data.id, data.synonymName, Trace.TABLE);
+        super(data.schema, data.id, data.synonymName, Trace.TABLE);
         this.data = data;
     }
 

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -920,7 +920,7 @@ public class TestTableEngines extends TestDb {
             public class Scan extends BaseIndex {
 
                 Scan(Table table) {
-                    initBaseIndex(table, table.getId(), table.getName() + "_SCAN",
+                    super(table, table.getId(), table.getName() + "_SCAN",
                             IndexColumn.wrap(table.getColumns()), IndexType.createScan(false));
                 }
 
@@ -1145,7 +1145,7 @@ public class TestTableEngines extends TestDb {
              */
             public class AffinityIndex extends BaseIndex {
                 AffinityIndex(Table table, int id, String name, IndexColumn[] newIndexColumns) {
-                    initBaseIndex(table, id, name, newIndexColumns, IndexType.createAffinity());
+                    super(table, id, name, newIndexColumns, IndexType.createAffinity());
                 }
 
                 @Override
@@ -1534,7 +1534,7 @@ public class TestTableEngines extends TestDb {
         final TreeSet<SearchRow> set = new TreeSet<>(this);
 
         TreeSetIndex(Table t, String name, IndexColumn[] cols, IndexType type) {
-            initBaseIndex(t, 0, name, cols, type);
+            super(t, 0, name, cols, type);
         }
 
         @Override


### PR DESCRIPTION
`DBObjectBase.initDBObjectBase()`, `SchemaObjectBase.initSchemaObjectBase()`, and `BaseIndex.initBaseIndex()` are replaced with constructors.

These methods were only invoked from constructors of subclasses.