### PR TITLE
Simplify execution flow in some places

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,66 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1357: Simplify execution flow in some places
+</li>
+<li>PR #1356: Fix NPE in Query.initExpression()
+</li>
+<li>PR #1355: Assorted changes in MetaTable
+</li>
+<li>Issue #1352: TestCrashAPI: Prepared.getObjectId() was called before
+</li>
+<li>PR #1349: Changes is conversion and comparison methods of Value
+</li>
+<li>Issue #1346: Exception when using IN condition for enums
+</li>
+<li>PR #1345: Replace some init methods with constructors
+</li>
+<li>PR #1344: Streamline last chunk verification on startup
+</li>
+<li>PR #1341: Optimize MVSecondaryIndex.convertToKey()
+</li>
+<li>PR #1340: NoSuchElementException instead of returning null
+</li>
+<li>PR #1339: Add support of TIMESTAMP WITH TIME ZONE to addition and subtraction operators
+</li>
+<li>PR #1337: Streamline Value comparison
+</li>
+<li>PR #1336: Minor refactorings
+</li>
+<li>Issue #1332: Constraint name not set correctly
+</li>
+<li>Rename fields to reflect actual type
+</li>
+<li>Issue #1331: Regression in Database.updateMeta()
+</li>
+<li>Issue #1323: Slow update after altering table in 1.4.197
+</li>
+<li>PR #1326: Add support of PERCENT in FETCH and TOP clauses
+</li>
+<li>PR #1325: Optimize WITH TIES in some queries and specify data types for KEY_COLUMN_USAGE
+</li>
+<li>PR #1321: Do not add rows before OFFSET to result if possible
+</li>
+<li>PR #1319: Treat NEXTVAL as an auto-generated key
+</li>
+<li>PR #1318: Mode append fo MVPlainTempResult
+</li>
+<li>PR #1314: Add ALTER VIEW RENAME command
+</li>
+<li>PR #1313, issue #1315: Bugfix - using default locale encoding issue in conversion between varchar and varbinary value, and checking javac output text issue in SourceCompiler
+</li>
+<li>PR #1312: Add Java 9+ support to NIO_CLEANER_HACK
+</li>
+<li>PR #1311: Fix minor issues with ResultSet.getObject(..., Class) and WITH TIES
+</li>
+<li>Issue #1298: TestKillRestartMulti: A map named undoLog.2 already exists
+</li>
+<li>Issue #1307: Invalid value "null" for parameter "calendar" [90008-193]
+</li>
+<li>PR #1306: Add initial implementation of WITH TIES clause
+</li>
+<li>PR #1304: Update changelog and fix building of documentation
+</li>
 <li>PR #1302: Use OpenJDK instead of OracleJDK 10 in Travis builds due to Travis problem
 </li>
 <li>Issue #1032: Error when executing "SELECT DISTINCT ON"

--- a/h2/src/main/org/h2/command/ddl/CommandWithColumns.java
+++ b/h2/src/main/org/h2/command/ddl/CommandWithColumns.java
@@ -43,20 +43,15 @@ public abstract class CommandWithColumns extends SchemaCommand {
      *            the statement to add
      */
     public void addConstraintCommand(DefineCommand command) {
-        if (command instanceof CreateIndex) {
-            getConstraintCommands().add(command);
-        } else {
+        if (!(command instanceof CreateIndex)) {
             AlterTableAddConstraint con = (AlterTableAddConstraint) command;
-            boolean alreadySet;
             if (con.getType() == CommandInterface.ALTER_TABLE_ADD_CONSTRAINT_PRIMARY_KEY) {
-                alreadySet = setPrimaryKey(con);
-            } else {
-                alreadySet = false;
-            }
-            if (!alreadySet) {
-                getConstraintCommands().add(command);
+                if (setPrimaryKey(con)) {
+                    return;
+                }
             }
         }
+        getConstraintCommands().add(command);
     }
 
     /**

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -754,7 +754,7 @@ public abstract class Value {
             case DECIMAL: {
                 switch (getType()) {
                 case BOOLEAN:
-                    return ValueDecimal.get(BigDecimal.valueOf(getBoolean() ? 1 : 0));
+                    return (ValueDecimal) (getBoolean() ? ValueDecimal.ONE : ValueDecimal.ZERO);
                 case BYTE:
                 case SHORT:
                 case ENUM:

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -514,11 +514,11 @@ public abstract class Value {
      * @return the result
      */
     public Value add(@SuppressWarnings("unused") Value v) {
-        throw throwUnsupportedExceptionForType("+");
+        throw getUnsupportedExceptionForOperation("+");
     }
 
     public int getSignum() {
-        throw throwUnsupportedExceptionForType("SIGNUM");
+        throw getUnsupportedExceptionForOperation("SIGNUM");
     }
 
     /**
@@ -527,7 +527,7 @@ public abstract class Value {
      * @return the negative
      */
     public Value negate() {
-        throw throwUnsupportedExceptionForType("NEG");
+        throw getUnsupportedExceptionForOperation("NEG");
     }
 
     /**
@@ -537,7 +537,7 @@ public abstract class Value {
      * @return the result
      */
     public Value subtract(@SuppressWarnings("unused") Value v) {
-        throw throwUnsupportedExceptionForType("-");
+        throw getUnsupportedExceptionForOperation("-");
     }
 
     /**
@@ -547,7 +547,7 @@ public abstract class Value {
      * @return the result
      */
     public Value divide(@SuppressWarnings("unused") Value v) {
-        throw throwUnsupportedExceptionForType("/");
+        throw getUnsupportedExceptionForOperation("/");
     }
 
     /**
@@ -557,7 +557,7 @@ public abstract class Value {
      * @return the result
      */
     public Value multiply(@SuppressWarnings("unused") Value v) {
-        throw throwUnsupportedExceptionForType("*");
+        throw getUnsupportedExceptionForOperation("*");
     }
 
     /**
@@ -567,7 +567,7 @@ public abstract class Value {
      * @return the result
      */
     public Value modulus(@SuppressWarnings("unused") Value v) {
-        throw throwUnsupportedExceptionForType("%");
+        throw getUnsupportedExceptionForOperation("%");
     }
 
     /**
@@ -1320,15 +1320,14 @@ public abstract class Value {
     }
 
     /**
-     * Throw the exception that the feature is not support for the given data
-     * type.
+     * Create an exception meaning the specified operation is not supported for
+     * this data type.
      *
      * @param op the operation
-     * @return never returns normally
-     * @throws DbException the exception
+     * @return the exception
      */
-    protected DbException throwUnsupportedExceptionForType(String op) {
-        throw DbException.getUnsupportedException(
+    protected final DbException getUnsupportedExceptionForOperation(String op) {
+        return DbException.getUnsupportedException(
                 DataType.getDataType(getType()).name + " " + op);
     }
 

--- a/h2/src/main/org/h2/value/ValueResultSet.java
+++ b/h2/src/main/org/h2/value/ValueResultSet.java
@@ -142,7 +142,7 @@ public class ValueResultSet extends Value {
 
     @Override
     public void set(PreparedStatement prep, int parameterIndex) {
-        throw throwUnsupportedExceptionForType("PreparedStatement.set");
+        throw getUnsupportedExceptionForOperation("PreparedStatement.set");
     }
 
     @Override


### PR DESCRIPTION
1. `Query.initExpression()` is now more readable and shorter.

2. `CommandWithColumns.addConstraintCommand()` is simplified.

3. `Value.throwUnsupportedExceptionForType()` is renamed to `getUnsupportedExceptionForOperation()`. Method was changed to return an exception instead of throwing it because all callers throw this exception by themselves, method was not `void` and was confusing. (It's better to throw exception in callers to see normal method instead of helper method on top of the stack trace.)

4. Conversion from `BOOLEAN` to `DECIMAL` is optimized; difference is very low, of course.