### PR TITLE
Add optional EXCEPT clause to wildcards

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2497,7 +2497,7 @@ COMPRESSION LZF
 "
 
 "Other Grammar","Select Expression","
-* | expression [ [ AS ] columnAlias ] | tableAlias.*
+wildcardExpression | expression [ [ AS ] columnAlias ]
 ","
 An expression in a SELECT statement.
 ","
@@ -2566,6 +2566,16 @@ A list of rows that can be used like a table.
 The column list of the resulting table is C1, C2, and so on.
 ","
 SELECT * FROM (VALUES(1, 'Hello'), (2, 'World')) AS V;
+"
+
+"Other Grammar","Wildcard expression","
+{* | tableAlias.*} [EXCEPT ([tableAlias.]columnName, [,...])]
+","
+A wildcard expression in a SELECT statement.
+A wildcard expression represents all visible columns. Some columns can be excluded with optional EXCEPT clause.
+","
+*
+* EXCEPT (DATA)
 "
 
 "Other Grammar","Window name or specification","

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -893,14 +893,14 @@ public class Select extends Query {
             String schemaName = expr.getSchemaName();
             String tableAlias = expr.getTableAlias();
             Wildcard w = (Wildcard) expr;
-            ArrayList<ExpressionColumn> exceptColumns = w.getExceptColumns();
+            boolean hasExceptColumns = w.getExceptColumns() != null;
             HashMap<Column, ExpressionColumn> exceptTableColumns = null;
             if (tableAlias == null) {
-                if (exceptColumns != null) {
+                if (hasExceptColumns) {
                     for (TableFilter filter : filters) {
                         w.mapColumns(filter, 1, Expression.MAP_INITIAL);
                     }
-                    exceptTableColumns = mapExceptColumns(exceptColumns);
+                    exceptTableColumns = w.mapExceptColumns();
                 }
                 expressions.remove(i);
                 for (TableFilter filter : filters) {
@@ -912,9 +912,9 @@ public class Select extends Query {
                 for (TableFilter f : filters) {
                     if (db.equalsIdentifiers(tableAlias, f.getTableAlias())) {
                         if (schemaName == null || db.equalsIdentifiers(schemaName, f.getSchemaName())) {
-                            if (exceptColumns != null) {
+                            if (hasExceptColumns) {
                                 w.mapColumns(f, 1, Expression.MAP_INITIAL);
-                                exceptTableColumns = mapExceptColumns(exceptColumns);
+                                exceptTableColumns = w.mapExceptColumns();
                             }
                             filter = f;
                             break;
@@ -929,20 +929,6 @@ public class Select extends Query {
                 i--;
             }
         }
-    }
-
-    public HashMap<Column, ExpressionColumn> mapExceptColumns(ArrayList<ExpressionColumn> exceptColumns) {
-        HashMap<Column, ExpressionColumn> exceptTableColumns = new HashMap<>();
-        for (ExpressionColumn ec : exceptColumns) {
-            Column column = ec.getColumn();
-            if (column == null) {
-                throw ec.getColumnException(ErrorCode.COLUMN_NOT_FOUND_1);
-            }
-            if (exceptTableColumns.put(column, ec) != null) {
-                throw ec.getColumnException(ErrorCode.DUPLICATE_COLUMN_NAME_1);
-            }
-        }
-        return exceptTableColumns;
     }
 
     private int expandColumnList(TableFilter filter, int index, HashMap<Column, ExpressionColumn> except) {

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -140,16 +140,20 @@ public class ExpressionColumn extends Expression {
                     return constant.getValue();
                 }
             }
-            String name = columnName;
-            if (tableAlias != null) {
-                name = tableAlias + "." + name;
-                if (schemaName != null) {
-                    name = schemaName + "." + name;
-                }
-            }
-            throw DbException.get(ErrorCode.COLUMN_NOT_FOUND_1, name);
+            throw getColumnException(ErrorCode.COLUMN_NOT_FOUND_1);
         }
         return columnResolver.optimize(this, column);
+    }
+
+    public DbException getColumnException(int code) {
+        String name = columnName;
+        if (tableAlias != null) {
+            name = tableAlias + '.' + name;
+            if (schemaName != null) {
+                name = schemaName + '.' + name;
+            }
+        }
+        return DbException.get(code, name);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/Wildcard.java
+++ b/h2/src/main/org/h2/expression/Wildcard.java
@@ -6,10 +6,12 @@
 package org.h2.expression;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.Session;
 import org.h2.message.DbException;
+import org.h2.table.Column;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.util.StringUtils;
@@ -37,6 +39,26 @@ public class Wildcard extends Expression {
 
     public void setExceptColumns(ArrayList<ExpressionColumn> exceptColumns) {
         this.exceptColumns = exceptColumns;
+    }
+
+    /**
+     * Returns map of excluded table columns to expression columns and validates
+     * that all columns are resolved and not duplicated.
+     *
+     * @return map of excluded table columns to expression columns
+     */
+    public HashMap<Column, ExpressionColumn> mapExceptColumns() {
+        HashMap<Column, ExpressionColumn> exceptTableColumns = new HashMap<>();
+        for (ExpressionColumn ec : exceptColumns) {
+            Column column = ec.getColumn();
+            if (column == null) {
+                throw ec.getColumnException(ErrorCode.COLUMN_NOT_FOUND_1);
+            }
+            if (exceptTableColumns.put(column, ec) != null) {
+                throw ec.getColumnException(ErrorCode.DUPLICATE_COLUMN_NAME_1);
+            }
+        }
+        return exceptTableColumns;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/scripts/dml/select.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/select.sql
@@ -329,3 +329,81 @@ SELECT * FROM TEST ORDER BY ?, ? FETCH FIRST ROW ONLY;
 
 DROP TABLE TEST;
 > ok
+
+CREATE TABLE TEST1(A INT, B INT, C INT) AS SELECT 1, 2, 3;
+> ok
+
+CREATE TABLE TEST2(A INT, D INT) AS SELECT 4, 5;
+> ok
+
+SELECT * FROM TEST1, TEST2;
+> A B C A D
+> - - - - -
+> 1 2 3 4 5
+> rows: 1
+
+SELECT * EXCEPT (A) FROM TEST1;
+> B C
+> - -
+> 2 3
+> rows: 1
+
+SELECT * EXCEPT (TEST1.A) FROM TEST1;
+> B C
+> - -
+> 2 3
+> rows: 1
+
+SELECT * EXCEPT (PUBLIC.TEST1.A) FROM TEST1;
+> B C
+> - -
+> 2 3
+> rows: 1
+
+SELECT * EXCEPT (SCRIPT.PUBLIC.TEST1.A) FROM TEST1;
+> B C
+> - -
+> 2 3
+> rows: 1
+
+SELECT * EXCEPT (Z) FROM TEST1;
+> exception COLUMN_NOT_FOUND_1
+
+SELECT * EXCEPT (B, TEST1.B) FROM TEST1;
+> exception DUPLICATE_COLUMN_NAME_1
+
+SELECT * EXCEPT (A) FROM TEST1, TEST2;
+> exception AMBIGUOUS_COLUMN_NAME_1
+
+SELECT * EXCEPT (TEST1.A, B, TEST2.D) FROM TEST1, TEST2;
+> C A
+> - -
+> 3 4
+> rows: 1
+
+SELECT TEST1.*, TEST2.* FROM TEST1, TEST2;
+> A B C A D
+> - - - - -
+> 1 2 3 4 5
+> rows: 1
+
+SELECT TEST1.* EXCEPT (A), TEST2.* EXCEPT (A) FROM TEST1, TEST2;
+> B C D
+> - - -
+> 2 3 5
+> rows: 1
+
+SELECT TEST1.* EXCEPT (A), TEST2.* EXCEPT (D) FROM TEST1, TEST2;
+> B C A
+> - - -
+> 2 3 4
+> rows: 1
+
+SELECT * EXCEPT (T1.A, T2.D) FROM TEST1 T1, TEST2 T2;
+> B C A
+> - - -
+> 2 3 4
+> rows: 1
+
+DROP TABLE TEST1, TEST2;
+> ok

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -800,4 +800,4 @@ ranks rno dro rko precede cume reopens preceding unbounded rightly itr lag maxim
 partitioned tri partitions
 
 discard enhancements nolock surefire logarithm
-qualification opportunity jumping exploited unacceptable vrs
+qualification opportunity jumping exploited unacceptable vrs duplicated


### PR DESCRIPTION
An implementation of non-standard, but very useful [EXCEPT](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select-except) clause for wildcard expressions. BigQuery-compatible syntax is used.

@lukaseder