### PR TITLE
FilePathSplit.moveTo() fixed

### DIFF
--- a/h2/src/main/org/h2/store/fs/FilePathSplit.java
+++ b/h2/src/main/org/h2/store/fs/FilePathSplit.java
@@ -186,6 +186,8 @@ public class FilePathSplit extends FilePathWrapper {
             FilePath o = getBase(i);
             if (o.exists()) {
                 o.moveTo(newName.getBase(i), atomicReplace);
+            } else if (newName.getBase(i).exists()) {
+                newName.getBase(i).delete();
             } else {
                 break;
             }


### PR DESCRIPTION
This PR fixes long-standing #187. Leftover files are removed, which would, among other things, fix SHUTDOWN DEFRAG