### PR TITLE
Fix some inconsistencies in documentation and improve mvn build

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -200,6 +200,10 @@
           <include>META-INF/**</include>
         </includes>
       </resource>
+      <resource>
+        <directory>src/java9/precompiled</directory>
+        <targetPath>META-INF/versions/9</targetPath>
+      </resource>
     </resources>
     <testResources>
   <testResource>

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -106,8 +106,8 @@ Before the result is returned to the application, all rows are read by the datab
 Server side cursors are not supported currently.
 If only the first few rows are interesting for the application, then the
 result set size should be limited to improve the performance.
-This can be done using <code>LIMIT</code> in a query
-(example: <code>SELECT * FROM TEST LIMIT 100</code>),
+This can be done using <code>FETCH</code> in a query
+(example: <code>SELECT * FROM TEST FETCH FIRST 100 ROWS ONLY</code>),
 or by using <code>Statement.setMaxRows(max)</code>.
 </p>
 

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -143,7 +143,7 @@ encrypted using the AES-128 encryption algorithm
 
 <h3>Other Features and Tools</h3>
 <ul>
-<li>Small footprint (smaller than 1.5 MB), low memory requirements
+<li>Small footprint (around 2 MB), low memory requirements
 </li><li>Multiple index types (b-tree, tree, hash)
 </li><li>Support for multi-dimensional indexes
 </li><li>CSV (comma separated values) file support

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -1044,8 +1044,6 @@ or the SQL statement <code>SET MODE DB2</code>.
 <ul><li>For aliased columns, <code>ResultSetMetaData.getColumnName()</code>
     returns the alias name and <code>getTableName()</code> returns
     <code>null</code>.
-</li><li>Support for the syntax <code>[OFFSET .. ROW] [FETCH ... ONLY]</code>
-    as an alternative for <code>LIMIT .. OFFSET</code>.
 </li><li>Concatenating <code>NULL</code> with another value
     results in the other value.
 </li><li>Support the pseudo-table SYSIBM.SYSDUMMY1.

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -119,7 +119,8 @@ Features
 </li><li>Many built-in functions, including XML and lossless data compression
 </li><li>Wide range of data types including large objects (BLOB/CLOB) and arrays
 </li><li>Sequence and autoincrement columns, computed columns (can be used for function based indexes)
-</li><li><code>ORDER BY, GROUP BY, HAVING, UNION, LIMIT, TOP</code>
+</li><li>ORDER BY, GROUP BY, HAVING, UNION, OFFSET / FETCH (including PERCENT and WITH TIES), LIMIT, TOP,
+    DISTINCT / DISTINCT ON (...)
 </li><li>Collation support, including support for the ICU4J library
 </li><li>Support for users and roles
 </li><li>Compatibility modes for IBM DB2, Apache Derby, HSQLDB,

--- a/h2/src/docsrc/html/fragments.html
+++ b/h2/src/docsrc/html/fragments.html
@@ -80,7 +80,7 @@ translate -->
 <a href="datatypes.html">Data Types</a><br />
 <a href="systemtables.html">System Tables</a><br />
 <a href="../javadoc/index.html">Javadoc</a><br />
-<a href="../h2.pdf">PDF (1 MB)</a><br />
+<a href="../h2.pdf">PDF (1.5 MB)</a><br />
 <br />
 <b>Support</b><br />
 <a href="faq.html">FAQ</a><br />

--- a/h2/src/docsrc/html/mainWeb.html
+++ b/h2/src/docsrc/html/mainWeb.html
@@ -29,7 +29,7 @@ Welcome to H2, the Java SQL database. The main features of H2 are:
 <li>Very fast, open source, JDBC API
 </li><li>Embedded and server modes; in-memory databases
 </li><li>Browser based Console application
-</li><li>Small footprint: around 1.5 MB jar file size
+</li><li>Small footprint: around 2 MB jar file size
 </li></ul>
 
 <table style="border: 0px; width: 470px;">
@@ -60,9 +60,9 @@ Welcome to H2, the Java SQL database. The main features of H2 are:
             <tr><td style="border: 0px; background-color: #eee;">
                 <h2 style="margin-top: 1em;">Support</h2>
                 <p>
-                    <a href="http://stackoverflow.com/questions/tagged/h2">Stack Overflow (tag H2)</a><br /><br />
-                    <a href="http://groups.google.com/group/h2-database">Google Group English</a>,
-                    <a href="http://groups.google.co.jp/group/h2-database-jp">Japanese</a><br /><br />
+                    <a href="https://stackoverflow.com/questions/tagged/h2">Stack Overflow (tag H2)</a><br /><br />
+                    <a href="https://groups.google.com/forum/#!forum/h2-database">Google Group English</a>,
+                    <a href="https://groups.google.com/forum/#!forum/h2-database-jp">Japanese</a><br /><br />
                     For non-technical issues, use: <br />
                     <script type="text/javascript">
                     <!--
@@ -86,8 +86,8 @@ Welcome to H2, the Java SQL database. The main features of H2 are:
         <th>H2</th>
         <th><a href="http://db.apache.org/derby">Derby</a></th>
         <th><a href="http://hsqldb.org">HSQLDB</a></th>
-        <th><a href="http://mysql.com">MySQL</a></th>
-        <th><a href="http://www.postgresql.org">PostgreSQL</a></th>
+        <th><a href="https://www.mysql.com/">MySQL</a></th>
+        <th><a href="https://www.postgresql.org/">PostgreSQL</a></th>
         </tr><tr>
         <td>Pure Java</td>
         <td class="compareY">Yes</td>
@@ -131,12 +131,19 @@ Welcome to H2, the Java SQL database. The main features of H2 are:
         <td class="compareY">Yes</td>
         <td class="compareY">Yes</td>
         </tr><tr>
-        <td>Footprint (jar/dll size)</td>
-        <td>~1 MB</td>
+        <td>Footprint (embedded)</td>
         <td>~2 MB</td>
+        <td>~3 MB</td>
+        <td>~1.5 MB</td>
+        <td>&#8212;</td>
+        <td>&#8212;</td>
+        </tr><tr>
+        <td>Footprint (client)</td>
+        <td>~500 KB</td>
+        <td>~600 KB</td>
+        <td>~1.5 MB</td>
         <td>~1 MB</td>
-        <td>~4 MB</td>
-        <td>~6 MB</td>
+        <td>~700 KB</td>
         </tr>
     </table>
     <p>
@@ -154,7 +161,7 @@ Welcome to H2, the Java SQL database. The main features of H2 are:
             or <a href="http://www.h2database.com/html/newsfeed-rss.xml">Header only (RSS)</a>.
             </p><p>
                 <b>Email Newsletter:</b> Subscribe to
-                <a href="https://groups.google.com/group/h2database-news/subscribe">
+                <a href="https://groups.google.com/forum/#!forum/h2database-news/join">
                 H2 Database News (Google account required)</a>
                 to get informed about new releases.
                 Your email address is only used in this context.

--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -63,7 +63,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Window functions: RANK() and DENSE_RANK(), partition using OVER().
     select *, count(*) over() as fullCount from ... limit 4;
 </li><li>PostgreSQL catalog: use BEFORE SELECT triggers instead of views over metadata tables.
-</li><li>Compatibility: automatically load functions from a script depending on the mode - see FunctionsMySQL.java, issue 211.
 </li><li>Test very large databases and LOBs (up to 256 GB).
 </li><li>Store all temp files in the temp directory.
 </li><li>Don't use temp files, specially not deleteOnExit (bug 4513817: File.deleteOnExit consumes memory).


### PR DESCRIPTION
1. `mainWeb.html` is updated to include actual file sizes and links to other databases.
2. `OFFSET` / `FETCH` is not specific to DB2 mode, this is a standard feature that is available in all modes. Mention of it is removed from description of this compatibility mode.
3. `OFFSET` / `FETCH` and `DISTINCT ON` are mentioned in features.
4. `FunctionsMySQL` was included into main jar and it is loaded automatically in MySQL mode so an entry about it is removed from a roadmap.
5. Java 9+ code is now included in Maven build. Maven build, however, is still partially broken and inconsistent, it requires manual execution of `build.sh` / `build.bat` to generate reduced version of `help.csv`.