### PR TITLE
Update Maven build instruction and fix some problems

### DIFF
--- a/h2/.mvn/wrapper/maven-wrapper.properties
+++ b/h2/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip

--- a/h2/MAVEN.md
+++ b/h2/MAVEN.md
@@ -5,24 +5,59 @@ Welcome to H2, the Java SQL database. The main features of H2 are:
 * Very fast, open source, JDBC API
 * Embedded and server modes; in-memory databases
 * Browser based Console application
-* Small footprint: around 1.5 MB jar file size
+* Small footprint: around 2 MB jar file size
 
 ## Experimental Building & Testing with Maven
 
-### Building
+### Preparation
 
-H2 uses [Maven Wrapper](https://github.com/takari/maven-wrapper) setup, you can instruct users to run wrapper scripts:
+Use non-Maven build to create all necessary resources:
 
-> $ ./mvnw clean test
+```Batchfile
+./build.cmd compile
+```
 
 or
 
-> $ ./mvnw.cmd clean test
+```sh
+./build.sh compile
+```
+
+### Building
+
+To build only the database jar use
+
+```sh
+mvn -Dmaven.test.skip=true package
+```
+
+If you don't have Maven installed use included [Maven Wrapper](https://github.com/takari/maven-wrapper) setup:
+
+```sh
+./mvnw -Dmaven.test.skip=true package
+```
+
+or
+
+```Batchfile
+./mvnw.cmd -Dmaven.test.skip=true package
+```
+
+Please note that jar generated with Maven is larger than official one and it does not include OSGi attributes.
+Use build script with `jar` target instead if you need a compatible jar.
+
+### Testing
+
+To run the tests use
+
+```sh
+mvn clean test
+```
 
 ### Running
 
 You can run the server like this
 
-```
+```sh
 mvn exec:java -Dexec.mainClass=org.h2.tools.Server  
 ```

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -210,7 +210,7 @@
     <directory>src/test</directory>
       <includes>
         <include>org/h2/test/scripts/testSimple.in.txt</include>
-        <include>org/h2/test/scripts/testScript.sql</include>
+        <include>org/h2/test/scripts/**/*.sql</include>
         <include>org/h2/samples/newsfeed.sql</include>
         <include>org/h2/samples/optimizations.sql</include>
       </includes>

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -220,6 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.0</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
1. Maven build instruction now includes information about preparation of resources and describes differences between results with different build systems. It also describes how to build jar without execution of a test case.

2. All scripts are now included in Maven test case, this significantly reduces number of failures. However, `mvn test` is still not reliable.

3. `maven-jar-plugin` how has a version attribute to avoid warning and possible failures in the future.

4. Maven wrapper now uses the current version of Maven.