### PR TITLE
Add support for ENUM in CAST and other changes

### DIFF
--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -135,9 +135,9 @@ public class ScriptCommand extends ScriptBase {
     }
 
     private LocalResult createResult() {
-        Expression[] expressions = { new ExpressionColumn(
-                session.getDatabase(), new Column("SCRIPT", Value.STRING)) };
-        return session.getDatabase().getResultFactory().create(session, expressions, 1);
+        Database db = session.getDatabase();
+        return db.getResultFactory().create(session,
+                new Expression[] { new ExpressionColumn(db, new Column("SCRIPT", Value.STRING)) }, 1);
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 
 import org.h2.api.ErrorCode;
+import org.h2.engine.Database;
 import org.h2.engine.Mode;
 import org.h2.engine.Session;
 import org.h2.engine.SysProperties;
@@ -159,7 +160,8 @@ public class SelectUnion extends Query {
             }
             limitExpr = ValueExpression.get(ValueInt.get(l));
         }
-        if (session.getDatabase().getSettings().optimizeInsertFromSelect) {
+        Database db = session.getDatabase();
+        if (db.getSettings().optimizeInsertFromSelect) {
             if (unionType == UnionType.UNION_ALL && target != null) {
                 if (sort == null && !distinct && maxRows == 0 &&
                         offsetExpr == null && limitExpr == null) {
@@ -189,7 +191,7 @@ public class SelectUnion extends Query {
                 return lazyResult;
             }
         }
-        LocalResult result = session.getDatabase().getResultFactory().create(session, expressionArray, columnCount);
+        LocalResult result = db.getResultFactory().create(session, expressionArray, columnCount);
         if (sort != null) {
             result.setSortOrder(sort);
         }
@@ -239,7 +241,7 @@ public class SelectUnion extends Query {
             break;
         }
         case INTERSECT: {
-            LocalResult temp = session.getDatabase().getResultFactory().create(session, expressionArray, columnCount);
+            LocalResult temp = db.getResultFactory().create(session, expressionArray, columnCount);
             temp.setDistinct();
             while (l.next()) {
                 temp.addRow(convert(l.currentRow(), columnCount));

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -162,6 +162,8 @@ public class Function extends Expression implements FunctionCall {
     protected int scale;
     protected long precision = PRECISION_UNKNOWN;
     protected int displaySize;
+    protected String[] enumerators;
+
     private final Database database;
 
     static {
@@ -892,7 +894,7 @@ public class Function extends Expression implements FunctionCall {
         case CAST:
         case CONVERT: {
             Mode mode = database.getMode();
-            v0 = v0.convertTo(dataType, mode);
+            v0 = v0.convertTo(dataType, MathUtils.convertLongToInt(precision), mode, null, enumerators);
             v0 = v0.convertScale(mode.convertOnlyToSmallerScale, scale);
             v0 = v0.convertPrecision(getPrecision(), false);
             result = v0;
@@ -2198,6 +2200,7 @@ public class Function extends Expression implements FunctionCall {
         precision = col.getPrecision();
         displaySize = col.getDisplaySize();
         scale = col.getScale();
+        enumerators = col.getEnumerators();
     }
 
     @Override
@@ -2598,7 +2601,7 @@ public class Function extends Expression implements FunctionCall {
         case CAST: {
             buff.append(args[0].getSQL()).append(" AS ").
                 append(new Column(null, dataType, precision,
-                        scale, displaySize).getCreateSQL());
+                        scale, displaySize, enumerators).getCreateSQL());
             break;
         }
         case CONVERT: {

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -307,6 +307,11 @@ public class Aggregate extends Expression {
         }
         lastGroupRowId = groupRowId;
 
+        if (filterCondition != null) {
+            if (!filterCondition.getBooleanValue(session)) {
+                return;
+            }
+        }
         AggregateData data = (AggregateData) select.getCurrentGroupExprData(this);
         if (data == null) {
             data = AggregateData.create(type);
@@ -320,11 +325,6 @@ public class Aggregate extends Expression {
         } else if (type == AggregateType.ARRAY_AGG) {
             if (v != ValueNull.INSTANCE) {
                 v = updateCollecting(session, v);
-            }
-        }
-        if (filterCondition != null) {
-            if (!filterCondition.getBooleanValue(session)) {
-                return;
             }
         }
         data.add(session.getDatabase(), dataType, distinct, v);

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -315,31 +315,11 @@ public class Aggregate extends Expression {
         Value v = on == null ? null : on.getValue(session);
         if (type == AggregateType.GROUP_CONCAT) {
             if (v != ValueNull.INSTANCE) {
-                v = v.convertTo(Value.STRING);
-                if (orderByList != null) {
-                    int size = orderByList.size();
-                    Value[] array = new Value[1 + size];
-                    array[0] = v;
-                    for (int i = 0; i < size; i++) {
-                        SelectOrderBy o = orderByList.get(i);
-                        array[i + 1] = o.expression.getValue(session);
-                    }
-                    v = ValueArray.get(array);
-                }
+                v = updateCollecting(session, v.convertTo(Value.STRING));
             }
-        }
-        if (type == AggregateType.ARRAY_AGG) {
+        } else if (type == AggregateType.ARRAY_AGG) {
             if (v != ValueNull.INSTANCE) {
-                if (orderByList != null) {
-                    int size = orderByList.size();
-                    Value[] array = new Value[1 + size];
-                    array[0] = v;
-                    for (int i = 0; i < size; i++) {
-                        SelectOrderBy o = orderByList.get(i);
-                        array[i + 1] = o.expression.getValue(session);
-                    }
-                    v = ValueArray.get(array);
-                }
+                v = updateCollecting(session, v);
             }
         }
         if (filterCondition != null) {
@@ -348,6 +328,20 @@ public class Aggregate extends Expression {
             }
         }
         data.add(session.getDatabase(), dataType, distinct, v);
+    }
+
+    private Value updateCollecting(Session session, Value v) {
+        if (orderByList != null) {
+            int size = orderByList.size();
+            Value[] array = new Value[1 + size];
+            array[0] = v;
+            for (int i = 0; i < size; i++) {
+                SelectOrderBy o = orderByList.get(i);
+                array[i + 1] = o.expression.getValue(session);
+            }
+            v = ValueArray.get(array);
+        }
+        return v;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
@@ -265,3 +265,6 @@ DROP VIEW V3;
 
 DROP TABLE TEST;
 > ok
+
+SELECT CAST (2 AS ENUM('a', 'b', 'c', 'd'));
+>> c

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -794,4 +794,4 @@ minxf maxxf minyf maxyf bminxf bmaxxf bminyf bmaxyf
 minxd maxxd minyd maxyd bminxd bmaxxd bminyd bmaxyd
 interior envelopes multilinestring multipoint packed exterior normalization awkward determination subgeometries
 xym normalizes coord setz xyzm geometrycollection multipolygon mixup rings polygons rejection finite
-pointzm pointz pointm dimensionality
+pointzm pointz pointm dimensionality redefine forum measures


### PR DESCRIPTION
1. A new method `updateCollecting()` is extracted from `Aggregate.updateAggregate()` to reduce code duplication.
2. `FILTER (WHERE …)` condition is now evaluated earlier to avoid unnecessary work for rows that are not going to be included into aggregated result.
3. `ENUM` data type support was implemented for `CAST` function.
4. Some local variables are extracted.
5. `dictionary.txt` is updated.