### PR TITLE
Include the META-INF resources in the resulting build.

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -197,6 +197,7 @@
           <include>org/h2/res/help.csv</include>
           <include>org/h2/res/javadoc.properties</include>
           <include>org/h2/server/pg/pg_catalog.sql</include>
+          <include>META-INF/**</include>
         </includes>
       </resource>
     </resources>


### PR DESCRIPTION
Without that the sql Driver service file is not there.

Closes #1327.