### PR TITLE
cleanup StringUtils.cache

### DIFF
--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -941,15 +941,13 @@ public class StringUtils {
         } else if (s.isEmpty()) {
             return "";
         }
-        int hash = s.hashCode();
         String[] cache = getCache();
         if (cache != null) {
+            int hash = s.hashCode();
             int index = hash & (SysProperties.OBJECT_CACHE_SIZE - 1);
             String cached = cache[index];
-            if (cached != null) {
-                if (s.equals(cached)) {
-                    return cached;
-                }
+            if (s.equals(cached)) {
+                return cached;
             }
             cache[index] = s;
         }


### PR DESCRIPTION
1. No need to call `hashCode` if  `cache=null`
2. Remove redundant `null` comparison. `String.equals` will anyway return `false`