### PR TITLE
Issue 1427: performance of MVSpatialIndex construction

### DIFF
--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -271,8 +271,11 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
             } else {
                 result = operate(c, key, value, decisionMaker);
                 Object bounds = p.getKey(index);
-                keyType.increaseBounds(bounds, key);
-                p.setKey(index, bounds);
+                if (!keyType.contains(bounds, key)) {
+                    bounds = keyType.createBoundingBox(bounds);
+                    keyType.increaseBounds(bounds, key);
+                    p.setKey(index, bounds);
+                }
                 p.setChild(index, c);
             }
         }

--- a/h2/src/main/org/h2/mvstore/rtree/SpatialDataType.java
+++ b/h2/src/main/org/h2/mvstore/rtree/SpatialDataType.java
@@ -163,8 +163,14 @@ public class SpatialDataType implements DataType {
             return;
         }
         for (int i = 0; i < dimensions; i++) {
-            b.setMin(i, Math.min(b.min(i), a.min(i)));
-            b.setMax(i, Math.max(b.max(i), a.max(i)));
+            float v = a.min(i);
+            if (v < b.min(i)) {
+                b.setMin(i, v);
+            }
+            v = a.max(i);
+            if (v > b.max(i)) {
+                b.setMax(i, v);
+            }
         }
     }
 
@@ -287,12 +293,7 @@ public class SpatialDataType implements DataType {
         if (a.isNull()) {
             return a;
         }
-        float[] minMax = new float[dimensions * 2];
-        for (int i = 0; i < dimensions; i++) {
-            minMax[i + i] = a.min(i);
-            minMax[i + i + 1] = a.max(i);
-        }
-        return new SpatialKey(0, minMax);
+        return new SpatialKey(0, a);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/rtree/SpatialKey.java
+++ b/h2/src/main/org/h2/mvstore/rtree/SpatialKey.java
@@ -26,6 +26,11 @@ public class SpatialKey {
         this.minMax = minMax;
     }
 
+    public SpatialKey(long id, SpatialKey other) {
+        this.id = id;
+        this.minMax = other.minMax.clone();
+    }
+
     /**
      * Get the minimum value for the given dimension.
      *

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -449,7 +449,10 @@ public class TransactionStore {
                         if (map != null) { // might be null if map was removed later
                             Object key = op[1];
                             commitDecisionMaker.setUndoKey(undoKey);
-                            map.operate(key, null, commitDecisionMaker);
+                            // although second parameter (value) is not really used
+                            // by CommitDecisionMaker, MVRTreeMap has weird traversal logic based on it,
+                            // and any non-null value will do, to signify update, not removal
+                            map.operate(key, VersionedValue.DUMMY, commitDecisionMaker);
                         }
                     }
                     undoLog.clear();


### PR DESCRIPTION
This PR somewhat fixes #1427. 
It addresses actual regression from 1.4.197, but not a more general performance problem of MVRTree implementation which scans child nodes and causes much worse asymptotic insert/delete performance. IMHO, interval tree would be a much better alternative.