### PR TITLE
Fix array element reference and add standard array value constructor

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2022,11 +2022,21 @@ ID=1 AND NAME='Hi'
 "
 
 "Other Grammar","Array","
-( [ expression, [ expression [,...] ] ] )
+ARRAY '[' [ expression, [,...] ] ']'
+    | ( [ expression, [ expression [,...] ] ] )
 ","
-An array of values. An empty array is '()'. Trailing commas are ignored.
-An array with one element must contain a comma to be parsed as an array.
+An array of values.
+
+The array can be declared with standard ARRAY[] syntax or with H2 syntax.
+
+With standard syntax trailing comma is not allowed.
+
+With H2 syntax an empty array is '()'. Trailing comma is ignored.
+An array with one element must contain a trailing comma to be parsed as an array.
 ","
+ARRAY[1, 2]
+ARRAY[1]
+ARRAY[]
 (1, 2)
 (1, )
 ()

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1516: Array element reference array[index] should be 1-based
+</li>
 <li>Issue #1512: TestMVTableEngine.testLowRetentionTime(): NPE in VersionedValue.Type
 </li>
 <li>PR #1513: Assorted minor changes

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3813,6 +3813,21 @@ public class Parser {
         // Unquoted identifier is never empty
         char ch = name.charAt(0);
         switch (ch) {
+        case 'A':
+        case 'a':
+            if (equalsToken("ARRAY", name)) {
+                read(OPEN_BRACKET);
+                ArrayList<Expression> list = Utils.newSmallArrayList();
+                if (!readIf(CLOSE_BRACKET)) {
+                    list.add(readExpression());
+                    while (readIf(COMMA)) {
+                        list.add(readExpression());
+                    }
+                    read(CLOSE_BRACKET);
+                }
+                return new ExpressionList(list.toArray(new Expression[0]));
+            }
+            break;
         case 'C':
         case 'c':
             if (equalsToken("CURRENT_DATE", name)) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3892,10 +3892,7 @@ public class Parser {
         if (readIf(OPEN_BRACKET)) {
             Function function = Function.getFunction(database, "ARRAY_GET");
             function.setParameter(0, r);
-            r = readExpression();
-            r = new BinaryOperation(OpType.PLUS, r, ValueExpression.get(ValueInt
-                    .get(1)));
-            function.setParameter(1, r);
+            function.setParameter(1, readExpression());
             r = function;
             read(CLOSE_BRACKET);
         }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3699,120 +3699,8 @@ public class Parser {
                     r = readCase();
                 } else if (readIf(OPEN_PAREN)) {
                     r = readFunction(null, name);
-                } else if (equalsToken("CURRENT_USER", name)) {
-                    r = readFunctionWithoutParameters("USER");
-                } else if (equalsToken("CURRENT_TIMESTAMP", name)) {
-                    r = readFunctionWithoutParameters("CURRENT_TIMESTAMP");
-                } else if (equalsToken("LOCALTIMESTAMP", name)) {
-                    r = readFunctionWithoutParameters("LOCALTIMESTAMP");
-                } else if (equalsToken("SYSDATE", name)) {
-                    r = readFunctionWithoutParameters("CURRENT_TIMESTAMP");
-                } else if (equalsToken("SYSTIMESTAMP", name)) {
-                    r = readFunctionWithoutParameters("CURRENT_TIMESTAMP");
-                } else if (equalsToken("CURRENT_DATE", name)) {
-                    r = readFunctionWithoutParameters("CURRENT_DATE");
-                } else if (equalsToken("TODAY", name)) {
-                    r = readFunctionWithoutParameters("CURRENT_DATE");
-                } else if (equalsToken("CURRENT_TIME", name)) {
-                    r = readFunctionWithoutParameters("CURRENT_TIME");
-                } else if (equalsToken("LOCALTIME", name)) {
-                    r = readFunctionWithoutParameters("LOCALTIME");
-                } else if (equalsToken("SYSTIME", name)) {
-                    r = readFunctionWithoutParameters("CURRENT_TIME");
-                } else if (database.getMode().getEnum() == ModeEnum.DB2 && equalsToken("CURRENT", name)) {
-                    r = parseDB2SpecialRegisters(name);
-                } else if (equalsToken("NEXT", name) && readIf("VALUE")) {
-                    read(FOR);
-                    Sequence sequence = readSequence();
-                    r = new SequenceValue(sequence);
-                } else if (equalsToken("TIME", name)) {
-                    boolean without = readIf("WITHOUT");
-                    if (without) {
-                        read("TIME");
-                        read("ZONE");
-                    }
-                    if (currentTokenType != VALUE
-                            || currentValue.getType() != Value.STRING) {
-                        if (without) {
-                            throw getSyntaxError();
-                        }
-                        r = new ExpressionColumn(database, null, null, name);
-                    } else {
-                        String time = currentValue.getString();
-                        read();
-                        r = ValueExpression.get(ValueTime.parse(time));
-                    }
-                } else if (equalsToken("TIMESTAMP", name)) {
-                    if (readIf(WITH)) {
-                        read("TIME");
-                        read("ZONE");
-                        if (currentTokenType != VALUE
-                                || currentValue.getType() != Value.STRING) {
-                            throw getSyntaxError();
-                        }
-                        String timestamp = currentValue.getString();
-                        read();
-                        r = ValueExpression.get(ValueTimestampTimeZone.parse(timestamp));
-                    } else {
-                        boolean without = readIf("WITHOUT");
-                        if (without) {
-                            read("TIME");
-                            read("ZONE");
-                        }
-                        if (currentTokenType != VALUE
-                                || currentValue.getType() != Value.STRING) {
-                            if (without) {
-                                throw getSyntaxError();
-                            }
-                            r = new ExpressionColumn(database, null, null, name);
-                        } else {
-                            String timestamp = currentValue.getString();
-                            read();
-                            r = ValueExpression.get(ValueTimestamp.parse(timestamp, database.getMode()));
-                        }
-                    }
-                } else if (equalsToken("INTERVAL", name)) {
-                    r = readInterval();
-                } else if (currentTokenType == VALUE &&
-                        currentValue.getType() == Value.STRING) {
-                    if (equalsToken("DATE", name) ||
-                            equalsToken("D", name)) {
-                        String date = currentValue.getString();
-                        read();
-                        r = ValueExpression.get(ValueDate.parse(date));
-                    } else if (equalsToken("T", name)) {
-                        String time = currentValue.getString();
-                        read();
-                        r = ValueExpression.get(ValueTime.parse(time));
-                    } else if (equalsToken("TS", name)) {
-                        String timestamp = currentValue.getString();
-                        read();
-                        r = ValueExpression
-                                .get(ValueTimestamp.parse(timestamp, database.getMode()));
-                    } else if (equalsToken("X", name)) {
-                        read();
-                        byte[] buffer = StringUtils
-                                .convertHexToBytes(currentValue.getString());
-                        r = ValueExpression.get(ValueBytes.getNoCopy(buffer));
-                    } else if (equalsToken("E", name)) {
-                        String text = currentValue.getString();
-                        // the PostgreSQL ODBC driver uses
-                        // LIKE E'PROJECT\\_DATA' instead of LIKE
-                        // 'PROJECT\_DATA'
-                        // N: SQL-92 "National Language" strings
-                        text = StringUtils.replaceAll(text, "\\\\", "\\");
-                        read();
-                        r = ValueExpression.get(ValueString.get(text));
-                    } else if (equalsToken("N", name)) {
-                        // SQL-92 "National Language" strings
-                        String text = currentValue.getString();
-                        read();
-                        r = ValueExpression.get(ValueString.get(text));
-                    } else {
-                        r = new ExpressionColumn(database, null, null, name);
-                    }
                 } else {
-                    r = new ExpressionColumn(database, null, null, name);
+                    r = readTermWithIdentifier(name);
                 }
             }
             break;
@@ -3917,6 +3805,126 @@ public class Parser {
                 function.setParameter(0, r);
                 r = function;
             }
+        }
+        return r;
+    }
+
+    private Expression readTermWithIdentifier(String name) {
+        Expression r;
+        if (equalsToken("CURRENT_USER", name)) {
+            r = readFunctionWithoutParameters("USER");
+        } else if (equalsToken("CURRENT_TIMESTAMP", name)) {
+            r = readFunctionWithoutParameters("CURRENT_TIMESTAMP");
+        } else if (equalsToken("LOCALTIMESTAMP", name)) {
+            r = readFunctionWithoutParameters("LOCALTIMESTAMP");
+        } else if (equalsToken("SYSDATE", name)) {
+            r = readFunctionWithoutParameters("CURRENT_TIMESTAMP");
+        } else if (equalsToken("SYSTIMESTAMP", name)) {
+            r = readFunctionWithoutParameters("CURRENT_TIMESTAMP");
+        } else if (equalsToken("CURRENT_DATE", name)) {
+            r = readFunctionWithoutParameters("CURRENT_DATE");
+        } else if (equalsToken("TODAY", name)) {
+            r = readFunctionWithoutParameters("CURRENT_DATE");
+        } else if (equalsToken("CURRENT_TIME", name)) {
+            r = readFunctionWithoutParameters("CURRENT_TIME");
+        } else if (equalsToken("LOCALTIME", name)) {
+            r = readFunctionWithoutParameters("LOCALTIME");
+        } else if (equalsToken("SYSTIME", name)) {
+            r = readFunctionWithoutParameters("CURRENT_TIME");
+        } else if (database.getMode().getEnum() == ModeEnum.DB2 && equalsToken("CURRENT", name)) {
+            r = parseDB2SpecialRegisters(name);
+        } else if (equalsToken("NEXT", name) && readIf("VALUE")) {
+            read(FOR);
+            Sequence sequence = readSequence();
+            r = new SequenceValue(sequence);
+        } else if (equalsToken("TIME", name)) {
+            boolean without = readIf("WITHOUT");
+            if (without) {
+                read("TIME");
+                read("ZONE");
+            }
+            if (currentTokenType != VALUE
+                    || currentValue.getType() != Value.STRING) {
+                if (without) {
+                    throw getSyntaxError();
+                }
+                r = new ExpressionColumn(database, null, null, name);
+            } else {
+                String time = currentValue.getString();
+                read();
+                r = ValueExpression.get(ValueTime.parse(time));
+            }
+        } else if (equalsToken("TIMESTAMP", name)) {
+            if (readIf(WITH)) {
+                read("TIME");
+                read("ZONE");
+                if (currentTokenType != VALUE
+                        || currentValue.getType() != Value.STRING) {
+                    throw getSyntaxError();
+                }
+                String timestamp = currentValue.getString();
+                read();
+                r = ValueExpression.get(ValueTimestampTimeZone.parse(timestamp));
+            } else {
+                boolean without = readIf("WITHOUT");
+                if (without) {
+                    read("TIME");
+                    read("ZONE");
+                }
+                if (currentTokenType != VALUE
+                        || currentValue.getType() != Value.STRING) {
+                    if (without) {
+                        throw getSyntaxError();
+                    }
+                    r = new ExpressionColumn(database, null, null, name);
+                } else {
+                    String timestamp = currentValue.getString();
+                    read();
+                    r = ValueExpression.get(ValueTimestamp.parse(timestamp, database.getMode()));
+                }
+            }
+        } else if (equalsToken("INTERVAL", name)) {
+            r = readInterval();
+        } else if (currentTokenType == VALUE &&
+                currentValue.getType() == Value.STRING) {
+            if (equalsToken("DATE", name) ||
+                    equalsToken("D", name)) {
+                String date = currentValue.getString();
+                read();
+                r = ValueExpression.get(ValueDate.parse(date));
+            } else if (equalsToken("T", name)) {
+                String time = currentValue.getString();
+                read();
+                r = ValueExpression.get(ValueTime.parse(time));
+            } else if (equalsToken("TS", name)) {
+                String timestamp = currentValue.getString();
+                read();
+                r = ValueExpression
+                        .get(ValueTimestamp.parse(timestamp, database.getMode()));
+            } else if (equalsToken("X", name)) {
+                read();
+                byte[] buffer = StringUtils
+                        .convertHexToBytes(currentValue.getString());
+                r = ValueExpression.get(ValueBytes.getNoCopy(buffer));
+            } else if (equalsToken("E", name)) {
+                String text = currentValue.getString();
+                // the PostgreSQL ODBC driver uses
+                // LIKE E'PROJECT\\_DATA' instead of LIKE
+                // 'PROJECT\_DATA'
+                // N: SQL-92 "National Language" strings
+                text = StringUtils.replaceAll(text, "\\\\", "\\");
+                read();
+                r = ValueExpression.get(ValueString.get(text));
+            } else if (equalsToken("N", name)) {
+                // SQL-92 "National Language" strings
+                String text = currentValue.getString();
+                read();
+                r = ValueExpression.get(ValueString.get(text));
+            } else {
+                r = new ExpressionColumn(database, null, null, name);
+            }
+        } else {
+            r = new ExpressionColumn(database, null, null, name);
         }
         return r;
     }

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -440,7 +440,7 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         stat.execute("create alias dynamic deterministic for \"" +
                 getClass().getName() + ".dynamic\"");
         setCount(0);
-        rs = stat.executeQuery("call dynamic(('a', 1))[0]");
+        rs = stat.executeQuery("call dynamic(('a', 1))[1]");
         rs.next();
         String a = rs.getString(1);
         assertEquals("a1", a);

--- a/h2/src/test/org/h2/test/scripts/datatypes/array.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/array.sql
@@ -14,3 +14,12 @@ SELECT (10, 20, 30)[0];
 
 SELECT (10, 20, 30)[4];
 >> null
+
+SELECT ARRAY[];
+>> ()
+
+SELECT ARRAY[10];
+>> (10)
+
+SELECT ARRAY[10, 20, 30];
+>> (10, 20, 30)

--- a/h2/src/test/org/h2/test/scripts/datatypes/array.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/array.sql
@@ -2,3 +2,15 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+SELECT (10, 20, 30)[1];
+>> 10
+
+SELECT (10, 20, 30)[3];
+>> 30
+
+SELECT (10, 20, 30)[0];
+>> null
+
+SELECT (10, 20, 30)[4];
+>> null


### PR DESCRIPTION
1. A fix for issue #1516.

2. Standard array value constructors are now supported.

3. A large block of code is extracted from `Parser.readTerm()` and long sequence of string comparisons is split by the first character.