### PR TITLE
In the REGEXP_REPLACE function, when in PostgreSQL compatibility mode, accept (but ignore/strip out) the 'g' flag.

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4296,7 +4296,7 @@ Replaces each substring that matches a regular expression.
 For details, see the Java ""String.replaceAll()"" method.
 If any parameter is null (except optional flagsString parameter), the result is null.
 
-Flags values limited to 'i', 'c', 'n', 'm'. Other symbols causes exception (except for 'g' which is ignored when running in PostgreSQL mode).
+Flags values limited to 'i', 'c', 'n', 'm'. Other symbols causes exception.
 Multiple symbols could be uses in one flagsString parameter (like 'im').
 Later flags overrides first ones, for example 'ic' equivalent to case sensitive matching 'c'.
 

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4296,7 +4296,7 @@ Replaces each substring that matches a regular expression.
 For details, see the Java ""String.replaceAll()"" method.
 If any parameter is null (except optional flagsString parameter), the result is null.
 
-Flags values limited to 'i', 'c', 'n', 'm'. Other symbols causes exception.
+Flags values limited to 'i', 'c', 'n', 'm'. Other symbols causes exception (except for 'g' which is ignored when running in PostgreSQL mode).
 Multiple symbols could be uses in one flagsString parameter (like 'im').
 Later flags overrides first ones, for example 'ic' equivalent to case sensitive matching 'c'.
 

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -950,7 +950,12 @@ or the SQL statement <code>SET MODE PostgreSQL</code>.
 </li><li>The system columns <code>CTID</code> and
     <code>OID</code> are supported.
 </li><li>LOG(x) is base 10 in this mode.
-</li><li>REGEXP_REPLACE() uses \ for back-references.
+</li><li>REGEXP_REPLACE():
+    <ul>
+    <li>Uses \ for back-references</li>
+    <li>Will not throw an exception when the <code>flagsString</code> parameter contains a 'g'</li>
+    <li>Will use Java's <code>String.replaceFirst()</code> method (instead of <code>String.replaceAll()</code>) if the 'g' flag is not present in the <code>flagsString</code> parameter.</li>
+    </ul>
 </li><li>Fixed-width strings are padded with spaces.
 </li><li>MONEY data type is treated like NUMERIC(19, 2) data type.
 </li><li>Datetime value functions return the same value within a transaction.

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -954,7 +954,7 @@ or the SQL statement <code>SET MODE PostgreSQL</code>.
     <ul>
     <li>Uses \ for back-references</li>
     <li>Will not throw an exception when the <code>flagsString</code> parameter contains a 'g'</li>
-    <li>Will use Java's <code>String.replaceFirst()</code> method (instead of <code>String.replaceAll()</code>) if the 'g' flag is not present in the <code>flagsString</code> parameter.</li>
+    <li>In the absence of the 'g' flag in the <code>flagsString</code> parameter, only the first-matched substring will be replaced</li>
     </ul>
 </li><li>Fixed-width strings are padded with spaces.
 </li><li>MONEY data type is treated like NUMERIC(19, 2) data type.

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1370,7 +1370,7 @@ public class Function extends Expression implements FunctionCall {
             }
             String regexpMode = v3 == null || v3.getString() == null ? "" :
                     v3.getString();
-            boolean isInPostgreSqlMode = Mode.ModeEnum.PostgreSQL.equals(database.getMode().getEnum())
+            boolean isInPostgreSqlMode = Mode.ModeEnum.PostgreSQL.equals(database.getMode().getEnum());
             int flags = makeRegexpFlags(regexpMode, isInPostgreSqlMode);
             try {
                 if(isInPostgreSqlMode && !regexpMode.contains("g")) {

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1370,6 +1370,10 @@ public class Function extends Expression implements FunctionCall {
             }
             String regexpMode = v3 == null || v3.getString() == null ? "" :
                     v3.getString();
+            if(database.getMode().getEnum().equals(Mode.ModeEnum.PostgreSQL)) {
+                // PostgreSQL doesn't do global replaces without a 'g' flag, but H2 does
+                regexpMode = regexpMode.replaceAll("g", "");
+            }
             int flags = makeRegexpFlags(regexpMode);
             try {
                 result = ValueString.get(

--- a/h2/src/main/org/h2/expression/Function.java
+++ b/h2/src/main/org/h2/expression/Function.java
@@ -1370,9 +1370,10 @@ public class Function extends Expression implements FunctionCall {
             }
             String regexpMode = v3 == null || v3.getString() == null ? "" :
                     v3.getString();
-            int flags = makeRegexpFlags(regexpMode, Mode.ModeEnum.PostgreSQL.equals(database.getMode().getEnum()));
+            boolean isInPostgreSqlMode = Mode.ModeEnum.PostgreSQL.equals(database.getMode().getEnum())
+            int flags = makeRegexpFlags(regexpMode, isInPostgreSqlMode);
             try {
-                if(Mode.ModeEnum.PostgreSQL.equals(database.getMode().getEnum()) && !regexpMode.contains("g")) {
+                if(isInPostgreSqlMode && !regexpMode.contains("g")) {
                   result = ValueString.get(
                     Pattern.compile(regexp, flags).matcher(v0.getString())
                       .replaceFirst(replacement),
@@ -2060,6 +2061,7 @@ public class Function extends Expression implements FunctionCall {
                         if (ignoreGlobalFlag) {
                             break;
                         }
+                    //$FALL-THROUGH$
                     default:
                         throw DbException.get(ErrorCode.INVALID_VALUE_2, stringFlags);
                 }

--- a/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/regex-replace.sql
@@ -35,3 +35,21 @@ select regexp_replace('first last', '(\w+) (\w+)', '\2 \1');
 
 select regexp_replace('first last', '(\w+) (\w+)', '$2 $1');
 >> last first
+
+select regexp_replace('AbcDef', '[^a-z]', '', 'g');
+> exception INVALID_VALUE_2
+
+select regexp_replace('First and Second', '[A-Z]', '');
+>> irst and econd
+
+set mode PostgreSQL;
+> ok
+
+select regexp_replace('AbcDef', '[^a-z]', '', 'g');
+>> bcef
+
+select regexp_replace('AbcDef123', '[a-z]', '!', 'gi');
+>> !!!!!!123
+
+select regexp_replace('First Only', '[A-Z]', '');
+>> irst Only


### PR DESCRIPTION
Addresses #1554 by removing the 'g' flag when in PostgreSQL mode, allowing the same query to run across both H2 and PostreSQL with the same behaviour.