### PR TITLE
Assorted minor changes

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1561: Incorrect documentation and strange fallback value of SysProperties.FILE_ENCODING
+</li>
+<li>PR #1557: increase lock timeout to TestConcurrentUpdate due to Travis failures
+</li>
+<li>Issue #1554: REGEXP_REPLACE - accept 'g' flag in PostgreSQL compatibility mode
+</li>
 <li>Issue #950: Comparison between databases in README.md and in features.html
 </li>
 <li>Issue #1549: [RFE] Implement locking modes (select for update)

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -42,14 +42,6 @@ public class SysProperties {
     public static final String H2_BROWSER = "h2.browser";
 
     /**
-     * System property <code>file.encoding</code> (default: Cp1252).<br />
-     * It is usually set by the system and is the default encoding used for the
-     * RunScript and CSV tool.
-     */
-    public static final String FILE_ENCODING =
-            Utils.getProperty("file.encoding", "Cp1252");
-
-    /**
      * System property <code>file.separator</code> (default: /).<br />
      * It is usually set by the system, and used to build absolute file names.
      */

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -5,6 +5,8 @@
  */
 package org.h2.engine;
 
+import java.io.File;
+
 import org.h2.util.MathUtils;
 import org.h2.util.Utils;
 
@@ -42,11 +44,10 @@ public class SysProperties {
     public static final String H2_BROWSER = "h2.browser";
 
     /**
-     * System property <code>file.separator</code> (default: /).<br />
-     * It is usually set by the system, and used to build absolute file names.
+     * System property <code>file.separator</code>.<br />
+     * It is set by the system, and used to build absolute file names.
      */
-    public static final String FILE_SEPARATOR =
-            Utils.getProperty("file.separator", "/");
+    public static final String FILE_SEPARATOR = File.separator;
 
     /**
      * System property <code>line.separator</code> (default: \n).<br />

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -50,11 +50,10 @@ public class SysProperties {
     public static final String FILE_SEPARATOR = File.separator;
 
     /**
-     * System property <code>line.separator</code> (default: \n).<br />
-     * It is usually set by the system, and used by the script and trace tools.
+     * System property <code>line.separator</code>.<br />
+     * It is set by the system, and used by the script and trace tools.
      */
-    public static final String LINE_SEPARATOR =
-            Utils.getProperty("line.separator", "\n");
+    public static final String LINE_SEPARATOR = System.lineSeparator();
 
     /**
      * System property <code>user.home</code> (empty string if not set).<br />

--- a/h2/src/main/org/h2/tools/Csv.java
+++ b/h2/src/main/org/h2/tools/Csv.java
@@ -44,7 +44,7 @@ public class Csv implements SimpleRowSource {
 
     private String[] columnNames;
 
-    private String characterSet = SysProperties.FILE_ENCODING;
+    private String characterSet;
     private char escapeCharacter = '\"';
     private char fieldDelimiter = '\"';
     private char fieldSeparatorRead = ',';
@@ -136,7 +136,6 @@ public class Csv implements SimpleRowSource {
      * @param rs the result set - the result set must be positioned before the
      *          first row.
      * @param charset the charset or null to use the system default charset
-     *          (see system property file.encoding)
      * @return the number of rows written
      */
     public int write(String outputFileName, ResultSet rs, String charset)
@@ -184,7 +183,6 @@ public class Csv implements SimpleRowSource {
      * @param colNames or null if the column names should be read from the CSV
      *          file
      * @param charset the charset or null to use the system default charset
-     *          (see system property file.encoding)
      * @return the result set
      */
     public ResultSet read(String inputFileName, String[] colNames,
@@ -246,9 +244,7 @@ public class Csv implements SimpleRowSource {
 
     private void init(String newFileName, String charset) {
         this.fileName = newFileName;
-        if (charset != null) {
-            this.characterSet = charset;
-        }
+        this.characterSet = charset;
     }
 
     private void initWrite() throws IOException {
@@ -256,7 +252,8 @@ public class Csv implements SimpleRowSource {
             try {
                 OutputStream out = FileUtils.newOutputStream(fileName, false);
                 out = new BufferedOutputStream(out, Constants.IO_BUFFER_SIZE);
-                output = new BufferedWriter(new OutputStreamWriter(out, characterSet));
+                output = new BufferedWriter(characterSet != null ?
+                        new OutputStreamWriter(out, characterSet) : new OutputStreamWriter(out));
             } catch (Exception e) {
                 close();
                 throw DbException.convertToIOException(e);
@@ -314,7 +311,7 @@ public class Csv implements SimpleRowSource {
             try {
                 InputStream in = FileUtils.newInputStream(fileName);
                 in = new BufferedInputStream(in, Constants.IO_BUFFER_SIZE);
-                input = new InputStreamReader(in, characterSet);
+                input = characterSet != null ? new InputStreamReader(in, characterSet) : new InputStreamReader(in);
             } catch (IOException e) {
                 close();
                 throw e;

--- a/h2/src/main/org/h2/util/Profiler.java
+++ b/h2/src/main/org/h2/util/Profiler.java
@@ -166,7 +166,7 @@ public class Profiler implements Runnable {
                     }
                     continue;
                 }
-                try (Reader reader = new InputStreamReader(new FileInputStream(arg), "CP1252")) {
+                try (Reader reader = new InputStreamReader(new FileInputStream(arg))) {
                     LineNumberReader r = new LineNumberReader(reader);
                     while (true) {
                         String line = r.readLine();
@@ -177,7 +177,7 @@ public class Profiler implements Runnable {
                         }
                     }
                 }
-                try (Reader reader = new InputStreamReader(new FileInputStream(arg), "CP1252")) {
+                try (Reader reader = new InputStreamReader(new FileInputStream(arg))) {
                     LineNumberReader r = new LineNumberReader(reader);
                     processList(readStackTrace(r));
                 }

--- a/h2/src/test/org/h2/test/scripts/TestScriptSimple.java
+++ b/h2/src/test/org/h2/test/scripts/TestScriptSimple.java
@@ -8,6 +8,7 @@ package org.h2.test.scripts;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -46,8 +47,7 @@ public class TestScriptSimple extends TestDb {
         reconnect();
         String inFile = "org/h2/test/scripts/testSimple.in.txt";
         InputStream is = getClass().getClassLoader().getResourceAsStream(inFile);
-        LineNumberReader lineReader = new LineNumberReader(
-                new InputStreamReader(is, "Cp1252"));
+        LineNumberReader lineReader = new LineNumberReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         try (ScriptReader reader = new ScriptReader(lineReader)) {
             while (true) {
                 String sql = reader.readStatement();

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -802,3 +802,4 @@ partitioned tri partitions
 discard enhancements nolock surefire logarithm
 qualification opportunity jumping exploited unacceptable vrs duplicated
 queryparser tokenized freeze factorings recompilation unenclosed rfe dsync
+econd irst bcef


### PR DESCRIPTION
Issue #1561:

1. ` SysProperties.FILE_ENCODING` is removed.

2. `SysProperties.FILE_SEPARATOR` now uses `File.separator` that is always available.

3. `SysProperties.LINE_SEPARATOR` now uses `System.lineSeparator()` that is available since Java 7 and Android API 19 (H2 requires API 21).

4. Other usages of CP1252 are replaced with system default encoding or with UTF-8.

5. `REGEXP_REPLACE` implementation is too large now, I extracted it into a separate method. Also I simplified handling of unspecified flags for both `REGEXP_REPLACE` and `REGEXP_LIKE`; `null` is a valid argument for `makeRegexpFlags`, no need to check for it explicitly.
