### PR TITLE
Add more subclases of SQLException and use it for some error codes

### DIFF
--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -533,9 +533,8 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Long running transactions: log session id when detected.
 </li><li>Optimization: "select id from test" should use the index on id even without "order by".
 </li><li>Sybase SQL Anywhere compatibility: SELECT TOP ... START AT ...
-</li><li>Use Java 6 SQLException subclasses.
+</li><li>Use Java 6 SQLException subclasses for more kinds of errors.
 </li><li>Issue 390: RUNSCRIPT FROM '...' CONTINUE_ON_ERROR
-</li><li>Use Java 6 exceptions: SQLDataException, SQLSyntaxErrorException, SQLTimeoutException,..
 </li></ul>
 
 <h2>Not Planned</h2>

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -16,7 +16,7 @@ import org.h2.api.JavaObjectSerializer;
 import org.h2.command.CommandInterface;
 import org.h2.command.CommandRemote;
 import org.h2.command.dml.SetTypes;
-import org.h2.jdbc.JdbcSQLException;
+import org.h2.jdbc.JdbcException;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.message.TraceSystem;
@@ -338,8 +338,7 @@ public class SessionRemote extends SessionWithState implements DataHandler {
             DbException e = DbException.convert(re);
             if (e.getErrorCode() == ErrorCode.DATABASE_ALREADY_OPEN_1) {
                 if (autoServerMode) {
-                    String serverKey = ((JdbcSQLException) e.getSQLException()).
-                            getSQL();
+                    String serverKey = ((JdbcException) e.getSQLException()).getSQL();
                     if (serverKey != null) {
                         backup.setServerKey(serverKey);
                         // OPEN_NEW must be removed now, otherwise

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -7,6 +7,7 @@ package org.h2.engine;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.sql.SQLException;
 import java.util.ArrayList;
 
 import org.h2.api.DatabaseEventListener;
@@ -604,8 +605,7 @@ public class SessionRemote extends SessionWithState implements DataHandler {
             String sql = transfer.readString();
             int errorCode = transfer.readInt();
             String stackTrace = transfer.readString();
-            JdbcSQLException s = new JdbcSQLException(message, sql, sqlstate,
-                    errorCode, null, stackTrace);
+            SQLException s = DbException.getJdbcSQLException(message, sql, sqlstate, errorCode, null, stackTrace);
             if (errorCode == ErrorCode.CONNECTION_BROKEN_1) {
                 // allow re-connect
                 throw new IOException(s.toString(), s);

--- a/h2/src/main/org/h2/jdbc/JdbcException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.jdbc;
+
+/**
+ * This interface contains additional methods for database exceptions.
+ */
+public interface JdbcException {
+
+    /**
+     * Returns the H2-specific error code.
+     *
+     * @return the H2-specific error code
+     */
+    public int getErrorCode();
+
+    /**
+     * INTERNAL
+     */
+    String getOriginalMessage();
+
+    /**
+     * Returns the SQL statement.
+     * <p>
+     * SQL statements that contain '--hide--' are not listed.
+     * </p>
+     *
+     * @return the SQL statement
+     */
+    String getSQL();
+
+    /**
+     * INTERNAL
+     */
+    void setSQL(String sql);
+
+    /**
+     * Returns the class name, the message, and in the server mode, the stack
+     * trace of the server
+     *
+     * @return the string representation
+     */
+    @Override
+    String toString();
+
+}

--- a/h2/src/main/org/h2/jdbc/JdbcSQLDataException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLDataException.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.jdbc;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.sql.SQLDataException;
+
+import org.h2.message.DbException;
+
+/**
+ * Represents a database exception.
+ */
+public class JdbcSQLDataException extends SQLDataException implements JdbcException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String originalMessage;
+    private final String stackTrace;
+    private String message;
+    private String sql;
+
+    /**
+     * Creates a SQLDataException.
+     *
+     * @param message the reason
+     * @param sql the SQL statement
+     * @param state the SQL state
+     * @param errorCode the error code
+     * @param cause the exception that was the reason for this exception
+     * @param stackTrace the stack trace
+     */
+    public JdbcSQLDataException(String message, String sql, String state,
+            int errorCode, Throwable cause, String stackTrace) {
+        super(message, state, errorCode);
+        this.originalMessage = message;
+        this.stackTrace = stackTrace;
+        // setSQL() also generates message
+        setSQL(sql);
+        initCause(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public String getSQL() {
+        return sql;
+    }
+
+    @Override
+    public void setSQL(String sql) {
+        this.sql = sql;
+        message = DbException.buildMessageForException(this);
+    }
+
+    @Override
+    public String toString() {
+        if (stackTrace == null) {
+            return super.toString();
+        }
+        return stackTrace;
+    }
+
+}

--- a/h2/src/main/org/h2/jdbc/JdbcSQLException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLException.java
@@ -24,8 +24,8 @@ public class JdbcSQLException extends SQLException {
     public static final String HIDE_SQL = "--hide--";
 
     private static final long serialVersionUID = 1L;
+
     private final String originalMessage;
-    private final Throwable cause;
     private final String stackTrace;
     private String message;
     private String sql;
@@ -44,7 +44,6 @@ public class JdbcSQLException extends SQLException {
             int errorCode, Throwable cause, String stackTrace) {
         super(message, state, errorCode);
         this.originalMessage = message;
-        this.cause = cause;
         this.stackTrace = stackTrace;
         // setSQL() invokes buildMessage() by itself
         setSQL(sql);
@@ -122,13 +121,6 @@ public class JdbcSQLException extends SQLException {
                 s.println("(truncated)");
             }
         }
-    }
-
-    /**
-     * INTERNAL
-     */
-    public Throwable getOriginalCause() {
-        return cause;
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcSQLFeatureNotSupportedException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLFeatureNotSupportedException.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.jdbc;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.sql.SQLFeatureNotSupportedException;
+
+import org.h2.message.DbException;
+
+/**
+ * Represents a database exception.
+ */
+public class JdbcSQLFeatureNotSupportedException extends SQLFeatureNotSupportedException implements JdbcException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String originalMessage;
+    private final String stackTrace;
+    private String message;
+    private String sql;
+
+    /**
+     * Creates a SQLFeatureNotSupportedException.
+     *
+     * @param message the reason
+     * @param sql the SQL statement
+     * @param state the SQL state
+     * @param errorCode the error code
+     * @param cause the exception that was the reason for this exception
+     * @param stackTrace the stack trace
+     */
+    public JdbcSQLFeatureNotSupportedException(String message, String sql, String state,
+            int errorCode, Throwable cause, String stackTrace) {
+        super(message, state, errorCode);
+        this.originalMessage = message;
+        this.stackTrace = stackTrace;
+        // setSQL() also generates message
+        setSQL(sql);
+        initCause(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public String getSQL() {
+        return sql;
+    }
+
+    @Override
+    public void setSQL(String sql) {
+        this.sql = sql;
+        message = DbException.buildMessageForException(this);
+    }
+
+    @Override
+    public String toString() {
+        if (stackTrace == null) {
+            return super.toString();
+        }
+        return stackTrace;
+    }
+
+}

--- a/h2/src/main/org/h2/jdbc/JdbcSQLIntegrityConstraintViolationException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLIntegrityConstraintViolationException.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.jdbc;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.sql.SQLIntegrityConstraintViolationException;
+
+import org.h2.message.DbException;
+
+/**
+ * Represents a database exception.
+ */
+public class JdbcSQLIntegrityConstraintViolationException extends SQLIntegrityConstraintViolationException
+        implements JdbcException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String originalMessage;
+    private final String stackTrace;
+    private String message;
+    private String sql;
+
+    /**
+     * Creates a SQLIntegrityConstraintViolationException.
+     *
+     * @param message the reason
+     * @param sql the SQL statement
+     * @param state the SQL state
+     * @param errorCode the error code
+     * @param cause the exception that was the reason for this exception
+     * @param stackTrace the stack trace
+     */
+    public JdbcSQLIntegrityConstraintViolationException(String message, String sql, String state,
+            int errorCode, Throwable cause, String stackTrace) {
+        super(message, state, errorCode);
+        this.originalMessage = message;
+        this.stackTrace = stackTrace;
+        // setSQL() also generates message
+        setSQL(sql);
+        initCause(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public String getSQL() {
+        return sql;
+    }
+
+    @Override
+    public void setSQL(String sql) {
+        this.sql = sql;
+        message = DbException.buildMessageForException(this);
+    }
+
+    @Override
+    public String toString() {
+        if (stackTrace == null) {
+            return super.toString();
+        }
+        return stackTrace;
+    }
+
+}

--- a/h2/src/main/org/h2/jdbc/JdbcSQLInvalidAuthorizationSpecException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLInvalidAuthorizationSpecException.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.jdbc;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.sql.SQLInvalidAuthorizationSpecException;
+
+import org.h2.message.DbException;
+
+/**
+ * Represents a database exception.
+ */
+public class JdbcSQLInvalidAuthorizationSpecException extends SQLInvalidAuthorizationSpecException
+        implements JdbcException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String originalMessage;
+    private final String stackTrace;
+    private String message;
+    private String sql;
+
+    /**
+     * Creates a SQLInvalidAuthorizationSpecException.
+     *
+     * @param message the reason
+     * @param sql the SQL statement
+     * @param state the SQL state
+     * @param errorCode the error code
+     * @param cause the exception that was the reason for this exception
+     * @param stackTrace the stack trace
+     */
+    public JdbcSQLInvalidAuthorizationSpecException(String message, String sql, String state,
+            int errorCode, Throwable cause, String stackTrace) {
+        super(message, state, errorCode);
+        this.originalMessage = message;
+        this.stackTrace = stackTrace;
+        // setSQL() also generates message
+        setSQL(sql);
+        initCause(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public String getSQL() {
+        return sql;
+    }
+
+    @Override
+    public void setSQL(String sql) {
+        this.sql = sql;
+        message = DbException.buildMessageForException(this);
+    }
+
+    @Override
+    public String toString() {
+        if (stackTrace == null) {
+            return super.toString();
+        }
+        return stackTrace;
+    }
+
+}

--- a/h2/src/main/org/h2/jdbc/JdbcSQLNonTransientConnectionException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLNonTransientConnectionException.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.jdbc;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.sql.SQLNonTransientConnectionException;
+
+import org.h2.message.DbException;
+
+/**
+ * Represents a database exception.
+ */
+public class JdbcSQLNonTransientConnectionException extends SQLNonTransientConnectionException
+        implements JdbcException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String originalMessage;
+    private final String stackTrace;
+    private String message;
+    private String sql;
+
+    /**
+     * Creates a SQLNonTransientConnectionException.
+     *
+     * @param message the reason
+     * @param sql the SQL statement
+     * @param state the SQL state
+     * @param errorCode the error code
+     * @param cause the exception that was the reason for this exception
+     * @param stackTrace the stack trace
+     */
+    public JdbcSQLNonTransientConnectionException(String message, String sql, String state,
+            int errorCode, Throwable cause, String stackTrace) {
+        super(message, state, errorCode);
+        this.originalMessage = message;
+        this.stackTrace = stackTrace;
+        // setSQL() also generates message
+        setSQL(sql);
+        initCause(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public String getSQL() {
+        return sql;
+    }
+
+    @Override
+    public void setSQL(String sql) {
+        this.sql = sql;
+        message = DbException.buildMessageForException(this);
+    }
+
+    @Override
+    public String toString() {
+        if (stackTrace == null) {
+            return super.toString();
+        }
+        return stackTrace;
+    }
+
+}

--- a/h2/src/main/org/h2/jdbc/JdbcSQLSyntaxErrorException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLSyntaxErrorException.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.jdbc;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.sql.SQLSyntaxErrorException;
+
+import org.h2.message.DbException;
+
+/**
+ * Represents a database exception.
+ */
+public class JdbcSQLSyntaxErrorException extends SQLSyntaxErrorException implements JdbcException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String originalMessage;
+    private final String stackTrace;
+    private String message;
+    private String sql;
+
+    /**
+     * Creates a SQLSyntaxErrorException.
+     *
+     * @param message the reason
+     * @param sql the SQL statement
+     * @param state the SQL state
+     * @param errorCode the error code
+     * @param cause the exception that was the reason for this exception
+     * @param stackTrace the stack trace
+     */
+    public JdbcSQLSyntaxErrorException(String message, String sql, String state,
+            int errorCode, Throwable cause, String stackTrace) {
+        super(message, state, errorCode);
+        this.originalMessage = message;
+        this.stackTrace = stackTrace;
+        // setSQL() also generates message
+        setSQL(sql);
+        initCause(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public String getSQL() {
+        return sql;
+    }
+
+    @Override
+    public void setSQL(String sql) {
+        this.sql = sql;
+        message = DbException.buildMessageForException(this);
+    }
+
+    @Override
+    public String toString() {
+        if (stackTrace == null) {
+            return super.toString();
+        }
+        return stackTrace;
+    }
+
+}

--- a/h2/src/main/org/h2/jdbc/JdbcSQLTransactionRollbackException.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLTransactionRollbackException.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.jdbc;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.sql.SQLTransactionRollbackException;
+
+import org.h2.message.DbException;
+
+/**
+ * Represents a database exception.
+ */
+public class JdbcSQLTransactionRollbackException extends SQLTransactionRollbackException implements JdbcException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String originalMessage;
+    private final String stackTrace;
+    private String message;
+    private String sql;
+
+    /**
+     * Creates a SQLTransactionRollbackException.
+     *
+     * @param message the reason
+     * @param sql the SQL statement
+     * @param state the SQL state
+     * @param errorCode the error code
+     * @param cause the exception that was the reason for this exception
+     * @param stackTrace the stack trace
+     */
+    public JdbcSQLTransactionRollbackException(String message, String sql, String state,
+            int errorCode, Throwable cause, String stackTrace) {
+        super(message, state, errorCode);
+        this.originalMessage = message;
+        this.stackTrace = stackTrace;
+        // setSQL() also generates message
+        setSQL(sql);
+        initCause(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        super.printStackTrace(s);
+        DbException.printNextExceptions(this, s);
+    }
+
+    @Override
+    public String getSQL() {
+        return sql;
+    }
+
+    @Override
+    public void setSQL(String sql) {
+        this.sql = sql;
+        message = DbException.buildMessageForException(this);
+    }
+
+    @Override
+    public String toString() {
+        if (stackTrace == null) {
+            return super.toString();
+        }
+        return stackTrace;
+    }
+
+}

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -406,8 +406,8 @@ public class DbException extends RuntimeException {
         }
         if (e instanceof JdbcSQLException) {
             JdbcSQLException e2 = (JdbcSQLException) e;
-            if (e2.getOriginalCause() != null) {
-                e = e2.getOriginalCause();
+            if (e2.getCause() != null) {
+                e = e2.getCause();
             }
         }
         return new IOException(e.toString(), e);

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -135,8 +135,8 @@ public class DbException extends RuntimeException {
      */
     public DbException addSQL(String sql) {
         SQLException e = getSQLException();
-        if (e instanceof JdbcSQLException) {
-            JdbcSQLException j = (JdbcSQLException) e;
+        if (e instanceof JdbcException) {
+            JdbcException j = (JdbcException) e;
             if (j.getSQL() == null) {
                 j.setSQL(filterSQL(sql));
             }

--- a/h2/src/main/org/h2/message/TraceSystem.java
+++ b/h2/src/main/org/h2/message/TraceSystem.java
@@ -13,7 +13,7 @@ import java.text.SimpleDateFormat;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
-import org.h2.jdbc.JdbcSQLException;
+import org.h2.jdbc.JdbcException;
 import org.h2.store.fs.FileUtils;
 import org.h2.util.IOUtils;
 
@@ -260,8 +260,8 @@ public class TraceSystem implements TraceWriter {
             }
             printWriter.println(s);
             if (t != null) {
-                if (levelFile == ERROR && t instanceof JdbcSQLException) {
-                    JdbcSQLException se = (JdbcSQLException) t;
+                if (levelFile == ERROR && t instanceof JdbcException) {
+                    JdbcException se = (JdbcException) t;
                     int code = se.getErrorCode();
                     if (ErrorCode.isCommon(code)) {
                         printWriter.println(t.toString());

--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -28,7 +28,7 @@ import org.h2.engine.SysProperties;
 import org.h2.expression.Parameter;
 import org.h2.expression.ParameterInterface;
 import org.h2.expression.ParameterRemote;
-import org.h2.jdbc.JdbcSQLException;
+import org.h2.jdbc.JdbcException;
 import org.h2.message.DbException;
 import org.h2.result.ResultColumn;
 import org.h2.result.ResultInterface;
@@ -235,8 +235,8 @@ public class TcpServerThread implements Runnable {
             String trace = writer.toString();
             String message;
             String sql;
-            if (e instanceof JdbcSQLException) {
-                JdbcSQLException j = (JdbcSQLException) e;
+            if (e instanceof JdbcException) {
+                JdbcException j = (JdbcException) e;
                 message = j.getOriginalMessage();
                 sql = j.getSQL();
             } else {

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -42,7 +42,7 @@ import org.h2.bnf.context.DbSchema;
 import org.h2.bnf.context.DbTableOrView;
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
-import org.h2.jdbc.JdbcSQLException;
+import org.h2.jdbc.JdbcException;
 import org.h2.message.DbException;
 import org.h2.security.SHA256;
 import org.h2.tools.Backup;
@@ -935,8 +935,7 @@ public class WebApp {
      * @return the formatted error message
      */
     private String getLoginError(Exception e, boolean isH2) {
-        if (e instanceof JdbcSQLException &&
-                ((JdbcSQLException) e).getErrorCode() == ErrorCode.CLASS_NOT_FOUND_1) {
+        if (e instanceof JdbcException && ((JdbcException) e).getErrorCode() == ErrorCode.CLASS_NOT_FOUND_1) {
             return "${text.login.driverNotFound}<br />" + getStackTrace(0, e, isH2);
         }
         return getStackTrace(0, e, isH2);

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -41,7 +41,6 @@ import org.h2.expression.ValueExpression;
 import org.h2.index.Index;
 import org.h2.index.IndexType;
 import org.h2.index.MetaIndex;
-import org.h2.jdbc.JdbcSQLException;
 import org.h2.message.DbException;
 import org.h2.mvstore.FileStore;
 import org.h2.mvstore.MVStore;
@@ -788,7 +787,7 @@ public class MetaTable extends Table {
                 }
                 String sql = table.getCreateSQL();
                 if (!admin) {
-                    if (sql != null && sql.contains(JdbcSQLException.HIDE_SQL)) {
+                    if (sql != null && sql.contains(DbException.HIDE_SQL)) {
                         // hide the password of linked tables
                         sql = "-";
                     }

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -24,7 +24,6 @@ import org.h2.engine.UndoLogRecord;
 import org.h2.index.Index;
 import org.h2.index.IndexType;
 import org.h2.index.LinkedIndex;
-import org.h2.jdbc.JdbcSQLException;
 import org.h2.message.DbException;
 import org.h2.result.Row;
 import org.h2.result.RowList;
@@ -392,7 +391,7 @@ public class TableLink extends Table {
         if (readOnly) {
             buff.append(" READONLY");
         }
-        buff.append(" /*").append(JdbcSQLException.HIDE_SQL).append("*/");
+        buff.append(" /*").append(DbException.HIDE_SQL).append("*/");
         return buff.toString();
     }
 

--- a/h2/src/main/org/h2/util/IntervalUtils.java
+++ b/h2/src/main/org/h2/util/IntervalUtils.java
@@ -395,7 +395,8 @@ public class IntervalUtils {
      *            the value of all remaining fields
      * @return string representation of the specified interval
      */
-    public static String intervalToString(IntervalQualifier qualifier, boolean negative, long leading, long remaining) {
+    public static String intervalToString(IntervalQualifier qualifier, boolean negative, long leading, long remaining)
+    {
         StringBuilder buff = new StringBuilder().append("INTERVAL ");
         buff.append('\'');
         if (negative) {
@@ -553,8 +554,8 @@ public class IntervalUtils {
         case MONTH:
             return ValueInterval.from(qualifier, absolute.signum() < 0, leadingExact(absolute), 0);
         case DAY:
-            return ValueInterval.from(qualifier, absolute.signum() < 0, leadingExact(absolute.divide(NANOS_PER_DAY_BI)),
-                    0);
+            return ValueInterval.from(qualifier, absolute.signum() < 0,
+                    leadingExact(absolute.divide(NANOS_PER_DAY_BI)), 0);
         case HOUR:
             return ValueInterval.from(qualifier, absolute.signum() < 0,
                     leadingExact(absolute.divide(NANOS_PER_HOUR_BI)), 0);
@@ -696,7 +697,8 @@ public class IntervalUtils {
      *            values of all remaining fields
      * @return months, or 0
      */
-    public static long monthsFromInterval(IntervalQualifier qualifier, boolean negative, long leading, long remaining) {
+    public static long monthsFromInterval(IntervalQualifier qualifier, boolean negative, long leading, long remaining)
+    {
         long v;
         if (qualifier == IntervalQualifier.MONTH) {
             v = leading;

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -15,7 +15,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.ErrorCode;
-import org.h2.jdbc.JdbcSQLException;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 
@@ -278,7 +277,7 @@ public class TestCompatibility extends TestDb {
             try {
                 stat.execute("CREATE TABLE TEST(COL " + type + ")");
                 fail("Expect type " + type + " to not exist in PostgreSQL mode");
-            } catch (org.h2.jdbc.JdbcSQLException e) {
+            } catch (SQLException e) {
                 /* Expected! */
             }
         }
@@ -675,7 +674,7 @@ public class TestCompatibility extends TestDb {
         try {
             getConnection("compatibility;MODE=Unknown").close();
             deleteDb("compatibility");
-        } catch (JdbcSQLException ex) {
+        } catch (SQLException ex) {
             assertEquals(ErrorCode.UNKNOWN_MODE_1, ex.getErrorCode());
             return;
         }

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -46,7 +46,6 @@ import org.h2.api.Aggregate;
 import org.h2.api.AggregateFunction;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
-import org.h2.jdbc.JdbcSQLException;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
@@ -2023,12 +2022,12 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         conn.close();
     }
 
-    private void testAnnotationProcessorsOutput() throws SQLException {
+    private void testAnnotationProcessorsOutput() {
         try {
             System.setProperty(TestAnnotationProcessor.MESSAGES_KEY, "WARNING,foo1|ERROR,foo2");
             callCompiledFunction("test_annotation_processor_warn_and_error");
             fail();
-        } catch (JdbcSQLException e) {
+        } catch (SQLException e) {
             assertEquals(ErrorCode.SYNTAX_ERROR_1, e.getErrorCode());
             assertContains(e.getMessage(), "foo1");
             assertContains(e.getMessage(), "foo2");

--- a/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
+++ b/h2/src/test/org/h2/test/db/TestGeneralCommonTableQueries.java
@@ -8,8 +8,8 @@ package org.h2.test.db;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
-import org.h2.jdbc.JdbcSQLException;
 import org.h2.test.TestAll;
 import org.h2.test.TestBase;
 
@@ -235,7 +235,7 @@ public class TestGeneralCommonTableQueries extends AbstractBaseForCommonTableExp
             rs = prep.executeQuery();
             fail("Temp view T1 was accessible after previous WITH statement finished "+
                     "- but should not have been.");
-        } catch (JdbcSQLException e) {
+        } catch (SQLException e) {
             // ensure the T1 table has been removed even without auto commit
             assertContains(e.getMessage(), "Table \"T1\" not found;");
         }

--- a/h2/src/test/org/h2/test/db/TestMergeUsing.java
+++ b/h2/src/test/org/h2/test/db/TestMergeUsing.java
@@ -347,7 +347,7 @@ public class TestMergeUsing extends TestDb implements Trigger {
         try {
             testMergeUsing(setupSQL, statementUnderTest, gatherResultsSQL,
                     expectedResultsSQL, expectedRowUpdateCount);
-        } catch (RuntimeException | org.h2.jdbc.JdbcSQLException e) {
+        } catch (RuntimeException | SQLException e) {
             if (!e.getMessage().contains(exceptionMessage)) {
                 e.printStackTrace();
             }

--- a/h2/src/test/org/h2/test/db/TestMultiThread.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThread.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.h2.api.ErrorCode;
-import org.h2.jdbc.JdbcSQLException;
 import org.h2.test.TestAll;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
@@ -372,9 +371,8 @@ public class TestMultiThread extends TestDb implements Runnable {
                     // ignore timeout exceptions, happens periodically when the
                     // machine is really busy and it's not the thing we are
                     // trying to test
-                    if (!(ex.getCause() instanceof JdbcSQLException)
-                            || ((JdbcSQLException) ex.getCause())
-                                    .getErrorCode() != ErrorCode.LOCK_TIMEOUT_1) {
+                    if (!(ex.getCause() instanceof SQLException)
+                            || ((SQLException) ex.getCause()).getErrorCode() != ErrorCode.LOCK_TIMEOUT_1) {
                         throw ex;
                     }
                 }

--- a/h2/src/test/org/h2/test/db/TestSetCollation.java
+++ b/h2/src/test/org/h2/test/db/TestSetCollation.java
@@ -5,7 +5,6 @@
  */
 package org.h2.test.db;
 
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -14,7 +13,6 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.h2.jdbc.JdbcSQLException;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 
@@ -124,7 +122,7 @@ public class TestSetCollation extends TestDb {
         try {
             getConnection(DB_NAME);
             fail();
-        } catch (JdbcSQLException e) {
+        } catch (SQLException e) {
             // expected
         } finally {
             config.collation = null;

--- a/h2/src/test/org/h2/test/db/TestSynonymForTable.java
+++ b/h2/src/test/org/h2/test/db/TestSynonymForTable.java
@@ -10,8 +10,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
-import org.h2.jdbc.JdbcSQLException;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 
@@ -71,7 +71,7 @@ public class TestSynonymForTable extends TestDb {
         stat.execute("CREATE OR REPLACE SYNONYM testsynonym FOR s1.backingtable");
         stat.execute("DROP SCHEMA s1 CASCADE");
 
-        assertThrows(JdbcSQLException.class, stat).execute("SELECT id FROM testsynonym");
+        assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, stat).execute("SELECT id FROM testsynonym");
         conn.close();
     }
 
@@ -82,7 +82,7 @@ public class TestSynonymForTable extends TestDb {
         stat.execute("DROP TABLE backingtable");
 
         // Backing table does not exist anymore.
-        assertThrows(JdbcSQLException.class, stat).execute("SELECT id FROM testsynonym");
+        assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, stat).execute("SELECT id FROM testsynonym");
 
         // Synonym should be dropped as well
         ResultSet synonyms = conn.createStatement().executeQuery(
@@ -92,7 +92,7 @@ public class TestSynonymForTable extends TestDb {
 
         // Reopening should work with dropped synonym
         Connection conn2 = getConnection("synonym");
-        assertThrows(JdbcSQLException.class, stat).execute("SELECT id FROM testsynonym");
+        assertThrows(ErrorCode.OBJECT_CLOSED, stat).execute("SELECT id FROM testsynonym");
         conn2.close();
     }
 
@@ -104,13 +104,13 @@ public class TestSynonymForTable extends TestDb {
         stat.execute("DROP SYNONYM testsynonym");
 
         // Synonym does not exist anymore.
-        assertThrows(JdbcSQLException.class, stat).execute("SELECT id FROM testsynonym");
+        assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, stat).execute("SELECT id FROM testsynonym");
 
         // Dropping with "if exists" should succeed even if the synonym does not exist anymore.
         stat.execute("DROP SYNONYM IF EXISTS testsynonym");
 
         // Without "if exists" the command should fail if the synonym does not exist.
-        assertThrows(JdbcSQLException.class, stat).execute("DROP SYNONYM testsynonym");
+        assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, stat).execute("DROP SYNONYM testsynonym");
         conn.close();
     }
 
@@ -132,7 +132,8 @@ public class TestSynonymForTable extends TestDb {
         Statement stat = conn.createStatement();
         stat.execute("CREATE TABLE IF NOT EXISTS backingtable(id INT PRIMARY KEY)");
 
-        assertThrows(JdbcSQLException.class, stat).execute("CREATE OR REPLACE SYNONYM backingtable FOR backingtable");
+        assertThrows(ErrorCode.TABLE_OR_VIEW_ALREADY_EXISTS_1, stat)
+                .execute("CREATE OR REPLACE SYNONYM backingtable FOR backingtable");
         conn.close();
     }
 
@@ -194,7 +195,8 @@ public class TestSynonymForTable extends TestDb {
         Connection conn = getConnection("synonym");
         Statement stat = conn.createStatement();
 
-        assertThrows(JdbcSQLException.class, stat).execute("CREATE SYNONYM someSynonym FOR nonexistingTable");
+        assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, stat)
+                .execute("CREATE SYNONYM someSynonym FOR nonexistingTable");
         conn.close();
     }
 
@@ -203,7 +205,8 @@ public class TestSynonymForTable extends TestDb {
         Statement stat = conn.createStatement();
         stat.execute("CREATE TABLE IF NOT EXISTS backingtable(id INT PRIMARY KEY)");
 
-        assertThrows(JdbcSQLException.class, stat).execute("CREATE SYNONYM backingtable FOR backingtable");
+        assertThrows(ErrorCode.TABLE_OR_VIEW_ALREADY_EXISTS_1, stat)
+                .execute("CREATE SYNONYM backingtable FOR backingtable");
         conn.close();
     }
 


### PR DESCRIPTION
Some tools and libraries also check class of exception to detect type of an error.

Some subclasses of `SQLException` are introduced here. Common error codes are now mapped to different exceptions.

This pull request does not introduce proper subclasses of `SQLException` for all possible errors. Many error codes have some generic class (50xxx or 90xxx) instead of proper class; few of them are mapped to subclasses too, however.

Missing subclasses:
* `SQLClientInfoException` is not used because it requires full information about all wrong settings.
* `SQLTimeoutException` is not introduced because timeout in H2 cannot be currently distinguished from cancelled command.
* `SQLNonTransientException`, `SQLRecoverableException`, and `SQLTransientException` are not used because it's too hard to check all error codes and decide proper types for them. It can be done later.
* `SQLWarning` is not introduced because there is no such feature in H2.

Some error codes like `SUM_OR_AVG_ON_WRONG_DATATYPE_1` should probably be mapped to `JdbcSQLSyntaxErrorException`, but I think that they should change error code to 42xxx instead of custom mapping. Currently most of such errors with generic codes simply throw `SQLException` without more detailed subclass.