### PR TITLE
Assorted minor changes

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2641,7 +2641,7 @@ preceding and following values means relative number of groups of rows,
 and CURRENT ROW in bound specification means current group of rows.
 
 If only window frame preceding clause is specified it is treated as
-BETWEEN windowFramePreceding AND CURRENT ROW
+BETWEEN windowFramePreceding AND CURRENT ROW.
 
 Optional window frame exclusion clause specifies rows that should be excluded from the frame.
 EXCLUDE CURRENT ROW excludes only the current row regardless the window frame unit.
@@ -5260,6 +5260,7 @@ PERCENT_RANK() OVER windowNameOrSpecification
 Returns the relative rank of the current row.
 The relative rank is calculated as (RANK - 1) / (NR - 1),
 where RANK is a rank of the row and NR is a number of rows in window partition with this row.
+Note that result is always 0 if window order clause is not specified.
 Window frame clause is not allowed for this function.
 
 Window functions are currently experimental in H2 and should be used with caution.
@@ -5276,6 +5277,7 @@ Returns the relative rank of the current row.
 The relative rank is calculated as NP / NR
 where NP is a number of rows that precede the current row or have the same values in ORDER BY columns
 and NR is a number of rows in window partition with this row.
+Note that result is always 1 if window order clause is not specified.
 Window frame clause is not allowed for this function.
 
 Window functions are currently experimental in H2 and should be used with caution.

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -313,11 +313,8 @@ Only when the change is committed, the new value is visible by other connections
 database waits until it can apply the change, but at most until the lock timeout expires.
 </p>
 <p>
-This feature is only available with the default MVStore storage engine.
-Changing the lock mode with it (<code>LOCK_MODE</code>) has no effect.
-</p>
-<p>
-MVCC is not used when using the PageStore storage engine.
+This feature is only available with the default MVStore storage engine,
+it is not used when using the PageStore storage engine.
 </p>
 
 <h2 id="clustering">Clustering / High Availability</h2>

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -273,10 +273,21 @@ When using the isolation level 'serializable', dirty reads, non-repeatable reads
 </li>
 </ul>
 
-<h3>Table Level Locking</h3>
+<h3 id="mvcc">Multi-Version Concurrency Control (MVCC)</h3>
 <p>
-The database allows multiple concurrent connections to the same database.
-To make sure all connections only see consistent data, table level locking is used by default.
+With default MVStore engine delete, insert and update operations only issue a shared lock on the table.
+An exclusive lock is still used when adding or removing columns,
+when dropping the table, and when using <code>SELECT ... FOR UPDATE</code>.
+Connections only 'see' committed data, and own changes. That means, if connection A updates
+a row but doesn't commit this change yet, connection B will see the old value.
+Only when the change is committed, the new value is visible by other connections
+(read committed). If multiple connections concurrently try to update the same row, the
+database waits until it can apply the change, but at most until the lock timeout expires.
+</p>
+
+<h3>Table Level Locking (PageStore engine)</h3>
+<p>
+With PageStore engine to make sure all connections only see consistent data, table level locking is used.
 This mechanism does not allow high concurrency, but is very fast.
 Shared locks and exclusive locks are supported.
 Before reading from a table, the database tries to add a shared lock to the table
@@ -298,23 +309,6 @@ lock commits and it is then possible to get the lock. If this is not possible be
 the other connection does not release the lock for some time, the unsuccessful
 connection will get a lock timeout exception. The lock timeout can be set individually
 for each connection.
-</p>
-
-<h2 id="mvcc">Multi-Version Concurrency Control (MVCC)</h2>
-<p>
-The MVCC feature allows higher concurrency than using (table level or row level) locks.
-Delete, insert and update operations will only issue a shared lock on the table.
-An exclusive lock is still used when adding or removing columns,
-when dropping the table, and when using <code>SELECT ... FOR UPDATE</code>.
-Connections only 'see' committed data, and own changes. That means, if connection A updates
-a row but doesn't commit this change yet, connection B will see the old value.
-Only when the change is committed, the new value is visible by other connections
-(read committed). If multiple connections concurrently try to update the same row, the
-database waits until it can apply the change, but at most until the lock timeout expires.
-</p>
-<p>
-This feature is only available with the default MVStore storage engine,
-it is not used when using the PageStore storage engine.
 </p>
 
 <h2 id="clustering">Clustering / High Availability</h2>

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1513: Assorted minor changes
+</li>
+<li>PR #1510: Add optional EXCEPT clause to wildcards
+</li>
+<li>PR #1509: Use domain term everywhere
+</li>
 <li>Issue #1507: Add INFORMATION_SCHEMA.COLUMNS.COLUMN_TYPE qualification for domains
 </li>
 <li>Issue #1499: TestScript::envelope.sql failure in &#8220;big&#8221; mode

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -937,6 +937,9 @@ The initial lock timeout (that is the timeout used for new connections) can be s
 To avoid deadlocks, ensure that all transactions lock the tables in the same order
 (for example in alphabetical order), and avoid upgrading read locks to write locks.
 Both can be achieved using explicitly locking tables using <code>SELECT ... FOR UPDATE</code>.
+</p><p>
+Note that delete, insert and update operations issue table level locks with PageStore engine,
+but does not issue them with default MVStore engine.
 </p>
 
 <h2 id="database_file_layout">Database File Layout</h2>

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -858,10 +858,14 @@ This database synchronizes access to the same connection, but other databases ma
 To get higher concurrency, you need to use multiple connections.
 </p>
 <p>
-By default, requests to the same database are synchronized.
-That means an application can use multiple threads that access the same database
-at the same time, however if one thread executes a long running query, the other threads need to wait.
-To enable concurrent database usage, see the setting <code>MULTI_THREADED</code>.
+An application can use multiple threads that access the same database at the same time.
+With default MVStore engine threads that use different connections can use the database concurrently.
+With PageStore engine requests to the same database are synchronized,
+that means that if one thread executes a long running query, the other threads need to wait.
+Concurrent database usage may be enabled for PageStore or disabled for MVStore
+with <code>MULTI_THREADED</code> setting.
+Note that multi-threaded mode for PageStore engine is not tested well and has some issues;
+it should be used with caution.
 </p>
 
 <h3>Locking, Lock-Timeout, Deadlocks</h3>

--- a/h2/src/main/org/h2/expression/ConditionInConstantSet.java
+++ b/h2/src/main/org/h2/expression/ConditionInConstantSet.java
@@ -135,7 +135,7 @@ public class ConditionInConstantSet extends Condition {
             return false;
         }
         switch (visitor.getType()) {
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
         case ExpressionVisitor.DETERMINISTIC:
         case ExpressionVisitor.READONLY:
         case ExpressionVisitor.INDEPENDENT:

--- a/h2/src/main/org/h2/expression/Expression.java
+++ b/h2/src/main/org/h2/expression/Expression.java
@@ -272,15 +272,6 @@ public abstract class Expression {
     }
 
     /**
-     * Only returns true if the expression is a wildcard.
-     *
-     * @return if this expression is a wildcard
-     */
-    public boolean isWildcard() {
-        return false;
-    }
-
-    /**
      * Returns the main expression, skipping aliases.
      *
      * @return the expression

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -292,7 +292,7 @@ public class ExpressionColumn extends Expression {
     @Override
     public boolean isEverything(ExpressionVisitor visitor) {
         switch (visitor.getType()) {
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
             return false;
         case ExpressionVisitor.READONLY:
         case ExpressionVisitor.DETERMINISTIC:

--- a/h2/src/main/org/h2/expression/ExpressionVisitor.java
+++ b/h2/src/main/org/h2/expression/ExpressionVisitor.java
@@ -33,10 +33,10 @@ public class ExpressionVisitor {
             new ExpressionVisitor(INDEPENDENT);
 
     /**
-     * Are all aggregates MIN(column), MAX(column), or COUNT(*) for the given
-     * table (getTable)?
+     * Are all aggregates MIN(column), MAX(column), COUNT(*), MEDIAN(column),
+     * ENVELOPE(count) for the given table (getTable)?
      */
-    public static final int OPTIMIZABLE_MIN_MAX_COUNT_ALL = 1;
+    public static final int OPTIMIZABLE_AGGREGATE = 1;
 
     /**
      * Does the expression return the same results for the same parameters?
@@ -209,7 +209,7 @@ public class ExpressionVisitor {
      * @return the new visitor
      */
     public static ExpressionVisitor getOptimizableVisitor(Table table) {
-        return new ExpressionVisitor(OPTIMIZABLE_MIN_MAX_COUNT_ALL, 0, null,
+        return new ExpressionVisitor(OPTIMIZABLE_AGGREGATE, 0, null,
                 null, table, null, null, null);
     }
 

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -2735,7 +2735,7 @@ public class Function extends Expression implements FunctionCall {
         case ExpressionVisitor.GET_DEPENDENCIES:
         case ExpressionVisitor.INDEPENDENT:
         case ExpressionVisitor.NOT_FROM_RESOLVER:
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
         case ExpressionVisitor.SET_MAX_DATA_MODIFICATION_ID:
         case ExpressionVisitor.GET_COLUMNS1:
         case ExpressionVisitor.GET_COLUMNS2:

--- a/h2/src/main/org/h2/expression/Parameter.java
+++ b/h2/src/main/org/h2/expression/Parameter.java
@@ -156,7 +156,7 @@ public class Parameter extends Expression implements ParameterInterface {
         case ExpressionVisitor.NOT_FROM_RESOLVER:
         case ExpressionVisitor.QUERY_COMPARABLE:
         case ExpressionVisitor.GET_DEPENDENCIES:
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
         case ExpressionVisitor.DETERMINISTIC:
         case ExpressionVisitor.READONLY:
         case ExpressionVisitor.GET_COLUMNS1:

--- a/h2/src/main/org/h2/expression/Rownum.java
+++ b/h2/src/main/org/h2/expression/Rownum.java
@@ -81,7 +81,7 @@ public class Rownum extends Expression {
     public boolean isEverything(ExpressionVisitor visitor) {
         switch (visitor.getType()) {
         case ExpressionVisitor.QUERY_COMPARABLE:
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
         case ExpressionVisitor.DETERMINISTIC:
         case ExpressionVisitor.INDEPENDENT:
             return false;

--- a/h2/src/main/org/h2/expression/SequenceValue.java
+++ b/h2/src/main/org/h2/expression/SequenceValue.java
@@ -80,7 +80,7 @@ public class SequenceValue extends Expression {
     public boolean isEverything(ExpressionVisitor visitor) {
         switch (visitor.getType()) {
         case ExpressionVisitor.EVALUATABLE:
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
         case ExpressionVisitor.NOT_FROM_RESOLVER:
         case ExpressionVisitor.GET_COLUMNS1:
         case ExpressionVisitor.GET_COLUMNS2:

--- a/h2/src/main/org/h2/expression/ValueExpression.java
+++ b/h2/src/main/org/h2/expression/ValueExpression.java
@@ -150,7 +150,7 @@ public class ValueExpression extends Expression {
     @Override
     public boolean isEverything(ExpressionVisitor visitor) {
         switch (visitor.getType()) {
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
         case ExpressionVisitor.DETERMINISTIC:
         case ExpressionVisitor.READONLY:
         case ExpressionVisitor.INDEPENDENT:

--- a/h2/src/main/org/h2/expression/Variable.java
+++ b/h2/src/main/org/h2/expression/Variable.java
@@ -69,7 +69,7 @@ public class Variable extends Expression {
         case ExpressionVisitor.SET_MAX_DATA_MODIFICATION_ID:
             // it is checked independently if the value is the same as the last
             // time
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
         case ExpressionVisitor.READONLY:
         case ExpressionVisitor.INDEPENDENT:
         case ExpressionVisitor.NOT_FROM_RESOLVER:

--- a/h2/src/main/org/h2/expression/Wildcard.java
+++ b/h2/src/main/org/h2/expression/Wildcard.java
@@ -62,11 +62,6 @@ public class Wildcard extends Expression {
     }
 
     @Override
-    public boolean isWildcard() {
-        return true;
-    }
-
-    @Override
     public Value getValue(Session session) {
         throw DbException.throwInternalError(toString());
     }

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -781,7 +781,7 @@ public class Aggregate extends AbstractAggregate {
         if (filterCondition != null && !filterCondition.isEverything(visitor)) {
             return false;
         }
-        if (visitor.getType() == ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL) {
+        if (visitor.getType() == ExpressionVisitor.OPTIMIZABLE_AGGREGATE) {
             switch (type) {
             case COUNT:
                 if (!distinct && on.getNullable() == Column.NOT_NULLABLE) {

--- a/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
+++ b/h2/src/main/org/h2/expression/aggregate/DataAnalysisOperation.java
@@ -227,7 +227,7 @@ public abstract class DataAnalysisOperation extends Expression {
         }
         switch (visitor.getType()) {
         case ExpressionVisitor.QUERY_COMPARABLE:
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
         case ExpressionVisitor.DETERMINISTIC:
         case ExpressionVisitor.INDEPENDENT:
             return false;

--- a/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/JavaAggregate.java
@@ -93,7 +93,7 @@ public class JavaAggregate extends AbstractAggregate {
         case ExpressionVisitor.DETERMINISTIC:
             // TODO optimization: some functions are deterministic, but we don't
             // know (no setting for that)
-        case ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL:
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
             // user defined aggregate functions can not be optimized
             return false;
         case ExpressionVisitor.GET_DEPENDENCIES:


### PR DESCRIPTION
1. `Expression.isWildcard()` is replaced with `instanceof`. Unlike other similar methods this method is only used in one place and checks only for one specific class of expression. Related code is slightly reorganized.

2. Multi-threaded mode description in `features.html` is updated to reflect that this mode is default for MVStore.

3. `LOCK_MODE` actually has effect in MVStore mode, I removed incorrect information about it.

4. `PERCENT_RANK` and `CUME_DIST` now has an additional note about `ORDER BY` clause (without it they are useless).

5. `ExpressionVisitor.OPTIMIZABLE_MIN_MAX_COUNT_ALL` is renamed to `OPTIMIZABLE_AGGREGATE`, because H2 already has 5 aggregate functions that use this visitor, its name was outdated.