### PR TITLE
Parse BINARY VARYING, BINARY LARGE OBJECT, and CHARACTER LARGE OBJECT

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2757,7 +2757,8 @@ TIMESTAMP WITH TIME ZONE
 "
 
 "Data Types","BINARY Type","
-{ BINARY | VARBINARY | LONGVARBINARY | RAW | BYTEA }
+{ BINARY | VARBINARY | BINARY VARYING
+    | LONGVARBINARY | RAW | BYTEA }
 [ ( precisionInt ) ]
 ","
 Represents a byte array. For very long arrays, use BLOB.
@@ -2786,7 +2787,7 @@ OTHER
 "
 
 "Data Types","VARCHAR Type","
-{ VARCHAR | LONGVARCHAR | VARCHAR2 | NVARCHAR
+{ VARCHAR | CHARACTER VARYING | LONGVARCHAR | VARCHAR2 | NVARCHAR
     | NVARCHAR2 | VARCHAR_CASESENSITIVE} [ ( precisionInt ) ]
 ","
 A Unicode String.
@@ -2839,7 +2840,8 @@ CHAR(10)
 "
 
 "Data Types","BLOB Type","
-{ BLOB | TINYBLOB | MEDIUMBLOB | LONGBLOB | IMAGE | OID }
+{ BLOB | BINARY LARGE OBJECT
+    | TINYBLOB | MEDIUMBLOB | LONGBLOB | IMAGE | OID }
 [ ( precisionInt ) ]
 ","
 Like BINARY, but intended for very large values such as files or images. Unlike
@@ -2853,7 +2855,8 @@ BLOB
 "
 
 "Data Types","CLOB Type","
-{ CLOB | TINYTEXT | TEXT | MEDIUMTEXT | LONGTEXT | NTEXT | NCLOB }
+{ CLOB | CHARACTER LARGE OBJECT
+    | TINYTEXT | TEXT | MEDIUMTEXT | LONGTEXT | NTEXT | NCLOB }
 [ ( precisionInt ) ]
 ","
 CLOB is like VARCHAR, but intended for very large values. Unlike when using

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4688,15 +4688,25 @@ public class Parser {
         int originalScale = -1;
         if (readIf("LONG")) {
             if (readIf("RAW")) {
-                original += " RAW";
+                original = "LONG RAW";
             }
         } else if (readIf("DOUBLE")) {
             if (readIf("PRECISION")) {
-                original += " PRECISION";
+                original = "DOUBLE PRECISION";
             }
         } else if (readIf("CHARACTER")) {
             if (readIf("VARYING")) {
-                original += " VARYING";
+                original = "CHARACTER VARYING";
+            } else if (readIf("LARGE")) {
+                read("OBJECT");
+                original = "CHARACTER LARGE OBJECT";
+            }
+        } else if (readIf("BINARY")) {
+            if (readIf("VARYING")) {
+                original = "BINARY VARYING";
+            } else if (readIf("LARGE")) {
+                read("OBJECT");
+                original = "BINARY LARGE OBJECT";
             }
         } else if (readIf("TIME")) {
             if (readIf(OPEN_PAREN)) {
@@ -4709,7 +4719,7 @@ public class Parser {
             if (readIf("WITHOUT")) {
                 read("TIME");
                 read("ZONE");
-                original += " WITHOUT TIME ZONE";
+                original = "TIME WITHOUT TIME ZONE";
             }
         } else if (readIf("TIMESTAMP")) {
             if (readIf(OPEN_PAREN)) {
@@ -4726,11 +4736,11 @@ public class Parser {
             if (readIf(WITH)) {
                 read("TIME");
                 read("ZONE");
-                original += " WITH TIME ZONE";
+                original = "TIMESTAMP WITH TIME ZONE";
             } else if (readIf("WITHOUT")) {
                 read("TIME");
                 read("ZONE");
-                original += " WITHOUT TIME ZONE";
+                original = "TIMESTAMP WITHOUT TIME ZONE";
             }
         } else {
             regular = true;

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -192,8 +192,8 @@ public class DataType {
         );
         add(Value.STRING, Types.VARCHAR,
                 createString(true),
-                new String[]{"VARCHAR", "VARCHAR2", "NVARCHAR", "NVARCHAR2",
-                    "VARCHAR_CASESENSITIVE", "CHARACTER VARYING", "TID"},
+                new String[]{"VARCHAR", "CHARACTER VARYING", "VARCHAR2", "NVARCHAR", "NVARCHAR2",
+                    "VARCHAR_CASESENSITIVE", "TID"},
                 // 24 for ValueString, 24 for String
                 48
         );
@@ -319,7 +319,7 @@ public class DataType {
         );
         add(Value.BYTES, Types.VARBINARY,
                 createString(false),
-                new String[]{"VARBINARY"},
+                new String[]{"VARBINARY", "BINARY VARYING"},
                 32
         );
         add(Value.BYTES, Types.BINARY,
@@ -345,14 +345,14 @@ public class DataType {
         );
         add(Value.BLOB, Types.BLOB,
                 createLob(),
-                new String[]{"BLOB", "TINYBLOB", "MEDIUMBLOB",
+                new String[]{"BLOB", "BINARY LARGE OBJECT", "TINYBLOB", "MEDIUMBLOB",
                     "LONGBLOB", "IMAGE", "OID"},
                 // 80 for ValueLob, 24 for String
                 104
         );
         add(Value.CLOB, Types.CLOB,
                 createLob(),
-                new String[]{"CLOB", "TINYTEXT", "TEXT", "MEDIUMTEXT",
+                new String[]{"CLOB", "CHARACTER LARGE OBJECT", "TINYTEXT", "TEXT", "MEDIUMTEXT",
                     "LONGTEXT", "NTEXT", "NCLOB"},
                 // 80 for ValueLob, 24 for String
                 104

--- a/h2/src/test/org/h2/test/scripts/datatypes/binary.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/binary.sql
@@ -2,3 +2,22 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+CREATE TABLE TEST(B1 VARBINARY, B2 BINARY VARYING, B3 BINARY, B4 RAW, B5 BYTEA, B6 LONG RAW, B7 LONGVARBINARY);
+> ok
+
+SELECT COLUMN_NAME, DATA_TYPE, TYPE_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME DATA_TYPE TYPE_NAME COLUMN_TYPE
+> ----------- --------- --------- --------------
+> B1          -3        VARBINARY VARBINARY
+> B2          -3        VARBINARY BINARY VARYING
+> B3          -3        VARBINARY BINARY
+> B4          -3        VARBINARY RAW
+> B5          -3        VARBINARY BYTEA
+> B6          -3        VARBINARY LONG RAW
+> B7          -3        VARBINARY LONGVARBINARY
+> rows (ordered): 7
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/datatypes/blob.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/blob.sql
@@ -2,3 +2,22 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+CREATE TABLE TEST(B1 BLOB, B2 BINARY LARGE OBJECT, B3 TINYBLOB, B4 MEDIUMBLOB, B5 LONGBLOB, B6 IMAGE, B7 OID);
+> ok
+
+SELECT COLUMN_NAME, DATA_TYPE, TYPE_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME DATA_TYPE TYPE_NAME COLUMN_TYPE
+> ----------- --------- --------- -------------------
+> B1          2004      BLOB      BLOB
+> B2          2004      BLOB      BINARY LARGE OBJECT
+> B3          2004      BLOB      TINYBLOB
+> B4          2004      BLOB      MEDIUMBLOB
+> B5          2004      BLOB      LONGBLOB
+> B6          2004      BLOB      IMAGE
+> B7          2004      BLOB      OID
+> rows (ordered): 7
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/datatypes/char.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/char.sql
@@ -2,3 +2,18 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+CREATE TABLE TEST(C1 CHAR, C2 CHARACTER, C3 NCHAR);
+> ok
+
+SELECT COLUMN_NAME, DATA_TYPE, TYPE_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME DATA_TYPE TYPE_NAME COLUMN_TYPE
+> ----------- --------- --------- -----------
+> C1          1         CHAR      CHAR
+> C2          1         CHAR      CHARACTER
+> C3          1         CHAR      NCHAR
+> rows (ordered): 3
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/datatypes/clob.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/clob.sql
@@ -2,3 +2,24 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+CREATE TABLE TEST(C1 CLOB, C2 CHARACTER LARGE OBJECT, C3 TINYTEXT, C4 TEXT, C5 MEDIUMTEXT, C6 LONGTEXT, C7 NTEXT,
+    C8 NCLOB);
+> ok
+
+SELECT COLUMN_NAME, DATA_TYPE, TYPE_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME DATA_TYPE TYPE_NAME COLUMN_TYPE
+> ----------- --------- --------- ----------------------
+> C1          2005      CLOB      CLOB
+> C2          2005      CLOB      CHARACTER LARGE OBJECT
+> C3          2005      CLOB      TINYTEXT
+> C4          2005      CLOB      TEXT
+> C5          2005      CLOB      MEDIUMTEXT
+> C6          2005      CLOB      LONGTEXT
+> C7          2005      CLOB      NTEXT
+> C8          2005      CLOB      NCLOB
+> rows (ordered): 8
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/datatypes/varchar-ignorecase.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/varchar-ignorecase.sql
@@ -2,3 +2,16 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+CREATE TABLE TEST(C1 VARCHAR_IGNORECASE);
+> ok
+
+SELECT COLUMN_NAME, DATA_TYPE, TYPE_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME DATA_TYPE TYPE_NAME          COLUMN_TYPE
+> ----------- --------- ------------------ ------------------
+> C1          12        VARCHAR_IGNORECASE VARCHAR_IGNORECASE
+> rows (ordered): 1
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/datatypes/varchar.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/varchar.sql
@@ -2,3 +2,24 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+CREATE TABLE TEST(C1 VARCHAR, C2 CHARACTER VARYING, C3 VARCHAR2, C4 NVARCHAR, C5 NVARCHAR2, C6 VARCHAR_CASESENSITIVE,
+    C7 LONGVARCHAR, C8 TID);
+> ok
+
+SELECT COLUMN_NAME, DATA_TYPE, TYPE_NAME, COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME DATA_TYPE TYPE_NAME COLUMN_TYPE
+> ----------- --------- --------- ---------------------
+> C1          12        VARCHAR   VARCHAR
+> C2          12        VARCHAR   CHARACTER VARYING
+> C3          12        VARCHAR   VARCHAR2
+> C4          12        VARCHAR   NVARCHAR
+> C5          12        VARCHAR   NVARCHAR2
+> C6          12        VARCHAR   VARCHAR_CASESENSITIVE
+> C7          12        VARCHAR   LONGVARCHAR
+> C8          12        VARCHAR   TID
+> rows (ordered): 8
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
`BINARY VARYING`, `BINARY LARGE OBJECT`, and `CHARACTER LARGE OBJECT` data types from the SQL standard are now mapped to `Value.BYTES`, `Value.BLOB` and `Value.CLOB`.

Some unnecessary string concatenations in `Parser.parseColumnWithType` are now avoided.