### PR TITLE
Crash api

### DIFF
--- a/h2/src/main/org/h2/command/Prepared.java
+++ b/h2/src/main/org/h2/command/Prepared.java
@@ -170,6 +170,11 @@ public abstract class Prepared {
      * @throws DbException if any parameter has not been set
      */
     protected void checkParameters() {
+        if (persistedObjectId < 0) {
+            // restore original persistedObjectId on Command re-run
+            // i.e. due to concurrent update
+            persistedObjectId = -persistedObjectId - 1;
+        }
         if (parameters != null) {
             for (Parameter param : parameters) {
                 param.checkSet();
@@ -268,7 +273,7 @@ public abstract class Prepared {
         } else if (id < 0) {
             throw DbException.throwInternalError("Prepared.getObjectId() was called before");
         }
-        persistedObjectId = -1;
+        persistedObjectId = -persistedObjectId - 1;  // while negative, it can be restored later
         return id;
     }
 

--- a/h2/src/main/org/h2/jdbc/JdbcBlob.java
+++ b/h2/src/main/org/h2/jdbc/JdbcBlob.java
@@ -102,6 +102,9 @@ public class JdbcBlob extends JdbcLob implements Blob {
      */
     @Override
     public int setBytes(long pos, byte[] bytes) throws SQLException {
+        if (bytes == null) {
+            return 0;
+        }
         try {
             if (isDebugEnabled()) {
                 debugCode("setBytes("+pos+", "+quoteBytes(bytes)+");");
@@ -129,6 +132,9 @@ public class JdbcBlob extends JdbcLob implements Blob {
     @Override
     public int setBytes(long pos, byte[] bytes, int offset, int len)
             throws SQLException {
+        if (bytes == null) {
+            return 0;
+        }
         try {
             if (isDebugEnabled()) {
                 debugCode("setBytes(" + pos + ", " + quoteBytes(bytes) + ", " + offset + ", " + len + ");");

--- a/h2/src/main/org/h2/jdbc/JdbcBlob.java
+++ b/h2/src/main/org/h2/jdbc/JdbcBlob.java
@@ -103,7 +103,7 @@ public class JdbcBlob extends JdbcLob implements Blob {
     @Override
     public int setBytes(long pos, byte[] bytes) throws SQLException {
         if (bytes == null) {
-            return 0;
+            throw new NullPointerException();
         }
         try {
             if (isDebugEnabled()) {
@@ -133,7 +133,7 @@ public class JdbcBlob extends JdbcLob implements Blob {
     public int setBytes(long pos, byte[] bytes, int offset, int len)
             throws SQLException {
         if (bytes == null) {
-            return 0;
+            throw new NullPointerException();
         }
         try {
             if (isDebugEnabled()) {


### PR DESCRIPTION
Fix for #1352. Allow for Command re-run, which is possible due to locking / concurrent updates. 
This PR also fixes issue in TestCrashAPI, when null is passed as byte[] to JdbcBlob::setBytes(). I don't think behavior is specified by JDBC, so it will return 0, instead of throwing SQLException, which upsets test.