### PR TITLE
Issue for #1619: postpone table analysis until after transaction commit

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -456,7 +456,7 @@ public class Transaction {
         if (status != STATUS_OPEN) {
             throw DataUtils.newIllegalStateException(
                     DataUtils.ERROR_TRANSACTION_ILLEGAL_STATE,
-                    "Transaction {0} has status {1}, not open", transactionId, status);
+                    "Transaction {0} has status {1}, not OPEN", transactionId, STATUS_NAMES[status]);
         }
     }
 

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -21,6 +21,7 @@ import org.h2.test.auth.TestAuthentication;
 import org.h2.test.bench.TestPerformance;
 import org.h2.test.db.TestAlter;
 import org.h2.test.db.TestAlterSchemaRename;
+import org.h2.test.db.TestAnalyzeTableTx;
 import org.h2.test.db.TestAutoRecompile;
 import org.h2.test.db.TestBackup;
 import org.h2.test.db.TestBigDb;
@@ -845,6 +846,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestMvccMultiThreaded());
         addTest(new TestMvccMultiThreaded2());
         addTest(new TestRowLocks());
+        addTest(new TestAnalyzeTableTx());
 
         // synth
         addTest(new TestBtreeIndex());

--- a/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
+++ b/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
@@ -24,6 +24,14 @@ public class TestAnalyzeTableTx extends TestDb {
     }
 
     @Override
+    public boolean isEnabled() {
+        if (config.networked && config.big) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public void test() throws Exception {
         deleteDb(getTestName());
         Connection shared = getConnection(getTestName());

--- a/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
+++ b/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
@@ -12,7 +12,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 
 public class TestAnalyzeTableTx extends TestDb {
-    static final int C = 100_000;
+    static final int C = 25_000;
 
     /**
      * Run just this test.

--- a/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
+++ b/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
@@ -25,7 +25,7 @@ public class TestAnalyzeTableTx extends TestDb {
 
     @Override
     public boolean isEnabled() {
-        if (config.networked && config.big) {
+        if (config.networked || config.big) {
             return false;
         }
         return true;

--- a/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
+++ b/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2004-2017 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.test.db;
+
+import org.h2.test.TestBase;
+import org.h2.test.TestDb;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class TestAnalyzeTableTx extends TestDb {
+    static final int C = 100_000;
+
+    /**
+     * Run just this test.
+     *
+     * @param a ignored
+     */
+    public static void main(String... a) throws Exception {
+        TestBase.createCaller().init().test();
+    }
+
+    @Override
+    public void test() throws Exception {
+        deleteDb(getTestName());
+        Connection shared = getConnection(getTestName());
+        Statement statement = shared.createStatement();
+        statement.executeUpdate("DROP TABLE IF EXISTS TEST");
+        statement.executeUpdate("CREATE TABLE TEST(ID INT PRIMARY KEY)");
+        Connection[] connections = new Connection[C];
+        for (int i = 0; i < C; i++) {
+            Connection c = getConnection(getTestName());
+            c.createStatement().executeUpdate("INSERT INTO TEST VALUES (" + i + ')');
+            connections[i] = c;
+        }
+        try (ResultSet rs = statement.executeQuery("SELECT * FROM TEST")) {
+            for (int i = 0; i < C; i++) {
+                if (!rs.next())
+                    throw new Exception("next");
+                if (rs.getInt(1) != i)
+                    throw new Exception(Integer.toString(i));
+            }
+        }
+    }
+}

--- a/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
+++ b/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
@@ -12,7 +12,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 
 public class TestAnalyzeTableTx extends TestDb {
-    static final int C = 25_000;
+    static final int C = 10_000;
 
     /**
      * Run just this test.


### PR DESCRIPTION
Fix for #1619.  This will open a new transaction for table analysis.
Error message fixed.
Not sure how that will affect pgstore. Tests seems to be ok, but maybe old order of action need to be preserved there, just to be on a safe side?