### PR TITLE
Minor changes in parser and documentation

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3418,7 +3418,7 @@ INTERVAL MINUTE TO SECOND
 "
 
 "Functions (Aggregate)","AVG","
-AVG ( [ DISTINCT ] { numeric } )
+AVG ( [ DISTINCT|ALL ] { numeric } )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 The average (mean) value.
@@ -3474,7 +3474,7 @@ ANY(NAME LIKE 'W%')
 "
 
 "Functions (Aggregate)","COUNT","
-COUNT( { * | { [ DISTINCT ] expression } } )
+COUNT( { * | { [ DISTINCT|ALL ] expression } } )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 The count of all row, or of the non-null values.
@@ -3486,7 +3486,7 @@ COUNT(*)
 "
 
 "Functions (Aggregate)","GROUP_CONCAT","
-GROUP_CONCAT ( [ DISTINCT ] string
+GROUP_CONCAT ( [ DISTINCT|ALL ] string
 [ ORDER BY { expression [ ASC | DESC ] } [,...] ]
 [ SEPARATOR expression ] )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
@@ -3501,7 +3501,7 @@ GROUP_CONCAT(NAME ORDER BY ID SEPARATOR ', ')
 "
 
 "Functions (Aggregate)","ARRAY_AGG","
-ARRAY_AGG ( [ DISTINCT ] string
+ARRAY_AGG ( [ DISTINCT|ALL ] string
 [ ORDER BY { expression [ ASC | DESC ] } [,...] ] )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
@@ -3538,7 +3538,7 @@ MIN(NAME)
 "
 
 "Functions (Aggregate)","SUM","
-SUM( [ DISTINCT ] { numeric } )
+SUM( [ DISTINCT|ALL ] { numeric } )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 The sum of all values.
@@ -3564,7 +3564,7 @@ SELECT SELECTIVITY(FIRSTNAME), SELECTIVITY(NAME) FROM TEST WHERE ROWNUM()<20000
 "
 
 "Functions (Aggregate)","STDDEV_POP","
-STDDEV_POP( [ DISTINCT ] numeric )
+STDDEV_POP( [ DISTINCT|ALL ] numeric )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 The population standard deviation.
@@ -3576,7 +3576,7 @@ STDDEV_POP(X)
 "
 
 "Functions (Aggregate)","STDDEV_SAMP","
-STDDEV_SAMP( [ DISTINCT ] numeric )
+STDDEV_SAMP( [ DISTINCT|ALL ] numeric )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 The sample standard deviation.
@@ -3588,7 +3588,7 @@ STDDEV(X)
 "
 
 "Functions (Aggregate)","VAR_POP","
-VAR_POP( [ DISTINCT ] numeric )
+VAR_POP( [ DISTINCT|ALL ] numeric )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 The population variance (square of the population standard deviation).
@@ -3600,7 +3600,7 @@ VAR_POP(X)
 "
 
 "Functions (Aggregate)","VAR_SAMP","
-VAR_SAMP( [ DISTINCT ] numeric )
+VAR_SAMP( [ DISTINCT|ALL ] numeric )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 The sample variance (square of the sample standard deviation).
@@ -3612,7 +3612,7 @@ VAR_SAMP(X)
 "
 
 "Functions (Aggregate)","MEDIAN","
-MEDIAN( [ DISTINCT ] value )
+MEDIAN( [ DISTINCT|ALL ] value )
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 The value separating the higher half of a values from the lower half.

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4600,7 +4600,7 @@ DAYNAME(CREATED)
 "
 
 "Functions (Time and Date)","DAY_OF_MONTH","
-DAY_OF_MONTH(dateAndTime)
+DAY_OF_MONTH(dateAndTime|interval)
 ","
 Returns the day of the month (1-31).
 ","
@@ -4624,7 +4624,7 @@ ISO_DAY_OF_WEEK(CREATED)
 "
 
 "Functions (Time and Date)","DAY_OF_YEAR","
-DAY_OF_YEAR(dateAndTime)
+DAY_OF_YEAR(dateAndTime|interval)
 ","
 Returns the day of the year (1-366).
 ","
@@ -4658,7 +4658,7 @@ CALL FORMATDATETIME(TIMESTAMP '2001-02-03 04:05:06',
 "
 
 "Functions (Time and Date)","HOUR","
-HOUR(dateAndTime)
+HOUR(dateAndTime|interval)
 ","
 Returns the hour (0-23) from a date/time value.
 ","
@@ -4666,7 +4666,7 @@ HOUR(CREATED)
 "
 
 "Functions (Time and Date)","MINUTE","
-MINUTE(dateAndTime)
+MINUTE(dateAndTime|interval)
 ","
 Returns the minute (0-59) from a date/time value.
 ","
@@ -4674,7 +4674,7 @@ MINUTE(CREATED)
 "
 
 "Functions (Time and Date)","MONTH","
-MONTH(dateAndTime)
+MONTH(dateAndTime|interval)
 ","
 Returns the month (1-12) from a date/time value.
 ","
@@ -4715,7 +4715,7 @@ SECOND(dateAndTime)
 ","
 Returns the second (0-59) from a date/time value.
 ","
-SECOND(CREATED)
+SECOND(CREATED|interval)
 "
 
 "Functions (Time and Date)","WEEK","
@@ -4739,7 +4739,7 @@ ISO_WEEK(CREATED)
 "
 
 "Functions (Time and Date)","YEAR","
-YEAR(dateAndTime)
+YEAR(dateAndTime|interval)
 ","
 Returns the year from a date/time value.
 ","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3672,7 +3672,8 @@ ABS(-2147483648) should be 2147483648, but this value is not allowed for this da
 It leads to an exception.
 To avoid it cast argument of this function to a higher data type.
 ","
-ABS(ID)
+ABS(VALUE)
+ABS(CAST(VALUE AS BIGINT))
 "
 
 "Functions (Numeric)","ACOS","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4756,10 +4756,10 @@ ISO_YEAR(CREATED)
 "Functions (System)","ARRAY_GET","
 ARRAY_GET(arrayExpression, indexExpression)
 ","
-Returns one element of an array.
+Returns element at the specified 1-based index from an array.
 Returns NULL if there is no such element or array is NULL.
 ","
-CALL ARRAY_GET(('Hello', 'World'), 2)
+CALL ARRAY_GET(ARRAY['Hello', 'World'], 2)
 "
 
 "Functions (System)","ARRAY_LENGTH","
@@ -4768,7 +4768,7 @@ ARRAY_LENGTH(arrayExpression)
 Returns the length of an array.
 Returns NULL if the specified array is NULL.
 ","
-CALL ARRAY_LENGTH(('Hello', 'World'))
+CALL ARRAY_LENGTH(ARRAY['Hello', 'World'])
 "
 
 "Functions (System)","ARRAY_CONTAINS","
@@ -4777,7 +4777,7 @@ ARRAY_CONTAINS(arrayExpression, value)
 Returns a boolean TRUE if the array contains the value or FALSE if it does not contain it.
 Returns NULL if the specified array is NULL.
 ","
-CALL ARRAY_CONTAINS(('Hello', 'World'), 'Hello')
+CALL ARRAY_CONTAINS(ARRAY['Hello', 'World'], 'Hello')
 "
 
 "Functions (System)","AUTOCOMMIT","

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -116,7 +116,7 @@ build jarClient
 <h3>Using Apache Lucene</h3>
 <p>
 Apache Lucene 5.5.5 is used for testing.
-Newer versions up to 7.5.0 can also be used.
+Newer versions up to 7.6.0 can also be used.
 </p>
 
 <h2 id="maven2">Using Maven 2</h2>

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -1234,7 +1234,7 @@ org.h2.fulltext.FullText.searchData(conn, text, limit, offset);
 <h3>Using the Apache Lucene Fulltext Search</h3>
 <p>
 To use the Apache Lucene full text search, you need the Lucene library in the classpath.
-Apache Lucene 5.5.5 or later version up to 7.5.0 is required.
+Apache Lucene 5.5.5 or later version up to 7.6.0 is required.
 Newer versions may also work, but were not tested.
 How to do that depends on the application; if you use the H2 Console, you can add the Lucene
 jar file to the environment variables <code>H2DRIVERS</code> or

--- a/h2/src/main/org/h2/expression/function/DateTimeFunctions.java
+++ b/h2/src/main/org/h2/expression/function/DateTimeFunctions.java
@@ -642,7 +642,6 @@ public final class DateTimeFunctions {
                 v = IntervalUtils.monthsFromInterval(qualifier, negative, leading, remaining);
                 break;
             case DAY_OF_MONTH:
-            case DAY_OF_WEEK:
             case DAY_OF_YEAR:
                 v = IntervalUtils.daysFromInterval(qualifier, negative, leading, remaining);
                 break;

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/sum.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/sum.sql
@@ -26,6 +26,15 @@ select sum(v), sum(v) filter (where v >= 4) from test where v <= 10;
 > 55     49
 > rows: 1
 
+insert into test values (1), (2), (8);
+> update count: 3
+
+select sum(v), sum(all v), sum(distinct v) from test;
+> SUM(V) SUM(V) SUM(DISTINCT V)
+> ------ ------ ---------------
+> 89     89     78
+> rows: 1
+
 drop table test;
 > ok
 


### PR DESCRIPTION
1. I don't see any failures with latest Lucene 7.6.0, so this version is marked as supported.

2. Standard `ARRAY` syntax is used instead of H2's own in documentation of `ARRAY_GET()`, `ARRAY_LENGTH()`, and `ARRAY_CONTAINS()`. H2's syntax is shorter, but it conflicts with standard row value expression syntax. They are currently parsed in the same way, but it's better to use correct standard syntax in our examples.

3. `ABS()` function got an example with `CAST` to illustrate notice about possible overflow.

4. Short `EXTRACT`-based functions like `YEAR()`, `MONTH()`, `HOUR`, etc. can handle `INTERVAL` arguments too, because they share code with `EXTRACT()` that supports this data type. BNF is updated.

5. `ALL` in aggregates is now parsed and ignored. This is a standard set quantifier that must be accepted and handled in the same way as absence of `DISTINCT`.