### PR TITLE
Added org.h2.store.fs package to exported osgi bundles

### DIFF
--- a/h2/src/main/META-INF/MANIFEST.MF
+++ b/h2/src/main/META-INF/MANIFEST.MF
@@ -68,6 +68,7 @@ Export-Package: org.h2;version="${version}",
  org.h2.mvstore;version="${version}",
  org.h2.mvstore.tx;version="${version}",
  org.h2.mvstore.type;version="${version}",
- org.h2.mvstore.rtree;version="${version}"
+ org.h2.mvstore.rtree;version="${version}",
+ org.h2.store.fs;version="${version}"
 Provide-Capability: osgi.service;objectClass:List<String>=org.osgi.service.jdbc.DataSourceFactory
 Premain-Class: org.h2.util.Profiler


### PR DESCRIPTION
H2 has the mechanism of registering custom FilePaths (FilePath.register) unfortunately this API is not exposed to an OSGi environment. This pull request adds the "org.h2.store.fs" package to the exported bundles.