### PR TITLE
Add TransactionStore to MVStore jar

### DIFF
--- a/h2/src/installer/mvstore/MANIFEST.MF
+++ b/h2/src/installer/mvstore/MANIFEST.MF
@@ -17,5 +17,6 @@ Bundle-Category: utility
 Import-Package: javax.crypto,
  javax.crypto.spec
 Export-Package: org.h2.mvstore;version="${version}",
+ org.h2.mvstore.tx;version="${version}",
  org.h2.mvstore.type;version="${version}",
  org.h2.mvstore.rtree;version="${version}"

--- a/h2/src/installer/mvstore/MANIFEST.MF
+++ b/h2/src/installer/mvstore/MANIFEST.MF
@@ -14,6 +14,7 @@ Bundle-Vendor: H2 Group
 Bundle-Version: ${version}
 Bundle-License: http://www.h2database.com/html/license.html
 Bundle-Category: utility
+Multi-Release: true
 Import-Package: javax.crypto,
  javax.crypto.spec
 Export-Package: org.h2.mvstore;version="${version}",

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -391,6 +391,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      *
      * @param key the key
      * @return the value, or null if not found
+     * @throws ClassCastException if type of the specified key is not compatible with this map
      */
     @Override
     public final V get(Object key) {
@@ -403,6 +404,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @param p the root of a snapshot
      * @param key the key
      * @return the value, or null if not found
+     * @throws ClassCastException if type of the specified key is not compatible with this map
      */
     @SuppressWarnings("unchecked")
     public V get(Page p, Object key) {
@@ -445,6 +447,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      *
      * @param key the key (may not be null)
      * @return the old value if the key existed, or null otherwise
+     * @throws ClassCastException if type of the specified key is not compatible with this map
      */
     @Override
     @SuppressWarnings("unchecked")

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -950,10 +950,11 @@ public class MVMap<K, V> extends AbstractMap<K, V>
     }
 
     /**
-     * Get the number of entries, as a integer. Integer.MAX_VALUE is returned if
-     * there are more than this entries.
+     * Get the number of entries, as a integer. {@link Integer#MAX_VALUE} is
+     * returned if there are more than this entries.
      *
      * @return the number of entries, as an integer
+     * @see #sizeAsLong()
      */
     @Override
     public final int size() {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -12,10 +12,12 @@ import org.h2.mvstore.Page;
 import org.h2.mvstore.type.DataType;
 
 import java.util.AbstractMap;
+import java.util.AbstractSet;
 import java.util.BitSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * A map that supports transactions.
@@ -23,7 +25,7 @@ import java.util.NoSuchElementException;
  * @param <K> the key type
  * @param <V> the value type
  */
-public class TransactionMap<K, V> {
+public class TransactionMap<K, V> extends AbstractMap<K, V> {
 
     /**
      * The map used for writing (the latest version).
@@ -51,6 +53,19 @@ public class TransactionMap<K, V> {
      */
     public TransactionMap<K, V> getInstance(Transaction transaction) {
         return new TransactionMap<>(transaction, map);
+    }
+
+    /**
+     * Get the number of entries, as a integer. {@link Integer#MAX_VALUE} is
+     * returned if there are more than this entries.
+     *
+     * @return the number of entries, as an integer
+     * @see #sizeAsLong()
+     */
+    @Override
+    public final int size() {
+        long size = sizeAsLong();
+        return size > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
     }
 
     /**
@@ -178,7 +193,8 @@ public class TransactionMap<K, V> {
      * @param key the key
      * @throws IllegalStateException if a lock timeout occurs
      */
-    public V remove(K key) {
+    @Override
+    public V remove(Object key) {
         return set(key, (V)null);
     }
 
@@ -193,6 +209,7 @@ public class TransactionMap<K, V> {
      * @return the old value
      * @throws IllegalStateException if a lock timeout occurs
      */
+    @Override
     public V put(K key, V value) {
         DataUtils.checkArgument(value != null, "The value may not be null");
         return set(key, value);
@@ -207,6 +224,7 @@ public class TransactionMap<K, V> {
      * @param value the new value (not null)
      * @return the old value
      */
+    // Do not add @Override, code should be compatible with Java 7
     public V putIfAbsent(K key, V value) {
         DataUtils.checkArgument(value != null, "The value may not be null");
         TxDecisionMaker decisionMaker = new TxDecisionMaker.PutIfAbsentDecisionMaker(map.getId(), key, value,
@@ -245,12 +263,12 @@ public class TransactionMap<K, V> {
         return result;
     }
 
-    private V set(K key, V value) {
+    private V set(Object key, V value) {
         TxDecisionMaker decisionMaker = new TxDecisionMaker.PutDecisionMaker(map.getId(), key, value, transaction);
         return set(key, decisionMaker);
     }
 
-    private V set(K key, TxDecisionMaker decisionMaker) {
+    private V set(Object key, TxDecisionMaker decisionMaker) {
         TransactionStore store = transaction.store;
         Transaction blockingTransaction;
         long sequenceNumWhenStarted;
@@ -262,7 +280,9 @@ public class TransactionMap<K, V> {
             // since TxDecisionMaker has it embedded,
             // MVRTreeMap has weird traversal logic based on it,
             // and any non-null value will do
-            result = map.put(key, VersionedValue.DUMMY, decisionMaker);
+            @SuppressWarnings("unchecked")
+            K k = (K) key;
+            result = map.put(k, VersionedValue.DUMMY, decisionMaker);
 
             MVMap.Decision decision = decisionMaker.getDecision();
             assert decision != null;
@@ -343,8 +363,9 @@ public class TransactionMap<K, V> {
      * @param key the key
      * @return the value or null
      */
+    @Override
     @SuppressWarnings("unchecked")
-    public V get(K key) {
+    public V get(Object key) {
         VersionedValue data = map.get(key);
         if (data == null) {
             // doesn't exist or deleted by a committed transaction
@@ -370,7 +391,8 @@ public class TransactionMap<K, V> {
      * @param key the key
      * @return true if the map contains an entry for this key
      */
-    public boolean containsKey(K key) {
+    @Override
+    public boolean containsKey(Object key) {
         return get(key) != null;
     }
 
@@ -403,9 +425,32 @@ public class TransactionMap<K, V> {
     /**
      * Clear the map.
      */
+    @Override
     public void clear() {
         // TODO truncate transactionally?
         map.clear();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return new AbstractSet<Entry<K, V>>() {
+
+            @Override
+            public Iterator<Entry<K, V>> iterator() {
+                return entryIterator(null, null);
+            }
+
+            @Override
+            public int size() {
+                return TransactionMap.this.size();
+            }
+
+            @Override
+            public boolean contains(Object o) {
+                return TransactionMap.this.containsKey(o);
+            }
+
+        };
     }
 
     /**
@@ -693,4 +738,5 @@ public class TransactionMap<K, V> {
                     "Removal is not supported");
         }
     }
+
 }

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -22,6 +22,13 @@ import java.util.Set;
 /**
  * A map that supports transactions.
  *
+ * <p>
+ * <b>Methods of this class may be changed at any time without notice.</b> If
+ * you use this class directly make sure that your application or library
+ * requires exactly the same version of MVStore or H2 jar as the version that
+ * you use during its development and build.
+ * </p>
+ *
  * @param <K> the key type
  * @param <V> the value type
  */
@@ -192,6 +199,7 @@ public class TransactionMap<K, V> extends AbstractMap<K, V> {
      *
      * @param key the key
      * @throws IllegalStateException if a lock timeout occurs
+     * @throws ClassCastException if type of the specified key is not compatible with this map
      */
     @Override
     public V remove(Object key) {
@@ -362,6 +370,7 @@ public class TransactionMap<K, V> extends AbstractMap<K, V> {
      *
      * @param key the key
      * @return the value or null
+     * @throws ClassCastException if type of the specified key is not compatible with this map
      */
     @Override
     @SuppressWarnings("unchecked")
@@ -390,6 +399,7 @@ public class TransactionMap<K, V> extends AbstractMap<K, V> {
      *
      * @param key the key
      * @return true if the map contains an entry for this key
+     * @throws ClassCastException if type of the specified key is not compatible with this map
      */
     @Override
     public boolean containsKey(Object key) {

--- a/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
@@ -12,7 +12,7 @@ import org.h2.mvstore.MVMap;
  *
  * @author <a href='mailto:andrei.tokar@gmail.com'>Andrei Tokar</a>
  */
-public abstract class TxDecisionMaker extends MVMap.DecisionMaker<VersionedValue> {
+abstract class TxDecisionMaker extends MVMap.DecisionMaker<VersionedValue> {
     private final int            mapId;
     private final Object         key;
     final Object                 value;

--- a/h2/src/test/org/h2/test/store/TestTransactionStore.java
+++ b/h2/src/test/org/h2/test/store/TestTransactionStore.java
@@ -13,6 +13,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -235,6 +236,7 @@ public class TestTransactionStore extends TestBase {
 
         Random r = new Random(1);
         for (int i = 0; i < size * 3; i++) {
+            assertEquals("op: " + i, size, map1.size());
             assertEquals("op: " + i, size, (int) map1.sizeAsLong());
             // keep the first 10%, and add 10%
             int k = size / 10 + r.nextInt(size);
@@ -507,6 +509,7 @@ public class TestTransactionStore extends TestBase {
         Transaction tx, tx2;
         TransactionMap<String, String> m, m2;
         Iterator<String> it, it2;
+        Iterator<Entry<String, String>> entryIt;
 
         tx = ts.begin();
         m = tx.openMap("test");
@@ -531,6 +534,15 @@ public class TestTransactionStore extends TestBase {
         assertTrue(it.hasNext());
         assertEquals("3", it.next());
         assertFalse(it.hasNext());
+
+        entryIt = m.entrySet().iterator();
+        assertTrue(entryIt.hasNext());
+        assertEquals("1", entryIt.next().getKey());
+        assertTrue(entryIt.hasNext());
+        assertEquals("2", entryIt.next().getKey());
+        assertTrue(entryIt.hasNext());
+        assertEquals("3", entryIt.next().getKey());
+        assertFalse(entryIt.hasNext());
 
         it2 = m2.keyIterator(null);
         assertTrue(it2.hasNext());

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -240,8 +240,7 @@ public class Build extends BuildBase {
         String classpath = "temp";
         FileList files;
         files = files("src/main/org/h2/mvstore").
-                exclude("src/main/org/h2/mvstore/db/*").
-                exclude("src/main/org/h2/mvstore/tx/*");
+                exclude("src/main/org/h2/mvstore/db/*");
         StringList args = args();
         if (debugInfo) {
             args = args.plus("-Xlint:unchecked", "-d", "temp", "-sourcepath",


### PR DESCRIPTION
As it was noticed by @andreitokar documentation actually has a reference to a `TransactionStore` for a long time.

1. `TransactionMap` now implements `java.util.Map` interface for better usability.

2. `TxDecisionMaker` is not public any more, it is not currently used outside its package.

3. `org.h2.mvstore.tx` package is included in MVStore jar.