### PR TITLE
Move more code from Aggregate and JavaAggregate to AbstractAggregate

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -217,6 +217,23 @@
     </testResource>
     </testResources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <mainClass>org.h2.tools.Console</mainClass>
+            </manifest>
+            <manifestEntries>
+              <Automatic-Module-Name>com.h2database</Automatic-Module-Name>
+              <Multi-Release>true</Multi-Release>
+              <Premain-Class>org.h2.util.Profiler</Premain-Class>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <!-- Add tools folder to test sources but consider moving them to src/test -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1449: Move more code from Aggregate and JavaAggregate to AbstractAggregate
+</li>
 <li>PR #1448: Add experimental implementation of grouped window queries
 </li>
 <li>PR #1447: Refactor OVER() processing code and fix some issues

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/sum.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/sum.sql
@@ -48,3 +48,17 @@ SELECT X, COUNT(*), SUM(COUNT(*)) OVER() FROM VALUES (1), (1), (1), (1), (2), (2
 > 2 2        7
 > 3 1        7
 > rows: 3
+
+CREATE TABLE TEST(ID INT);
+> ok
+
+SELECT SUM(ID) FROM TEST;
+>> null
+
+SELECT SUM(ID) OVER () FROM TEST;
+> SUM(ID) OVER ()
+> ---------------
+> rows: 0
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
1. A lot of common code, including window-processing code, is moved to `AbstractAggregate` to reduce code duplication and avoid potential problems in `JavaAggregate` that has only some basic test.

2. An additional test is introduced to ensure that window aggregates don't produce an implicit grand total row like normal aggregates if result set has no rows, I forgot to add test for it earlier.