### PR TITLE
Fix NPE in VersionedValue.Type.compare()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1512: TestMVTableEngine.testLowRetentionTime(): NPE in VersionedValue.Type
+</li>
 <li>PR #1513: Assorted minor changes
 </li>
 <li>PR #1510: Add optional EXCEPT clause to wildcards

--- a/h2/src/main/org/h2/mvstore/tx/VersionedValue.java
+++ b/h2/src/main/org/h2/mvstore/tx/VersionedValue.java
@@ -122,6 +122,10 @@ public class VersionedValue {
         public int compare(Object aObj, Object bObj) {
             if (aObj == bObj) {
                 return 0;
+            } else if (aObj == null) {
+                return -1;
+            } else if (bObj == null) {
+                return 1;
             }
             VersionedValue a = (VersionedValue) aObj;
             VersionedValue b = (VersionedValue) bObj;


### PR DESCRIPTION
Issue #1512.

Unfortunately I didn't found a way to test it. This method is rarely invoked. But null values are possible here, so let's support them.