### PR TITLE
Minor fixes for INTERVAL data type

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2244,7 +2244,7 @@ intType | booleanType | tinyintType | smallintType | bigintType | identityType
     | decimalType | doubleType | realType | dateType | timeType | timestampType
     | timestampWithTimeZoneType | binaryType | otherType | varcharType
     | varcharIgnorecaseType | charType | blobType | clobType | uuidType
-    | arrayType | enumType
+    | arrayType | enumType | intervalType
 ","
 A data type definition.
 ","
@@ -3048,7 +3048,7 @@ and ""ResultSet.getObject(..)"" or ""ResultSet.getString(..)"" to retrieve the v
 GEOMETRY
 "
 
-"Data Types","INTERVAL Types","
+"Data Types","INTERVAL Type","
 intervalYearType | intervalMonthType | intervalDayType
     | intervalHourType| intervalMinuteType | intervalSecondType
     | intervalYearToMonthType | intervalDayToHourType
@@ -3056,8 +3056,8 @@ intervalYearType | intervalMonthType | intervalDayType
     | intervalHourToMinuteType | intervalHourToSecondType
     | intervalMinuteToSecondType
 ","
-Interval data types.
-There are two classes of intervals. Year-month intervals can store years or months.
+Interval data type.
+There are two classes of intervals. Year-month intervals can store years and months.
 Day-time intervals can store days, hours, minutes, and seconds.
 Year-month intervals are comparable only with another year-month intervals.
 Day-time intervals are comparable only with another day-time intervals.

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -1285,7 +1285,11 @@ public abstract class Value {
                 if (JdbcUtils.customDataTypesHandler != null) {
                     return JdbcUtils.customDataTypesHandler.convert(this, targetType);
                 }
-                throw DbException.throwInternalError("type=" + targetType);
+                DataType from = DataType.getDataType(getType());
+                DataType to = DataType.getDataType(targetType);
+                throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1,
+                        (from != null ? from.name : "type=" + getType()) + " to "
+                                + (to != null ? to.name : "type=" + targetType));
             }
         } catch (NumberFormatException e) {
             throw DbException.get(

--- a/h2/src/test/org/h2/test/synth/TestCrashAPI.java
+++ b/h2/src/test/org/h2/test/synth/TestCrashAPI.java
@@ -527,13 +527,11 @@ public class TestCrashAPI extends TestDb implements Runnable {
 
     private void initMethods() {
         for (Class<?> inter : INTERFACES) {
-            classMethods.put(inter, new ArrayList<Method>());
-        }
-        for (Class<?> inter : INTERFACES) {
-            ArrayList<Method> list = classMethods.get(inter);
+            ArrayList<Method> list = new ArrayList<>();
             for (Method m : inter.getMethods()) {
                 list.add(m);
             }
+            classMethods.put(inter, list);
         }
     }
 


### PR DESCRIPTION
1. Throw data conversion error on unsupported casts instead of general error. This behavior is more correct. Fixes failure in `TestCrashAPI`.

2. Loops are joined in `TestCrashAPI.initMethods()`.

3. A link to `INTERVAL` data type is added to a list of data types in other grammar section of documentation.