### PR TITLE
Reset aggregates before reuse

### DIFF
--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -276,9 +276,9 @@ public abstract class Query extends Prepared {
      * Update all aggregate function values.
      *
      * @param s the session
-     * @param window true for window processing stage, false for group stage
+     * @param stage select stage
      */
-    public abstract void updateAggregate(Session s, boolean window);
+    public abstract void updateAggregate(Session s, int stage);
 
     /**
      * Call the before triggers on all tables.

--- a/h2/src/main/org/h2/command/dml/SelectGroups.java
+++ b/h2/src/main/org/h2/command/dml/SelectGroups.java
@@ -115,6 +115,7 @@ public abstract class SelectGroups {
 
         @Override
         public void done() {
+            super.done();
             if (groupIndex == null && groupByData.size() == 0) {
                 groupByData.put(defaultGroup,
                         new Object[Math.max(exprToIndexInGroupByData.size(), expressions.size())]);
@@ -175,6 +176,7 @@ public abstract class SelectGroups {
 
         @Override
         public void done() {
+            super.done();
             cursor = rows.iterator();
         }
 
@@ -314,13 +316,6 @@ public abstract class SelectGroups {
         currentGroupByExprData = null;
         exprToIndexInGroupByData.clear();
         windowData.clear();
-    }
-
-    /**
-     * Reset the row id counter.
-     */
-    public void resetCounter() {
-        // TODO merge into reset() and done()
         currentGroupRowId = 0;
     }
 
@@ -333,7 +328,9 @@ public abstract class SelectGroups {
     /**
      * Invoked after all source rows are evaluated.
      */
-    public abstract void done();
+    public void done() {
+        currentGroupRowId = 0;
+    }
 
     /**
      * Returns the key of the next group.
@@ -347,6 +344,7 @@ public abstract class SelectGroups {
      */
     public void resetLazy() {
         currentGroupByExprData = null;
+        currentGroupRowId = 0;
     }
 
     /**

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -449,9 +449,9 @@ public class SelectUnion extends Query {
     }
 
     @Override
-    public void updateAggregate(Session s, boolean window) {
-        left.updateAggregate(s, window);
-        right.updateAggregate(s, window);
+    public void updateAggregate(Session s, int stage) {
+        left.updateAggregate(s, stage);
+        right.updateAggregate(s, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/Alias.java
+++ b/h2/src/main/org/h2/expression/Alias.java
@@ -83,8 +83,8 @@ public class Alias extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        expr.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        expr.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/BinaryOperation.java
+++ b/h2/src/main/org/h2/expression/BinaryOperation.java
@@ -436,9 +436,9 @@ public class BinaryOperation extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
-        right.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
+        right.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/CompareLike.java
+++ b/h2/src/main/org/h2/expression/CompareLike.java
@@ -495,11 +495,11 @@ public class CompareLike extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
-        right.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
+        right.updateAggregate(session, stage);
         if (escape != null) {
-            escape.updateAggregate(session, window);
+            escape.updateAggregate(session, stage);
         }
     }
 

--- a/h2/src/main/org/h2/expression/Comparison.java
+++ b/h2/src/main/org/h2/expression/Comparison.java
@@ -475,10 +475,10 @@ public class Comparison extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
         if (right != null) {
-            right.updateAggregate(session, window);
+            right.updateAggregate(session, stage);
         }
     }
 

--- a/h2/src/main/org/h2/expression/ConditionAndOr.java
+++ b/h2/src/main/org/h2/expression/ConditionAndOr.java
@@ -268,9 +268,9 @@ public class ConditionAndOr extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
-        right.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
+        right.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/ConditionExists.java
+++ b/h2/src/main/org/h2/expression/ConditionExists.java
@@ -46,7 +46,7 @@ public class ConditionExists extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         // TODO exists: is it allowed that the subquery contains aggregates?
         // probably not
         // select id from test group by id having exists (select * from test2

--- a/h2/src/main/org/h2/expression/ConditionIn.java
+++ b/h2/src/main/org/h2/expression/ConditionIn.java
@@ -163,10 +163,10 @@ public class ConditionIn extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
         for (Expression e : valueList) {
-            e.updateAggregate(session, window);
+            e.updateAggregate(session, stage);
         }
     }
 

--- a/h2/src/main/org/h2/expression/ConditionInConstantSet.java
+++ b/h2/src/main/org/h2/expression/ConditionInConstantSet.java
@@ -125,8 +125,8 @@ public class ConditionInConstantSet extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/ConditionInParameter.java
+++ b/h2/src/main/org/h2/expression/ConditionInParameter.java
@@ -145,8 +145,8 @@ public class ConditionInParameter extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/ConditionInSelect.java
+++ b/h2/src/main/org/h2/expression/ConditionInSelect.java
@@ -146,9 +146,9 @@ public class ConditionInSelect extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
-        query.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
+        query.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/ConditionNot.java
+++ b/h2/src/main/org/h2/expression/ConditionNot.java
@@ -70,8 +70,8 @@ public class ConditionNot extends Condition {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        condition.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        condition.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/Expression.java
+++ b/h2/src/main/org/h2/expression/Expression.java
@@ -105,9 +105,9 @@ public abstract class Expression {
      * be used to make sure the internal state is only updated once.
      *
      * @param session the session
-     * @param window true for window processing stage, false for group stage
+     * @param stage select stage
      */
-    public abstract void updateAggregate(Session session, boolean window);
+    public abstract void updateAggregate(Session session, int stage);
 
     /**
      * Check if this expression and all sub-expressions can fulfill a criteria.

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -153,7 +153,7 @@ public class ExpressionColumn extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         Value now = columnResolver.getValue(column);
         Select select = columnResolver.getSelect();
         if (select == null) {

--- a/h2/src/main/org/h2/expression/ExpressionList.java
+++ b/h2/src/main/org/h2/expression/ExpressionList.java
@@ -98,9 +98,9 @@ public class ExpressionList extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         for (Expression e : list) {
-            e.updateAggregate(session, window);
+            e.updateAggregate(session, stage);
         }
     }
 

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -2633,10 +2633,10 @@ public class Function extends Expression implements FunctionCall {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         for (Expression e : args) {
             if (e != null) {
-                e.updateAggregate(session, window);
+                e.updateAggregate(session, stage);
             }
         }
     }

--- a/h2/src/main/org/h2/expression/IntervalOperation.java
+++ b/h2/src/main/org/h2/expression/IntervalOperation.java
@@ -291,9 +291,9 @@ public class IntervalOperation extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        left.updateAggregate(session, window);
-        right.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
+        right.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/JavaFunction.java
+++ b/h2/src/main/org/h2/expression/JavaFunction.java
@@ -107,10 +107,10 @@ public class JavaFunction extends Expression implements FunctionCall {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         for (Expression e : args) {
             if (e != null) {
-                e.updateAggregate(session, window);
+                e.updateAggregate(session, stage);
             }
         }
     }

--- a/h2/src/main/org/h2/expression/Parameter.java
+++ b/h2/src/main/org/h2/expression/Parameter.java
@@ -141,7 +141,7 @@ public class Parameter extends Expression implements ParameterInterface {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         // nothing to do
     }
 

--- a/h2/src/main/org/h2/expression/Rownum.java
+++ b/h2/src/main/org/h2/expression/Rownum.java
@@ -73,7 +73,7 @@ public class Rownum extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         // nothing to do
     }
 

--- a/h2/src/main/org/h2/expression/SequenceValue.java
+++ b/h2/src/main/org/h2/expression/SequenceValue.java
@@ -72,7 +72,7 @@ public class SequenceValue extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         // nothing to do
     }
 

--- a/h2/src/main/org/h2/expression/Subquery.java
+++ b/h2/src/main/org/h2/expression/Subquery.java
@@ -94,8 +94,8 @@ public class Subquery extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        query.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        query.updateAggregate(session, stage);
     }
 
     private Expression getExpression() {

--- a/h2/src/main/org/h2/expression/UnaryOperation.java
+++ b/h2/src/main/org/h2/expression/UnaryOperation.java
@@ -82,8 +82,8 @@ public class UnaryOperation extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
-        arg.updateAggregate(session, window);
+    public void updateAggregate(Session session, int stage) {
+        arg.updateAggregate(session, stage);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/ValueExpression.java
+++ b/h2/src/main/org/h2/expression/ValueExpression.java
@@ -143,7 +143,7 @@ public class ValueExpression extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         // nothing to do
     }
 

--- a/h2/src/main/org/h2/expression/Variable.java
+++ b/h2/src/main/org/h2/expression/Variable.java
@@ -101,7 +101,7 @@ public class Variable extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         // nothing to do
     }
 

--- a/h2/src/main/org/h2/expression/Wildcard.java
+++ b/h2/src/main/org/h2/expression/Wildcard.java
@@ -91,7 +91,7 @@ public class Wildcard extends Expression {
     }
 
     @Override
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         DbException.throwInternalError(toString());
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -150,6 +150,21 @@ public class Aggregate extends AbstractAggregate {
         ENVELOPE,
     }
 
+    /**
+     * Reset stage. Used to reset internal data to its initial state.
+     */
+    public static final int STAGE_RESET = 0;
+
+    /**
+     * Group stage, used for explicit or implicit GROUP BY operation.
+     */
+    public static final int STAGE_GROUP = 1;
+
+    /**
+     * Window processing stage.
+     */
+    public static final int STAGE_WINDOW = 2;
+
     private static final HashMap<String, AggregateType> AGGREGATES = new HashMap<>(64);
 
     private final AggregateType type;
@@ -291,13 +306,13 @@ public class Aggregate extends AbstractAggregate {
     }
 
     @Override
-    protected void updateGroupAggregates(Session session) {
+    protected void updateGroupAggregates(Session session, int stage) {
         if (on != null) {
-            on.updateAggregate(session, false);
+            on.updateAggregate(session, stage);
         }
         if (orderByList != null) {
             for (SelectOrderBy orderBy : orderByList) {
-                orderBy.expression.updateAggregate(session, false);
+                orderBy.expression.updateAggregate(session, stage);
             }
         }
     }

--- a/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
@@ -228,9 +228,9 @@ public class JavaAggregate extends AbstractAggregate {
     }
 
     @Override
-    protected void updateGroupAggregates(Session session) {
+    protected void updateGroupAggregates(Session session, int stage) {
         for (Expression expr : args) {
-            expr.updateAggregate(session, false);
+            expr.updateAggregate(session, stage);
         }
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/Window.java
+++ b/h2/src/main/org/h2/expression/aggregate/Window.java
@@ -163,19 +163,19 @@ public final class Window {
      *
      * @param session
      *            the session
-     * @param window
-     *            true for window processing stage, false for group stage
-     * @see Expression#updateAggregate(Session, boolean)
+     * @param stage
+     *            select stage
+     * @see Expression#updateAggregate(Session, int)
      */
-    public void updateAggregate(Session session, boolean window) {
+    public void updateAggregate(Session session, int stage) {
         if (partitionBy != null) {
             for (Expression expr : partitionBy) {
-                expr.updateAggregate(session, window);
+                expr.updateAggregate(session, stage);
             }
         }
         if (orderBy != null) {
             for (SelectOrderBy o : orderBy) {
-                o.expression.updateAggregate(session, false);
+                o.expression.updateAggregate(session, stage);
             }
         }
     }


### PR DESCRIPTION
Aggregates change their internal state (last row identity) in `updateAggregate()`, but this state was never reset to initial even if query is reused.

With these changes when already executed grouped or window query executed again aggregates are reset to their initial state. The same `updageAggregate()` method is reused to ensure the same code paths.

It allows to restart now numbers safely in all situations, a trick that was introduced earlier is removed.