### PR TITLE
Separate aggregate and window code in some places

### DIFF
--- a/h2/src/docsrc/html/grammar.html
+++ b/h2/src/docsrc/html/grammar.html
@@ -256,7 +256,12 @@ ${item.example}</p>
 <c:forEach var="item" items="otherGrammar">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
+<pre name="bnf" style="display: none">
+${item.syntax}
+</pre>
+<div name="railroad">
 ${item.railroad}
+</div>
 <!-- railroad-end -->
 <!-- syntax-start
 <pre>

--- a/h2/src/main/org/h2/command/dml/SelectGroups.java
+++ b/h2/src/main/org/h2/command/dml/SelectGroups.java
@@ -14,6 +14,7 @@ import java.util.Map.Entry;
 
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
+import org.h2.expression.aggregate.DataAnalysisOperation;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
 
@@ -210,7 +211,7 @@ public abstract class SelectGroups {
     /**
      * Maps an expression object to its data.
      */
-    private final HashMap<Expression, Object> windowData = new HashMap<>();
+    private final HashMap<DataAnalysisOperation, Object> windowData = new HashMap<>();
 
     /**
      * The id of the current group.
@@ -292,7 +293,7 @@ public abstract class SelectGroups {
      *            expression
      * @return expression data or null
      */
-    public final Object getWindowExprData(Expression expr) {
+    public final Object getWindowExprData(DataAnalysisOperation expr) {
         return windowData.get(expr);
     }
 
@@ -304,7 +305,7 @@ public abstract class SelectGroups {
      * @param object
      *            expression data to set
      */
-    public final void setWindowExprData(Expression expr, Object obj) {
+    public final void setWindowExprData(DataAnalysisOperation expr, Object obj) {
         Object old = windowData.put(expr, obj);
         assert old == null;
     }

--- a/h2/src/main/org/h2/command/dml/SelectGroups.java
+++ b/h2/src/main/org/h2/command/dml/SelectGroups.java
@@ -251,14 +251,9 @@ public abstract class SelectGroups {
      *
      * @param expr
      *            expression
-     * @param window
-     *            true if expression is a window expression
      * @return expression data or null
      */
-    public Object getCurrentGroupExprData(Expression expr, boolean window) {
-        if (window) {
-            return windowData.get(expr);
-        }
+    public final Object getCurrentGroupExprData(Expression expr) {
         Integer index = exprToIndexInGroupByData.get(expr);
         if (index == null) {
             return null;
@@ -273,15 +268,8 @@ public abstract class SelectGroups {
      *            expression
      * @param object
      *            expression data to set
-     * @param window
-     *            true if expression is a window expression
      */
-    public void setCurrentGroupExprData(Expression expr, Object obj, boolean window) {
-        if (window) {
-            Object old = windowData.put(expr, obj);
-            assert old == null;
-            return;
-        }
+    public final void setCurrentGroupExprData(Expression expr, Object obj) {
         Integer index = exprToIndexInGroupByData.get(expr);
         if (index != null) {
             assert currentGroupByExprData[index] == null;
@@ -295,6 +283,30 @@ public abstract class SelectGroups {
             updateCurrentGroupExprData();
         }
         currentGroupByExprData[index] = obj;
+    }
+
+    /**
+     * Get the window data for the specified expression.
+     *
+     * @param expr
+     *            expression
+     * @return expression data or null
+     */
+    public final Object getWindowExprData(Expression expr) {
+        return windowData.get(expr);
+    }
+
+    /**
+     * Set the window data for the specified expression.
+     *
+     * @param expr
+     *            expression
+     * @param object
+     *            expression data to set
+     */
+    public final void setWindowExprData(Expression expr, Object obj) {
+        Object old = windowData.put(expr, obj);
+        assert old == null;
     }
 
     abstract void updateCurrentGroupExprData();

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -164,9 +164,9 @@ public class ExpressionColumn extends Expression {
             // this is a different level (the enclosing query)
             return;
         }
-        Value v = (Value) groupData.getCurrentGroupExprData(this, false);
+        Value v = (Value) groupData.getCurrentGroupExprData(this);
         if (v == null) {
-            groupData.setCurrentGroupExprData(this, now, false);
+            groupData.setCurrentGroupExprData(this, now);
         } else {
             if (!database.areEqual(now, v)) {
                 throw DbException.get(ErrorCode.MUST_GROUP_BY_COLUMN_1, getSQL());
@@ -180,7 +180,7 @@ public class ExpressionColumn extends Expression {
         if (select != null) {
             SelectGroups groupData = select.getGroupDataIfCurrent(false);
             if (groupData != null) {
-                Value v = (Value) groupData.getCurrentGroupExprData(this, false);
+                Value v = (Value) groupData.getCurrentGroupExprData(this);
                 if (v != null) {
                     return v;
                 }

--- a/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
@@ -6,58 +6,32 @@
 package org.h2.expression.aggregate;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 
-import org.h2.api.ErrorCode;
 import org.h2.command.dml.Select;
 import org.h2.command.dml.SelectGroups;
 import org.h2.command.dml.SelectOrderBy;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
-import org.h2.expression.ExpressionVisitor;
-import org.h2.message.DbException;
-import org.h2.result.SortOrder;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
-import org.h2.util.ValueHashMap;
-import org.h2.value.Value;
-import org.h2.value.ValueArray;
-import org.h2.value.ValueInt;
 
 /**
- * A base class for aggregates and window functions.
+ * A base class for aggregate functions.
  */
-public abstract class AbstractAggregate extends Expression {
-
-    protected final Select select;
+public abstract class AbstractAggregate extends DataAnalysisOperation {
 
     protected final boolean distinct;
 
     protected Expression filterCondition;
 
-    protected Window over;
-
-    protected SortOrder overOrderBySort;
-
-    private int lastGroupRowId;
-
-    protected static SortOrder createOrder(Session session, ArrayList<SelectOrderBy> orderBy, int offset) {
-        int size = orderBy.size();
-        int[] index = new int[size];
-        int[] sortType = new int[size];
-        for (int i = 0; i < size; i++) {
-            SelectOrderBy o = orderBy.get(i);
-            index[i] = i + offset;
-            sortType[i] = o.sortType;
-        }
-        return new SortOrder(session.getDatabase(), index, sortType, null);
+    AbstractAggregate(Select select, boolean distinct) {
+        super(select);
+        this.distinct = distinct;
     }
 
-    AbstractAggregate(Select select, boolean distinct) {
-        this.select = select;
-        this.distinct = distinct;
+    @Override
+    public final boolean isAggregate() {
+        return true;
     }
 
     /**
@@ -67,38 +41,7 @@ public abstract class AbstractAggregate extends Expression {
      *            FILTER condition
      */
     public void setFilterCondition(Expression filterCondition) {
-        if (isAggregate()) {
-            this.filterCondition = filterCondition;
-        } else {
-            throw DbException.getUnsupportedException("Window function");
-        }
-    }
-
-    /**
-     * Sets the OVER condition.
-     *
-     * @param over
-     *            OVER condition
-     */
-    public void setOverCondition(Window over) {
-        this.over = over;
-    }
-
-    /**
-     * Checks whether this expression is an aggregate function.
-     *
-     * @return true if this is an aggregate function (including aggregates with
-     *         OVER clause), false if this is a window function
-     */
-    public abstract boolean isAggregate();
-
-    /**
-     * Returns the sort order for OVER clause.
-     *
-     * @return the sort order for OVER clause
-     */
-    SortOrder getOverOrderBySort() {
-        return overOrderBySort;
+        this.filterCondition = filterCondition;
     }
 
     @Override
@@ -106,23 +49,15 @@ public abstract class AbstractAggregate extends Expression {
         if (filterCondition != null) {
             filterCondition.mapColumns(resolver, level);
         }
-        if (over != null) {
-            over.mapColumns(resolver, level);
-        }
+        super.mapColumns(resolver, level);
     }
 
     @Override
     public Expression optimize(Session session) {
-        if (over != null) {
-            over.optimize(session);
-            ArrayList<SelectOrderBy> orderBy = over.getOrderBy();
-            if (orderBy != null) {
-                overOrderBySort = createOrder(session, orderBy, getNumExpressions());
-            } else if (!isAggregate()) {
-                overOrderBySort = new SortOrder(session.getDatabase(), new int[getNumExpressions()], new int[0], null);
-            }
+        if (filterCondition != null) {
+            filterCondition = filterCondition.optimize(session);
         }
-        return this;
+        return super.optimize(session);
     }
 
     @Override
@@ -130,69 +65,18 @@ public abstract class AbstractAggregate extends Expression {
         if (filterCondition != null) {
             filterCondition.setEvaluatable(tableFilter, b);
         }
-        if (over != null) {
-            over.setEvaluatable(tableFilter, b);
-        }
+        super.setEvaluatable(tableFilter, b);
     }
 
     @Override
-    public void updateAggregate(Session session, int stage) {
-        if (stage == Aggregate.STAGE_RESET) {
-            updateSubAggregates(session, Aggregate.STAGE_RESET);
-            lastGroupRowId = 0;
-            return;
-        }
-        boolean window = stage == Aggregate.STAGE_WINDOW;
-        if (window != (over != null)) {
-            if (!window && select.isWindowQuery()) {
-                updateSubAggregates(session, stage);
-            }
-            return;
-        }
-        // TODO aggregates: check nested MIN(MAX(ID)) and so on
-        // if (on != null) {
-        // on.updateAggregate();
-        // }
-        SelectGroups groupData = select.getGroupDataIfCurrent(window);
-        if (groupData == null) {
-            // this is a different level (the enclosing query)
-            return;
-        }
-
-        int groupRowId = groupData.getCurrentGroupRowId();
-        if (lastGroupRowId == groupRowId) {
-            // already visited
-            return;
-        }
-        lastGroupRowId = groupRowId;
-
-        if (over != null) {
-            if (!select.isGroupQuery()) {
-                over.updateAggregate(session, stage);
-            }
-        }
-        if (filterCondition != null) {
-            if (!filterCondition.getBooleanValue(session)) {
-                return;
-            }
-        }
-        if (over != null) {
-            ArrayList<SelectOrderBy> orderBy = over.getOrderBy();
-            if (orderBy != null || !isAggregate()) {
+    protected void updateAggregate(Session session, SelectGroups groupData, int groupRowId) {
+        if (filterCondition == null || filterCondition.getBooleanValue(session)) {
+            ArrayList<SelectOrderBy> orderBy;
+            if (over != null && (orderBy = over.getOrderBy()) != null) {
                 updateOrderedAggregate(session, groupData, groupRowId, orderBy);
-                return;
+            } else {
+                updateAggregate(session, getData(session, groupData, false, false));
             }
-        }
-        updateAggregate(session, getData(session, groupData, false, false));
-    }
-
-    private void updateSubAggregates(Session session, int stage) {
-        updateGroupAggregates(session, stage);
-        if (filterCondition != null) {
-            filterCondition.updateAggregate(session, stage);
-        }
-        if (over != null) {
-            over.updateAggregate(session, stage);
         }
     }
 
@@ -206,267 +90,20 @@ public abstract class AbstractAggregate extends Expression {
      */
     protected abstract void updateAggregate(Session session, Object aggregateData);
 
-    /**
-     * Invoked when processing group stage of grouped window queries to update
-     * arguments of this aggregate.
-     *
-     * @param session
-     *            the session
-     * @param stage
-     *            select stage
-     */
-    protected abstract void updateGroupAggregates(Session session, int stage);
-
-    /**
-     * Returns the number of expressions, excluding FILTER and OVER clauses.
-     *
-     * @return the number of expressions
-     */
-    protected abstract int getNumExpressions();
-
-    /**
-     * Stores current values of expressions into the specified array.
-     *
-     * @param session
-     *            the session
-     * @param array
-     *            array to store values of expressions
-     */
-    protected abstract void rememberExpressions(Session session, Value[] array);
-
-    /**
-     * Updates the provided aggregate data from the remembered expressions.
-     *
-     * @param session
-     *            the session
-     * @param aggregateData
-     *            aggregate data
-     * @param array
-     *            values of expressions
-     */
-    protected abstract void updateFromExpressions(Session session, Object aggregateData, Value[] array);
-
-    protected Object getData(Session session, SelectGroups groupData, boolean ifExists, boolean forOrderBy) {
-        Object data;
-        if (over != null) {
-            ValueArray key = over.getCurrentKey(session);
-            if (key != null) {
-                @SuppressWarnings("unchecked")
-                ValueHashMap<Object> map = (ValueHashMap<Object>) groupData.getWindowExprData(this);
-                if (map == null) {
-                    if (ifExists) {
-                        return null;
-                    }
-                    map = new ValueHashMap<>();
-                    groupData.setWindowExprData(this, map);
-                }
-                PartitionData partition = (PartitionData) map.get(key);
-                if (partition == null) {
-                    if (ifExists) {
-                        return null;
-                    }
-                    data = forOrderBy ? new ArrayList<>() : createAggregateData();
-                    map.put(key, new PartitionData(data));
-                } else {
-                    data = partition.getData();
-                }
-            } else {
-                PartitionData partition = (PartitionData) groupData.getWindowExprData(this);
-                if (partition == null) {
-                    if (ifExists) {
-                        return null;
-                    }
-                    data = forOrderBy ? new ArrayList<>() : createAggregateData();
-                    groupData.setWindowExprData(this, new PartitionData(data));
-                } else {
-                    data = partition.getData();
-                }
-            }
-        } else {
-            data = groupData.getCurrentGroupExprData(this);
-            if (data == null) {
-                if (ifExists) {
-                    return null;
-                }
-                data = forOrderBy ? new ArrayList<>() : createAggregateData();
-                groupData.setCurrentGroupExprData(this, data);
-            }
-        }
-        return data;
-    }
-
-    protected abstract Object createAggregateData();
-
     @Override
-    public boolean isEverything(ExpressionVisitor visitor) {
-        if (over == null) {
-            return true;
+    protected void updateGroupAggregates(Session session, int stage) {
+        if (filterCondition != null) {
+            filterCondition.updateAggregate(session, stage);
         }
-        switch (visitor.getType()) {
-        case ExpressionVisitor.QUERY_COMPARABLE:
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
-        case ExpressionVisitor.DETERMINISTIC:
-        case ExpressionVisitor.INDEPENDENT:
-            return false;
-        case ExpressionVisitor.EVALUATABLE:
-        case ExpressionVisitor.READONLY:
-        case ExpressionVisitor.NOT_FROM_RESOLVER:
-        case ExpressionVisitor.GET_DEPENDENCIES:
-        case ExpressionVisitor.SET_MAX_DATA_MODIFICATION_ID:
-        case ExpressionVisitor.GET_COLUMNS1:
-        case ExpressionVisitor.GET_COLUMNS2:
-            return true;
-        default:
-            throw DbException.throwInternalError("type=" + visitor.getType());
-        }
+        super.updateGroupAggregates(session, stage);
     }
 
     @Override
-    public Value getValue(Session session) {
-        SelectGroups groupData = select.getGroupDataIfCurrent(over != null);
-        if (groupData == null) {
-            throw DbException.get(ErrorCode.INVALID_USE_OF_AGGREGATE_FUNCTION_1, getSQL());
-        }
-        return over == null ? getAggregatedValue(session, getData(session, groupData, true, false))
-                : getWindowResult(session, groupData);
-    }
-
-    private Value getWindowResult(Session session, SelectGroups groupData) {
-        PartitionData partition;
-        Object data;
-        boolean forOrderBy = over.getOrderBy() != null;
-        ValueArray key = over.getCurrentKey(session);
-        if (key != null) {
-            @SuppressWarnings("unchecked")
-            ValueHashMap<Object> map = (ValueHashMap<Object>) groupData.getWindowExprData(this);
-            if (map == null) {
-                map = new ValueHashMap<>();
-                groupData.setWindowExprData(this, map);
-            }
-            partition = (PartitionData) map.get(key);
-            if (partition == null) {
-                data = forOrderBy ? new ArrayList<>() : createAggregateData();
-                partition = new PartitionData(data);
-                map.put(key, partition);
-            } else {
-                data = partition.getData();
-            }
-        } else {
-            partition = (PartitionData) groupData.getWindowExprData(this);
-            if (partition == null) {
-                data = forOrderBy ? new ArrayList<>() : createAggregateData();
-                partition = new PartitionData(data);
-                groupData.setWindowExprData(this, partition);
-            } else {
-                data = partition.getData();
-            }
-        }
-        if (over.getOrderBy() != null || !isAggregate()) {
-            return getOrderedResult(session, groupData, partition, data);
-        }
-        Value result = partition.getResult();
-        if (result == null) {
-            result = getAggregatedValue(session, data);
-            partition.setResult(result);
-        }
-        return result;
-    }
-
-    /***
-     * Returns aggregated value.
-     *
-     * @param session
-     *            the session
-     * @param aggregateData
-     *            the aggregate data
-     * @return aggregated value.
-     */
-    protected abstract Value getAggregatedValue(Session session, Object aggregateData);
-
-    private void updateOrderedAggregate(Session session, SelectGroups groupData, int groupRowId,
-            ArrayList<SelectOrderBy> orderBy) {
-        int ne = getNumExpressions();
-        int size = orderBy != null ? orderBy.size() : 0;
-        Value[] array = new Value[ne + size + 1];
-        rememberExpressions(session, array);
-        for (int i = 0; i < size; i++) {
-            @SuppressWarnings("null")
-            SelectOrderBy o = orderBy.get(i);
-            array[ne++] = o.expression.getValue(session);
-        }
-        array[ne] = ValueInt.get(groupRowId);
-        @SuppressWarnings("unchecked")
-        ArrayList<Value[]> data = (ArrayList<Value[]>) getData(session, groupData, false, true);
-        data.add(array);
-    }
-
-    private Value getOrderedResult(Session session, SelectGroups groupData, PartitionData partition, Object data) {
-        HashMap<Integer, Value> result = partition.getOrderedResult();
-        if (result == null) {
-            result = new HashMap<>();
-            @SuppressWarnings("unchecked")
-            ArrayList<Value[]> orderedData = (ArrayList<Value[]>) data;
-            int rowIdColumn = getNumExpressions();
-            ArrayList<SelectOrderBy> orderBy = over.getOrderBy();
-            if (orderBy != null) {
-                rowIdColumn += orderBy.size();
-                Collections.sort(orderedData, overOrderBySort);
-            }
-            getOrderedResultLoop(session, result, orderedData, rowIdColumn);
-            partition.setOrderedResult(result);
-        }
-        return result.get(groupData.getCurrentGroupRowId());
-    }
-
-    /**
-     * @param session
-     *            the session
-     * @param result
-     *            the map to append result to
-     * @param ordered
-     *            ordered data
-     * @param rowIdColumn
-     *            the index of row id value
-     */
-    protected void getOrderedResultLoop(Session session, HashMap<Integer, Value> result, ArrayList<Value[]> ordered,
-            int rowIdColumn) {
-        WindowFrame frame = over.getWindowFrame();
-        if (frame == null || frame.isDefault()) {
-            Object aggregateData = createAggregateData();
-            for (Value[] row : ordered) {
-                updateFromExpressions(session, aggregateData, row);
-                result.put(row[rowIdColumn].getInt(), getAggregatedValue(session, aggregateData));
-            }
-        } else if (frame.isFullPartition()) {
-            Object aggregateData = createAggregateData();
-            for (Value[] row : ordered) {
-                updateFromExpressions(session, aggregateData, row);
-            }
-            Value value = getAggregatedValue(session, aggregateData);
-            for (Value[] row : ordered) {
-                result.put(row[rowIdColumn].getInt(), value);
-            }
-        } else {
-            int size = ordered.size();
-            for (int i = 0; i < size; i++) {
-                Object aggregateData = createAggregateData();
-                for (Iterator<Value[]> iter = frame.iterator(session, ordered, getOverOrderBySort(), i, false); iter
-                        .hasNext();) {
-                    updateFromExpressions(session, aggregateData, iter.next());
-                }
-                result.put(ordered.get(i)[rowIdColumn].getInt(), getAggregatedValue(session, aggregateData));
-            }
-        }
-    }
-
     protected StringBuilder appendTailConditions(StringBuilder builder) {
         if (filterCondition != null) {
             builder.append(" FILTER (WHERE ").append(filterCondition.getSQL()).append(')');
         }
-        if (over != null) {
-            builder.append(' ').append(over.getSQL());
-        }
-        return builder;
+        return super.appendTailConditions(builder);
     }
 
 }

--- a/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
@@ -252,13 +252,13 @@ public abstract class AbstractAggregate extends Expression {
             ValueArray key = over.getCurrentKey(session);
             if (key != null) {
                 @SuppressWarnings("unchecked")
-                ValueHashMap<Object> map = (ValueHashMap<Object>) groupData.getCurrentGroupExprData(this, true);
+                ValueHashMap<Object> map = (ValueHashMap<Object>) groupData.getWindowExprData(this);
                 if (map == null) {
                     if (ifExists) {
                         return null;
                     }
                     map = new ValueHashMap<>();
-                    groupData.setCurrentGroupExprData(this, map, true);
+                    groupData.setWindowExprData(this, map);
                 }
                 PartitionData partition = (PartitionData) map.get(key);
                 if (partition == null) {
@@ -271,25 +271,25 @@ public abstract class AbstractAggregate extends Expression {
                     data = partition.getData();
                 }
             } else {
-                PartitionData partition = (PartitionData) groupData.getCurrentGroupExprData(this, true);
+                PartitionData partition = (PartitionData) groupData.getWindowExprData(this);
                 if (partition == null) {
                     if (ifExists) {
                         return null;
                     }
                     data = forOrderBy ? new ArrayList<>() : createAggregateData();
-                    groupData.setCurrentGroupExprData(this, new PartitionData(data), true);
+                    groupData.setWindowExprData(this, new PartitionData(data));
                 } else {
                     data = partition.getData();
                 }
             }
         } else {
-            data = groupData.getCurrentGroupExprData(this, false);
+            data = groupData.getCurrentGroupExprData(this);
             if (data == null) {
                 if (ifExists) {
                     return null;
                 }
                 data = forOrderBy ? new ArrayList<>() : createAggregateData();
-                groupData.setCurrentGroupExprData(this, data, false);
+                groupData.setCurrentGroupExprData(this, data);
             }
         }
         return data;
@@ -338,10 +338,10 @@ public abstract class AbstractAggregate extends Expression {
         ValueArray key = over.getCurrentKey(session);
         if (key != null) {
             @SuppressWarnings("unchecked")
-            ValueHashMap<Object> map = (ValueHashMap<Object>) groupData.getCurrentGroupExprData(this, true);
+            ValueHashMap<Object> map = (ValueHashMap<Object>) groupData.getWindowExprData(this);
             if (map == null) {
                 map = new ValueHashMap<>();
-                groupData.setCurrentGroupExprData(this, map, true);
+                groupData.setWindowExprData(this, map);
             }
             partition = (PartitionData) map.get(key);
             if (partition == null) {
@@ -352,11 +352,11 @@ public abstract class AbstractAggregate extends Expression {
                 data = partition.getData();
             }
         } else {
-            partition = (PartitionData) groupData.getCurrentGroupExprData(this, true);
+            partition = (PartitionData) groupData.getWindowExprData(this);
             if (partition == null) {
                 data = forOrderBy ? new ArrayList<>() : createAggregateData();
                 partition = new PartitionData(data);
-                groupData.setCurrentGroupExprData(this, partition, true);
+                groupData.setWindowExprData(this, partition);
             } else {
                 data = partition.getData();
             }

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -251,11 +251,6 @@ public class Aggregate extends AbstractAggregate {
         return AGGREGATES.get(name);
     }
 
-    @Override
-    public boolean isAggregate() {
-        return true;
-    }
-
     /**
      * Set the order for ARRAY_AGG() or GROUP_CONCAT() aggregate.
      *
@@ -312,6 +307,7 @@ public class Aggregate extends AbstractAggregate {
 
     @Override
     protected void updateGroupAggregates(Session session, int stage) {
+        super.updateGroupAggregates(session, stage);
         if (on != null) {
             on.updateAggregate(session, stage);
         }
@@ -513,9 +509,6 @@ public class Aggregate extends AbstractAggregate {
         }
         if (groupConcatSeparator != null) {
             groupConcatSeparator = groupConcatSeparator.optimize(session);
-        }
-        if (filterCondition != null) {
-            filterCondition = filterCondition.optimize(session);
         }
         switch (type) {
         case GROUP_CONCAT:

--- a/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
+++ b/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2004-2018 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.aggregate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+
+import org.h2.api.ErrorCode;
+import org.h2.command.dml.Select;
+import org.h2.command.dml.SelectGroups;
+import org.h2.command.dml.SelectOrderBy;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionVisitor;
+import org.h2.message.DbException;
+import org.h2.result.SortOrder;
+import org.h2.table.ColumnResolver;
+import org.h2.table.TableFilter;
+import org.h2.util.ValueHashMap;
+import org.h2.value.Value;
+import org.h2.value.ValueArray;
+import org.h2.value.ValueInt;
+
+/**
+ * A base class for data analysis operations such as aggregates and window
+ * functions.
+ */
+public abstract class DataAnalysisOperation extends Expression {
+
+    protected final Select select;
+
+    protected Window over;
+
+    protected SortOrder overOrderBySort;
+
+    private int lastGroupRowId;
+
+    protected static SortOrder createOrder(Session session, ArrayList<SelectOrderBy> orderBy, int offset) {
+        int size = orderBy.size();
+        int[] index = new int[size];
+        int[] sortType = new int[size];
+        for (int i = 0; i < size; i++) {
+            SelectOrderBy o = orderBy.get(i);
+            index[i] = i + offset;
+            sortType[i] = o.sortType;
+        }
+        return new SortOrder(session.getDatabase(), index, sortType, null);
+    }
+
+    DataAnalysisOperation(Select select) {
+        this.select = select;
+    }
+
+    /**
+     * Sets the OVER condition.
+     *
+     * @param over
+     *            OVER condition
+     */
+    public void setOverCondition(Window over) {
+        this.over = over;
+    }
+
+    /**
+     * Checks whether this expression is an aggregate function.
+     *
+     * @return true if this is an aggregate function (including aggregates with
+     *         OVER clause), false if this is a window function
+     */
+    public abstract boolean isAggregate();
+
+    /**
+     * Returns the sort order for OVER clause.
+     *
+     * @return the sort order for OVER clause
+     */
+    SortOrder getOverOrderBySort() {
+        return overOrderBySort;
+    }
+
+    @Override
+    public void mapColumns(ColumnResolver resolver, int level) {
+        if (over != null) {
+            over.mapColumns(resolver, level);
+        }
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        if (over != null) {
+            over.optimize(session);
+            ArrayList<SelectOrderBy> orderBy = over.getOrderBy();
+            if (orderBy != null) {
+                overOrderBySort = createOrder(session, orderBy, getNumExpressions());
+            } else if (!isAggregate()) {
+                overOrderBySort = new SortOrder(session.getDatabase(), new int[getNumExpressions()], new int[0], null);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public void setEvaluatable(TableFilter tableFilter, boolean b) {
+        if (over != null) {
+            over.setEvaluatable(tableFilter, b);
+        }
+    }
+
+    @Override
+    public void updateAggregate(Session session, int stage) {
+        if (stage == Aggregate.STAGE_RESET) {
+            updateGroupAggregates(session, Aggregate.STAGE_RESET);
+            lastGroupRowId = 0;
+            return;
+        }
+        boolean window = stage == Aggregate.STAGE_WINDOW;
+        if (window != (over != null)) {
+            if (!window && select.isWindowQuery()) {
+                updateGroupAggregates(session, stage);
+            }
+            return;
+        }
+        // TODO aggregates: check nested MIN(MAX(ID)) and so on
+        // if (on != null) {
+        // on.updateAggregate();
+        // }
+        SelectGroups groupData = select.getGroupDataIfCurrent(window);
+        if (groupData == null) {
+            // this is a different level (the enclosing query)
+            return;
+        }
+
+        int groupRowId = groupData.getCurrentGroupRowId();
+        if (lastGroupRowId == groupRowId) {
+            // already visited
+            return;
+        }
+        lastGroupRowId = groupRowId;
+
+        if (over != null) {
+            if (!select.isGroupQuery()) {
+                over.updateAggregate(session, stage);
+            }
+        }
+        updateAggregate(session, groupData, groupRowId);
+    }
+
+    protected abstract void updateAggregate(Session session, SelectGroups groupData, int groupRowId);
+
+    /**
+     * Invoked when processing group stage of grouped window queries to update
+     * arguments of this aggregate.
+     *
+     * @param session
+     *            the session
+     * @param stage
+     *            select stage
+     */
+    protected void updateGroupAggregates(Session session, int stage) {
+        if (over != null) {
+            over.updateAggregate(session, stage);
+        }
+    }
+
+    /**
+     * Returns the number of expressions, excluding FILTER and OVER clauses.
+     *
+     * @return the number of expressions
+     */
+    protected abstract int getNumExpressions();
+
+    /**
+     * Stores current values of expressions into the specified array.
+     *
+     * @param session
+     *            the session
+     * @param array
+     *            array to store values of expressions
+     */
+    protected abstract void rememberExpressions(Session session, Value[] array);
+
+    /**
+     * Updates the provided aggregate data from the remembered expressions.
+     *
+     * @param session
+     *            the session
+     * @param aggregateData
+     *            aggregate data
+     * @param array
+     *            values of expressions
+     */
+    protected abstract void updateFromExpressions(Session session, Object aggregateData, Value[] array);
+
+    protected Object getData(Session session, SelectGroups groupData, boolean ifExists, boolean forOrderBy) {
+        Object data;
+        if (over != null) {
+            ValueArray key = over.getCurrentKey(session);
+            if (key != null) {
+                @SuppressWarnings("unchecked")
+                ValueHashMap<Object> map = (ValueHashMap<Object>) groupData.getWindowExprData(this);
+                if (map == null) {
+                    if (ifExists) {
+                        return null;
+                    }
+                    map = new ValueHashMap<>();
+                    groupData.setWindowExprData(this, map);
+                }
+                PartitionData partition = (PartitionData) map.get(key);
+                if (partition == null) {
+                    if (ifExists) {
+                        return null;
+                    }
+                    data = forOrderBy ? new ArrayList<>() : createAggregateData();
+                    map.put(key, new PartitionData(data));
+                } else {
+                    data = partition.getData();
+                }
+            } else {
+                PartitionData partition = (PartitionData) groupData.getWindowExprData(this);
+                if (partition == null) {
+                    if (ifExists) {
+                        return null;
+                    }
+                    data = forOrderBy ? new ArrayList<>() : createAggregateData();
+                    groupData.setWindowExprData(this, new PartitionData(data));
+                } else {
+                    data = partition.getData();
+                }
+            }
+        } else {
+            data = groupData.getCurrentGroupExprData(this);
+            if (data == null) {
+                if (ifExists) {
+                    return null;
+                }
+                data = forOrderBy ? new ArrayList<>() : createAggregateData();
+                groupData.setCurrentGroupExprData(this, data);
+            }
+        }
+        return data;
+    }
+
+    protected abstract Object createAggregateData();
+
+    @Override
+    public boolean isEverything(ExpressionVisitor visitor) {
+        if (over == null) {
+            return true;
+        }
+        switch (visitor.getType()) {
+        case ExpressionVisitor.QUERY_COMPARABLE:
+        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.DETERMINISTIC:
+        case ExpressionVisitor.INDEPENDENT:
+            return false;
+        case ExpressionVisitor.EVALUATABLE:
+        case ExpressionVisitor.READONLY:
+        case ExpressionVisitor.NOT_FROM_RESOLVER:
+        case ExpressionVisitor.GET_DEPENDENCIES:
+        case ExpressionVisitor.SET_MAX_DATA_MODIFICATION_ID:
+        case ExpressionVisitor.GET_COLUMNS1:
+        case ExpressionVisitor.GET_COLUMNS2:
+            return true;
+        default:
+            throw DbException.throwInternalError("type=" + visitor.getType());
+        }
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        SelectGroups groupData = select.getGroupDataIfCurrent(over != null);
+        if (groupData == null) {
+            throw DbException.get(ErrorCode.INVALID_USE_OF_AGGREGATE_FUNCTION_1, getSQL());
+        }
+        return over == null ? getAggregatedValue(session, getData(session, groupData, true, false))
+                : getWindowResult(session, groupData);
+    }
+
+    private Value getWindowResult(Session session, SelectGroups groupData) {
+        PartitionData partition;
+        Object data;
+        boolean forOrderBy = over.getOrderBy() != null;
+        ValueArray key = over.getCurrentKey(session);
+        if (key != null) {
+            @SuppressWarnings("unchecked")
+            ValueHashMap<Object> map = (ValueHashMap<Object>) groupData.getWindowExprData(this);
+            if (map == null) {
+                map = new ValueHashMap<>();
+                groupData.setWindowExprData(this, map);
+            }
+            partition = (PartitionData) map.get(key);
+            if (partition == null) {
+                data = forOrderBy ? new ArrayList<>() : createAggregateData();
+                partition = new PartitionData(data);
+                map.put(key, partition);
+            } else {
+                data = partition.getData();
+            }
+        } else {
+            partition = (PartitionData) groupData.getWindowExprData(this);
+            if (partition == null) {
+                data = forOrderBy ? new ArrayList<>() : createAggregateData();
+                partition = new PartitionData(data);
+                groupData.setWindowExprData(this, partition);
+            } else {
+                data = partition.getData();
+            }
+        }
+        if (over.getOrderBy() != null || !isAggregate()) {
+            return getOrderedResult(session, groupData, partition, data);
+        }
+        Value result = partition.getResult();
+        if (result == null) {
+            result = getAggregatedValue(session, data);
+            partition.setResult(result);
+        }
+        return result;
+    }
+
+    /***
+     * Returns aggregated value.
+     *
+     * @param session
+     *            the session
+     * @param aggregateData
+     *            the aggregate data
+     * @return aggregated value.
+     */
+    protected abstract Value getAggregatedValue(Session session, Object aggregateData);
+
+    protected void updateOrderedAggregate(Session session, SelectGroups groupData, int groupRowId,
+            ArrayList<SelectOrderBy> orderBy) {
+        int ne = getNumExpressions();
+        int size = orderBy != null ? orderBy.size() : 0;
+        Value[] array = new Value[ne + size + 1];
+        rememberExpressions(session, array);
+        for (int i = 0; i < size; i++) {
+            @SuppressWarnings("null")
+            SelectOrderBy o = orderBy.get(i);
+            array[ne++] = o.expression.getValue(session);
+        }
+        array[ne] = ValueInt.get(groupRowId);
+        @SuppressWarnings("unchecked")
+        ArrayList<Value[]> data = (ArrayList<Value[]>) getData(session, groupData, false, true);
+        data.add(array);
+    }
+
+    private Value getOrderedResult(Session session, SelectGroups groupData, PartitionData partition, Object data) {
+        HashMap<Integer, Value> result = partition.getOrderedResult();
+        if (result == null) {
+            result = new HashMap<>();
+            @SuppressWarnings("unchecked")
+            ArrayList<Value[]> orderedData = (ArrayList<Value[]>) data;
+            int rowIdColumn = getNumExpressions();
+            ArrayList<SelectOrderBy> orderBy = over.getOrderBy();
+            if (orderBy != null) {
+                rowIdColumn += orderBy.size();
+                Collections.sort(orderedData, overOrderBySort);
+            }
+            getOrderedResultLoop(session, result, orderedData, rowIdColumn);
+            partition.setOrderedResult(result);
+        }
+        return result.get(groupData.getCurrentGroupRowId());
+    }
+
+    /**
+     * @param session
+     *            the session
+     * @param result
+     *            the map to append result to
+     * @param ordered
+     *            ordered data
+     * @param rowIdColumn
+     *            the index of row id value
+     */
+    protected void getOrderedResultLoop(Session session, HashMap<Integer, Value> result, ArrayList<Value[]> ordered,
+            int rowIdColumn) {
+        WindowFrame frame = over.getWindowFrame();
+        if (frame == null || frame.isDefault()) {
+            Object aggregateData = createAggregateData();
+            for (Value[] row : ordered) {
+                updateFromExpressions(session, aggregateData, row);
+                result.put(row[rowIdColumn].getInt(), getAggregatedValue(session, aggregateData));
+            }
+        } else if (frame.isFullPartition()) {
+            Object aggregateData = createAggregateData();
+            for (Value[] row : ordered) {
+                updateFromExpressions(session, aggregateData, row);
+            }
+            Value value = getAggregatedValue(session, aggregateData);
+            for (Value[] row : ordered) {
+                result.put(row[rowIdColumn].getInt(), value);
+            }
+        } else {
+            int size = ordered.size();
+            for (int i = 0; i < size; i++) {
+                Object aggregateData = createAggregateData();
+                for (Iterator<Value[]> iter = frame.iterator(session, ordered, getOverOrderBySort(), i, false); iter
+                        .hasNext();) {
+                    updateFromExpressions(session, aggregateData, iter.next());
+                }
+                result.put(ordered.get(i)[rowIdColumn].getInt(), getAggregatedValue(session, aggregateData));
+            }
+        }
+    }
+
+    protected StringBuilder appendTailConditions(StringBuilder builder) {
+        if (over != null) {
+            builder.append(' ').append(over.getSQL());
+        }
+        return builder;
+    }
+
+}

--- a/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
@@ -41,11 +41,6 @@ public class JavaAggregate extends AbstractAggregate {
     }
 
     @Override
-    public boolean isAggregate() {
-        return true;
-    }
-
-    @Override
     public int getCost() {
         int cost = 5;
         for (Expression e : args) {
@@ -139,9 +134,6 @@ public class JavaAggregate extends AbstractAggregate {
             dataType = aggregate.getInternalType(argTypes);
         } catch (SQLException e) {
             throw DbException.convert(e);
-        }
-        if (filterCondition != null) {
-            filterCondition = filterCondition.optimize(session);
         }
         return this;
     }
@@ -237,6 +229,7 @@ public class JavaAggregate extends AbstractAggregate {
 
     @Override
     protected void updateGroupAggregates(Session session, int stage) {
+        super.updateGroupAggregates(session, stage);
         for (Expression expr : args) {
             expr.updateAggregate(session, stage);
         }

--- a/h2/src/main/org/h2/expression/aggregate/WindowFunction.java
+++ b/h2/src/main/org/h2/expression/aggregate/WindowFunction.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 
 import org.h2.command.dml.Select;
+import org.h2.command.dml.SelectGroups;
 import org.h2.command.dml.SelectOrderBy;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
@@ -24,7 +25,7 @@ import org.h2.value.ValueNull;
 /**
  * A window function.
  */
-public class WindowFunction extends AbstractAggregate {
+public class WindowFunction extends DataAnalysisOperation {
 
     private final WindowFunctionType type;
 
@@ -105,7 +106,7 @@ public class WindowFunction extends AbstractAggregate {
      *            arguments, or null
      */
     public WindowFunction(WindowFunctionType type, Select select, Expression[] args) {
-        super(select, false);
+        super(select);
         this.type = type;
         this.args = args;
     }
@@ -145,12 +146,13 @@ public class WindowFunction extends AbstractAggregate {
     }
 
     @Override
-    protected void updateAggregate(Session session, Object aggregateData) {
-        throw DbException.getUnsupportedException("Window function");
+    protected void updateAggregate(Session session, SelectGroups groupData, int groupRowId) {
+        updateOrderedAggregate(session, groupData, groupRowId, over.getOrderBy());
     }
 
     @Override
     protected void updateGroupAggregates(Session session, int stage) {
+        super.updateGroupAggregates(session, stage);
         if (args != null) {
             for (Expression expr : args) {
                 expr.updateAggregate(session, stage);

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -449,9 +449,10 @@ public class TransactionStore {
                         if (map != null) { // might be null if map was removed later
                             Object key = op[1];
                             commitDecisionMaker.setUndoKey(undoKey);
-                            // although second parameter (value) is not really used
-                            // by CommitDecisionMaker, MVRTreeMap has weird traversal logic based on it,
-                            // and any non-null value will do, to signify update, not removal
+                            // although second parameter (value) is not really
+                            // used by CommitDecisionMaker, MVRTreeMap has weird
+                            // traversal logic based on it, and any non-null
+                            // value will do, to signify update, not removal
                             map.operate(key, VersionedValue.DUMMY, commitDecisionMaker);
                         }
                     }

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -796,4 +796,4 @@ interior envelopes multilinestring multipoint packed exterior normalization awkw
 xym normalizes coord setz xyzm geometrycollection multipolygon mixup rings polygons rejection finite
 pointzm pointz pointm dimensionality redefine forum measures
 mpg casted pzm mls constrained subtypes complains
-ranks rno dro rko precede cume reopens preceding unbounded rightly itr lag maximal tiles tile ntile
+ranks rno dro rko precede cume reopens preceding unbounded rightly itr lag maximal tiles tile ntile signify


### PR DESCRIPTION
1. A new `DataAnalysisOperation` class is used instead of `AbstractAggregate` as a base class for aggregates and window functions. `AbstractAggregate` now contains only aggregate-specific logic.

2. Access to storage in `SelectGroups` now has smaller separate methods for aggregates and window functions for simplicity.

3. Building of documentation is fixed (long lines in comments, missing word in `dictionary.txt`).

4. BNF / railroad switch is fixed for other grammar in `grammar.html`.