### PR TITLE
Export datetime value functions to SQL using standard syntax

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2975,9 +2975,10 @@ If fractional seconds precision is specified it should be from 0 to 9, 0 is defa
 
 Mapped to ""java.sql.Time"". When converted to a ""java.sql.Date"", the date is set to ""1970-01-01"".
 ""java.time.LocalTime"" is also supported on Java 8 and later versions.
-Resolution of ""java.sql.Time"" is limited to milliseconds, use ""String"" or ""java.time.LocalTime"" if you need nanosecond resolution.
+Use ""java.time.LocalTime"" or ""String"" instead of ""java.sql.Time"" when non-zero precision is needed.
 ","
 TIME
+TIME(9)
 "
 
 "Data Types","DATE Type","
@@ -3005,6 +3006,7 @@ Mapped to ""java.sql.Timestamp"" (""java.util.Date"" may be used too).
 ""java.time.LocalDateTime"" is also supported on Java 8 and later versions.
 ","
 TIMESTAMP
+TIMESTAMP(9)
 "
 
 "Data Types","TIMESTAMP WITH TIME ZONE Type","
@@ -3023,6 +3025,7 @@ Conversion to ""TIMESTAMP"" uses time zone offset to get UTC time and converts i
 Conversion from ""TIMESTAMP"" does the same operations in reverse and sets time zone offset to offset of the system time zone.
 ","
 TIMESTAMP WITH TIME ZONE
+TIMESTAMP(9) WITH TIME ZONE
 "
 
 "Data Types","BINARY Type","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -19,7 +19,7 @@ FROM tableExpression [,...] [ WHERE expression ]
 ","
 Selects data from a table or multiple tables.
 GROUP BY groups the the result by the given expression(s).
-HAVING filter rows after grouping.
+HAVING filters rows after grouping.
 ORDER BY sorts the result by the given column(s) or expression(s).
 UNION combines the result of this query with the results of another query.
 
@@ -4529,7 +4529,7 @@ LOCALTIME(9)
 CURRENT_TIMESTAMP [ (int) ]
 ","
 Returns the current timestamp with time zone.
-Time zone offset is set to a current time zone offset
+Time zone offset is set to a current time zone offset.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 The specified value can be used only to limit precision of a result.
 The actual maximum available precision depends on operating system and JVM and can be 3 (milliseconds) or higher.

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2976,6 +2976,7 @@ If fractional seconds precision is specified it should be from 0 to 9, 0 is defa
 Mapped to ""java.sql.Time"". When converted to a ""java.sql.Date"", the date is set to ""1970-01-01"".
 ""java.time.LocalTime"" is also supported on Java 8 and later versions.
 Use ""java.time.LocalTime"" or ""String"" instead of ""java.sql.Time"" when non-zero precision is needed.
+Cast from higher fractional seconds precision to lower fractional seconds precision performs round half up.
 ","
 TIME
 TIME(9)
@@ -3004,6 +3005,7 @@ Fractional seconds precision of SMALLDATETIME is always 0 and cannot be specifie
 
 Mapped to ""java.sql.Timestamp"" (""java.util.Date"" may be used too).
 ""java.time.LocalDateTime"" is also supported on Java 8 and later versions.
+Cast from higher fractional seconds precision to lower fractional seconds precision performs round half up.
 ","
 TIMESTAMP
 TIMESTAMP(9)
@@ -3023,6 +3025,7 @@ Values of this data type are compared by UTC values. It means that ""2010-01-01 
 
 Conversion to ""TIMESTAMP"" uses time zone offset to get UTC time and converts it to local time using the system time zone.
 Conversion from ""TIMESTAMP"" does the same operations in reverse and sets time zone offset to offset of the system time zone.
+Cast from higher fractional seconds precision to lower fractional seconds precision performs round half up.
 ","
 TIMESTAMP WITH TIME ZONE
 TIMESTAMP(9) WITH TIME ZONE

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4493,17 +4493,17 @@ CALL TRANSLATE('Hello world', 'eo', 'EO')
 "
 
 "Functions (Time and Date)","CURRENT_DATE","
-{ CURRENT_DATE [ () ] | CURDATE() | SYSDATE | TODAY }
+{ CURRENT_DATE | CURDATE() | SYSDATE | TODAY }
 ","
 Returns the current date.
 These methods always return the same value within a transaction (default)
 or within a command depending on database mode.
 ","
-CURRENT_DATE()
+CURRENT_DATE
 "
 
 "Functions (Time and Date)","CURRENT_TIME","
-{ CURRENT_TIME [ ( [ int ] ) ] | LOCALTIME [ ( [ int ] ) ] | CURTIME() }
+{ CURRENT_TIME [ (int) ] | LOCALTIME [ (int) ] | CURTIME([ int ]) }
 ","
 Returns the current time.
 If fractional seconds precision is specified it should be from 0 to 9, 0 is default.
@@ -4513,11 +4513,13 @@ Higher precision is not available before Java 9.
 These methods always return the same value within a transaction (default)
 or within a command depending on database mode.
 ","
-CURRENT_TIME()
+CURRENT_TIME
+LOCALTIME
+LOCALTIME(9)
 "
 
 "Functions (Time and Date)","CURRENT_TIMESTAMP","
-CURRENT_TIMESTAMP [ ( [ int ] ) ]
+CURRENT_TIMESTAMP [ (int) ]
 ","
 Returns the current timestamp with time zone.
 Time zone offset is set to a current time zone offset
@@ -4528,11 +4530,12 @@ Higher precision is not available before Java 9.
 This method always returns the same value within a transaction (default)
 or within a command depending on database mode.
 ","
-CURRENT_TIMESTAMP()
+CURRENT_TIMESTAMP
+CURRENT_TIMESTAMP(9)
 "
 
 "Functions (Time and Date)","LOCALTIMESTAMP","
-{ LOCALTIMESTAMP [ ( [ int ] ) ] | NOW( [ int ] ) }
+{ LOCALTIMESTAMP [ (int) ] | NOW( [ int ] ) }
 ","
 Returns the current timestamp.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
@@ -4542,7 +4545,8 @@ Higher precision is not available before Java 9.
 These methods always return the same value within a transaction (default)
 or within a command depending on database mode.
 ","
-LOCALTIMESTAMP()
+LOCALTIMESTAMP
+LOCALTIMESTAMP(9)
 "
 
 "Functions (Time and Date)","DATEADD","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2976,7 +2976,8 @@ If fractional seconds precision is specified it should be from 0 to 9, 0 is defa
 Mapped to ""java.sql.Time"". When converted to a ""java.sql.Date"", the date is set to ""1970-01-01"".
 ""java.time.LocalTime"" is also supported on Java 8 and later versions.
 Use ""java.time.LocalTime"" or ""String"" instead of ""java.sql.Time"" when non-zero precision is needed.
-Cast from higher fractional seconds precision to lower fractional seconds precision performs round half up.
+Cast from higher fractional seconds precision to lower fractional seconds precision performs round half up;
+if result of rounding is higher than maximum supported value 23:59:59.999999999 it is saturated to 23:59:59.999999999.
 ","
 TIME
 TIME(9)

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -482,7 +482,7 @@ PRIMARY, ROWNUM, SELECT, SYSDATE, SYSTIME, SYSTIMESTAMP, TODAY, TOP, TRUE, UNION
 WINDOW, WITH
 </code>
 </p><p>
-Certain words of this list are keywords because they are functions that can be used without '()' for compatibility,
+Certain words of this list are keywords because they are functions that can be used without '()',
 for example <code>CURRENT_TIMESTAMP</code>.
 </p>
 

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1545: Export datetime value functions to SQL using standard syntax
+</li>
+<li>Issue #1371: NPE in CacheLRU
+</li>
 <li>Issue #1534: Typo in message
 </li>
 <li>Issue #1527: Parser performance: Excessive use of regular expressions to validate column names

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -99,14 +99,14 @@ public class Function extends Expression implements FunctionCall {
             LPAD = 91, CONCAT_WS = 92, TO_CHAR = 93, TRANSLATE = 94, /* 95 */
             TO_DATE = 96, TO_TIMESTAMP = 97, ADD_MONTHS = 98, TO_TIMESTAMP_TZ = 99;
 
-    public static final int CURDATE = 100, CURTIME = 101, DATE_ADD = 102,
-            DATE_DIFF = 103, DAY_NAME = 104, DAY_OF_MONTH = 105,
-            DAY_OF_WEEK = 106, DAY_OF_YEAR = 107, HOUR = 108, MINUTE = 109,
-            MONTH = 110, MONTH_NAME = 111, LOCALTIMESTAMP = 112, QUARTER = 113,
-            SECOND = 114, WEEK = 115, YEAR = 116, CURRENT_DATE = 117,
-            CURRENT_TIME = 118, CURRENT_TIMESTAMP = 119, EXTRACT = 120,
-            FORMATDATETIME = 121, PARSEDATETIME = 122, ISO_YEAR = 123,
-            ISO_WEEK = 124, ISO_DAY_OF_WEEK = 125, DATE_TRUNC = 132;
+    public static final int CURRENT_DATE = 100, CURRENT_TIME = 101, LOCALTIME = 102,
+            CURRENT_TIMESTAMP = 103, LOCALTIMESTAMP = 104,
+            DATE_ADD = 105, DATE_DIFF = 106, DAY_NAME = 107, DAY_OF_MONTH = 108,
+            DAY_OF_WEEK = 109, DAY_OF_YEAR = 110, HOUR = 111, MINUTE = 112,
+            MONTH = 113, MONTH_NAME = 114, QUARTER = 115,
+            SECOND = 116, WEEK = 117, YEAR = 118, EXTRACT = 119,
+            FORMATDATETIME = 120, PARSEDATETIME = 121, ISO_YEAR = 122,
+            ISO_WEEK = 123, ISO_DAY_OF_WEEK = 124, DATE_TRUNC = 125;
 
     /**
      * Pseudo functions for DATEADD, DATEDIFF, and EXTRACT.
@@ -284,34 +284,27 @@ public class Function extends Expression implements FunctionCall {
         addFunction("REGEXP_LIKE", REGEXP_LIKE, VAR_ARGS, Value.BOOLEAN);
 
         // date
-        addFunctionNotDeterministic("CURRENT_DATE", CURRENT_DATE,
-                0, Value.DATE);
-        addFunctionNotDeterministic("CURDATE", CURDATE,
-                0, Value.DATE);
-        addFunctionNotDeterministic("TODAY", CURRENT_DATE,
-                0, Value.DATE);
+        addFunctionNotDeterministic("CURRENT_DATE", CURRENT_DATE, 0, Value.DATE, false);
+        addFunctionNotDeterministic("CURDATE", CURRENT_DATE, 0, Value.DATE);
+        addFunctionNotDeterministic("SYSDATE", CURRENT_DATE, 0, Value.DATE, false);
+        addFunctionNotDeterministic("TODAY", CURRENT_DATE, 0, Value.DATE, false);
+
+        addFunctionNotDeterministic("CURRENT_TIME", CURRENT_TIME, VAR_ARGS, Value.TIME);
+
+        addFunctionNotDeterministic("LOCALTIME", LOCALTIME, VAR_ARGS, Value.TIME, false);
+        addFunctionNotDeterministic("SYSTIME", LOCALTIME, 0, Value.TIME, false);
+        addFunctionNotDeterministic("CURTIME", LOCALTIME, VAR_ARGS, Value.TIME);
+
+        addFunctionNotDeterministic("CURRENT_TIMESTAMP", CURRENT_TIMESTAMP, VAR_ARGS, Value.TIMESTAMP_TZ, false);
+        addFunctionNotDeterministic("SYSTIMESTAMP", CURRENT_TIMESTAMP, VAR_ARGS, Value.TIMESTAMP_TZ, false);
+
+        addFunctionNotDeterministic("LOCALTIMESTAMP", LOCALTIMESTAMP, VAR_ARGS, Value.TIMESTAMP, false);
+        addFunctionNotDeterministic("NOW", LOCALTIMESTAMP, VAR_ARGS, Value.TIMESTAMP);
+
         addFunction("TO_DATE", TO_DATE, VAR_ARGS, Value.TIMESTAMP);
         addFunction("TO_TIMESTAMP", TO_TIMESTAMP, VAR_ARGS, Value.TIMESTAMP);
         addFunction("ADD_MONTHS", ADD_MONTHS, 2, Value.TIMESTAMP);
         addFunction("TO_TIMESTAMP_TZ", TO_TIMESTAMP_TZ, VAR_ARGS, Value.TIMESTAMP_TZ);
-        addFunctionNotDeterministic("CURRENT_TIME", CURRENT_TIME,
-                VAR_ARGS, Value.TIME);
-        addFunctionNotDeterministic("LOCALTIME", CURRENT_TIME,
-                VAR_ARGS, Value.TIME);
-        addFunctionNotDeterministic("SYSTIME", CURRENT_TIME,
-                0, Value.TIME);
-        addFunctionNotDeterministic("CURTIME", CURTIME,
-                0, Value.TIME);
-        addFunctionNotDeterministic("CURRENT_TIMESTAMP", CURRENT_TIMESTAMP,
-                VAR_ARGS, Value.TIMESTAMP_TZ);
-        addFunctionNotDeterministic("SYSDATE", CURRENT_TIMESTAMP,
-                VAR_ARGS, Value.TIMESTAMP_TZ);
-        addFunctionNotDeterministic("SYSTIMESTAMP", CURRENT_TIMESTAMP,
-                VAR_ARGS, Value.TIMESTAMP_TZ);
-        addFunctionNotDeterministic("LOCALTIMESTAMP", LOCALTIMESTAMP,
-                VAR_ARGS, Value.TIMESTAMP);
-        addFunctionNotDeterministic("NOW", LOCALTIMESTAMP,
-                VAR_ARGS, Value.TIMESTAMP);
         addFunction("DATEADD", DATE_ADD,
                 3, Value.TIMESTAMP);
         addFunction("TIMESTAMPADD", DATE_ADD,
@@ -422,9 +415,9 @@ public class Function extends Expression implements FunctionCall {
                 2, Value.NULL);
         addFunctionWithNull("ARRAY_CONTAINS", ARRAY_CONTAINS, 2, Value.BOOLEAN);
         addFunction("CSVREAD", CSVREAD,
-                VAR_ARGS, Value.RESULT_SET, false, false, false);
+                VAR_ARGS, Value.RESULT_SET, false, false, false, true);
         addFunction("CSVWRITE", CSVWRITE,
-                VAR_ARGS, Value.INT, false, false, true);
+                VAR_ARGS, Value.INT, false, false, true, true);
         addFunctionNotDeterministic("MEMORY_FREE", MEMORY_FREE,
                 0, Value.INT);
         addFunctionNotDeterministic("MEMORY_USED", MEMORY_USED,
@@ -446,11 +439,11 @@ public class Function extends Expression implements FunctionCall {
         addFunctionNotDeterministic("CANCEL_SESSION", CANCEL_SESSION,
                 1, Value.BOOLEAN);
         addFunction("SET", SET,
-                2, Value.NULL, false, false, true);
+                2, Value.NULL, false, false, true, true);
         addFunction("FILE_READ", FILE_READ,
-                VAR_ARGS, Value.NULL, false, false, true);
+                VAR_ARGS, Value.NULL, false, false, true, true);
         addFunction("FILE_WRITE", FILE_WRITE,
-                2, Value.LONG, false, false, true);
+                2, Value.LONG, false, false, true, true);
         addFunctionNotDeterministic("TRANSACTION_ID", TRANSACTION_ID,
                 0, Value.STRING);
         addFunctionWithNull("DECODE", DECODE,
@@ -468,7 +461,7 @@ public class Function extends Expression implements FunctionCall {
                 VAR_ARGS, Value.RESULT_SET);
 
         // ON DUPLICATE KEY VALUES function
-        addFunction("VALUES", VALUES, 1, Value.NULL, false, true, false);
+        addFunction("VALUES", VALUES, 1, Value.NULL, false, true, false, true);
     }
 
     /**
@@ -489,24 +482,29 @@ public class Function extends Expression implements FunctionCall {
 
     private static void addFunction(String name, int type, int parameterCount,
             int returnDataType, boolean nullIfParameterIsNull, boolean deterministic,
-            boolean bufferResultSetToLocalTemp) {
+            boolean bufferResultSetToLocalTemp, boolean requireParentheses) {
         FUNCTIONS.put(name, new FunctionInfo(name, type, parameterCount, returnDataType, nullIfParameterIsNull,
-                deterministic, bufferResultSetToLocalTemp));
+                deterministic, bufferResultSetToLocalTemp, requireParentheses));
     }
 
     private static void addFunctionNotDeterministic(String name, int type,
             int parameterCount, int returnDataType) {
-        addFunction(name, type, parameterCount, returnDataType, true, false, true);
+        addFunctionNotDeterministic(name, type, parameterCount, returnDataType, true);
+    }
+
+    private static void addFunctionNotDeterministic(String name, int type,
+            int parameterCount, int returnDataType, boolean requireParentheses) {
+        addFunction(name, type, parameterCount, returnDataType, true, false, true, requireParentheses);
     }
 
     private static void addFunction(String name, int type, int parameterCount,
             int returnDataType) {
-        addFunction(name, type, parameterCount, returnDataType, true, true, true);
+        addFunction(name, type, parameterCount, returnDataType, true, true, true, true);
     }
 
     private static void addFunctionWithNull(String name, int type,
             int parameterCount, int returnDataType) {
-        addFunction(name, type, parameterCount, returnDataType, false, true, true);
+        addFunction(name, type, parameterCount, returnDataType, false, true, true, true);
     }
 
     /**
@@ -801,6 +799,32 @@ public class Function extends Expression implements FunctionCall {
             result = ValueString.get(StringUtils.xmlStartDoc(),
                     database.getMode().treatEmptyStringsAsNull);
             break;
+        case CURRENT_DATE: {
+            result = (database.getMode().dateTimeValueWithinTransaction ? session.getTransactionStart()
+                    : session.getCurrentCommandStart()).convertTo(Value.DATE);
+            break;
+        }
+        case CURRENT_TIME:
+        case LOCALTIME: {
+            ValueTime vt = (ValueTime) (database.getMode().dateTimeValueWithinTransaction
+                    ? session.getTransactionStart()
+                    : session.getCurrentCommandStart()).convertTo(Value.TIME);
+            result = vt.convertScale(false, v0 == null ? 0 : v0.getInt());
+            break;
+        }
+        case CURRENT_TIMESTAMP: {
+            ValueTimestampTimeZone vt = database.getMode().dateTimeValueWithinTransaction
+                    ? session.getTransactionStart()
+                    : session.getCurrentCommandStart();
+            result = vt.convertScale(false, v0 == null ? 6 : v0.getInt());
+            break;
+        }
+        case LOCALTIMESTAMP: {
+            Value vt = (database.getMode().dateTimeValueWithinTransaction ? session.getTransactionStart()
+                    : session.getCurrentCommandStart()).convertTo(Value.TIMESTAMP);
+            result = vt.convertScale(false, v0 == null ? 6 : v0.getInt());
+            break;
+        }
         case DAY_NAME: {
             int dayOfWeek = DateTimeUtils.getSundayDayOfWeek(DateTimeUtils.dateAndTimeFromValue(v0)[0]);
             result = ValueString.get(DateTimeFunctions.getMonthsAndWeeks(1)[dayOfWeek],
@@ -826,33 +850,6 @@ public class Function extends Expression implements FunctionCall {
             int month = DateTimeUtils.monthFromDateValue(DateTimeUtils.dateAndTimeFromValue(v0)[0]);
             result = ValueString.get(DateTimeFunctions.getMonthsAndWeeks(0)[month - 1],
                     database.getMode().treatEmptyStringsAsNull);
-            break;
-        }
-        case CURDATE:
-        case CURRENT_DATE: {
-            result = (database.getMode().dateTimeValueWithinTransaction ? session.getTransactionStart()
-                    : session.getCurrentCommandStart()).convertTo(Value.DATE);
-            break;
-        }
-        case CURTIME:
-        case CURRENT_TIME: {
-            ValueTime vt = (ValueTime) (database.getMode().dateTimeValueWithinTransaction
-                    ? session.getTransactionStart()
-                    : session.getCurrentCommandStart()).convertTo(Value.TIME);
-            result = vt.convertScale(false, v0 == null ? 0 : v0.getInt());
-            break;
-        }
-        case LOCALTIMESTAMP: {
-            Value vt = (database.getMode().dateTimeValueWithinTransaction ? session.getTransactionStart()
-                    : session.getCurrentCommandStart()).convertTo(Value.TIMESTAMP);
-            result = vt.convertScale(false, v0 == null ? 6 : v0.getInt());
-            break;
-        }
-        case CURRENT_TIMESTAMP: {
-            ValueTimestampTimeZone vt = database.getMode().dateTimeValueWithinTransaction
-                    ? session.getTransactionStart()
-                    : session.getCurrentCommandStart();
-            result = vt.convertScale(false, v0 == null ? 6 : v0.getInt());
             break;
         }
         case DATABASE:
@@ -2089,9 +2086,10 @@ public class Function extends Expression implements FunctionCall {
         case GREATEST:
             min = 1;
             break;
-        case LOCALTIMESTAMP:
         case CURRENT_TIME:
+        case LOCALTIME:
         case CURRENT_TIMESTAMP:
+        case LOCALTIMESTAMP:
         case RAND:
             max = 1;
             break;
@@ -2600,7 +2598,10 @@ public class Function extends Expression implements FunctionCall {
             }
             return builder.append(" END");
         }
-        builder.append('(');
+        boolean addParentheses = args.length > 0 || info.requireParentheses;
+        if (addParentheses) {
+            builder.append('(');
+        }
         switch (info.type) {
         case CAST: {
             args[0].getSQL(builder).append(" AS ").
@@ -2630,7 +2631,10 @@ public class Function extends Expression implements FunctionCall {
         default:
             writeExpressions(builder, args);
         }
-        return builder.append(')');
+        if (addParentheses) {
+            builder.append(')');
+        }
+        return builder;
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/FunctionInfo.java
+++ b/h2/src/main/org/h2/expression/FunctionInfo.java
@@ -46,6 +46,11 @@ public final class FunctionInfo {
     final boolean bufferResultSetToLocalTemp;
 
     /**
+     * Should the no-arg function require parentheses.
+     */
+    final boolean requireParentheses;
+
+    /**
      * Creates new instance of built-in function information.
      *
      * @param name
@@ -65,9 +70,11 @@ public final class FunctionInfo {
      * @param bufferResultSetToLocalTemp
      *            should the return value ResultSet be buffered in a local
      *            temporary file?
+     * @param requireParentheses
+     *            should the no-arg function require parentheses
      */
     public FunctionInfo(String name, int type, int parameterCount, int returnDataType, boolean nullIfParameterIsNull,
-            boolean deterministic, boolean bufferResultSetToLocalTemp) {
+            boolean deterministic, boolean bufferResultSetToLocalTemp, boolean requireParentheses) {
         this.name = name;
         this.type = type;
         this.parameterCount = parameterCount;
@@ -75,10 +82,12 @@ public final class FunctionInfo {
         this.nullIfParameterIsNull = nullIfParameterIsNull;
         this.deterministic = deterministic;
         this.bufferResultSetToLocalTemp = bufferResultSetToLocalTemp;
+        this.requireParentheses = requireParentheses;
     }
 
     /**
-     * Creates a copy of built-in function information with a different name.
+     * Creates a copy of built-in function information with a different name. A
+     * copy will require parentheses.
      *
      * @param source
      *            the source information
@@ -93,6 +102,7 @@ public final class FunctionInfo {
         nullIfParameterIsNull = source.nullIfParameterIsNull;
         deterministic = source.deterministic;
         bufferResultSetToLocalTemp = source.bufferResultSetToLocalTemp;
+        requireParentheses = true;
     }
 
 }

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -38,11 +38,11 @@ public class FunctionsMySQL extends FunctionsBase {
 
     static {
         FUNCTIONS.put("UNIX_TIMESTAMP", new FunctionInfo("UNIX_TIMESTAMP", UNIX_TIMESTAMP,
-                VAR_ARGS, Value.INT, false, false, false));
+                VAR_ARGS, Value.INT, false, false, false, true));
         FUNCTIONS.put("FROM_UNIXTIME", new FunctionInfo("FROM_UNIXTIME", FROM_UNIXTIME,
-                VAR_ARGS, Value.STRING, false, true, false));
+                VAR_ARGS, Value.STRING, false, true, false, true));
         FUNCTIONS.put("DATE", new FunctionInfo("DATE", DATE,
-                1, Value.DATE, false, true, false));
+                1, Value.DATE, false, true, false, true));
     }
 
     /**

--- a/h2/src/test/org/h2/test/scripts/default-and-on_update.sql
+++ b/h2/src/test/org/h2/test/scripts/default-and-on_update.sql
@@ -88,10 +88,10 @@ ALTER TABLE TEST ALTER COLUMN V SET ON UPDATE NULL;
 
 SELECT COLUMN_NAME, COLUMN_DEFAULT, COLUMN_ON_UPDATE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'TEST' ORDER BY COLUMN_NAME;
 > COLUMN_NAME COLUMN_DEFAULT              COLUMN_ON_UPDATE
-> ----------- --------------------------- -------------------
+> ----------- --------------------------- -----------------
 > ID          null                        null
 > V           (NEXT VALUE FOR PUBLIC.SEQ) NULL
-> V2          null                        CURRENT_TIMESTAMP()
+> V2          null                        CURRENT_TIMESTAMP
 > rows (ordered): 3
 
 ALTER TABLE TEST ALTER COLUMN V DROP ON UPDATE;
@@ -99,10 +99,10 @@ ALTER TABLE TEST ALTER COLUMN V DROP ON UPDATE;
 
 SELECT COLUMN_NAME, COLUMN_DEFAULT, COLUMN_ON_UPDATE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'TEST' ORDER BY COLUMN_NAME;
 > COLUMN_NAME COLUMN_DEFAULT              COLUMN_ON_UPDATE
-> ----------- --------------------------- -------------------
+> ----------- --------------------------- -----------------
 > ID          null                        null
 > V           (NEXT VALUE FOR PUBLIC.SEQ) null
-> V2          null                        CURRENT_TIMESTAMP()
+> V2          null                        CURRENT_TIMESTAMP
 > rows (ordered): 3
 
 DROP TABLE TEST;


### PR DESCRIPTION
1. Expressions like `CURRENT_TIMESTAMP()` are not valid, datetime value functions have parentheses only when they have parameters.
```
<current date value function> ::=
CURRENT_DATE

<current time value function> ::=
CURRENT_TIME [ <left paren> <time precision> <right paren> ]

<current local time value function> ::=
LOCALTIME [ <left paren> <time precision> <right paren> ]

<current timestamp value function> ::=
CURRENT_TIMESTAMP [ <left paren> <timestamp precision> <right paren> ]

<current local timestamp value function> ::=
LOCALTIMESTAMP [ <left paren> <timestamp precision> <right paren> ]
```
H2 now exports them back to SQL in standard-compatible way. Examples in documentation are also fixed. H2 still accepts all these functions with or without parentheses to avoid compatibility issues.

2. Non-standard datetime value functions are also normalized to make implementation and documentation more consistent with databases where they came from.

3. `java.sql.Time` has only half-way support of milliseconds, so recommend usage of other data types (`LocalTime` or `String`) when any fractional parts of seconds are needed.

4. Rounding mode for datetime values is documented.

5. I removed “for compatibility” words from description why `CURRENT_TIMESTAMP` etc. are keywords. They are standard keywords that all more or less standard-compliant databases should have.