### PR TITLE
Evaluate window aggregates only once for each partition

### DIFF
--- a/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
@@ -8,7 +8,6 @@ package org.h2.expression.aggregate;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.h2.api.Aggregate;
-import org.h2.api.ErrorCode;
 import org.h2.command.Parser;
 import org.h2.command.dml.Select;
 import org.h2.command.dml.SelectGroups;
@@ -158,16 +157,12 @@ public class JavaAggregate extends AbstractAggregate {
     }
 
     @Override
-    public Value getValue(Session session) {
-        SelectGroups groupData = select.getGroupDataIfCurrent(over != null);
-        if (groupData == null) {
-            throw DbException.get(ErrorCode.INVALID_USE_OF_AGGREGATE_FUNCTION_1, getSQL());
-        }
+    public Value getAggregatedValue(Session session, Object aggregateData) {
         try {
             Aggregate agg;
             if (distinct) {
                 agg = getInstance();
-                AggregateDataCollecting data = (AggregateDataCollecting) getData(session, groupData, true);
+                AggregateDataCollecting data = (AggregateDataCollecting) aggregateData;
                 if (data != null) {
                     for (Value value : data.values) {
                         if (args.length == 1) {
@@ -183,7 +178,7 @@ public class JavaAggregate extends AbstractAggregate {
                     }
                 }
             } else {
-                agg = (Aggregate) getData(session, groupData, true);
+                agg = (Aggregate) aggregateData;
                 if (agg == null) {
                     agg = getInstance();
                 }

--- a/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
@@ -10,7 +10,6 @@ import java.sql.SQLException;
 import org.h2.api.Aggregate;
 import org.h2.command.Parser;
 import org.h2.command.dml.Select;
-import org.h2.command.dml.SelectGroups;
 import org.h2.engine.Session;
 import org.h2.engine.UserAggregate;
 import org.h2.expression.Expression;

--- a/h2/src/main/org/h2/expression/aggregate/PartitionData.java
+++ b/h2/src/main/org/h2/expression/aggregate/PartitionData.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.aggregate;
+
+import org.h2.value.Value;
+
+/**
+ * Partition data of a window aggregate.
+ */
+final class PartitionData {
+
+    /**
+     * Aggregate data.
+     */
+    private final Object data;
+
+    /**
+     * Evaluated result.
+     */
+    private Value result;
+
+    /**
+     * Creates new instance of partition data.
+     *
+     * @param data
+     *            aggregate data
+     */
+    PartitionData(Object data) {
+        this.data = data;
+    }
+
+    /**
+     * Returns the aggregate data.
+     *
+     * @return the aggregate data
+     */
+    Object getData() {
+        return data;
+    }
+
+    /**
+     * Returns the result.
+     *
+     * @return the result
+     */
+    Value getResult() {
+        return result;
+    }
+
+    /**
+     * Sets the result.
+     *
+     * @param result
+     *            the result to set
+     */
+    void setResult(Value result) {
+        this.result = result;
+    }
+
+}

--- a/h2/src/main/org/h2/result/LocalResultImpl.java
+++ b/h2/src/main/org/h2/result/LocalResultImpl.java
@@ -84,6 +84,7 @@ public class LocalResultImpl implements LocalResult {
         return false;
     }
 
+    @Override
     public void setMaxMemoryRows(int maxValue) {
         this.maxMemoryRows = maxValue;
     }
@@ -134,6 +135,7 @@ public class LocalResultImpl implements LocalResult {
      *
      * @param sort the sort order
      */
+    @Override
     public void setSortOrder(SortOrder sort) {
         this.sort = sort;
     }
@@ -141,6 +143,7 @@ public class LocalResultImpl implements LocalResult {
     /**
      * Remove duplicate rows.
      */
+    @Override
     public void setDistinct() {
         assert distinctIndexes == null;
         distinct = true;
@@ -152,6 +155,7 @@ public class LocalResultImpl implements LocalResult {
      *
      * @param distinctIndexes distinct indexes
      */
+    @Override
     public void setDistinct(int[] distinctIndexes) {
         assert !distinct;
         this.distinctIndexes = distinctIndexes;
@@ -170,6 +174,7 @@ public class LocalResultImpl implements LocalResult {
      *
      * @param values the row
      */
+    @Override
     public void removeDistinct(Value[] values) {
         if (!distinct) {
             DbException.throwInternalError();
@@ -329,6 +334,7 @@ public class LocalResultImpl implements LocalResult {
     /**
      * This method is called after all rows have been added.
      */
+    @Override
     public void done() {
         if (external != null) {
             addRowsToDisk();
@@ -455,6 +461,7 @@ public class LocalResultImpl implements LocalResult {
      *
      * @param limit the limit (-1 means no limit, 0 means no rows)
      */
+    @Override
     public void setLimit(int limit) {
         this.limit = limit;
     }
@@ -462,6 +469,7 @@ public class LocalResultImpl implements LocalResult {
     /**
      * @param fetchPercent whether limit expression specifies percentage of rows
      */
+    @Override
     public void setFetchPercent(boolean fetchPercent) {
         this.fetchPercent = fetchPercent;
     }
@@ -469,6 +477,7 @@ public class LocalResultImpl implements LocalResult {
     /**
      * @param withTies whether tied rows should be included in result too
      */
+    @Override
     public void setWithTies(boolean withTies) {
         this.withTies = withTies;
     }
@@ -542,6 +551,7 @@ public class LocalResultImpl implements LocalResult {
      *
      * @param offset the offset
      */
+    @Override
     public void setOffset(int offset) {
         this.offset = offset;
     }

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/array-agg.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/array-agg.sql
@@ -151,12 +151,47 @@ SELECT ARRAY_AGG(ARRAY_AGG(ID ORDER /**/ BY ID)) OVER (PARTITION BY NAME), NAME 
 > ((4, 5, 6))                                                   c
 > rows: 3
 
-SELECT ARRAY_AGG(ARRAY_AGG(ID ORDER /**/ BY ID)) OVER (PARTITION BY NAME), NAME FROM TEST GROUP BY NAME ORDER /**/ BY NAME OFFSET 1 ROW;
+SELECT ARRAY_AGG(ARRAY_AGG(ID ORDER /**/ BY ID)) OVER (PARTITION BY NAME), NAME FROM TEST
+    GROUP BY NAME ORDER /**/ BY NAME OFFSET 1 ROW;
 > ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) OVER (PARTITION BY NAME) NAME
 > ------------------------------------------------------------- ----
 > ((3))                                                         b
 > ((4, 5, 6))                                                   c
 > rows: 2
+
+SELECT ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) FILTER (WHERE NAME > 'b') OVER (PARTITION BY NAME), NAME FROM TEST
+    GROUP BY NAME ORDER BY NAME;
+> ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) FILTER (WHERE (NAME > 'b')) OVER (PARTITION BY NAME) NAME
+> ----------------------------------------------------------------------------------------- ----
+> null                                                                                      a
+> null                                                                                      b
+> ((4, 5, 6))                                                                               c
+> rows (ordered): 3
+
+SELECT ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) FILTER (WHERE NAME > 'c') OVER (PARTITION BY NAME), NAME FROM TEST
+    GROUP BY NAME ORDER BY NAME;
+> ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) FILTER (WHERE (NAME > 'c')) OVER (PARTITION BY NAME) NAME
+> ----------------------------------------------------------------------------------------- ----
+> null                                                                                      a
+> null                                                                                      b
+> null                                                                                      c
+> rows (ordered): 3
+
+SELECT ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) FILTER (WHERE NAME > 'b') OVER () FROM TEST GROUP BY NAME ORDER BY NAME;
+> ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) FILTER (WHERE (NAME > 'b')) OVER ()
+> ------------------------------------------------------------------------
+> ((4, 5, 6))
+> ((4, 5, 6))
+> ((4, 5, 6))
+> rows (ordered): 3
+
+SELECT ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) FILTER (WHERE NAME > 'c') OVER () FROM TEST GROUP BY NAME ORDER BY NAME;
+> ARRAY_AGG(ARRAY_AGG(ID ORDER BY ID)) FILTER (WHERE (NAME > 'c')) OVER ()
+> ------------------------------------------------------------------------
+> null
+> null
+> null
+> rows (ordered): 3
 
 SELECT ARRAY_AGG(ID) OVER() FROM TEST GROUP BY NAME;
 > exception MUST_GROUP_BY_COLUMN_1


### PR DESCRIPTION
Because such aggregates with empty `OVER()` clause of with `OVER (PARTITION BY …)` clause return the same value for each row in a partition it's more reasonable to evaluate value only once, especially for slow aggregates or aggregates with large results (`ARRAY_AGG` etc.).

These changes are also a preparation work for `OVER (ORDER BY …)` clause.

Functionality is not changed here.

There are also a few new tests for corner cases based on code coverage results. Some branches were not covered by tests.