### PR TITLE
Remove SysProperties.CHECK preconditions around simple assertions

### DIFF
--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -16,7 +16,6 @@ import org.h2.command.Parser;
 import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.expression.Alias;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
@@ -963,7 +962,7 @@ public class Select extends Query {
 
     @Override
     public void init() {
-        if (SysProperties.CHECK && checkInit) {
+        if (checkInit) {
             DbException.throwInternalError();
         }
         expandColumnList();
@@ -1079,7 +1078,7 @@ public class Select extends Query {
             // sometimes a subquery is prepared twice (CREATE TABLE AS SELECT)
             return;
         }
-        if (SysProperties.CHECK && !checkInit) {
+        if (!checkInit) {
             DbException.throwInternalError("not initialized");
         }
         if (orderList != null) {

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -12,7 +12,6 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Database;
 import org.h2.engine.Mode;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.expression.ExpressionVisitor;
@@ -283,7 +282,7 @@ public class SelectUnion extends Query {
 
     @Override
     public void init() {
-        if (SysProperties.CHECK && checkInit) {
+        if (checkInit) {
             DbException.throwInternalError();
         }
         checkInit = true;
@@ -312,7 +311,7 @@ public class SelectUnion extends Query {
             // sometimes a subquery is prepared twice (CREATE TABLE AS SELECT)
             return;
         }
-        if (SysProperties.CHECK && !checkInit) {
+        if (!checkInit) {
             DbException.throwInternalError("not initialized");
         }
         isPrepared = true;

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -99,7 +99,7 @@ public class ConnectionInfo implements Cloneable {
         HashSet<String> set = new HashSet<>(128);
         set.addAll(SetTypes.getTypes());
         for (String key : connectionTime) {
-            if (!set.add(key) && SysProperties.CHECK) {
+            if (!set.add(key)) {
                 DbException.throwInternalError(key);
             }
         }

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1076,10 +1076,8 @@ public class Database implements DataHandler {
             try {
                 Cursor cursor = metaIdIndex.find(session, r, r);
                 if (cursor.next()) {
-                    if (SysProperties.CHECK) {
-                        if (lockMode != Constants.LOCK_MODE_OFF && !wasLocked) {
-                            throw DbException.throwInternalError();
-                        }
+                    if (lockMode != Constants.LOCK_MODE_OFF && !wasLocked) {
+                        throw DbException.throwInternalError();
                     }
                     Row found = cursor.get();
                     meta.removeRow(session, found);
@@ -2780,7 +2778,7 @@ public class Database implements DataHandler {
         }
         long now = System.nanoTime();
         if (now > reconnectCheckNext + reconnectCheckDelayNs) {
-            if (SysProperties.CHECK && checkpointAllowed < 0) {
+            if (checkpointAllowed < 0) {
                 DbException.throwInternalError(Integer.toString(checkpointAllowed));
             }
             synchronized (reconnectSync) {
@@ -2849,8 +2847,7 @@ public class Database implements DataHandler {
         }
         synchronized (reconnectSync) {
             if (reconnectModified(true)) {
-                checkpointAllowed++;
-                if (SysProperties.CHECK && checkpointAllowed > 20) {
+                if (++checkpointAllowed > 20) {
                     throw DbException.throwInternalError(Integer.toString(checkpointAllowed));
                 }
                 return true;
@@ -2872,7 +2869,7 @@ public class Database implements DataHandler {
         synchronized (reconnectSync) {
             checkpointAllowed--;
         }
-        if (SysProperties.CHECK && checkpointAllowed < 0) {
+        if (checkpointAllowed < 0) {
             throw DbException.throwInternalError(Integer.toString(checkpointAllowed));
         }
     }

--- a/h2/src/main/org/h2/engine/DbObjectBase.java
+++ b/h2/src/main/org/h2/engine/DbObjectBase.java
@@ -129,7 +129,7 @@ public abstract class DbObjectBase implements DbObject {
      * used.
      */
     protected void invalidate() {
-        if (SysProperties.CHECK && id == -1) {
+        if (id == -1) {
             throw DbException.throwInternalError();
         }
         setModified();

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -968,10 +968,8 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
     }
 
     private void unlockAll() {
-        if (SysProperties.CHECK) {
-            if (undoLog != null && undoLog.size() > 0) {
-                DbException.throwInternalError();
-            }
+        if (undoLog != null && undoLog.size() > 0) {
+            DbException.throwInternalError();
         }
         if (!locks.isEmpty()) {
             for (Table t : locks) {
@@ -1349,7 +1347,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
      */
     public void removeAtCommit(Value v) {
         final String key = v.toString();
-        if (SysProperties.CHECK && !v.isLinkedToTable()) {
+        if (!v.isLinkedToTable()) {
             DbException.throwInternalError(key);
         }
         if (removeLobMap == null) {

--- a/h2/src/main/org/h2/engine/UndoLogRecord.java
+++ b/h2/src/main/org/h2/engine/UndoLogRecord.java
@@ -196,10 +196,8 @@ public class UndoLogRecord {
         }
         int oldOp = operation;
         load(buff, log);
-        if (SysProperties.CHECK) {
-            if (operation != oldOp) {
-                DbException.throwInternalError("operation=" + operation + " op=" + oldOp);
-            }
+        if (operation != oldOp) {
+            DbException.throwInternalError("operation=" + operation + " op=" + oldOp);
         }
     }
 

--- a/h2/src/main/org/h2/expression/condition/Comparison.java
+++ b/h2/src/main/org/h2/expression/condition/Comparison.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Database;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.expression.ExpressionVisitor;
@@ -229,7 +228,7 @@ public class Comparison extends Condition {
                 return ValueExpression.get(getValue(session));
             }
         } else {
-            if (SysProperties.CHECK && (left == null || right == null)) {
+            if (left == null || right == null) {
                 DbException.throwInternalError(left + " " + right);
             }
             if (left == ValueExpression.getNull() ||

--- a/h2/src/main/org/h2/expression/condition/ConditionAndOr.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionAndOr.java
@@ -6,7 +6,6 @@
 package org.h2.expression.condition;
 
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.ValueExpression;
@@ -39,7 +38,7 @@ public class ConditionAndOr extends Condition {
         this.andOrType = andOrType;
         this.left = left;
         this.right = right;
-        if (SysProperties.CHECK && (left == null || right == null)) {
+        if (left == null || right == null) {
             DbException.throwInternalError(left + " " + right);
         }
     }

--- a/h2/src/main/org/h2/index/PageBtreeIndex.java
+++ b/h2/src/main/org/h2/index/PageBtreeIndex.java
@@ -176,7 +176,7 @@ public class PageBtreeIndex extends PageIndex {
 
     private Cursor find(Session session, SearchRow first, boolean bigger,
             SearchRow last) {
-        if (SysProperties.CHECK && store == null) {
+        if (store == null) {
             throw DbException.get(ErrorCode.OBJECT_CLOSED);
         }
         PageBtree root = getPage(rootPageId);

--- a/h2/src/main/org/h2/index/PageBtreeLeaf.java
+++ b/h2/src/main/org/h2/index/PageBtreeLeaf.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.result.SearchRow;
 import org.h2.store.Data;
@@ -132,7 +131,7 @@ public class PageBtreeLeaf extends PageBtree {
             }
             last = entryCount == 0 ? pageSize : offsets[entryCount - 1];
             rowLength = index.getRowSize(data, row, true);
-            if (SysProperties.CHECK && last - rowLength < start + OFFSET_LENGTH) {
+            if (last - rowLength < start + OFFSET_LENGTH) {
                 throw DbException.throwInternalError();
             }
         }

--- a/h2/src/main/org/h2/index/PageBtreeNode.java
+++ b/h2/src/main/org/h2/index/PageBtreeNode.java
@@ -171,8 +171,7 @@ public class PageBtreeNode extends PageBtree {
             }
             last = entryCount == 0 ? pageSize : offsets[entryCount - 1];
             rowLength = index.getRowSize(data, row, true);
-            if (SysProperties.CHECK && last - rowLength <
-                    start + CHILD_OFFSET_PAIR_LENGTH) {
+            if (last - rowLength < start + CHILD_OFFSET_PAIR_LENGTH) {
                 throw DbException.throwInternalError();
             }
         }

--- a/h2/src/main/org/h2/index/PageDataLeaf.java
+++ b/h2/src/main/org/h2/index/PageDataLeaf.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.result.Row;
 import org.h2.store.Data;
@@ -578,7 +577,7 @@ public class PageDataLeaf extends PageData {
      * @param overflow the new overflow page id
      */
     void setOverflow(int old, int overflow) {
-        if (SysProperties.CHECK && old != firstOverflowPageId) {
+        if (old != firstOverflowPageId) {
             DbException.throwInternalError("move " + this + " " + firstOverflowPageId);
         }
         index.getPageStore().logUndo(this, data);

--- a/h2/src/main/org/h2/index/PageDataOverflow.java
+++ b/h2/src/main/org/h2/index/PageDataOverflow.java
@@ -8,7 +8,6 @@ package org.h2.index;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.store.Data;
 import org.h2.store.Page;
@@ -245,7 +244,7 @@ public class PageDataOverflow extends Page {
     }
 
     private void setNext(int old, int nextPage) {
-        if (SysProperties.CHECK && old != this.nextPage) {
+        if (old != this.nextPage) {
             DbException.throwInternalError("move " + this + " " + nextPage);
         }
         store.logUndo(this, data);

--- a/h2/src/main/org/h2/index/TreeIndex.java
+++ b/h2/src/main/org/h2/index/TreeIndex.java
@@ -7,7 +7,6 @@ package org.h2.index;
 
 import org.h2.command.dml.AllColumnsForPlan;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
@@ -205,7 +204,7 @@ public class TreeIndex extends BaseIndex {
                 x.left = d.left;
             }
 
-            if (SysProperties.CHECK && x.right == null) {
+            if (x.right == null) {
                 DbException.throwInternalError("tree corrupted");
             }
             x.right.parent = x;

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -609,7 +609,7 @@ public class MVTable extends TableBase {
         } else {
             addRowsToIndex(session, buffer, index);
         }
-        if (SysProperties.CHECK && remaining != 0) {
+        if (remaining != 0) {
             DbException.throwInternalError("rowcount remaining=" + remaining +
                     " " + getName());
         }
@@ -636,7 +636,7 @@ public class MVTable extends TableBase {
             remaining--;
         }
         addRowsToIndex(session, buffer, index);
-        if (SysProperties.CHECK && remaining != 0) {
+        if (remaining != 0) {
             DbException.throwInternalError("rowcount remaining=" + remaining +
                     " " + getName());
         }

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -270,7 +270,7 @@ public class Schema extends DbObjectBase {
      * @param obj the object to add
      */
     public void add(SchemaObject obj) {
-        if (SysProperties.CHECK && obj.getSchema() != this) {
+        if (obj.getSchema() != this) {
             DbException.throwInternalError("wrong schema");
         }
         String name = obj.getName();

--- a/h2/src/main/org/h2/security/XTEA.java
+++ b/h2/src/main/org/h2/security/XTEA.java
@@ -5,7 +5,6 @@
  */
 package org.h2.security;
 
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.util.Bits;
 
@@ -47,10 +46,8 @@ public class XTEA implements BlockCipher {
 
     @Override
     public void encrypt(byte[] bytes, int off, int len) {
-        if (SysProperties.CHECK) {
-            if (len % ALIGN != 0) {
-                DbException.throwInternalError("unaligned len " + len);
-            }
+        if (len % ALIGN != 0) {
+            DbException.throwInternalError("unaligned len " + len);
         }
         for (int i = off; i < off + len; i += 8) {
             encryptBlock(bytes, bytes, i);
@@ -59,10 +56,8 @@ public class XTEA implements BlockCipher {
 
     @Override
     public void decrypt(byte[] bytes, int off, int len) {
-        if (SysProperties.CHECK) {
-            if (len % ALIGN != 0) {
-                DbException.throwInternalError("unaligned len " + len);
-            }
+        if (len % ALIGN != 0) {
+            DbException.throwInternalError("unaligned len " + len);
         }
         for (int i = off; i < off + len; i += 8) {
             decryptBlock(bytes, bytes, i);

--- a/h2/src/main/org/h2/store/FileStore.java
+++ b/h2/src/main/org/h2/store/FileStore.java
@@ -273,8 +273,7 @@ public class FileStore {
      * @param len the number of bytes to read
      */
     public void readFully(byte[] b, int off, int len) {
-        if (SysProperties.CHECK &&
-                (len < 0 || len % Constants.FILE_BLOCK_SIZE != 0)) {
+        if (len < 0 || len % Constants.FILE_BLOCK_SIZE != 0) {
             DbException.throwInternalError(
                     "unaligned read " + name + " len " + len);
         }
@@ -293,8 +292,7 @@ public class FileStore {
      * @param pos the location
      */
     public void seek(long pos) {
-        if (SysProperties.CHECK &&
-                pos % Constants.FILE_BLOCK_SIZE != 0) {
+        if (pos % Constants.FILE_BLOCK_SIZE != 0) {
             DbException.throwInternalError(
                     "unaligned seek " + name + " pos " + pos);
         }
@@ -327,8 +325,7 @@ public class FileStore {
      * @param len the number of bytes to write
      */
     public void write(byte[] b, int off, int len) {
-        if (SysProperties.CHECK && (len < 0 ||
-                len % Constants.FILE_BLOCK_SIZE != 0)) {
+        if (len < 0 || len % Constants.FILE_BLOCK_SIZE != 0) {
             DbException.throwInternalError(
                     "unaligned write " + name + " len " + len);
         }
@@ -350,7 +347,7 @@ public class FileStore {
      * @param newLength the new file size
      */
     public void setLength(long newLength) {
-        if (SysProperties.CHECK && newLength % Constants.FILE_BLOCK_SIZE != 0) {
+        if (newLength % Constants.FILE_BLOCK_SIZE != 0) {
             DbException.throwInternalError(
                     "unaligned setLength " + name + " pos " + newLength);
         }

--- a/h2/src/main/org/h2/store/PageLog.java
+++ b/h2/src/main/org/h2/store/PageLog.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import org.h2.api.ErrorCode;
 import org.h2.compress.CompressLZF;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.result.Row;
@@ -498,10 +497,8 @@ public class PageLog {
         if (trace.isDebugEnabled()) {
             trace.debug("log undo " + pageId);
         }
-        if (SysProperties.CHECK) {
-            if (page == null) {
-                DbException.throwInternalError("Undo entry not written");
-            }
+        if (page == null) {
+            DbException.throwInternalError("Undo entry not written");
         }
         undo.set(pageId);
         undoAll.set(pageId);

--- a/h2/src/main/org/h2/store/PageStore.java
+++ b/h2/src/main/org/h2/store/PageStore.java
@@ -717,8 +717,7 @@ public class PageStore implements CacheWriter {
             try {
                 p.moveTo(pageStoreSession, free);
             } finally {
-                changeCount++;
-                if (SysProperties.CHECK && changeCount < 0) {
+                if (++changeCount < 0) {
                     throw DbException.throwInternalError(
                             "changeCount has wrapped");
                 }
@@ -1670,10 +1669,8 @@ public class PageStore implements CacheWriter {
         metaRootPageId.put(id, rootPageId);
         if (type == META_TYPE_DATA_INDEX) {
             CreateTableData data = new CreateTableData();
-            if (SysProperties.CHECK) {
-                if (columns == null) {
-                    throw DbException.throwInternalError(row.toString());
-                }
+            if (columns == null) {
+                throw DbException.throwInternalError(row.toString());
             }
             for (int i = 0, len = columns.length; i < len; i++) {
                 Column col = new Column("C" + i, Value.INT);
@@ -1980,8 +1977,7 @@ public class PageStore implements CacheWriter {
      * Increment the change count. To be done after the operation has finished.
      */
     public void incrementChangeCount() {
-        changeCount++;
-        if (SysProperties.CHECK && changeCount < 0) {
+        if (++changeCount < 0) {
             throw DbException.throwInternalError("changeCount has wrapped");
         }
     }

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -257,7 +257,7 @@ public class RegularTable extends TableBase {
                     remaining--;
                 }
                 addRowsToIndex(session, buffer, index);
-                if (SysProperties.CHECK && remaining != 0) {
+                if (remaining != 0) {
                     DbException.throwInternalError("rowcount remaining=" +
                             remaining + " " + getName());
                 }

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -14,7 +14,6 @@ import org.h2.command.dml.AllColumnsForPlan;
 import org.h2.command.dml.Select;
 import org.h2.engine.Right;
 import org.h2.engine.Session;
-import org.h2.engine.SysProperties;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.expression.condition.Comparison;
@@ -321,13 +320,13 @@ public class TableFilter implements ColumnResolver {
             }
         }
         if (nestedJoin != null) {
-            if (SysProperties.CHECK && nestedJoin == this) {
+            if (nestedJoin == this) {
                 DbException.throwInternalError("self join");
             }
             nestedJoin.prepare();
         }
         if (join != null) {
-            if (SysProperties.CHECK && join == this) {
+            if (join == this) {
                 DbException.throwInternalError("self join");
             }
             join.prepare();

--- a/h2/src/main/org/h2/util/CacheLRU.java
+++ b/h2/src/main/org/h2/util/CacheLRU.java
@@ -131,11 +131,8 @@ public class CacheLRU implements Cache {
         if (old == null) {
             put(rec);
         } else {
-            if (SysProperties.CHECK) {
-                if (old != rec) {
-                    DbException.throwInternalError("old!=record pos:" + pos +
-                            " old:" + old + " new:" + rec);
-                }
+            if (old != rec) {
+                DbException.throwInternalError("old!=record pos:" + pos + " old:" + old + " new:" + rec);
             }
             if (!fifo) {
                 removeFromLinkedList(rec);
@@ -190,7 +187,7 @@ public class CacheLRU implements Cache {
                     break;
                 }
             }
-            if (SysProperties.CHECK && check == head) {
+            if (check == head) {
                 DbException.throwInternalError("try to remove head");
             }
             // we are not allowed to remove it if the log is not yet written
@@ -230,17 +227,15 @@ public class CacheLRU implements Cache {
             for (i = 0; i < size; i++) {
                 CacheObject rec = changed.get(i);
                 remove(rec.getPos());
-                if (SysProperties.CHECK) {
-                    if (rec.cacheNext != null) {
-                        throw DbException.throwInternalError();
-                    }
+                if (rec.cacheNext != null) {
+                    throw DbException.throwInternalError();
                 }
             }
         }
     }
 
     private void addToFront(CacheObject rec) {
-        if (SysProperties.CHECK && rec == head) {
+        if (rec == head) {
             DbException.throwInternalError("try to move head");
         }
         rec.cacheNext = head;
@@ -250,7 +245,7 @@ public class CacheLRU implements Cache {
     }
 
     private void removeFromLinkedList(CacheObject rec) {
-        if (SysProperties.CHECK && rec == head) {
+        if (rec == head) {
             DbException.throwInternalError("try to remove head");
         }
         rec.cachePrevious.cacheNext = rec.cacheNext;

--- a/h2/src/main/org/h2/util/CacheObject.java
+++ b/h2/src/main/org/h2/util/CacheObject.java
@@ -5,7 +5,6 @@
  */
 package org.h2.util;
 
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 
 /**
@@ -49,10 +48,8 @@ public abstract class CacheObject implements Comparable<CacheObject> {
     public abstract int getMemory();
 
     public void setPos(int pos) {
-        if (SysProperties.CHECK) {
-            if (cachePrevious != null || cacheNext != null || cacheChained != null) {
-                DbException.throwInternalError("setPos too late");
-            }
+        if (cachePrevious != null || cacheNext != null || cacheChained != null) {
+            DbException.throwInternalError("setPos too late");
         }
         this.pos = pos;
     }

--- a/h2/src/main/org/h2/util/IntArray.java
+++ b/h2/src/main/org/h2/util/IntArray.java
@@ -7,8 +7,6 @@ package org.h2.util;
 
 import java.util.Arrays;
 
-import org.h2.engine.SysProperties;
-
 /**
  * An array with integer element.
  */
@@ -63,10 +61,8 @@ public class IntArray {
      * @return the value
      */
     public int get(int index) {
-        if (SysProperties.CHECK) {
-            if (index >= size) {
-                throw new ArrayIndexOutOfBoundsException("i=" + index + " size=" + size);
-            }
+        if (index >= size) {
+            throw new ArrayIndexOutOfBoundsException("i=" + index + " size=" + size);
         }
         return data[index];
     }
@@ -77,10 +73,8 @@ public class IntArray {
      * @param index the index
      */
     public void remove(int index) {
-        if (SysProperties.CHECK) {
-            if (index >= size) {
-                throw new ArrayIndexOutOfBoundsException("i=" + index + " size=" + size);
-            }
+        if (index >= size) {
+            throw new ArrayIndexOutOfBoundsException("i=" + index + " size=" + size);
         }
         System.arraycopy(data, index + 1, data, index, size - index - 1);
         size--;
@@ -164,11 +158,8 @@ public class IntArray {
      * @param toIndex upper bound (exclusive)
      */
     public void removeRange(int fromIndex, int toIndex) {
-        if (SysProperties.CHECK) {
-            if (fromIndex > toIndex || toIndex > size) {
-                throw new ArrayIndexOutOfBoundsException("from=" + fromIndex +
-                        " to=" + toIndex + " size=" + size);
-            }
+        if (fromIndex > toIndex || toIndex > size) {
+            throw new ArrayIndexOutOfBoundsException("from=" + fromIndex + " to=" + toIndex + " size=" + size);
         }
         System.arraycopy(data, toIndex, data, fromIndex, size - toIndex);
         size -= toIndex - fromIndex;

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -433,14 +433,10 @@ public class StringUtils {
             } else if (ch == '%') {
                 buff[j++] = (byte) Integer.parseInt(encoded.substring(i + 1, i + 3), 16);
                 i += 2;
-            } else {
-                if (SysProperties.CHECK) {
-                    if (ch > 127 || ch < ' ') {
-                        throw new IllegalArgumentException(
-                                "Unexpected char " + (int) ch + " decoding " + encoded);
-                    }
-                }
+            } else if (ch <= 127 && ch >= ' ') {
                 buff[j++] = (byte) ch;
+            } else {
+                throw new IllegalArgumentException("Unexpected char " + (int) ch + " decoding " + encoded);
             }
         }
         return new String(buff, 0, j, StandardCharsets.UTF_8);

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -208,7 +208,7 @@ public class ValueLob extends Value {
 
     private static String getFileName(DataHandler handler, int tableId,
             int objectId) {
-        if (SysProperties.CHECK && tableId == 0 && objectId == 0) {
+        if (tableId == 0 && objectId == 0) {
             DbException.throwInternalError("0 LOB");
         }
         String table = tableId < 0 ? ".temp" : ".t" + tableId;


### PR DESCRIPTION
AFAIK, `SysProperties.CHECK` was designed to disable expensive additional sanity checks on Android platforms that were slow at that time. However, we have a lot of simple fast conditions with such guard. I don't see a reason to disable them with this setting. It does not improve performance in any measurable way.

Map lookups and other non-trivial checks are not touched here.