### PR TITLE
increase lock timeout to TestConcurrentUpdate due to Travis failures

### DIFF
--- a/h2/src/test/org/h2/test/synth/TestConcurrentUpdate.java
+++ b/h2/src/test/org/h2/test/synth/TestConcurrentUpdate.java
@@ -45,7 +45,7 @@ public class TestConcurrentUpdate extends TestDb {
     @Override
     public void test() throws Exception {
         deleteDb("concurrent");
-        final String url = getURL("concurrent", true);
+        final String url = getURL("concurrent;LOCK_TIMEOUT=2000", true);
         try (Connection conn = getConnection(url)) {
             Statement stat = conn.createStatement();
             stat.execute("create table test(id int primary key, name varchar)");


### PR DESCRIPTION
It can be replicated locally as well with increase of number of threads and test duration. Default lock timeout for tests (50ms) is just not long enough.