### PR TITLE
Use fork-join thread pool in unused chunks discovery

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -993,7 +993,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @param memory the number of bytes used for this page
      */
     protected final void removePage(long pos, int memory) {
-        store.removePage(this, pos, memory);
+        store.removePage(pos, memory);
     }
 
     /**
@@ -1190,10 +1190,10 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         int attempt = 0;
         int keyCount;
         while((keyCount = rootReference.getAppendCounter()) > 0) {
-            Page page = Page.create(this,
+            Page page = Page.createLeaf(this,
                     Arrays.copyOf(keysBuffer, keyCount),
                     Arrays.copyOf(valuesBuffer, keyCount),
-                    null, keyCount, 0);
+                    0);
             CursorPos pos = rootReference.root.getAppendCursorPos(null);
             assert page.map == this;
             assert pos != null;
@@ -1215,7 +1215,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                         Page.PageReference children[] = new Page.PageReference[] {
                                                             new Page.PageReference(p),
                                                             new Page.PageReference(page)};
-                        p = Page.create(this, keys, null, children, p.getTotalCount() + page.getTotalCount(), 0);
+                        p = Page.createNode(this, keys, children, p.getTotalCount() + page.getTotalCount(), 0);
                     }
                     break;
                 }
@@ -1784,7 +1784,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                                             new Page.PageReference(p),
                                             new Page.PageReference(split)
                                     };
-                                    p = Page.create(this, keys, null, children, totalCount, 0);
+                                    p = Page.createNode(this, keys, children, totalCount, 0);
                                     break;
                                 }
                                 Page c = p;

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1511,8 +1511,7 @@ public class MVStore {
         }
 
         private void registerChunk(int chunkId) {
-            if (!referencedChunks.contains(chunkId) &&
-                    referencedChunks.put(chunkId, 1) == null && parent != null) {
+            if (referencedChunks.put(chunkId, 1) == null && parent != null) {
                 parent.registerChunk(chunkId);
             }
         }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1511,7 +1511,8 @@ public class MVStore {
         }
 
         private void registerChunk(int chunkId) {
-            if (referencedChunks.put(chunkId, 1) == null && parent != null) {
+            if (!referencedChunks.contains(chunkId) &&
+                    referencedChunks.put(chunkId, 1) == null && parent != null) {
                 parent.registerChunk(chunkId);
             }
         }

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -130,7 +130,7 @@ public abstract class Page implements Cloneable
         memory = source.memory;
     }
 
-    Page(MVMap<?, ?> map, Object keys[]) {
+    Page(MVMap<?, ?> map, Object[] keys) {
         this.map = map;
         this.keys = keys;
     }
@@ -142,37 +142,46 @@ public abstract class Page implements Cloneable
      * @return the new page
      */
     static Page createEmptyLeaf(MVMap<?, ?> map) {
-        Page page = new Leaf(map, EMPTY_OBJECT_ARRAY, EMPTY_OBJECT_ARRAY);
-        page.initMemoryAccount(PAGE_LEAF_MEMORY);
-        return page;
+        return createLeaf(map, EMPTY_OBJECT_ARRAY, EMPTY_OBJECT_ARRAY, PAGE_LEAF_MEMORY);
     }
 
-    public static Page createEmptyNode(MVMap<?, ?> map) {
-        Page page = new NonLeaf(map, EMPTY_OBJECT_ARRAY, SINGLE_EMPTY, 0);
-        page.initMemoryAccount(PAGE_NODE_MEMORY +
-                                MEMORY_POINTER + PAGE_MEMORY_CHILD); // there is always one child
-        return page;
+    static Page createEmptyNode(MVMap<?, ?> map) {
+        return createNode(map, EMPTY_OBJECT_ARRAY, SINGLE_EMPTY, 0,
+                            PAGE_NODE_MEMORY + MEMORY_POINTER + PAGE_MEMORY_CHILD); // there is always one child
     }
 
     /**
-     * Create a new page. The arrays are not cloned.
+     * Create a new non-leaf page. The arrays are not cloned.
      *
      * @param map the map
      * @param keys the keys
-     * @param values the values
      * @param children the child page positions
      * @param totalCount the total number of keys
      * @param memory the memory used in bytes
      * @return the page
      */
-    public static Page create(MVMap<?, ?> map,
-            Object[] keys, Object[] values, PageReference[] children,
-            long totalCount, int memory) {
+    public static Page createNode(MVMap<?, ?> map, Object[] keys, PageReference[] children,
+                                    long totalCount, int memory) {
         assert keys != null;
-        Page p = children == null ? new Leaf(map, keys, values) :
-                                    new NonLeaf(map, keys, children, totalCount);
-        p.initMemoryAccount(memory);
-        return p;
+        Page page = new NonLeaf(map, keys, children, totalCount);
+        page.initMemoryAccount(memory);
+        return page;
+    }
+
+    /**
+     * Create a new leaf page. The arrays are not cloned.
+     *
+     * @param map the map
+     * @param keys the keys
+     * @param values the values
+     * @param memory the memory used in bytes
+     * @return the page
+     */
+    public static Page createLeaf(MVMap<?, ?> map, Object[] keys, Object[] values, int memory) {
+        assert keys != null;
+        Page page = new Leaf(map, keys, values);
+        page.initMemoryAccount(memory);
+        return page;
     }
 
     private void initMemoryAccount(int memoryCount) {
@@ -511,8 +520,8 @@ public abstract class Page implements Cloneable
 
     final Object[] splitKeys(int aCount, int bCount) {
         assert aCount + bCount <= getKeyCount();
-        Object aKeys[] = createKeyStorage(aCount);
-        Object bKeys[] = createKeyStorage(bCount);
+        Object[] aKeys = createKeyStorage(aCount);
+        Object[] bKeys = createKeyStorage(bCount);
         System.arraycopy(keys, 0, aKeys, 0, aCount);
         System.arraycopy(keys, getKeyCount() - bCount, bKeys, 0, bCount);
         keys = aKeys;
@@ -618,7 +627,7 @@ public abstract class Page implements Cloneable
             Object old = getKey(index);
             addMemory(-MEMORY_POINTER - keyType.getMemory(old));
         }
-        Object newKeys[] = new Object[keyCount - 1];
+        Object[] newKeys = new Object[keyCount - 1];
         DataUtils.copyExcept(keys, newKeys, keyCount, index);
         keys = newKeys;
     }
@@ -852,7 +861,7 @@ public abstract class Page implements Cloneable
         memory += mem;
     }
 
-    protected final void recalculateMemory() {
+    final void recalculateMemory() {
         assert isPersistent();
         memory = calculateMemory();
     }
@@ -984,13 +993,13 @@ public abstract class Page implements Cloneable
             super(map);
         }
 
-        private NonLeaf(MVMap<?, ?> map, NonLeaf source, PageReference children[], long totalCount) {
+        private NonLeaf(MVMap<?, ?> map, NonLeaf source, PageReference[] children, long totalCount) {
             super(map, source);
             this.children = children;
             this.totalCount = totalCount;
         }
 
-        NonLeaf(MVMap<?, ?> map, Object keys[], PageReference children[], long totalCount) {
+        NonLeaf(MVMap<?, ?> map, Object[] keys, PageReference[] children, long totalCount) {
             super(map, keys);
             this.children = children;
             this.totalCount = totalCount;
@@ -1037,11 +1046,10 @@ public abstract class Page implements Cloneable
         }
 
         @Override
-        @SuppressWarnings("SuspiciousSystemArraycopy")
         public Page split(int at) {
             assert !isSaved();
             int b = getKeyCount() - at;
-            Object bKeys[] = splitKeys(at, b - 1);
+            Object[] bKeys = splitKeys(at, b - 1);
             PageReference[] aChildren = new PageReference[at + 1];
             PageReference[] bChildren = new PageReference[b];
             System.arraycopy(children, 0, aChildren, 0, at + 1);
@@ -1057,7 +1065,7 @@ public abstract class Page implements Cloneable
             for (PageReference x : bChildren) {
                 t += x.count;
             }
-            Page newPage = create(map, bKeys, null, bChildren, t, 0);
+            Page newPage = createNode(map, bKeys, bChildren, t, 0);
             if(isPersistent()) {
                 recalculateMemory();
             }
@@ -1111,7 +1119,7 @@ public abstract class Page implements Cloneable
             int childCount = getRawChildPageCount();
             insertKey(index, key);
 
-            PageReference newChildren[] = new PageReference[childCount + 1];
+            PageReference[] newChildren = new PageReference[childCount + 1];
             DataUtils.copyWithGap(children, newChildren, childCount, index);
             children = newChildren;
             children[index] = new PageReference(childPage);
@@ -1130,7 +1138,7 @@ public abstract class Page implements Cloneable
                 addMemory(-MEMORY_POINTER - PAGE_MEMORY_CHILD);
             }
             totalCount -= children[index].count;
-            PageReference newChildren[] = new PageReference[childCount - 1];
+            PageReference[] newChildren = new PageReference[childCount - 1];
             DataUtils.copyExcept(children, newChildren, childCount, index);
             children = newChildren;
         }
@@ -1169,7 +1177,7 @@ public abstract class Page implements Cloneable
         protected void readPayLoad(ByteBuffer buff) {
             int keyCount = getKeyCount();
             children = new PageReference[keyCount + 1];
-            long p[] = new long[keyCount + 1];
+            long[] p = new long[keyCount + 1];
             for (int i = 0; i <= keyCount; i++) {
                 p[i] = buff.getLong();
             }
@@ -1261,7 +1269,7 @@ public abstract class Page implements Cloneable
         /**
          * The storage for values.
          */
-        private Object values[];
+        private Object[] values;
 
         Leaf(MVMap<?, ?> map) {
             super(map);
@@ -1272,7 +1280,7 @@ public abstract class Page implements Cloneable
             this.values = source.values;
         }
 
-        Leaf(MVMap<?, ?> map, Object keys[], Object values[]) {
+        Leaf(MVMap<?, ?> map, Object[] keys, Object[] values) {
             super(map, keys);
             this.values = values;
         }
@@ -1306,19 +1314,18 @@ public abstract class Page implements Cloneable
         }
 
         @Override
-        @SuppressWarnings("SuspiciousSystemArraycopy")
         public Page split(int at) {
             assert !isSaved();
             int b = getKeyCount() - at;
-            Object bKeys[] = splitKeys(at, b);
-            Object bValues[] = createValueStorage(b);
+            Object[] bKeys = splitKeys(at, b);
+            Object[] bValues = createValueStorage(b);
             if(values != null) {
-                Object aValues[] = createValueStorage(at);
+                Object[] aValues = createValueStorage(at);
                 System.arraycopy(values, 0, aValues, 0, at);
                 System.arraycopy(values, at, bValues, 0, b);
                 values = aValues;
             }
-            Page newPage = create(map, bKeys, bValues, null, b, 0);
+            Page newPage = createLeaf(map, bKeys, bValues, 0);
             if(isPersistent()) {
                 recalculateMemory();
             }
@@ -1363,7 +1370,7 @@ public abstract class Page implements Cloneable
             insertKey(index, key);
 
             if(values != null) {
-                Object newValues[] = createValueStorage(keyCount + 1);
+                Object[] newValues = createValueStorage(keyCount + 1);
                 DataUtils.copyWithGap(values, newValues, keyCount, index);
                 values = newValues;
                 setValueInternal(index, value);
@@ -1386,7 +1393,7 @@ public abstract class Page implements Cloneable
                     Object old = getValue(index);
                     addMemory(-MEMORY_POINTER - map.getValueType().getMemory(old));
                 }
-                Object newValues[] = createValueStorage(keyCount - 1);
+                Object[] newValues = createValueStorage(keyCount - 1);
                 DataUtils.copyExcept(values, newValues, keyCount, index);
                 values = newValues;
             }

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -154,7 +154,7 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
                         new Page.PageReference(split),
                         Page.PageReference.EMPTY
                 };
-                p = Page.create(this, keys, null, children, totalCount, 0);
+                p = Page.createNode(this, keys, children, totalCount, 0);
                 if(store.getFileStore() != null) {
                     store.registerUnsavedPage(p.getMemory());
                 }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -182,10 +182,6 @@ public class Transaction {
             int currentStatus = getStatus(currentState);
             boolean valid;
             switch (status) {
-                case STATUS_OPEN:
-                    valid = currentStatus == STATUS_CLOSED ||
-                            currentStatus == STATUS_ROLLING_BACK;
-                    break;
                 case STATUS_ROLLING_BACK:
                     valid = currentStatus == STATUS_OPEN;
                     break;
@@ -207,6 +203,7 @@ public class Transaction {
                     valid = currentStatus == STATUS_COMMITTED ||
                             currentStatus == STATUS_ROLLED_BACK;
                     break;
+                case STATUS_OPEN:
                 default:
                     valid = false;
                     break;


### PR DESCRIPTION
Since it is a recursive algorithm, use of fork-joint thread pool here will simplify code and improve capacity utilization.