### PR TITLE
Changes is conversion and comparison methods of Value

### DIFF
--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -143,7 +143,7 @@ public class SelectUnion extends Query {
         Mode mode = session.getDatabase().getMode();
         for (int i = 0; i < columnCount; i++) {
             Expression e = expressions.get(i);
-            newValues[i] = values[i].convertTo(e.getType(), -1, mode);
+            newValues[i] = values[i].convertTo(e.getType(), mode);
         }
         return newValues;
     }

--- a/h2/src/main/org/h2/engine/FunctionAlias.java
+++ b/h2/src/main/org/h2/engine/FunctionAlias.java
@@ -412,11 +412,11 @@ public class FunctionAlias extends SchemaObjectBase {
                             paramClass.getComponentType());
                     Mode mode = session.getDatabase().getMode();
                     for (int i = 0; i < objArray.length; i++) {
-                        objArray[i] = array[i].convertTo(componentType, -1, mode).getObject();
+                        objArray[i] = array[i].convertTo(componentType, mode).getObject();
                     }
                     o = objArray;
                 } else {
-                    v = v.convertTo(type, -1, session.getDatabase().getMode());
+                    v = v.convertTo(type, session.getDatabase().getMode());
                     o = v.getObject();
                 }
                 if (o == null) {

--- a/h2/src/main/org/h2/expression/ConditionInConstantSet.java
+++ b/h2/src/main/org/h2/expression/ConditionInConstantSet.java
@@ -60,7 +60,7 @@ public class ConditionInConstantSet extends Condition {
             }
         } else {
             for (Expression expression : valueList) {
-                valueSet.add(expression.getValue(session).convertTo(type, -1, mode));
+                valueSet.add(expression.getValue(session).convertTo(type, mode));
             }
         }
     }
@@ -172,7 +172,7 @@ public class ConditionInConstantSet extends Condition {
                 if (type == Value.ENUM) {
                     valueSet.add(add.getValue(session).convertToEnum(enumerators));
                 } else {
-                    valueSet.add(add.getValue(session).convertTo(type, -1, session.getDatabase().getMode()));
+                    valueSet.add(add.getValue(session).convertTo(type, session.getDatabase().getMode()));
                 }
                 return this;
             }

--- a/h2/src/main/org/h2/expression/ConditionInSelect.java
+++ b/h2/src/main/org/h2/expression/ConditionInSelect.java
@@ -62,7 +62,7 @@ public class ConditionInSelect extends Condition {
         if (dataType == Value.NULL) {
             return ValueBoolean.FALSE;
         }
-        l = l.convertTo(dataType, -1, database.getMode());
+        l = l.convertTo(dataType, database.getMode());
         if (rows.containsDistinct(new Value[] { l })) {
             return ValueBoolean.TRUE;
         }

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -873,7 +873,7 @@ public class Function extends Expression implements FunctionCall {
         case CAST:
         case CONVERT: {
             Mode mode = database.getMode();
-            v0 = v0.convertTo(dataType, -1, mode);
+            v0 = v0.convertTo(dataType, mode);
             v0 = v0.convertScale(mode.convertOnlyToSmallerScale, scale);
             v0 = v0.convertPrecision(getPrecision(), false);
             result = v0;
@@ -902,7 +902,7 @@ public class Function extends Expression implements FunctionCall {
             if (v0 == ValueNull.INSTANCE) {
                 result = getNullOrValue(session, args, values, 1);
             }
-            result = result.convertTo(dataType, -1, database.getMode());
+            result = result.convertTo(dataType, database.getMode());
             break;
         }
         case CASEWHEN: {

--- a/h2/src/main/org/h2/expression/Operation.java
+++ b/h2/src/main/org/h2/expression/Operation.java
@@ -110,14 +110,14 @@ public class Operation extends Expression {
     @Override
     public Value getValue(Session session) {
         Mode mode = session.getDatabase().getMode();
-        Value l = left.getValue(session).convertTo(dataType, -1, mode);
+        Value l = left.getValue(session).convertTo(dataType, mode);
         Value r;
         if (right == null) {
             r = null;
         } else {
             r = right.getValue(session);
             if (convertRight) {
-                r = r.convertTo(dataType, -1, mode);
+                r = r.convertTo(dataType, mode);
             }
         }
         switch (opType) {

--- a/h2/src/main/org/h2/index/HashIndex.java
+++ b/h2/src/main/org/h2/index/HashIndex.java
@@ -77,7 +77,7 @@ public class HashIndex extends BaseIndex {
          * case we need to convert, otherwise the ValueHashMap will not find the
          * result.
          */
-        v = v.convertTo(tableData.getColumn(indexColumn).getType(), -1, database.getMode());
+        v = v.convertTo(tableData.getColumn(indexColumn).getType(), database.getMode());
         Row result;
         Long pos = rows.get(v);
         if (pos == null) {

--- a/h2/src/main/org/h2/index/NonUniqueHashIndex.java
+++ b/h2/src/main/org/h2/index/NonUniqueHashIndex.java
@@ -101,7 +101,7 @@ public class NonUniqueHashIndex extends BaseIndex {
          * case we need to convert, otherwise the ValueHashMap will not find the
          * result.
          */
-        v = v.convertTo(tableData.getColumn(indexColumn).getType(), -1, database.getMode());
+        v = v.convertTo(tableData.getColumn(indexColumn).getType(), database.getMode());
         ArrayList<Long> positions = rows.get(v);
         return new NonUniqueHashCursor(session, tableData, positions);
     }

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -562,7 +562,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
                 setParameter(parameterIndex, ValueNull.INSTANCE);
             } else {
                 Value v = DataType.convertToValue(conn.getSession(), x, type);
-                setParameter(parameterIndex, v.convertTo(type, -1, conn.getMode()));
+                setParameter(parameterIndex, v.convertTo(type, conn.getMode()));
             }
         } catch (Exception e) {
             throw logAndConvert(e);

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -1066,7 +1066,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public byte[] getBytes(int columnIndex) throws SQLException {
         try {
             debugCodeCall("getBytes", columnIndex);
-            return get(columnIndex).convertTo(Value.BYTES, -1, conn.getMode()).getBytes();
+            return get(columnIndex).convertTo(Value.BYTES, conn.getMode()).getBytes();
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -576,7 +576,7 @@ public abstract class Value {
      * @param targetType the type of the returned value
      * @return the converted value
      */
-    public Value convertTo(int targetType) {
+    public final Value convertTo(int targetType) {
         // Use -1 to indicate "default behaviour" where value conversion should not
         // depend on any datatype precision.
         return convertTo(targetType, null);
@@ -587,7 +587,7 @@ public abstract class Value {
      * @param enumerators allowed values for the ENUM to which the value is converted
      * @return value represented as ENUM
      */
-    public Value convertToEnum(String[] enumerators) {
+    public final Value convertToEnum(String[] enumerators) {
         // Use -1 to indicate "default behaviour" where value conversion should not
         // depend on any datatype precision.
         return convertTo(ENUM, -1, null, null, enumerators);

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -265,16 +265,6 @@ public abstract class Value {
     public abstract void set(PreparedStatement prep, int parameterIndex)
             throws SQLException;
 
-    /**
-     * Compare the value with another value of the same type.
-     *
-     * @param v the other value
-     * @param mode the compare mode
-     * @return 0 if both values are equal, -1 if the other value is smaller, and
-     *         1 otherwise
-     */
-    protected abstract int compareSecure(Value v, CompareMode mode);
-
     @Override
     public abstract int hashCode();
 
@@ -1157,9 +1147,7 @@ public abstract class Value {
      * @return 0 if both values are equal, -1 if the other value is smaller, and
      *         1 otherwise
      */
-    public final int compareTypeSafe(Value v, CompareMode mode) {
-        return compareSecure(v, mode);
-    }
+    public abstract int compareTypeSafe(Value v, CompareMode mode);
 
     /**
      * Compare this value against another value using the specified compare
@@ -1194,7 +1182,7 @@ public abstract class Value {
                 v = v.convertTo(dataType, databaseMode);
             }
         }
-        return l.compareSecure(v, compareMode);
+        return l.compareTypeSafe(v, compareMode);
     }
 
     public int getScale() {

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -589,7 +589,7 @@ public abstract class Value {
     public Value convertTo(int targetType) {
         // Use -1 to indicate "default behaviour" where value conversion should not
         // depend on any datatype precision.
-        return convertTo(targetType, -1, null);
+        return convertTo(targetType, null);
     }
 
     /**
@@ -607,14 +607,11 @@ public abstract class Value {
      * Compare a value to the specified type.
      *
      * @param targetType the type of the returned value
-     * @param precision the precision of the column to convert this value to.
-     *        The special constant <code>-1</code> is used to indicate that
-     *        the precision plays no role when converting the value
      * @param mode the mode
      * @return the converted value
      */
-    public final Value convertTo(int targetType, int precision, Mode mode) {
-        return convertTo(targetType, precision, mode, null, null);
+    public final Value convertTo(int targetType, Mode mode) {
+        return convertTo(targetType, -1, mode, null, null);
     }
 
     /**
@@ -1193,8 +1190,8 @@ public abstract class Value {
                 l = l.convertToEnum(enumerators);
                 v = v.convertToEnum(enumerators);
             } else {
-                l = l.convertTo(dataType, -1, databaseMode);
-                v = v.convertTo(dataType, -1, databaseMode);
+                l = l.convertTo(dataType, databaseMode);
+                v = v.convertTo(dataType, databaseMode);
             }
         }
         return l.compareSecure(v, compareMode);

--- a/h2/src/main/org/h2/value/ValueArray.java
+++ b/h2/src/main/org/h2/value/ValueArray.java
@@ -11,7 +11,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 
 import org.h2.engine.Constants;
-import org.h2.engine.Mode;
 import org.h2.engine.SysProperties;
 import org.h2.util.MathUtils;
 import org.h2.util.StatementBuilder;
@@ -99,7 +98,7 @@ public class ValueArray extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
+    public int compareTypeSafe(Value o, CompareMode mode) {
         ValueArray v = (ValueArray) o;
         if (values == v.values) {
             return 0;

--- a/h2/src/main/org/h2/value/ValueBoolean.java
+++ b/h2/src/main/org/h2/value/ValueBoolean.java
@@ -66,9 +66,8 @@ public class ValueBoolean extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueBoolean v = (ValueBoolean) o;
-        return Boolean.compare(value, v.value);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return Boolean.compare(value, ((ValueBoolean) o).value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueByte.java
+++ b/h2/src/main/org/h2/value/ValueByte.java
@@ -108,9 +108,8 @@ public class ValueByte extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueByte v = (ValueByte) o;
-        return Integer.compare(value, v.value);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return Integer.compare(value, ((ValueByte) o).value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueBytes.java
+++ b/h2/src/main/org/h2/value/ValueBytes.java
@@ -94,7 +94,7 @@ public class ValueBytes extends Value {
     }
 
     @Override
-    protected int compareSecure(Value v, CompareMode mode) {
+    public int compareTypeSafe(Value v, CompareMode mode) {
         byte[] v2 = ((ValueBytes) v).value;
         if (mode.isBinaryUnsigned()) {
             return Bits.compareNotNullUnsigned(value, v2);

--- a/h2/src/main/org/h2/value/ValueDate.java
+++ b/h2/src/main/org/h2/value/ValueDate.java
@@ -113,7 +113,7 @@ public class ValueDate extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
+    public int compareTypeSafe(Value o, CompareMode mode) {
         return Long.compare(dateValue, ((ValueDate) o).dateValue);
     }
 

--- a/h2/src/main/org/h2/value/ValueDecimal.java
+++ b/h2/src/main/org/h2/value/ValueDecimal.java
@@ -127,9 +127,8 @@ public class ValueDecimal extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueDecimal v = (ValueDecimal) o;
-        return value.compareTo(v.value);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return value.compareTo(((ValueDecimal) o).value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueDouble.java
+++ b/h2/src/main/org/h2/value/ValueDouble.java
@@ -101,9 +101,8 @@ public class ValueDouble extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueDouble v = (ValueDouble) o;
-        return Double.compare(value, v.value);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return Double.compare(value, ((ValueDouble) o).value);
     }
 
     @Override
@@ -180,7 +179,7 @@ public class ValueDouble extends Value {
         if (!(other instanceof ValueDouble)) {
             return false;
         }
-        return compareSecure((ValueDouble) other, null) == 0;
+        return compareTypeSafe((ValueDouble) other, null) == 0;
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueEnumBase.java
+++ b/h2/src/main/org/h2/value/ValueEnumBase.java
@@ -33,7 +33,7 @@ public class ValueEnumBase extends Value {
     }
 
     @Override
-    protected int compareSecure(final Value v, final CompareMode mode) {
+    public int compareTypeSafe(Value v, CompareMode mode) {
         return Integer.compare(getInt(), v.getInt());
     }
 

--- a/h2/src/main/org/h2/value/ValueFloat.java
+++ b/h2/src/main/org/h2/value/ValueFloat.java
@@ -102,9 +102,8 @@ public class ValueFloat extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueFloat v = (ValueFloat) o;
-        return Float.compare(value, v.value);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return Float.compare(value, ((ValueFloat) o).value);
     }
 
     @Override
@@ -180,7 +179,7 @@ public class ValueFloat extends Value {
         if (!(other instanceof ValueFloat)) {
             return false;
         }
-        return compareSecure((ValueFloat) other, null) == 0;
+        return compareTypeSafe((ValueFloat) other, null) == 0;
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueGeometry.java
+++ b/h2/src/main/org/h2/value/ValueGeometry.java
@@ -243,9 +243,8 @@ public class ValueGeometry extends Value {
     }
 
     @Override
-    protected int compareSecure(Value v, CompareMode mode) {
-        Geometry g = ((ValueGeometry) v).getGeometryNoCopy();
-        return getGeometryNoCopy().compareTo(g);
+    public int compareTypeSafe(Value v, CompareMode mode) {
+        return getGeometryNoCopy().compareTo(((ValueGeometry) v).getGeometryNoCopy());
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueInt.java
+++ b/h2/src/main/org/h2/value/ValueInt.java
@@ -141,9 +141,8 @@ public class ValueInt extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueInt v = (ValueInt) o;
-        return Integer.compare(value, v.value);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return Integer.compare(value, ((ValueInt) o).value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueJavaObject.java
+++ b/h2/src/main/org/h2/value/ValueJavaObject.java
@@ -102,7 +102,7 @@ public class ValueJavaObject extends ValueBytes {
         }
 
         @Override
-        protected int compareSecure(Value v, CompareMode mode) {
+        public int compareTypeSafe(Value v, CompareMode mode) {
             Object o1 = getObject();
             Object o2 = v.getObject();
 

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -515,7 +515,7 @@ public class ValueLob extends Value {
     }
 
     @Override
-    protected int compareSecure(Value v, CompareMode mode) {
+    public int compareTypeSafe(Value v, CompareMode mode) {
         return compare(this, v);
     }
 
@@ -613,7 +613,7 @@ public class ValueLob extends Value {
     public boolean equals(Object other) {
         if (other instanceof ValueLob) {
             ValueLob o = (ValueLob) other;
-            return valueType == o.valueType && compareSecure(o, null) == 0;
+            return valueType == o.valueType && compareTypeSafe(o, null) == 0;
         }
         return false;
     }

--- a/h2/src/main/org/h2/value/ValueLobDb.java
+++ b/h2/src/main/org/h2/value/ValueLobDb.java
@@ -375,7 +375,7 @@ public class ValueLobDb extends Value {
     }
 
     @Override
-    protected int compareSecure(Value v, CompareMode mode) {
+    public int compareTypeSafe(Value v, CompareMode mode) {
         if (v instanceof ValueLobDb) {
             ValueLobDb v2 = (ValueLobDb) v;
             if (v == this) {
@@ -511,7 +511,7 @@ public class ValueLobDb extends Value {
         ValueLobDb otherLob = (ValueLobDb) other;
         if (hashCode() != otherLob.hashCode())
             return false;
-        return compareSecure((Value) other, null) == 0;
+        return compareTypeSafe((Value) other, null) == 0;
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueLong.java
+++ b/h2/src/main/org/h2/value/ValueLong.java
@@ -161,9 +161,8 @@ public class ValueLong extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueLong v = (ValueLong) o;
-        return Long.compare(value, v.value);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return Long.compare(value, ((ValueLong) o).value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueNull.java
+++ b/h2/src/main/org/h2/value/ValueNull.java
@@ -139,7 +139,7 @@ public class ValueNull extends Value {
     }
 
     @Override
-    protected int compareSecure(Value v, CompareMode mode) {
+    public int compareTypeSafe(Value v, CompareMode mode) {
         throw DbException.throwInternalError("compare null");
     }
 

--- a/h2/src/main/org/h2/value/ValueResultSet.java
+++ b/h2/src/main/org/h2/value/ValueResultSet.java
@@ -116,7 +116,7 @@ public class ValueResultSet extends Value {
     }
 
     @Override
-    protected int compareSecure(Value v, CompareMode mode) {
+    public int compareTypeSafe(Value v, CompareMode mode) {
         return this == v ? 0 : super.toString().compareTo(v.toString());
     }
 

--- a/h2/src/main/org/h2/value/ValueShort.java
+++ b/h2/src/main/org/h2/value/ValueShort.java
@@ -108,9 +108,8 @@ public class ValueShort extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueShort v = (ValueShort) o;
-        return Integer.compare(value, v.value);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return Integer.compare(value, ((ValueShort) o).value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueString.java
+++ b/h2/src/main/org/h2/value/ValueString.java
@@ -45,10 +45,8 @@ public class ValueString extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        // compatibility: the other object could be another type
-        ValueString v = (ValueString) o;
-        return mode.compareString(value, v.value, false);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return mode.compareString(value, ((ValueString) o).value, false);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueStringIgnoreCase.java
+++ b/h2/src/main/org/h2/value/ValueStringIgnoreCase.java
@@ -27,9 +27,8 @@ public class ValueStringIgnoreCase extends ValueString {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
-        ValueStringIgnoreCase v = (ValueStringIgnoreCase) o;
-        return mode.compareString(value, v.value, true);
+    public int compareTypeSafe(Value o, CompareMode mode) {
+        return mode.compareString(value, ((ValueStringIgnoreCase) o).value, true);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueTime.java
+++ b/h2/src/main/org/h2/value/ValueTime.java
@@ -181,7 +181,7 @@ public class ValueTime extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
+    public int compareTypeSafe(Value o, CompareMode mode) {
         return Long.compare(nanos, ((ValueTime) o).nanos);
     }
 

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -235,7 +235,7 @@ public class ValueTimestamp extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
+    public int compareTypeSafe(Value o, CompareMode mode) {
         ValueTimestamp t = (ValueTimestamp) o;
         int c = Long.compare(dateValue, t.dateValue);
         if (c != 0) {

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -224,7 +224,7 @@ public class ValueTimestampTimeZone extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
+    public int compareTypeSafe(Value o, CompareMode mode) {
         ValueTimestampTimeZone t = (ValueTimestampTimeZone) o;
         // Maximum time zone offset is +/-18 hours so difference in days between local
         // and UTC cannot be more than one day

--- a/h2/src/main/org/h2/value/ValueUuid.java
+++ b/h2/src/main/org/h2/value/ValueUuid.java
@@ -163,7 +163,7 @@ public class ValueUuid extends Value {
     }
 
     @Override
-    protected int compareSecure(Value o, CompareMode mode) {
+    public int compareTypeSafe(Value o, CompareMode mode) {
         if (o == this) {
             return 0;
         }
@@ -176,7 +176,7 @@ public class ValueUuid extends Value {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueUuid && compareSecure((Value) other, null) == 0;
+        return other instanceof ValueUuid && compareTypeSafe((Value) other, null) == 0;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/jdbc/TestCustomDataTypesHandler.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCustomDataTypesHandler.java
@@ -371,7 +371,7 @@ public class TestCustomDataTypesHandler extends TestDb {
         }
 
         @Override
-        protected int compareSecure(Value v, CompareMode mode) {
+        public int compareTypeSafe(Value v, CompareMode mode) {
             return val.compare((ComplexNumber) v.getObject());
         }
 

--- a/h2/src/test/org/h2/test/jdbc/TestCustomDataTypesHandler.java
+++ b/h2/src/test/org/h2/test/jdbc/TestCustomDataTypesHandler.java
@@ -16,6 +16,7 @@ import java.text.DecimalFormat;
 import java.util.Locale;
 import org.h2.api.CustomDataTypesHandler;
 import org.h2.api.ErrorCode;
+import org.h2.engine.Mode;
 import org.h2.message.DbException;
 import org.h2.store.DataHandler;
 import org.h2.test.TestBase;
@@ -393,7 +394,7 @@ public class TestCustomDataTypesHandler extends TestDb {
         }
 
         @Override
-        public Value convertTo(int targetType) {
+        public Value convertTo(int targetType, int precision, Mode mode, Object column, String[] enumerators) {
             if (getType() == targetType) {
                 return this;
             }


### PR DESCRIPTION
1. `Value.convertTo(int, int, Mode)` was always used with `-1` precision, because places where this method with reduced number of arguments is used do nothing with precision and don't know it. This argument is removed. (Also this argument actually doesn't convert the precision and has any meaning only for `STRING_FIXED` data type. Places where precision is used also call `convertScale()` / `convertPrecision()`.)

2. `Value.compareTypeSafe()` and `Value.compareSecure()` are merged together, they are not different any more.
