### PR TITLE
Optimize UUID to VARCHAR conversion and use correct time check in Engine.openSession()

### DIFF
--- a/h2/src/main/org/h2/command/ddl/SequenceOptions.java
+++ b/h2/src/main/org/h2/command/ddl/SequenceOptions.java
@@ -106,7 +106,7 @@ public class SequenceOptions {
      *
      * @param sequence the sequence to get default min value.
      * @param session The session to calculate the value.
-     * @return max value when the MINVALUE expression is set, otherwise returns default min value.
+     * @return min value when the MINVALUE expression is set, otherwise returns default min value.
      */
     public Long getMinValue(Sequence sequence, Session session) {
         if (minValue == ValueExpression.getNull() && sequence != null) {

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -196,14 +196,15 @@ public class Engine implements SessionFactory {
         String cipher = ci.removeProperty("CIPHER", null);
         String init = ci.removeProperty("INIT", null);
         Session session;
-        for (int i = 0;; i++) {
+        long start = System.nanoTime();
+        for (;;) {
             session = openSession(ci, ifExists, cipher);
             if (session != null) {
                 break;
             }
             // we found a database that is currently closing
             // wait a bit to avoid a busy loop (the method is synchronized)
-            if (i > 60 * 1000) {
+            if (System.nanoTime() - start > 60_000_000_000L) {
                 // retry at most 1 minute
                 throw DbException.get(ErrorCode.DATABASE_ALREADY_OPEN_1,
                         "Waited for database closing longer than 1 minute");
@@ -211,7 +212,7 @@ public class Engine implements SessionFactory {
             try {
                 Thread.sleep(1);
             } catch (InterruptedException e) {
-                // ignore
+                throw DbException.get(ErrorCode.DATABASE_CALLED_AT_SHUTDOWN);
             }
         }
         synchronized (session) {

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -256,7 +256,7 @@ public final class DataUtils {
      */
     public static void writeVarInt(OutputStream out, int x) throws IOException {
         while ((x & ~0x7f) != 0) {
-            out.write((byte) (0x80 | (x & 0x7f)));
+            out.write((byte) (x | 0x80));
             x >>>= 7;
         }
         out.write((byte) x);
@@ -270,7 +270,7 @@ public final class DataUtils {
      */
     public static void writeVarInt(ByteBuffer buff, int x) {
         while ((x & ~0x7f) != 0) {
-            buff.put((byte) (0x80 | (x & 0x7f)));
+            buff.put((byte) (x | 0x80));
             x >>>= 7;
         }
         buff.put((byte) x);
@@ -331,7 +331,7 @@ public final class DataUtils {
      */
     public static void writeVarLong(ByteBuffer buff, long x) {
         while ((x & ~0x7f) != 0) {
-            buff.put((byte) (0x80 | (x & 0x7f)));
+            buff.put((byte) (x | 0x80));
             x >>>= 7;
         }
         buff.put((byte) x);
@@ -347,7 +347,7 @@ public final class DataUtils {
     public static void writeVarLong(OutputStream out, long x)
             throws IOException {
         while ((x & ~0x7f) != 0) {
-            out.write((byte) (0x80 | (x & 0x7f)));
+            out.write((byte) (x | 0x80));
             x >>>= 7;
         }
         out.write((byte) x);

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1939,7 +1939,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         if (notificationRequested) {
             synchronized (lock) {
                 notificationRequested = false;
-                lock.notifyAll();;
+                lock.notifyAll();
             }
         }
         return updatedRootReference;

--- a/h2/src/main/org/h2/mvstore/tx/VersionedValueCommitted.java
+++ b/h2/src/main/org/h2/mvstore/tx/VersionedValueCommitted.java
@@ -27,10 +27,12 @@ class VersionedValueCommitted extends VersionedValue {
         return value instanceof VersionedValue ? (VersionedValue) value : new VersionedValueCommitted(value);
     }
 
+    @Override
     public Object getCurrentValue() {
         return value;
     }
 
+    @Override
     public Object getCommittedValue() {
         return value;
     }

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -1224,7 +1224,7 @@ public class Data {
      */
     public void writeVarInt(int x) {
         while ((x & ~0x7f) != 0) {
-            data[pos++] = (byte) (0x80 | (x & 0x7f));
+            data[pos++] = (byte) (x | 0x80);
             x >>>= 7;
         }
         data[pos++] = (byte) x;
@@ -1293,7 +1293,7 @@ public class Data {
      */
     public void writeVarLong(long x) {
         while ((x & ~0x7f) != 0) {
-            data[pos++] = (byte) ((x & 0x7f) | 0x80);
+            data[pos++] = (byte) (x | 0x80);
             x >>>= 7;
         }
         data[pos++] = (byte) x;

--- a/h2/src/main/org/h2/store/FileStore.java
+++ b/h2/src/main/org/h2/store/FileStore.java
@@ -375,9 +375,9 @@ public class FileStore {
      * @return the file size
      */
     public long length() {
-        try {
-            long len = fileLength;
-            if (ASSERT) {
+        long len = fileLength;
+        if (ASSERT) {
+            try {
                 len = file.size();
                 if (len != fileLength) {
                     DbException.throwInternalError(
@@ -391,11 +391,11 @@ public class FileStore {
                     DbException.throwInternalError(
                             "unaligned file length " + name + " len " + len);
                 }
+            } catch (IOException e) {
+                throw DbException.convertIOException(e, name);
             }
-            return len;
-        } catch (IOException e) {
-            throw DbException.convertIOException(e, name);
         }
+        return len;
     }
 
     /**

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -1080,6 +1080,26 @@ public class StringUtils {
     }
 
     /**
+     * Appends specified number of trailing bytes from unsigned long value to a
+     * specified string builder.
+     *
+     * @param builder
+     *            string builder to append to
+     * @param x
+     *            value to append
+     * @param bytes
+     *            number of bytes to append
+     * @return the specified string builder
+     */
+    public static StringBuilder appendHex(StringBuilder builder, long x, int bytes) {
+        char[] hex = HEX;
+        for (int i = bytes * 8; i > 0;) {
+            builder.append(hex[(int) (x >> (i -= 4)) & 0xf]).append(hex[(int) (x >> (i -= 4)) & 0xf]);
+        }
+        return builder;
+    }
+
+    /**
      * Check if this string is a decimal number.
      *
      * @param s the string

--- a/h2/src/main/org/h2/value/ValueUuid.java
+++ b/h2/src/main/org/h2/value/ValueUuid.java
@@ -141,29 +141,17 @@ public class ValueUuid extends Value {
         return PRECISION;
     }
 
-    private static void appendHex(StringBuilder buff, long x, int bytes) {
-        for (int i = bytes * 8 - 4; i >= 0; i -= 8) {
-            buff.append(Integer.toHexString((int) (x >> i) & 0xf)).
-                append(Integer.toHexString((int) (x >> (i - 4)) & 0xf));
-        }
-    }
-
     @Override
     public String getString() {
         return addString(new StringBuilder(36)).toString();
     }
 
     private StringBuilder addString(StringBuilder builder) {
-        appendHex(builder, high >> 32, 4);
-        builder.append('-');
-        appendHex(builder, high >> 16, 2);
-        builder.append('-');
-        appendHex(builder, high, 2);
-        builder.append('-');
-        appendHex(builder, low >> 48, 2);
-        builder.append('-');
-        appendHex(builder, low, 6);
-        return builder;
+        StringUtils.appendHex(builder, high >> 32, 4).append('-');
+        StringUtils.appendHex(builder, high >> 16, 2).append('-');
+        StringUtils.appendHex(builder, high, 2).append('-');
+        StringUtils.appendHex(builder, low >> 48, 2).append('-');
+        return StringUtils.appendHex(builder, low, 6);
     }
 
     @Override

--- a/h2/src/test/org/h2/test/auth/TestAuthentication.java
+++ b/h2/src/test/org/h2/test/auth/TestAuthentication.java
@@ -77,11 +77,11 @@ public class TestAuthentication extends TestBase {
         return externalUserPassword;
     }
 
-    private String getRealmName() {
+    private static String getRealmName() {
         return "testRealm";
     }
 
-    private String getStaticRoleName() {
+    private static String getStaticRoleName() {
         return "staticRole";
     }
 
@@ -117,7 +117,7 @@ public class TestAuthentication extends TestBase {
         return "jdbc:h2:mem:" + getClass().getSimpleName();
     }
 
-    private String getExternalUser() {
+    private static String getExternalUser() {
         return "user";
     }
 

--- a/h2/src/test/org/h2/test/db/TestLIRSMemoryConsumption.java
+++ b/h2/src/test/org/h2/test/db/TestLIRSMemoryConsumption.java
@@ -92,12 +92,12 @@ public class TestLIRSMemoryConsumption extends TestDb {
         }
     }
 
-    private Object createValue(long key) {
+    private static Object createValue(long key) {
 //        return new Object();
         return new byte[2540];
     }
 
-    private int getValueSize(long key) {
+    private static int getValueSize(long key) {
 //        return 16;
         return 2560;
     }


### PR DESCRIPTION
1. Conversion from `ValueUuid` to string does not allocate a lot of small strings for each digit any more.

2. `Engine.openSession()` now waits up to 60 seconds, instead of 60,000 delays with `Thread.sleep(1)` with connection attempts between them, old time measure method is not reliable.

3. `Engine.openSession()` does not ignore thread interruption attempts any more.

4. Some warnings and typos are fixed.