### PR TITLE
Add row value storage format for temporary storages

### DIFF
--- a/h2/src/test/org/h2/test/scripts/datatypes/row.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/row.sql
@@ -71,3 +71,11 @@ SELECT (1, ARRAY[1]) IN (SELECT 1, ARRAY[2]);
 
 SELECT (1, ARRAY[NULL]) IN (SELECT 1, ARRAY[NULL]);
 >> null
+
+-- The next tests should be at the of this file
+
+SET MAX_MEMORY_ROWS = 2;
+> ok
+
+SELECT (X, X) FROM SYSTEM_RANGE(1, 100000) ORDER BY -X FETCH FIRST ROW ONLY;
+>> ROW (100000, 100000)


### PR DESCRIPTION
An additional fix for issue #1608.

If row value is selected in a large query or subquery, it can be buffered into temporary result on disk. A storage format is introduced here, it's the same as `ARRAY` storage, but with different data type.