### PR TITLE
Assorted minor changes

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1397,18 +1397,17 @@ public class Parser {
 
 
     private Prepared parseMerge() {
-        Merge command = new Merge(session);
-        currentPrepared = command;
         int start = lastParseIndex;
         read("INTO");
         List<String> excludeIdentifiers = Arrays.asList("USING", "KEY", "VALUES");
         TableFilter targetTableFilter = readSimpleTableFilter(0, excludeIdentifiers);
+        if (readIf("USING")) {
+            return parseMergeUsing(targetTableFilter, start);
+        }
+        Merge command = new Merge(session);
+        currentPrepared = command;
         command.setTargetTableFilter(targetTableFilter);
         Table table = command.getTargetTable();
-
-        if (readIf("USING")) {
-            return parseMergeUsing(command, start);
-        }
         if (readIf(OPEN_PAREN)) {
             if (isSelect()) {
                 command.setQuery(parseSelect());
@@ -1434,8 +1433,8 @@ public class Parser {
         return command;
     }
 
-    private MergeUsing parseMergeUsing(Merge oldCommand, int start) {
-        MergeUsing command = new MergeUsing(oldCommand);
+    private MergeUsing parseMergeUsing(TableFilter targetTableFilter, int start) {
+        MergeUsing command = new MergeUsing(session, targetTableFilter);
         currentPrepared = command;
 
         if (readIf(OPEN_PAREN)) {

--- a/h2/src/main/org/h2/command/dml/MergeUsing.java
+++ b/h2/src/main/org/h2/command/dml/MergeUsing.java
@@ -15,6 +15,7 @@ import org.h2.api.Trigger;
 import org.h2.command.CommandInterface;
 import org.h2.command.Prepared;
 import org.h2.engine.Right;
+import org.h2.engine.Session;
 import org.h2.expression.ConditionAndOr;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
@@ -32,7 +33,7 @@ import org.h2.value.Value;
 
 /**
  * This class represents the statement syntax
- * MERGE table alias USING...
+ * MERGE INTO table alias USING...
  *
  * It does not replace the existing MERGE INTO... KEYS... form.
  *
@@ -119,12 +120,10 @@ public class MergeUsing extends Prepared {
     private int sourceQueryRowNumber;
 
 
-    public MergeUsing(Merge merge) {
-        super(merge.getSession());
-
-        // bring across only the already parsed data from Merge...
-        this.targetTable = merge.getTargetTable();
-        this.targetTableFilter = merge.getTargetTableFilter();
+    public MergeUsing(Session session, TableFilter targetTableFilter) {
+        super(session);
+        this.targetTable = targetTableFilter.getTable();
+        this.targetTableFilter = targetTableFilter;
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -577,14 +577,13 @@ public abstract class Query extends Prepared {
 
     /**
      * Create a {@link SortOrder} object given the list of {@link SelectOrderBy}
-     * objects. The expression list is extended if necessary.
+     * objects.
      *
      * @param orderList a list of {@link SelectOrderBy} elements
      * @param expressionCount the number of columns in the query
      * @return the {@link SortOrder} object
      */
-    public SortOrder prepareOrder(ArrayList<SelectOrderBy> orderList,
-            int expressionCount) {
+    public SortOrder prepareOrder(ArrayList<SelectOrderBy> orderList, int expressionCount) {
         int size = orderList.size();
         int[] index = new int[size];
         int[] sortType = new int[size];
@@ -592,8 +591,7 @@ public abstract class Query extends Prepared {
             SelectOrderBy o = orderList.get(i);
             int idx;
             boolean reverse = false;
-            Expression expr = o.columnIndexExpr;
-            Value v = expr.getValue(null);
+            Value v = o.columnIndexExpr.getValue(null);
             if (v == ValueNull.INSTANCE) {
                 // parameter not yet set - order by first column
                 idx = 0;
@@ -612,11 +610,7 @@ public abstract class Query extends Prepared {
             int type = o.sortType;
             if (reverse) {
                 // TODO NULLS FIRST / LAST should be inverted too?
-                if ((type & SortOrder.DESCENDING) != 0) {
-                    type &= ~SortOrder.DESCENDING;
-                } else {
-                    type |= SortOrder.DESCENDING;
-                }
+                type ^= SortOrder.DESCENDING;
             }
             sortType[i] = type;
         }

--- a/h2/src/main/org/h2/expression/ConditionInParameter.java
+++ b/h2/src/main/org/h2/expression/ConditionInParameter.java
@@ -116,7 +116,7 @@ public class ConditionInParameter extends Condition {
     @Override
     public Expression optimize(Session session) {
         left = left.optimize(session);
-        if (left.isConstant() && left == ValueExpression.getNull()) {
+        if (left == ValueExpression.getNull()) {
             return left;
         }
         return this;

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -104,7 +104,7 @@ public class Transfer {
      * @return the value
      */
     public boolean readBoolean() throws IOException {
-        return in.readByte() == 1;
+        return in.readByte() != 0;
     }
 
     /**
@@ -217,11 +217,8 @@ public class Transfer {
         if (s == null) {
             out.writeInt(-1);
         } else {
-            int len = s.length();
-            out.writeInt(len);
-            for (int i = 0; i < len; i++) {
-                out.writeChar(s.charAt(i));
-            }
+            out.writeInt(s.length());
+            out.writeChars(s);
         }
         return this;
     }

--- a/h2/src/main/org/h2/value/ValueBytes.java
+++ b/h2/src/main/org/h2/value/ValueBytes.java
@@ -153,8 +153,7 @@ public class ValueBytes extends Value {
             return this;
         }
         int len = MathUtils.convertLongToInt(precision);
-        byte[] buff = Arrays.copyOf(value, len);
-        return get(buff);
+        return getNoCopy(Arrays.copyOf(value, len));
     }
 
 }

--- a/h2/src/test/org/h2/test/scripts/dml/select.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/select.sql
@@ -289,3 +289,43 @@ SELECT ID FROM TEST FETCH NEXT ROW ONLY LIMIT 1;
 
 DROP TABLE TEST;
 > ok
+
+-- ORDER BY with parameter
+CREATE TABLE TEST(A INT, B INT);
+> ok
+
+INSERT INTO TEST VALUES (1, 1), (1, 2), (2, 1), (2, 2);
+> update count: 4
+
+SELECT * FROM TEST ORDER BY ?, ? FETCH FIRST ROW ONLY;
+{
+1, 2
+> A B
+> - -
+> 1 1
+> rows (ordered): 1
+-1, 2
+> A B
+> - -
+> 2 1
+> rows (ordered): 1
+1, -2
+> A B
+> - -
+> 1 2
+> rows (ordered): 1
+-1, -2
+> A B
+> - -
+> 2 2
+> rows (ordered): 1
+2, -1
+> A B
+> - -
+> 2 1
+> rows (ordered): 1
+}
+> update count: 0
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
1. `Transfer.readBoolean()` should use traditional `!= 0`, it also generates shorter code.
2. `Transfer.writeString()` can use `writeChars()` instead of own code.
3. Use short and simple bit mask in rarely used part of `Query.prepareOrder()`. Javadoc of this method is also fixed, it has nothing to do with list of expressions, they are already processed during preparation stage. I didn't found where this code was tested (may be nowhere?), so I wrote a new tests for it.
4. `ConditionInParameter.optimize()` can simply compare left part with `NULL` expression.
5. Temporary `Merge` object in not used for `MergeUsing`, mostly to simplify reading of the code. It looks like `Merge` is used somewhere, but it's not, it's only a temporary holder for a table filter.