### PR TITLE
Assorted minor changes in window processing code

### DIFF
--- a/h2/src/main/org/h2/command/dml/SelectGroups.java
+++ b/h2/src/main/org/h2/command/dml/SelectGroups.java
@@ -298,7 +298,7 @@ public abstract class SelectGroups {
      *            a key of partition
      * @return expression data or null
      */
-    public final PartitionData getWindowExprData(DataAnalysisOperation expr, ValueArray partitionKey) {
+    public final PartitionData getWindowExprData(DataAnalysisOperation expr, Value partitionKey) {
         if (partitionKey == null) {
             return windowData.get(expr);
         } else {
@@ -317,7 +317,7 @@ public abstract class SelectGroups {
      * @param object
      *            window expression data to set
      */
-    public final void setWindowExprData(DataAnalysisOperation expr, ValueArray partitionKey, PartitionData obj) {
+    public final void setWindowExprData(DataAnalysisOperation expr, Value partitionKey, PartitionData obj) {
         if (partitionKey == null) {
             Object old = windowData.put(expr, obj);
             assert old == null;

--- a/h2/src/main/org/h2/command/dml/SelectGroups.java
+++ b/h2/src/main/org/h2/command/dml/SelectGroups.java
@@ -99,7 +99,7 @@ public abstract class SelectGroups {
             }
             Object[] values = groupByData.get(currentGroupsKey);
             if (values == null) {
-                values = new Object[Math.max(exprToIndexInGroupByData.size(), expressions.size())];
+                values = createRow();
                 groupByData.put(currentGroupsKey, values);
             }
             currentGroupByExprData = values;
@@ -120,8 +120,7 @@ public abstract class SelectGroups {
         public void done() {
             super.done();
             if (groupIndex == null && groupByData.size() == 0) {
-                groupByData.put(defaultGroup,
-                        new Object[Math.max(exprToIndexInGroupByData.size(), expressions.size())]);
+                groupByData.put(defaultGroup, createRow());
             }
             cursor = groupByData.entrySet().iterator();
         }
@@ -166,7 +165,7 @@ public abstract class SelectGroups {
 
         @Override
         public void nextSource() {
-            Object[] values = new Object[Math.max(exprToIndexInGroupByData.size(), expressions.size())];
+            Object[] values = createRow();
             rows.add(values);
             currentGroupByExprData = values;
             currentGroupRowId++;
@@ -208,7 +207,7 @@ public abstract class SelectGroups {
      * Maps an expression object to an index, to use in accessing the Object[]
      * pointed to by groupByData.
      */
-    final HashMap<Expression, Integer> exprToIndexInGroupByData = new HashMap<>();
+    private final HashMap<Expression, Integer> exprToIndexInGroupByData = new HashMap<>();
 
     /**
      * Maps an window expression object to its data.
@@ -291,6 +290,10 @@ public abstract class SelectGroups {
             updateCurrentGroupExprData();
         }
         currentGroupByExprData[index] = obj;
+    }
+
+    final Object[] createRow() {
+        return new Object[Math.max(exprToIndexInGroupByData.size(), expressions.size())];
     }
 
     /**

--- a/h2/src/main/org/h2/command/dml/SelectGroups.java
+++ b/h2/src/main/org/h2/command/dml/SelectGroups.java
@@ -64,12 +64,6 @@ public abstract class SelectGroups {
          */
         private Iterator<Entry<ValueArray, Object[]>> cursor;
 
-        /**
-         * The key for the default group.
-         */
-        // Can be static, but TestClearReferences complains about it
-        private final ValueArray defaultGroup = ValueArray.get(new Value[0]);
-
         Grouped(Session session, ArrayList<Expression> expressions, int[] groupIndex) {
             super(session, expressions);
             this.groupIndex = groupIndex;
@@ -86,7 +80,7 @@ public abstract class SelectGroups {
         @Override
         public void nextSource() {
             if (groupIndex == null) {
-                currentGroupsKey = defaultGroup;
+                currentGroupsKey = ValueArray.getEmpty();
             } else {
                 Value[] keyValues = new Value[groupIndex.length];
                 // update group
@@ -120,7 +114,7 @@ public abstract class SelectGroups {
         public void done() {
             super.done();
             if (groupIndex == null && groupByData.size() == 0) {
-                groupByData.put(defaultGroup, createRow());
+                groupByData.put(ValueArray.getEmpty(), createRow());
             }
             cursor = groupByData.entrySet().iterator();
         }
@@ -185,10 +179,9 @@ public abstract class SelectGroups {
         @Override
         public ValueArray next() {
             if (cursor.hasNext()) {
-                Object[] values = cursor.next();
-                currentGroupByExprData = values;
+                currentGroupByExprData = cursor.next();
                 currentGroupRowId++;
-                return ValueArray.get(new Value[0]);
+                return ValueArray.getEmpty();
             }
             return null;
         }

--- a/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
@@ -6,6 +6,8 @@
 package org.h2.expression.aggregate;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 
 import org.h2.command.dml.Select;
 import org.h2.command.dml.SelectGroups;
@@ -14,6 +16,7 @@ import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
+import org.h2.value.Value;
 
 /**
  * A base class for aggregate functions.
@@ -67,6 +70,50 @@ public abstract class AbstractAggregate extends DataAnalysisOperation {
         }
         super.setEvaluatable(tableFilter, b);
     }
+
+    @Override
+    protected void getOrderedResultLoop(Session session, HashMap<Integer, Value> result, ArrayList<Value[]> ordered,
+            int rowIdColumn) {
+        WindowFrame frame = over.getWindowFrame();
+        if (frame == null || frame.isDefault()) {
+            Object aggregateData = createAggregateData();
+            for (Value[] row : ordered) {
+                updateFromExpressions(session, aggregateData, row);
+                result.put(row[rowIdColumn].getInt(), getAggregatedValue(session, aggregateData));
+            }
+        } else if (frame.isFullPartition()) {
+            Object aggregateData = createAggregateData();
+            for (Value[] row : ordered) {
+                updateFromExpressions(session, aggregateData, row);
+            }
+            Value value = getAggregatedValue(session, aggregateData);
+            for (Value[] row : ordered) {
+                result.put(row[rowIdColumn].getInt(), value);
+            }
+        } else {
+            int size = ordered.size();
+            for (int i = 0; i < size; i++) {
+                Object aggregateData = createAggregateData();
+                for (Iterator<Value[]> iter = frame.iterator(session, ordered, getOverOrderBySort(), i, false); iter
+                        .hasNext();) {
+                    updateFromExpressions(session, aggregateData, iter.next());
+                }
+                result.put(ordered.get(i)[rowIdColumn].getInt(), getAggregatedValue(session, aggregateData));
+            }
+        }
+    }
+
+    /**
+     * Updates the provided aggregate data from the remembered expressions.
+     *
+     * @param session
+     *            the session
+     * @param aggregateData
+     *            aggregate data
+     * @param array
+     *            values of expressions
+     */
+    protected abstract void updateFromExpressions(Session session, Object aggregateData, Value[] array);
 
     @Override
     protected void updateAggregate(Session session, SelectGroups groupData, int groupRowId) {

--- a/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
@@ -76,21 +76,26 @@ public abstract class AbstractAggregate extends DataAnalysisOperation {
             int rowIdColumn) {
         WindowFrame frame = over.getWindowFrame();
         if (frame == null || frame.isDefault()) {
+            // Aggregate all values before the current row (including)
             Object aggregateData = createAggregateData();
             for (Value[] row : ordered) {
+                // Collect values one by one
                 updateFromExpressions(session, aggregateData, row);
                 result.put(row[rowIdColumn].getInt(), getAggregatedValue(session, aggregateData));
             }
         } else if (frame.isFullPartition()) {
+            // Aggregate values from the whole partition
             Object aggregateData = createAggregateData();
             for (Value[] row : ordered) {
                 updateFromExpressions(session, aggregateData, row);
             }
+            // All rows have the same value
             Value value = getAggregatedValue(session, aggregateData);
             for (Value[] row : ordered) {
                 result.put(row[rowIdColumn].getInt(), value);
             }
         } else {
+            // All other types of frames (slow)
             int size = ordered.size();
             for (int i = 0; i < size; i++) {
                 Object aggregateData = createAggregateData();

--- a/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
@@ -123,7 +123,7 @@ public abstract class AbstractAggregate extends DataAnalysisOperation {
                 if ((orderBy = over.getOrderBy()) != null) {
                     updateOrderedAggregate(session, groupData, groupRowId, orderBy);
                 } else {
-                    updateAggregate(session, getWindowData(session, groupData, false, false));
+                    updateAggregate(session, getWindowData(session, groupData, false));
                 }
             } else {
                 updateAggregate(session, getGroupData(groupData, false));

--- a/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
@@ -119,10 +119,14 @@ public abstract class AbstractAggregate extends DataAnalysisOperation {
     protected void updateAggregate(Session session, SelectGroups groupData, int groupRowId) {
         if (filterCondition == null || filterCondition.getBooleanValue(session)) {
             ArrayList<SelectOrderBy> orderBy;
-            if (over != null && (orderBy = over.getOrderBy()) != null) {
-                updateOrderedAggregate(session, groupData, groupRowId, orderBy);
+            if (over != null) {
+                if ((orderBy = over.getOrderBy()) != null) {
+                    updateOrderedAggregate(session, groupData, groupRowId, orderBy);
+                } else {
+                    updateAggregate(session, getWindowData(session, groupData, false, false));
+                }
             } else {
-                updateAggregate(session, getData(session, groupData, false, false));
+                updateAggregate(session, getGroupData(groupData, false));
             }
         }
     }

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataHistogram.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataHistogram.java
@@ -54,7 +54,7 @@ class AggregateDataHistogram extends AggregateData {
     @Override
     Value getValue(Database database, int dataType) {
         if (distinctValues == null) {
-            return ValueArray.get(new Value[0]).convertTo(dataType);
+            return ValueArray.getEmpty().convertTo(dataType);
         }
         ValueArray[] values = new ValueArray[distinctValues.size()];
         int i = 0;

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataHistogram.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataHistogram.java
@@ -38,7 +38,7 @@ class AggregateDataHistogram extends AggregateData {
     @Override
     void add(Database database, int dataType, Value v) {
         if (distinctValues == null) {
-            distinctValues = ValueHashMap.newInstance();
+            distinctValues = new ValueHashMap<>();
         }
         LongDataCounter a = distinctValues.get(v);
         if (a == null) {

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataMode.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataMode.java
@@ -25,7 +25,7 @@ class AggregateDataMode extends AggregateData {
             return;
         }
         if (distinctValues == null) {
-            distinctValues = ValueHashMap.newInstance();
+            distinctValues = new ValueHashMap<>();
         }
         LongDataCounter a = distinctValues.get(v);
         if (a == null) {

--- a/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
+++ b/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
@@ -182,14 +182,11 @@ public abstract class DataAnalysisOperation extends Expression {
      */
     protected abstract void rememberExpressions(Session session, Value[] array);
 
-    protected Object getWindowData(Session session, SelectGroups groupData, boolean ifExists, boolean forOrderBy) {
+    protected Object getWindowData(Session session, SelectGroups groupData, boolean forOrderBy) {
         Object data;
         ValueArray key = over.getCurrentKey(session);
         PartitionData partition = groupData.getWindowExprData(this, key);
         if (partition == null) {
-            if (ifExists) {
-                return null;
-            }
             data = forOrderBy ? new ArrayList<>() : createAggregateData();
             groupData.setWindowExprData(this, key, new PartitionData(data));
         } else {
@@ -295,7 +292,7 @@ public abstract class DataAnalysisOperation extends Expression {
         }
         array[ne] = ValueInt.get(groupRowId);
         @SuppressWarnings("unchecked")
-        ArrayList<Value[]> data = (ArrayList<Value[]>) getWindowData(session, groupData, false, true);
+        ArrayList<Value[]> data = (ArrayList<Value[]>) getWindowData(session, groupData, true);
         data.add(array);
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
+++ b/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
@@ -225,7 +225,7 @@ public abstract class DataAnalysisOperation extends Expression {
                 if (ifExists) {
                     return null;
                 }
-                data = forOrderBy ? new ArrayList<>() : createAggregateData();
+                data = createAggregateData();
                 groupData.setCurrentGroupExprData(this, data);
             }
         }

--- a/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
+++ b/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
@@ -21,7 +21,6 @@ import org.h2.result.SortOrder;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.value.Value;
-import org.h2.value.ValueArray;
 import org.h2.value.ValueInt;
 
 /**
@@ -184,7 +183,7 @@ public abstract class DataAnalysisOperation extends Expression {
 
     protected Object getWindowData(Session session, SelectGroups groupData, boolean forOrderBy) {
         Object data;
-        ValueArray key = over.getCurrentKey(session);
+        Value key = over.getCurrentKey(session);
         PartitionData partition = groupData.getWindowExprData(this, key);
         if (partition == null) {
             data = forOrderBy ? new ArrayList<>() : createAggregateData();
@@ -258,7 +257,7 @@ public abstract class DataAnalysisOperation extends Expression {
         PartitionData partition;
         Object data;
         boolean forOrderBy = over.getOrderBy() != null;
-        ValueArray key = over.getCurrentKey(session);
+        Value key = over.getCurrentKey(session);
         partition = groupData.getWindowExprData(this, key);
         if (partition == null) {
             // Window aggregates with FILTER clause may have no collected values

--- a/h2/src/main/org/h2/expression/aggregate/PartitionData.java
+++ b/h2/src/main/org/h2/expression/aggregate/PartitionData.java
@@ -12,7 +12,7 @@ import org.h2.value.Value;
 /**
  * Partition data of a window aggregate.
  */
-final class PartitionData {
+public final class PartitionData {
 
     /**
      * Aggregate data.

--- a/h2/src/main/org/h2/expression/aggregate/Window.java
+++ b/h2/src/main/org/h2/expression/aggregate/Window.java
@@ -185,18 +185,22 @@ public final class Window {
      *            session
      * @return key for the current group, or null
      */
-    public ValueArray getCurrentKey(Session session) {
+    public Value getCurrentKey(Session session) {
         if (partitionBy == null) {
             return null;
         }
         int len = partitionBy.size();
-        Value[] keyValues = new Value[len];
-        // update group
-        for (int i = 0; i < len; i++) {
-            Expression expr = partitionBy.get(i);
-            keyValues[i] = expr.getValue(session);
+        if (len == 1) {
+            return partitionBy.get(0).getValue(session);
+        } else {
+            Value[] keyValues = new Value[len];
+            // update group
+            for (int i = 0; i < len; i++) {
+                Expression expr = partitionBy.get(i);
+                keyValues[i] = expr.getValue(session);
+            }
+            return ValueArray.get(keyValues);
         }
-        return ValueArray.get(keyValues);
     }
 
     /**

--- a/h2/src/main/org/h2/expression/aggregate/WindowFunction.java
+++ b/h2/src/main/org/h2/expression/aggregate/WindowFunction.java
@@ -175,11 +175,6 @@ public class WindowFunction extends DataAnalysisOperation {
     }
 
     @Override
-    protected void updateFromExpressions(Session session, Object aggregateData, Value[] array) {
-        throw DbException.getUnsupportedException("Window function");
-    }
-
-    @Override
     protected Object createAggregateData() {
         throw DbException.getUnsupportedException("Window function");
     }

--- a/h2/src/main/org/h2/expression/aggregate/WindowFunction.java
+++ b/h2/src/main/org/h2/expression/aggregate/WindowFunction.java
@@ -183,62 +183,58 @@ public class WindowFunction extends DataAnalysisOperation {
     protected void getOrderedResultLoop(Session session, HashMap<Integer, Value> result, ArrayList<Value[]> ordered,
             int rowIdColumn) {
         switch (type) {
+        case ROW_NUMBER:
+            for (int i = 0, size = ordered.size(); i < size;) {
+                result.put(ordered.get(i)[rowIdColumn].getInt(), ValueInt.get(++i));
+            }
+            break;
+        case RANK:
+        case DENSE_RANK:
+        case PERCENT_RANK:
+            getRank(result, ordered, rowIdColumn);
+            break;
         case CUME_DIST:
             getCumeDist(session, result, ordered, rowIdColumn);
-            return;
+            break;
         case NTILE:
             getNtile(session, result, ordered, rowIdColumn);
-            return;
+            break;
         case LEAD:
         case LAG:
             getLeadLag(session, result, ordered, rowIdColumn);
-            return;
+            break;
         case FIRST_VALUE:
         case LAST_VALUE:
         case NTH_VALUE:
             getNth(session, result, ordered, rowIdColumn);
-            return;
+            break;
         default:
+            throw DbException.throwInternalError("type=" + type);
         }
+    }
+
+    private void getRank(HashMap<Integer, Value> result, ArrayList<Value[]> ordered, int rowIdColumn) {
         int size = ordered.size();
         int number = 0;
         for (int i = 0; i < size; i++) {
             Value[] row = ordered.get(i);
-            int rowId = row[rowIdColumn].getInt();
+            if (i == 0) {
+                number = 1;
+            } else if (getOverOrderBySort().compare(ordered.get(i - 1), row) != 0) {
+                if (type == WindowFunctionType.DENSE_RANK) {
+                    number++;
+                } else {
+                    number = i + 1;
+                }
+            }
             Value v;
-            switch (type) {
-            case ROW_NUMBER:
-                v = ValueInt.get(i + 1);
-                break;
-            case RANK:
-            case DENSE_RANK:
-            case PERCENT_RANK: {
-                if (i == 0) {
-                    number = 1;
-                } else {
-                    if (getOverOrderBySort().compare(ordered.get(i - 1), row) != 0) {
-                        switch (type) {
-                        case RANK:
-                        case PERCENT_RANK:
-                            number = i + 1;
-                            break;
-                        default: // DENSE_RANK
-                            number++;
-                        }
-                    }
-                }
-                if (type == WindowFunctionType.PERCENT_RANK) {
-                    int nm = number - 1;
-                    v = nm == 0 ? ValueDouble.ZERO : ValueDouble.get((double) nm / (size - 1));
-                } else {
-                    v = ValueInt.get(number);
-                }
-                break;
+            if (type == WindowFunctionType.PERCENT_RANK) {
+                int nm = number - 1;
+                v = nm == 0 ? ValueDouble.ZERO : ValueDouble.get((double) nm / (size - 1));
+            } else {
+                v = ValueInt.get(number);
             }
-            default:
-                throw DbException.throwInternalError("type=" + type);
-            }
-            result.put(rowId, v);
+            result.put(row[rowIdColumn].getInt(), v);
         }
     }
 

--- a/h2/src/main/org/h2/index/HashIndex.java
+++ b/h2/src/main/org/h2/index/HashIndex.java
@@ -40,7 +40,7 @@ public class HashIndex extends BaseIndex {
     }
 
     private void reset() {
-        rows = ValueHashMap.newInstance();
+        rows = new ValueHashMap<>();
     }
 
     @Override

--- a/h2/src/main/org/h2/index/NonUniqueHashIndex.java
+++ b/h2/src/main/org/h2/index/NonUniqueHashIndex.java
@@ -45,7 +45,7 @@ public class NonUniqueHashIndex extends BaseIndex {
     }
 
     private void reset() {
-        rows = ValueHashMap.newInstance();
+        rows = new ValueHashMap<>();
         rowCount = 0;
     }
 

--- a/h2/src/main/org/h2/result/LocalResultImpl.java
+++ b/h2/src/main/org/h2/result/LocalResultImpl.java
@@ -147,7 +147,7 @@ public class LocalResultImpl implements LocalResult {
     public void setDistinct() {
         assert distinctIndexes == null;
         distinct = true;
-        distinctRows = ValueHashMap.newInstance();
+        distinctRows = new ValueHashMap<>();
     }
 
     /**
@@ -159,7 +159,7 @@ public class LocalResultImpl implements LocalResult {
     public void setDistinct(int[] distinctIndexes) {
         assert !distinct;
         this.distinctIndexes = distinctIndexes;
-        distinctRows = ValueHashMap.newInstance();
+        distinctRows = new ValueHashMap<>();
     }
 
     /**
@@ -202,7 +202,7 @@ public class LocalResultImpl implements LocalResult {
             return external.contains(values);
         }
         if (distinctRows == null) {
-            distinctRows = ValueHashMap.newInstance();
+            distinctRows = new ValueHashMap<>();
             for (Value[] row : rows) {
                 ValueArray array = getArrayOfDistinct(row);
                 distinctRows.put(array, array.getList());

--- a/h2/src/main/org/h2/util/ValueHashMap.java
+++ b/h2/src/main/org/h2/util/ValueHashMap.java
@@ -38,15 +38,6 @@ public class ValueHashMap<V> extends HashBase {
     Value[] keys;
     V[] values;
 
-    /**
-     * Create a new value hash map.
-     *
-     * @return the object
-     */
-    public static <T> ValueHashMap<T> newInstance() {
-        return new ValueHashMap<>();
-    }
-
     @Override
     @SuppressWarnings("unchecked")
     protected void reset(int newLevel) {

--- a/h2/src/main/org/h2/value/ValueArray.java
+++ b/h2/src/main/org/h2/value/ValueArray.java
@@ -20,6 +20,11 @@ import org.h2.util.StatementBuilder;
  */
 public class ValueArray extends Value {
 
+    /**
+     * Empty array.
+     */
+    private static final Object EMPTY = get(new Value[0]);
+
     private final Class<?> componentType;
     private final Value[] values;
     private int hash;
@@ -50,6 +55,15 @@ public class ValueArray extends Value {
      */
     public static ValueArray get(Class<?> componentType, Value[] list) {
         return new ValueArray(componentType, list);
+    }
+
+    /**
+     * Returns empty array.
+     *
+     * @return empty array
+     */
+    public static ValueArray getEmpty() {
+        return (ValueArray) EMPTY;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/count.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/count.sql
@@ -83,3 +83,14 @@ SELECT I, V, COUNT(V) OVER W C, COUNT(DISTINCT V) OVER W D FROM
 > 6 2 6 2
 > 7 3 7 3
 > rows (ordered): 7
+
+SELECT I, C, COUNT(I) OVER (PARTITION BY C) CNT FROM
+    VALUES (1, 1), (2, 1), (3, 2), (4, 2), (5, 2) T(I, C);
+> I C CNT
+> - - ---
+> 1 1 2
+> 2 1 2
+> 3 2 3
+> 4 2 3
+> 5 2 3
+> rows: 5

--- a/h2/src/test/org/h2/test/scripts/functions/window/lead.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/window/lead.sql
@@ -143,3 +143,11 @@ SELECT LAG(VALUE) OVER (ORDER BY ID RANGE CURRENT ROW) FROM TEST;
 
 DROP TABLE TEST;
 > ok
+
+SELECT C, SUM(I) S, LEAD(SUM(I)) OVER (ORDER /**/ BY SUM(I)) L FROM
+    VALUES (1, 1), (2, 1), (4, 2), (8, 2) T(I, C) GROUP BY C;
+> C S  L
+> - -- ----
+> 1 3  12
+> 2 12 null
+> rows: 2

--- a/h2/src/test/org/h2/test/scripts/functions/window/row_number.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/window/row_number.sql
@@ -149,3 +149,9 @@ SELECT DENSE_RANK () OVER () FROM TEST;
 
 DROP TABLE TEST;
 > ok
+
+SELECT ROW_NUMBER() OVER () FROM VALUES (1);
+> ROW_NUMBER() OVER ()
+> --------------------
+> 1
+> rows: 1

--- a/h2/src/test/org/h2/test/scripts/functions/window/row_number.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/window/row_number.sql
@@ -133,13 +133,23 @@ INSERT INTO TEST VALUES
     (4, 'b', 8);
 > update count: 4
 
-SELECT ROW_NUMBER() OVER(ORDER /**/ BY TYPE) RN, TYPE, SUM(CNT) SUM FROM TEST GROUP BY TYPE;
+SELECT ROW_NUMBER() OVER (ORDER /**/ BY TYPE) RN, TYPE, SUM(CNT) SUM FROM TEST GROUP BY TYPE;
 > RN TYPE SUM
 > -- ---- ---
 > 1  a    1
 > 2  b    10
 > 3  c    4
 > rows: 3
+
+SELECT A, B, C, ROW_NUMBER() OVER (PARTITION BY A, B) N FROM
+    VALUES (1, 1, 1), (1, 1, 2), (1, 2, 3), (2, 1, 4) T(A, B, C);
+> A B C N
+> - - - -
+> 1 1 1 1
+> 1 1 2 2
+> 1 2 3 1
+> 2 1 4 1
+> rows: 4
 
 SELECT RANK () OVER () FROM TEST;
 > exception SYNTAX_ERROR_2

--- a/h2/src/test/org/h2/test/unit/TestValueHashMap.java
+++ b/h2/src/test/org/h2/test/unit/TestValueHashMap.java
@@ -47,7 +47,7 @@ public class TestValueHashMap extends TestBase implements DataHandler {
     }
 
     private void testNotANumber() {
-        ValueHashMap<Integer> map = ValueHashMap.newInstance();
+        ValueHashMap<Integer> map = new ValueHashMap<>();
         for (int i = 1; i < 100; i++) {
             double d = Double.longBitsToDouble(0x7ff0000000000000L | i);
             ValueDouble v = ValueDouble.get(d);
@@ -57,7 +57,7 @@ public class TestValueHashMap extends TestBase implements DataHandler {
     }
 
     private void testRandomized() {
-        ValueHashMap<Value> map = ValueHashMap.newInstance();
+        ValueHashMap<Value> map = new ValueHashMap<>();
         HashMap<Value, Value> hash = new HashMap<>();
         Random random = new Random(1);
         Comparator<Value> vc = new Comparator<Value>() {


### PR DESCRIPTION
1. Some methods are reorganized.

2. Code coverage is slightly improved with some additional test cases.

3. Partitions with 1 column use its value directly as a key instead of `ValueArray` wrapper.

4. A new constant with empty `ValueArray` is introduced. It is accessed with a method to avoid a cast in the callers. `TestClearReferences` complains about such constants if they do not have `Object` type.

5. `ValueHashMap.newInstance()` is removed. It looks like a Java 1.4 / 5 code switch leftover, similar methods in `New` class were removed some time ago.

6. Some comments are placed.

7. Storage for partitioned and not partitioned windows is separated for now to simplify some methods.