### PR TITLE
Fix some window aggregates and reduce amount of collecting implementations

### DIFF
--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -402,7 +402,7 @@ public class Aggregate extends AbstractAggregate {
             return v;
         }
         case MEDIAN:
-            return AggregateDataMedian.getResultFromIndex(session, on, dataType);
+            return AggregateMedian.medianFromIndex(session, on, dataType);
         case ENVELOPE:
             return ((MVSpatialIndex) AggregateDataEnvelope.getGeometryColumnIndex(on)).getBounds(session);
         default:
@@ -458,6 +458,13 @@ public class Aggregate extends AbstractAggregate {
                 }
             }
             return ValueArray.get(array);
+        }
+        case MEDIAN: {
+            Value[] array = ((AggregateDataCollecting) data).getArray();
+            if (array == null) {
+                return ValueNull.INSTANCE;
+            }
+            return AggregateMedian.median(session.getDatabase(), array, dataType);
         }
         case MODE:
             if (orderByList != null) {
@@ -762,7 +769,7 @@ public class Aggregate extends AbstractAggregate {
                 if (distinct) {
                     return false;
                 }
-                return AggregateDataMedian.getMedianColumnIndex(on) != null;
+                return AggregateMedian.getMedianColumnIndex(on) != null;
             case ENVELOPE:
                 return AggregateDataEnvelope.getGeometryColumnIndex(on) != null;
             default:

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -192,6 +192,9 @@ public class Aggregate extends AbstractAggregate {
      */
     public Aggregate(AggregateType type, Expression on, Select select, boolean distinct) {
         super(select, distinct);
+        if (distinct && type == AggregateType.COUNT_ALL) {
+            throw DbException.throwInternalError();
+        }
         this.type = type;
         this.on = on;
     }
@@ -303,7 +306,7 @@ public class Aggregate extends AbstractAggregate {
                 v = updateCollecting(session, v, remembered);
             }
         }
-        data.add(session.getDatabase(), dataType, distinct, v);
+        data.add(session.getDatabase(), dataType, v);
     }
 
     @Override
@@ -437,9 +440,9 @@ public class Aggregate extends AbstractAggregate {
                 AggregateDataDefault d = new AggregateDataDefault(type);
                 Database db = session.getDatabase();
                 for (Value v : c) {
-                    d.add(db, dataType, false, v);
+                    d.add(db, dataType, v);
                 }
-                return d.getValue(db, dataType, false);
+                return d.getValue(db, dataType);
             }
             break;
         case GROUP_CONCAT: {
@@ -500,7 +503,7 @@ public class Aggregate extends AbstractAggregate {
         default:
             // Avoid compiler warning
         }
-        return data.getValue(session.getDatabase(), dataType, distinct);
+        return data.getValue(session.getDatabase(), dataType);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -369,7 +369,7 @@ public class Aggregate extends AbstractAggregate {
 
     @Override
     protected Object createAggregateData() {
-        return AggregateData.create(type);
+        return AggregateData.create(type, distinct);
     }
 
     @Override
@@ -417,6 +417,12 @@ public class Aggregate extends AbstractAggregate {
             data = (AggregateData) createAggregateData();
         }
         switch (type) {
+        case COUNT: {
+            if (!distinct) {
+                return data.getValue(session.getDatabase(), dataType, distinct);
+            }
+            return ValueLong.get(((AggregateDataCollecting) data).getCount());
+        }
         case GROUP_CONCAT: {
             Value[] array = ((AggregateDataCollecting) data).getArray();
             if (array == null) {

--- a/h2/src/main/org/h2/expression/aggregate/AggregateData.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateData.java
@@ -53,9 +53,9 @@ abstract class AggregateData {
             }
             break;
         case SELECTIVITY:
-            return new AggregateDataSelectivity();
+            return new AggregateDataSelectivity(distinct);
         case HISTOGRAM:
-            return new AggregateDataHistogram();
+            return new AggregateDataHistogram(distinct);
         case MODE:
             return new AggregateDataMode();
         case ENVELOPE:
@@ -63,7 +63,7 @@ abstract class AggregateData {
         default:
             throw DbException.throwInternalError("type=" + aggregateType);
         }
-        return new AggregateDataCollecting();
+        return new AggregateDataCollecting(distinct);
     }
 
     /**
@@ -71,18 +71,16 @@ abstract class AggregateData {
      *
      * @param database the database
      * @param dataType the datatype of the computed result
-     * @param distinct if the calculation should be distinct
      * @param v the value
      */
-    abstract void add(Database database, int dataType, boolean distinct, Value v);
+    abstract void add(Database database, int dataType, Value v);
 
     /**
      * Get the aggregate result.
      *
      * @param database the database
      * @param dataType the datatype of the computed result
-     * @param distinct if distinct is used
      * @return the value
      */
-    abstract Value getValue(Database database, int dataType, boolean distinct);
+    abstract Value getValue(Database database, int dataType);
 }

--- a/h2/src/main/org/h2/expression/aggregate/AggregateData.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateData.java
@@ -7,6 +7,7 @@ package org.h2.expression.aggregate;
 
 import org.h2.engine.Database;
 import org.h2.expression.aggregate.Aggregate.AggregateType;
+import org.h2.message.DbException;
 import org.h2.value.Value;
 
 /**
@@ -23,12 +24,6 @@ abstract class AggregateData {
      */
     static AggregateData create(AggregateType aggregateType, boolean distinct) {
         switch (aggregateType) {
-        case SELECTIVITY:
-            return new AggregateDataSelectivity();
-        case GROUP_CONCAT:
-        case ARRAY_AGG:
-        case MEDIAN:
-            break;
         case COUNT_ALL:
             return new AggregateDataCountAll();
         case COUNT:
@@ -36,6 +31,29 @@ abstract class AggregateData {
                 return new AggregateDataCount();
             }
             break;
+        case GROUP_CONCAT:
+        case ARRAY_AGG:
+        case MEDIAN:
+            break;
+        case MIN:
+        case MAX:
+        case BIT_OR:
+        case BIT_AND:
+        case BOOL_OR:
+        case BOOL_AND:
+            return new AggregateDataDefault(aggregateType);
+        case SUM:
+        case AVG:
+        case STDDEV_POP:
+        case STDDEV_SAMP:
+        case VAR_POP:
+        case VAR_SAMP:
+            if (!distinct) {
+                return new AggregateDataDefault(aggregateType);
+            }
+            break;
+        case SELECTIVITY:
+            return new AggregateDataSelectivity();
         case HISTOGRAM:
             return new AggregateDataHistogram();
         case MODE:
@@ -43,7 +61,7 @@ abstract class AggregateData {
         case ENVELOPE:
             return new AggregateDataEnvelope();
         default:
-            return new AggregateDataDefault(aggregateType);
+            throw DbException.throwInternalError("type=" + aggregateType);
         }
         return new AggregateDataCollecting();
     }

--- a/h2/src/main/org/h2/expression/aggregate/AggregateData.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateData.java
@@ -18,20 +18,24 @@ abstract class AggregateData {
      * Create an AggregateData object of the correct sub-type.
      *
      * @param aggregateType the type of the aggregate operation
+     * @param distinct if the calculation should be distinct
      * @return the aggregate data object of the specified type
      */
-    static AggregateData create(AggregateType aggregateType) {
+    static AggregateData create(AggregateType aggregateType, boolean distinct) {
         switch (aggregateType) {
         case SELECTIVITY:
             return new AggregateDataSelectivity();
         case GROUP_CONCAT:
         case ARRAY_AGG:
         case MEDIAN:
-            return new AggregateDataCollecting();
+            break;
         case COUNT_ALL:
             return new AggregateDataCountAll();
         case COUNT:
-            return new AggregateDataCount();
+            if (!distinct) {
+                return new AggregateDataCount();
+            }
+            break;
         case HISTOGRAM:
             return new AggregateDataHistogram();
         case MODE:
@@ -41,6 +45,7 @@ abstract class AggregateData {
         default:
             return new AggregateDataDefault(aggregateType);
         }
+        return new AggregateDataCollecting();
     }
 
     /**

--- a/h2/src/main/org/h2/expression/aggregate/AggregateData.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateData.java
@@ -26,6 +26,7 @@ abstract class AggregateData {
             return new AggregateDataSelectivity();
         case GROUP_CONCAT:
         case ARRAY_AGG:
+        case MEDIAN:
             return new AggregateDataCollecting();
         case COUNT_ALL:
             return new AggregateDataCountAll();
@@ -33,8 +34,6 @@ abstract class AggregateData {
             return new AggregateDataCount();
         case HISTOGRAM:
             return new AggregateDataHistogram();
-        case MEDIAN:
-            return new AggregateDataMedian();
         case MODE:
             return new AggregateDataMode();
         case ENVELOPE:

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataCollecting.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataCollecting.java
@@ -17,20 +17,31 @@ import org.h2.value.ValueNull;
 
 /**
  * Data stored while calculating an aggregate that needs collecting of all
- * values.
+ * values or a distinct aggregate.
  *
  * <p>
- * NULL values are not collected. {@link #getValue(Database, int, boolean)}
+ * NULL values are not collected. {@link #getValue(Database, int)}
  * method returns {@code null}. Use {@link #getArray()} for instances of this
  * class instead.
  * </p>
  */
 class AggregateDataCollecting extends AggregateData implements Iterable<Value> {
 
+    private final boolean distinct;
+
     Collection<Value> values;
 
+    /**
+     * Creates new instance of data for collecting aggregates.
+     *
+     * @param distinct if distinct is used
+     */
+    AggregateDataCollecting(boolean distinct) {
+        this.distinct = distinct;
+    }
+
     @Override
-    void add(Database database, int dataType, boolean distinct, Value v) {
+    void add(Database database, int dataType, Value v) {
         if (v == ValueNull.INSTANCE) {
             return;
         }
@@ -42,7 +53,7 @@ class AggregateDataCollecting extends AggregateData implements Iterable<Value> {
     }
 
     @Override
-    Value getValue(Database database, int dataType, boolean distinct) {
+    Value getValue(Database database, int dataType) {
         return null;
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataCollecting.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataCollecting.java
@@ -20,8 +20,7 @@ import org.h2.value.ValueNull;
  * <p>
  * NULL values are not collected. {@link #getValue(Database, int, boolean)}
  * method returns {@code null}. Use {@link #getArray()} for instances of this
- * class instead. Notice that subclasses like {@link AggregateDataMedian} may
- * override {@link #getValue(Database, int, boolean)} to return useful result.
+ * class instead.
  * </p>
  */
 class AggregateDataCollecting extends AggregateData {

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataCollecting.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataCollecting.java
@@ -44,6 +44,15 @@ class AggregateDataCollecting extends AggregateData {
     }
 
     /**
+     * Returns the count of values.
+     *
+     * @return the count of values
+     */
+    int getCount() {
+        return values != null ? values.size() : 0;
+    }
+
+    /**
      * Returns array with values or {@code null}.
      *
      * @return array with values or {@code null}

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataCollecting.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataCollecting.java
@@ -7,7 +7,9 @@ package org.h2.expression.aggregate;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 
 import org.h2.engine.Database;
 import org.h2.value.Value;
@@ -23,7 +25,8 @@ import org.h2.value.ValueNull;
  * class instead.
  * </p>
  */
-class AggregateDataCollecting extends AggregateData {
+class AggregateDataCollecting extends AggregateData implements Iterable<Value> {
+
     Collection<Value> values;
 
     @Override
@@ -64,4 +67,10 @@ class AggregateDataCollecting extends AggregateData {
         }
         return values.toArray(new Value[0]);
     }
+
+    @Override
+    public Iterator<Value> iterator() {
+        return values != null ? values.iterator() : Collections.<Value>emptyIterator();
+    }
+
 }

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataCount.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataCount.java
@@ -17,15 +17,14 @@ class AggregateDataCount extends AggregateData {
     private long count;
 
     @Override
-    void add(Database database, int dataType, boolean distinct, Value v) {
-        if (v == ValueNull.INSTANCE) {
-            return;
+    void add(Database database, int dataType, Value v) {
+        if (v != ValueNull.INSTANCE) {
+            count++;
         }
-        count++;
     }
 
     @Override
-    Value getValue(Database database, int dataType, boolean distinct) {
+    Value getValue(Database database, int dataType) {
         return ValueLong.get(count).convertTo(dataType);
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataCount.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataCount.java
@@ -6,7 +6,6 @@
 package org.h2.expression.aggregate;
 
 import org.h2.engine.Database;
-import org.h2.util.ValueHashMap;
 import org.h2.value.Value;
 import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
@@ -16,7 +15,6 @@ import org.h2.value.ValueNull;
  */
 class AggregateDataCount extends AggregateData {
     private long count;
-    private ValueHashMap<AggregateDataCount> distinctValues;
 
     @Override
     void add(Database database, int dataType, boolean distinct, Value v) {
@@ -24,23 +22,10 @@ class AggregateDataCount extends AggregateData {
             return;
         }
         count++;
-        if (distinct) {
-            if (distinctValues == null) {
-                distinctValues = ValueHashMap.newInstance();
-            }
-            distinctValues.put(v, this);
-        }
     }
 
     @Override
     Value getValue(Database database, int dataType, boolean distinct) {
-        if (distinct) {
-            if (distinctValues != null) {
-                count = distinctValues.size();
-            } else {
-                count = 0;
-            }
-        }
         return ValueLong.get(count).convertTo(dataType);
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataCountAll.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataCountAll.java
@@ -6,7 +6,6 @@
 package org.h2.expression.aggregate;
 
 import org.h2.engine.Database;
-import org.h2.message.DbException;
 import org.h2.value.Value;
 import org.h2.value.ValueLong;
 
@@ -14,21 +13,16 @@ import org.h2.value.ValueLong;
  * Data stored while calculating a COUNT(*) aggregate.
  */
 class AggregateDataCountAll extends AggregateData {
+
     private long count;
 
     @Override
-    void add(Database database, int dataType, boolean distinct, Value v) {
-        if (distinct) {
-            throw DbException.throwInternalError();
-        }
+    void add(Database database, int dataType, Value v) {
         count++;
     }
 
     @Override
-    Value getValue(Database database, int dataType, boolean distinct) {
-        if (distinct) {
-            throw DbException.throwInternalError();
-        }
+    Value getValue(Database database, int dataType) {
         return ValueLong.get(count).convertTo(dataType);
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataDefault.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataDefault.java
@@ -129,8 +129,7 @@ class AggregateDataDefault extends AggregateData {
     @Override
     Value getValue(Database database, int dataType, boolean distinct) {
         if (distinct) {
-            count = 0;
-            groupDistinct(database, dataType);
+            return getDistinct(database, dataType);
         }
         Value v = null;
         switch (aggregateType) {
@@ -192,14 +191,15 @@ class AggregateDataDefault extends AggregateData {
         return a;
     }
 
-    private void groupDistinct(Database database, int dataType) {
+    private Value getDistinct(Database database, int dataType) {
         if (distinctValues == null) {
-            return;
+            return ValueNull.INSTANCE;
         }
-        count = 0;
+        AggregateDataDefault d = new AggregateDataDefault(aggregateType);
         for (Value v : distinctValues.keys()) {
-            add(database, dataType, false, v);
+            d.add(database, dataType, false, v);
         }
+        return d.getValue(database, dataType, false);
     }
 
 }

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataDefault.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataDefault.java
@@ -33,7 +33,7 @@ class AggregateDataDefault extends AggregateData {
     }
 
     @Override
-    void add(Database database, int dataType, boolean distinct, Value v) {
+    void add(Database database, int dataType, Value v) {
         if (v == ValueNull.INSTANCE) {
             return;
         }
@@ -119,7 +119,7 @@ class AggregateDataDefault extends AggregateData {
     }
 
     @Override
-    Value getValue(Database database, int dataType, boolean distinct) {
+    Value getValue(Database database, int dataType) {
         Value v = null;
         switch (aggregateType) {
         case SUM:

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataEnvelope.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataEnvelope.java
@@ -57,7 +57,7 @@ class AggregateDataEnvelope extends AggregateData {
     }
 
     @Override
-    void add(Database database, int dataType, boolean distinct, Value v) {
+    void add(Database database, int dataType, Value v) {
         if (v == ValueNull.INSTANCE) {
             return;
         }
@@ -65,7 +65,7 @@ class AggregateDataEnvelope extends AggregateData {
     }
 
     @Override
-    Value getValue(Database database, int dataType, boolean distinct) {
+    Value getValue(Database database, int dataType) {
         return ValueGeometry.fromEnvelope(envelope);
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataHistogram.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataHistogram.java
@@ -22,10 +22,21 @@ import org.h2.value.ValueLong;
  */
 class AggregateDataHistogram extends AggregateData {
 
+    private final boolean distinct;
+
     private ValueHashMap<LongDataCounter> distinctValues;
 
+    /**
+     * Creates new instance of data for HISTOGRAM aggregate.
+     *
+     * @param distinct if distinct is used
+     */
+    AggregateDataHistogram(boolean distinct) {
+        this.distinct = distinct;
+    }
+
     @Override
-    void add(Database database, int dataType, boolean distinct, Value v) {
+    void add(Database database, int dataType, Value v) {
         if (distinctValues == null) {
             distinctValues = ValueHashMap.newInstance();
         }
@@ -41,7 +52,7 @@ class AggregateDataHistogram extends AggregateData {
     }
 
     @Override
-    Value getValue(Database database, int dataType, boolean distinct) {
+    Value getValue(Database database, int dataType) {
         if (distinctValues == null) {
             return ValueArray.get(new Value[0]).convertTo(dataType);
         }

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataMode.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataMode.java
@@ -20,7 +20,7 @@ class AggregateDataMode extends AggregateData {
     private ValueHashMap<LongDataCounter> distinctValues;
 
     @Override
-    void add(Database database, int dataType, boolean distinct, Value v) {
+    void add(Database database, int dataType, Value v) {
         if (v == ValueNull.INSTANCE) {
             return;
         }
@@ -36,7 +36,7 @@ class AggregateDataMode extends AggregateData {
     }
 
     @Override
-    Value getValue(Database database, int dataType, boolean distinct) {
+    Value getValue(Database database, int dataType) {
         Value v = ValueNull.INSTANCE;
         if (distinctValues != null) {
             long count = 0L;

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataSelectivity.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataSelectivity.java
@@ -15,12 +15,24 @@ import org.h2.value.ValueInt;
  * Data stored while calculating a SELECTIVITY aggregate.
  */
 class AggregateDataSelectivity extends AggregateData {
+
+    private final boolean distinct;
+
     private long count;
     private IntIntHashMap distinctHashes;
     private double m2;
 
+    /**
+     * Creates new instance of data for SELECTIVITY aggregate.
+     *
+     * @param distinct if distinct is used
+     */
+    AggregateDataSelectivity(boolean distinct) {
+        this.distinct = distinct;
+    }
+
     @Override
-    void add(Database database, int dataType, boolean distinct, Value v) {
+    void add(Database database, int dataType, Value v) {
         count++;
         if (distinctHashes == null) {
             distinctHashes = new IntIntHashMap();
@@ -36,7 +48,7 @@ class AggregateDataSelectivity extends AggregateData {
     }
 
     @Override
-    Value getValue(Database database, int dataType, boolean distinct) {
+    Value getValue(Database database, int dataType) {
         if (distinct) {
             count = 0;
         }
@@ -53,4 +65,5 @@ class AggregateDataSelectivity extends AggregateData {
         v = ValueInt.get(s);
         return v.convertTo(dataType);
     }
+
 }

--- a/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
@@ -209,7 +209,7 @@ public class JavaAggregate extends AbstractAggregate {
                     arg = arg.convertTo(argTypes[i]);
                     argValues[i] = arg;
                 }
-                data.add(session.getDatabase(), dataType, true, args.length == 1 ? arg : ValueArray.get(argValues));
+                data.add(session.getDatabase(), dataType, args.length == 1 ? arg : ValueArray.get(argValues));
             } else {
                 Aggregate agg = (Aggregate) aggregateData;
                 Object[] argValues = new Object[args.length];
@@ -254,7 +254,7 @@ public class JavaAggregate extends AbstractAggregate {
 
     @Override
     protected Object createAggregateData() {
-        return distinct ? new AggregateDataCollecting() : getInstance();
+        return distinct ? new AggregateDataCollecting(true) : getInstance();
     }
 
 }

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/count.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/count.sql
@@ -69,3 +69,17 @@ SELECT NR FROM (SELECT COUNT(ID) OVER (ORDER BY NAME) AS NR,
 
 DROP TABLE TEST;
 > ok
+
+SELECT I, V, COUNT(V) OVER W C, COUNT(DISTINCT V) OVER W D FROM
+    VALUES (1, 1), (2, 1), (3, 1), (4, 1), (5, 2), (6, 2), (7, 3) T(I, V)
+    WINDOW W AS (ORDER BY I);
+> I V C D
+> - - - -
+> 1 1 1 1
+> 2 1 2 1
+> 3 1 3 1
+> 4 1 4 1
+> 5 2 5 2
+> 6 2 6 2
+> 7 3 7 3
+> rows (ordered): 7

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/sum.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/sum.sql
@@ -81,3 +81,17 @@ SELECT
 > 7  28 28    15    36
 > 8  36 36    8     36
 > rows (ordered): 8
+
+SELECT I, V, SUM(V) OVER W S, SUM(DISTINCT V) OVER W D FROM
+    VALUES (1, 1), (2, 1), (3, 1), (4, 1), (5, 2), (6, 2), (7, 3) T(I, V)
+    WINDOW W AS (ORDER BY I);
+> I V S  D
+> - - -- -
+> 1 1 1  1
+> 2 1 2  1
+> 3 1 3  1
+> 4 1 4  1
+> 5 2 6  3
+> 6 2 8  3
+> 7 3 11 6
+> rows (ordered): 7


### PR DESCRIPTION
1. Some distinct aggregates like `SUM (DISTINCT …)` returned incorrect results when they were used as a window aggregate.

2. `MEDIAN` now uses `AggregateDataCollecting`.

3. `MIN`, `MAX`, `BOOL_AND`, `BOOL_OR`, `BIT_AND`, and `BIT_OR` do not collect values any more if `DISTINCT` was specified for them. This is not required.

4. `AggregateDataDefault` does not collect values any more, if it is necessary `AggregateDataCollecting` is used as a storage.

5. Methods of `AggregateData` do not have `distinct` parameter any more, now it is used only in a few places and all these aggregates get it in constructor parameters instead.

Now only `AggregateDataCollecting` and window functions may collect unlimited number of values and `AggregateDataSelectivity` and most likely unused `AggregateDataHistogram` may collect limited number of values controlled by `Constants.SELECTIVITY_DISTINCT_COUNT`.