### PR TITLE
Add h2.sortUuidUnsigned and SetTypes.UUID_COLLATION

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -1248,8 +1248,7 @@ SET CLUSTER ''
 "
 
 "Commands (Other)","SET BINARY_COLLATION","
-SET BINARY_COLLATION
-{ UNSIGNED | SIGNED } ] }
+SET BINARY_COLLATION { UNSIGNED | SIGNED }
 ","
 Sets the collation used for comparing BINARY columns, the default is SIGNED
 for version 1.3 and older, and UNSIGNED for version 1.4 and newer.
@@ -1263,8 +1262,7 @@ SET BINARY_COLLATION SIGNED
 "
 
 "Commands (Other)","SET BUILTIN_ALIAS_OVERRIDE","
-SET BUILTIN_ALIAS_OVERRIDE
-{ TRUE | FALSE } ] }
+SET BUILTIN_ALIAS_OVERRIDE { TRUE | FALSE }
 ","
 Allows the overriding of the builtin system date/time functions
 for unit testing purposes.
@@ -1435,7 +1433,6 @@ This setting can be appended to the database URL: ""jdbc:h2:test;JAVA_OBJECT_SER
 ","
 SET JAVA_OBJECT_SERIALIZER 'com.acme.SerializerClassName'
 "
-
 
 "Commands (Other)","SET LAZY_QUERY_EXECUTION","
 SET LAZY_QUERY_EXECUTION int
@@ -3206,7 +3203,6 @@ ARRAY
 An array of values.
 Mapped to ""java.lang.Object[]"" (arrays of any non-primitive type are also supported).
 
-
 Use a value list (1, 2) or ""PreparedStatement.setObject(.., new Object[] {..})"" to store values,
 and ""ResultSet.getObject(..)"" or ""ResultSet.getArray(..)"" to retrieve the values.
 ","
@@ -4377,7 +4373,6 @@ Later flags overrides first ones, for example 'ic' equivalent to case sensitive 
 REGEXP_LIKE('Hello    World', '[A-Z ]*', 'i')
 "
 
-
 "Functions (String)","REPEAT","
 REPEAT(string, int)
 ","
@@ -5517,4 +5512,3 @@ Contains all values from start to end (this is a dynamic table).
 ","
 SYSTEM_RANGE(0, 100)
 "
-

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -1261,6 +1261,24 @@ This setting is persistent.
 SET BINARY_COLLATION SIGNED
 "
 
+"Commands (Other)","SET UUID_COLLATION","
+SET UUID_COLLATION { UNSIGNED | SIGNED }
+","
+Sets the collation used for comparing UUID columns, the default is SIGNED.
+This command can only be executed if there are no tables defined.
+
+SIGNED means signed comparison between first 64 bits of compared values treated as long values
+and if they are equal a signed comparison of the last 64 bits of compared values treated as long values.
+See also Java ""UUID.compareTo()"".
+UNSIGNED means RFC 4122 compatible unsigned comparison.
+
+Admin rights are required to execute this command.
+This command commits an open transaction in this connection.
+This setting is persistent.
+","
+SET UUID_COLLATION UNSIGNED
+"
+
 "Commands (Other)","SET BUILTIN_ALIAS_OVERRIDE","
 SET BUILTIN_ALIAS_OVERRIDE { TRUE | FALSE }
 ","

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1620: UUIDs are unexpectedly sorted as signed
+</li>
+<li>PR #1614: Use bulk .addAll() operation
+</li>
 <li>PR #1613: Add explicit table query
 </li>
 <li>Issue #1608: ARRAY and row value expression should not be the same

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6653,7 +6653,10 @@ public class Parser {
             return parseSetCollation();
         } else if (readIf("BINARY_COLLATION")) {
             readIfEqualOrTo();
-            return parseSetBinaryCollation();
+            return parseSetBinaryCollation(SetTypes.BINARY_COLLATION);
+        } else if (readIf("UUID_COLLATION")) {
+            readIfEqualOrTo();
+            return parseSetBinaryCollation(SetTypes.UUID_COLLATION);
         } else if (readIf("CLUSTER")) {
             readIfEqualOrTo();
             Set command = new Set(session, SetTypes.CLUSTER);
@@ -6842,14 +6845,14 @@ public class Parser {
         return command;
     }
 
-    private Set parseSetBinaryCollation() {
+    private Set parseSetBinaryCollation(int type) {
         String name = readAliasIdentifier();
         if (equalsToken(name, CompareMode.UNSIGNED) || equalsToken(name, CompareMode.SIGNED)) {
-            Set command = new Set(session, SetTypes.BINARY_COLLATION);
+            Set command = new Set(session, type);
             command.setString(name);
             return command;
         }
-        throw DbException.getInvalidValueException("BINARY_COLLATION", name);
+        throw DbException.getInvalidValueException(SetTypes.getTypeName(type), name);
     }
 
     private Set parseSetJavaObjectSerializer() {

--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -158,42 +158,46 @@ public class Set extends Prepared {
         }
         case SetTypes.BINARY_COLLATION: {
             session.getUser().checkAdmin();
-            Table table = database.getFirstUserTable();
-            if (table != null) {
-                throw DbException.get(ErrorCode.COLLATION_CHANGE_WITH_DATA_TABLE_1, table.getSQL());
-            }
-            CompareMode currentMode = database.getCompareMode();
-            CompareMode newMode;
+            boolean unsigned;
             if (stringValue.equals(CompareMode.SIGNED)) {
-                newMode = CompareMode.getInstance(currentMode.getName(),
-                        currentMode.getStrength(), false, currentMode.isUuidUnsigned());
+                unsigned = false;
             } else if (stringValue.equals(CompareMode.UNSIGNED)) {
-                newMode = CompareMode.getInstance(currentMode.getName(),
-                        currentMode.getStrength(), true, currentMode.isUuidUnsigned());
+                unsigned = true;
             } else {
                 throw DbException.getInvalidValueException("BINARY_COLLATION", stringValue);
             }
+            CompareMode currentMode = database.getCompareMode();
+            if (currentMode.isBinaryUnsigned() != unsigned) {
+                Table table = database.getFirstUserTable();
+                if (table != null) {
+                    throw DbException.get(ErrorCode.COLLATION_CHANGE_WITH_DATA_TABLE_1, table.getSQL());
+                }
+            }
+            CompareMode newMode = CompareMode.getInstance(currentMode.getName(),
+                    currentMode.getStrength(), unsigned, currentMode.isUuidUnsigned());
             addOrUpdateSetting(name, stringValue, 0);
             database.setCompareMode(newMode);
             break;
         }
         case SetTypes.UUID_COLLATION: {
             session.getUser().checkAdmin();
-            Table table = database.getFirstUserTable();
-            if (table != null) {
-                throw DbException.get(ErrorCode.COLLATION_CHANGE_WITH_DATA_TABLE_1, table.getSQL());
-            }
-            CompareMode currentMode = database.getCompareMode();
-            CompareMode newMode;
+            boolean unsigned;
             if (stringValue.equals(CompareMode.SIGNED)) {
-                newMode = CompareMode.getInstance(currentMode.getName(),
-                        currentMode.getStrength(), currentMode.isBinaryUnsigned(), false);
+                unsigned = false;
             } else if (stringValue.equals(CompareMode.UNSIGNED)) {
-                newMode = CompareMode.getInstance(currentMode.getName(),
-                        currentMode.getStrength(), currentMode.isBinaryUnsigned(), true);
+                unsigned = true;
             } else {
                 throw DbException.getInvalidValueException("UUID_COLLATION", stringValue);
             }
+            CompareMode currentMode = database.getCompareMode();
+            if (currentMode.isUuidUnsigned() != unsigned) {
+                Table table = database.getFirstUserTable();
+                if (table != null) {
+                    throw DbException.get(ErrorCode.COLLATION_CHANGE_WITH_DATA_TABLE_1, table.getSQL());
+                }
+            }
+            CompareMode newMode = CompareMode.getInstance(currentMode.getName(),
+                    currentMode.getStrength(), currentMode.isBinaryUnsigned(), unsigned);
             addOrUpdateSetting(name, stringValue, 0);
             database.setCompareMode(newMode);
             break;

--- a/h2/src/main/org/h2/command/dml/SetTypes.java
+++ b/h2/src/main/org/h2/command/dml/SetTypes.java
@@ -257,7 +257,12 @@ public class SetTypes {
      */
     public static final int LOCAL_RESULT_FACTORY = 49;
 
-    private static final int COUNT = LOCAL_RESULT_FACTORY + 1;
+    /**
+     * The type of a SET UUID_COLLATION statement.
+     */
+    public static final int UUID_COLLATION = 50;
+
+    private static final int COUNT = UUID_COLLATION + 1;
 
     private static final ArrayList<String> TYPES;
 
@@ -317,6 +322,7 @@ public class SetTypes {
         list.add(COLUMN_NAME_RULES, "COLUMN_NAME_RULES");
         list.add(AUTHENTICATOR, "AUTHENTICATOR");
         list.add(LOCAL_RESULT_FACTORY, "LOCAL_RESULT_FACTORY");
+        list.add(UUID_COLLATION, "UUID_COLLATION");
         TYPES = list;
     }
 

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -855,6 +855,8 @@ public class Database implements DataHandler {
                 lockMeta(systemSession);
                 addDatabaseObject(systemSession, setting);
             }
+            setSortSetting(SetTypes.BINARY_COLLATION, SysProperties.SORT_BINARY_UNSIGNED);
+            setSortSetting(SetTypes.UUID_COLLATION, SysProperties.SORT_UUID_UNSIGNED);
             // mark all ids used in the page store
             if (pageStore != null) {
                 BitSet f = pageStore.getObjectIds();
@@ -875,6 +877,15 @@ public class Database implements DataHandler {
         }
     }
 
+    private void setSortSetting(int type, boolean defValue) {
+        String name = SetTypes.getTypeName(type);
+        if (settings.get(name) == null) {
+            Setting setting = new Setting(this, allocateObjectId(), name);
+            setting.setStringValue(defValue ? CompareMode.UNSIGNED : CompareMode.SIGNED);
+            lockMeta(systemSession);
+            addDatabaseObject(systemSession, setting);
+        }
+    }
 
     private void handleUpgradeIssues() {
         if (store != null && !isReadOnly()) {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -855,8 +855,8 @@ public class Database implements DataHandler {
                 lockMeta(systemSession);
                 addDatabaseObject(systemSession, setting);
             }
-            setSortSetting(SetTypes.BINARY_COLLATION, SysProperties.SORT_BINARY_UNSIGNED);
-            setSortSetting(SetTypes.UUID_COLLATION, SysProperties.SORT_UUID_UNSIGNED);
+            setSortSetting(SetTypes.BINARY_COLLATION, SysProperties.SORT_BINARY_UNSIGNED, true);
+            setSortSetting(SetTypes.UUID_COLLATION, SysProperties.SORT_UUID_UNSIGNED, false);
             // mark all ids used in the page store
             if (pageStore != null) {
                 BitSet f = pageStore.getObjectIds();
@@ -877,7 +877,22 @@ public class Database implements DataHandler {
         }
     }
 
-    private void setSortSetting(int type, boolean defValue) {
+    /**
+     * Preserves a current default value of a sorting setting if it is not the
+     * same as default for older versions of H2 and if it was not modified by
+     * user.
+     *
+     * @param type
+     *            setting type
+     * @param defValue
+     *            current default value (may be modified via system properties)
+     * @param oldDefault
+     *            default value for old versions
+     */
+    private void setSortSetting(int type, boolean defValue, boolean oldDefault) {
+        if (defValue == oldDefault) {
+            return;
+        }
         String name = SetTypes.getTypeName(type);
         if (settings.get(name) == null) {
             Setting setting = new Setting(this, allocateObjectId(), name);

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -418,10 +418,20 @@ public class SysProperties {
      * System property <code>h2.sortBinaryUnsigned</code>
      * (default: true).<br />
      * Whether binary data should be sorted in unsigned mode
-     * (0xff is larger than 0x00).
+     * (0xff is larger than 0x00) by default in new databases.
      */
     public static final boolean SORT_BINARY_UNSIGNED =
             Utils.getProperty("h2.sortBinaryUnsigned", true);
+
+    /**
+     * System property {@code h2.sortUuidUnsigned}, {@code false} by default
+     * unless {@code h2.preview} is enabled.
+     * Whether UUID data should be sorted in unsigned mode
+     * ('ffffffff-ffff-ffff-ffff-ffffffffffff' is larger than
+     * '00000000-0000-0000-0000-000000000000') by default in new databases.
+     */
+    public static final boolean SORT_UUID_UNSIGNED =
+            Utils.getProperty("h2.sortUuidUnsigned", PREVIEW);
 
     /**
      * System property <code>h2.sortNullsHigh</code> (default: false).<br />

--- a/h2/src/main/org/h2/store/PageStore.java
+++ b/h2/src/main/org/h2/store/PageStore.java
@@ -1689,8 +1689,12 @@ public class PageStore implements CacheWriter {
             if (options.length > 3) {
                 binaryUnsigned = Boolean.parseBoolean(options[3]);
             }
+            boolean uuidUnsigned = SysProperties.SORT_UUID_UNSIGNED;
+            if (options.length > 4) {
+                uuidUnsigned = Boolean.parseBoolean(options[4]);
+            }
             CompareMode mode = CompareMode.getInstance(
-                    options[0], Integer.parseInt(options[1]), binaryUnsigned);
+                    options[0], Integer.parseInt(options[1]), binaryUnsigned, uuidUnsigned);
             table.setCompareMode(mode);
             meta = table.getScanIndex(session);
         } else {
@@ -1775,21 +1779,22 @@ public class PageStore implements CacheWriter {
             }
             String columnList = buff.toString();
             CompareMode mode = table.getCompareMode();
-            String options = mode.getName()+ "," + mode.getStrength() + ",";
+            StringBuilder options = new StringBuilder().append(mode.getName()).append(',').append(mode.getStrength())
+                    .append(',');
             if (table.isTemporary()) {
-                options += "temp";
+                options.append("temp");
             }
-            options += ",";
+            options.append(',');
             if (index instanceof PageDelegateIndex) {
-                options += "d";
+                options.append('d');
             }
-            options += "," + mode.isBinaryUnsigned();
+            options.append(',').append(mode.isBinaryUnsigned()).append(',').append(mode.isUuidUnsigned());
             Row row = metaTable.getTemplateRow();
             row.setValue(0, ValueInt.get(index.getId()));
             row.setValue(1, ValueInt.get(type));
             row.setValue(2, ValueInt.get(table.getId()));
             row.setValue(3, ValueInt.get(index.getRootPageId()));
-            row.setValue(4, ValueString.get(options));
+            row.setValue(4, ValueString.get(options.toString()));
             row.setValue(5, ValueString.get(columnList));
             row.setKey(index.getId() + 1);
             metaIndex.add(session, row);

--- a/h2/src/main/org/h2/value/CompareMode.java
+++ b/h2/src/main/org/h2/value/CompareMode.java
@@ -80,7 +80,8 @@ public class CompareMode implements Comparator<Value> {
     private final boolean binaryUnsigned;
 
     /**
-     * If true, sort UUID columns as if they contain unsigned bytes instead of Java-compatible sorting.
+     * If true, sort UUID columns as if they contain unsigned bytes instead of
+     * Java-compatible sorting.
      */
     private final boolean uuidUnsigned;
 

--- a/h2/src/main/org/h2/value/CompareModeDefault.java
+++ b/h2/src/main/org/h2/value/CompareModeDefault.java
@@ -20,9 +20,8 @@ public class CompareModeDefault extends CompareMode {
     private final Collator collator;
     private final SmallLRUCache<String, CollationKey> collationKeys;
 
-    protected CompareModeDefault(String name, int strength,
-            boolean binaryUnsigned) {
-        super(name, strength, binaryUnsigned);
+    protected CompareModeDefault(String name, int strength, boolean binaryUnsigned, boolean uuidUnsigned) {
+        super(name, strength, binaryUnsigned, uuidUnsigned);
         collator = CompareMode.getCollator(name);
         if (collator == null) {
             throw DbException.throwInternalError(name);

--- a/h2/src/main/org/h2/value/CompareModeIcu4J.java
+++ b/h2/src/main/org/h2/value/CompareModeIcu4J.java
@@ -20,8 +20,8 @@ public class CompareModeIcu4J extends CompareMode {
 
     private final Comparator<String> collator;
 
-    protected CompareModeIcu4J(String name, int strength, boolean binaryUnsigned) {
-        super(name, strength, binaryUnsigned);
+    protected CompareModeIcu4J(String name, int strength, boolean binaryUnsigned, boolean uuidUnsigned) {
+        super(name, strength, binaryUnsigned, uuidUnsigned);
         collator = getIcu4jCollator(name, strength);
     }
 

--- a/h2/src/main/org/h2/value/ValueUuid.java
+++ b/h2/src/main/org/h2/value/ValueUuid.java
@@ -172,15 +172,30 @@ public class ValueUuid extends Value {
             return 0;
         }
         ValueUuid v = (ValueUuid) o;
-        if (high == v.high) {
-            return Long.compare(low, v.low);
+        long v1 = high, v2 = v.high;
+        if (v1 == v2) {
+            v1 = low;
+            v2 = v.low;
+            if (mode.isUuidUnsigned()) {
+                v1 += Long.MIN_VALUE;
+                v2 += Long.MIN_VALUE;
+            }
+            return Long.compare(v1, v2);
         }
-        return high > v.high ? 1 : -1;
+        if (mode.isUuidUnsigned()) {
+            v1 += Long.MIN_VALUE;
+            v2 += Long.MIN_VALUE;
+        }
+        return v1 > v2 ? 1 : -1;
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueUuid && compareTypeSafe((Value) other, null) == 0;
+        if (!(other instanceof ValueUuid)) {
+            return false;
+        }
+        ValueUuid v = (ValueUuid) other;
+        return high == v.high && low == v.low;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/scripts/datatypes/uuid.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/uuid.sql
@@ -2,3 +2,46 @@
 -- and the EPL 1.0 (http://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+CREATE TABLE TEST(U UUID) AS (SELECT * FROM VALUES
+    ('00000000-0000-0000-0000-000000000000'), ('00000000-0000-0000-9000-000000000000'),
+    ('11111111-1111-1111-1111-111111111111'), ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'));
+> ok
+
+SELECT U FROM TEST ORDER BY U;
+> U
+> ------------------------------------
+> aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+> 00000000-0000-0000-9000-000000000000
+> 00000000-0000-0000-0000-000000000000
+> 11111111-1111-1111-1111-111111111111
+> rows (ordered): 4
+
+SET UUID_COLLATION UNSIGNED;
+> exception COLLATION_CHANGE_WITH_DATA_TABLE_1
+
+DROP TABLE TEST;
+> ok
+
+SET UUID_COLLATION UNSIGNED;
+> ok
+
+CREATE TABLE TEST(U UUID) AS (SELECT * FROM VALUES
+    ('00000000-0000-0000-0000-000000000000'), ('00000000-0000-0000-9000-000000000000'),
+    ('11111111-1111-1111-1111-111111111111'), ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'));
+> ok
+
+SELECT U FROM TEST ORDER BY U;
+> U
+> ------------------------------------
+> 00000000-0000-0000-0000-000000000000
+> 00000000-0000-0000-9000-000000000000
+> 11111111-1111-1111-1111-111111111111
+> aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+> rows (ordered): 4
+
+DROP TABLE TEST;
+> ok
+
+SET UUID_COLLATION SIGNED;
+> ok


### PR DESCRIPTION
Issue #1620.

1. `h2.sortUuidUnsigned` controls default for a new databases (similar to `h2.sortBinaryUnsigned`). `SET UUID_COLLATION [SIGNED | UNSIGNED]` can be used to change this default for a specific database while database is empty.

2. Values of `BINARY_COLLATION` and `UUID_COLLATION` are preserved in writable databases even when setting was not explicitly used to avoid bug with indexes if value of system property was changed (by end user with `-Dh2.***=***` or due to changed default), especially in a MVStore that does not preserve collation in indexes. Unfortunately, it creates an issue on downgrade attempt, because `UUID_COLLATION` is not known by older versions and `IGNORE_UNKNOWN_SETTINGS` does not work with `SET *** ***` settings. May be write `UUID_COLLATION` only if it is `UNSIGNED` (non-default) for now to allow downgrade from 1.4.198 and start to write it unconditionally in some version after 1.4.198 during the preparation for 1.5 series of releases?

