### PR TITLE
Add support for Java 11 to test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 matrix:
   include:
-    - jdk: openjdk10
+    - jdk: openjdk11
       dist: trusty
       group: edge
       sudo: required

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>6.1</version>
+      <version>7.0</version>
       <scope>test</scope>
     </dependency>
     <!-- END TEST DEPENDENCIES !-->

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,20 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1638: Add support for Java 11 to test suite
+</li>
+<li>PR #1637: Remove explicit unboxing
+</li>
+<li>PR #1635: Optimize UUID to VARCHAR conversion and use correct time check in Engine.openSession()
+</li>
+<li>Issue #1632: TestMVTableEngine failure
+</li>
+<li>PR #1631: Prepere to release: javadoc cleanup
+</li>
+<li>PR #1630: fix duplicate words typos in comments and javadoc
+</li>
+<li>PR #1627: Use lock to protect append buffer
+</li>
 <li>Issue #1618: GROUP BY does not work with two identical columns in selected expressions
 </li>
 <li>Issue #1619: Two-phase commit regression in MASTER

--- a/h2/src/test/org/h2/test/db/TestDateStorage.java
+++ b/h2/src/test/org/h2/test/db/TestDateStorage.java
@@ -172,6 +172,15 @@ public class TestDateStorage extends TestDb {
         try {
             ArrayList<TimeZone> distinct = TestDate.getDistinctTimeZones();
             for (TimeZone tz : distinct) {
+                /*
+                 * Some OpenJDKs have unusable timezones with negative DST that
+                 * causes IAE in SimpleTimeZone().
+                 */
+                if (tz.getID().startsWith("SystemV/")) {
+                    if (tz.getDSTSavings() < 0) {
+                       continue;
+                    }
+                }
                 // println(tz.getID());
                 TimeZone.setDefault(tz);
                 DateTimeUtils.resetCalendar();

--- a/h2/src/test/org/h2/test/unit/TestKeywords.java
+++ b/h2/src/test/org/h2/test/unit/TestKeywords.java
@@ -39,7 +39,7 @@ public class TestKeywords extends TestBase {
     public void test() throws Exception {
         final HashSet<String> set = new HashSet<>();
         ClassReader r = new ClassReader(Parser.class.getResourceAsStream("Parser.class"));
-        r.accept(new ClassVisitor(Opcodes.ASM6) {
+        r.accept(new ClassVisitor(Opcodes.ASM7) {
             @Override
             public FieldVisitor visitField(int access, String name, String descriptor, String signature,
                     Object value) {
@@ -50,7 +50,7 @@ public class TestKeywords extends TestBase {
             @Override
             public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
                     String[] exceptions) {
-                return new MethodVisitor(Opcodes.ASM6) {
+                return new MethodVisitor(Opcodes.ASM7) {
                     @Override
                     public void visitLdcInsn(Object value) {
                         add(set, value);

--- a/h2/src/test/org/h2/test/unit/TestNetUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestNetUtils.java
@@ -15,6 +15,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
+import org.h2.build.BuildBase;
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
 import org.h2.util.NetUtils;
@@ -57,6 +58,10 @@ public class TestNetUtils extends TestBase {
      * (no SSL certificate is needed).
      */
     private void testAnonymousTlsSession() throws Exception {
+        if (BuildBase.getJavaVersion() >= 11) {
+            // Issue #1303
+            return;
+        }
         assertTrue("Failed assumption: the default value of ENABLE_ANONYMOUS_TLS" +
                 " property should be true", SysProperties.ENABLE_ANONYMOUS_TLS);
         boolean ssl = true;

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -136,10 +136,10 @@ public class Build extends BuildBase {
     public void coverage() {
         compile();
         downloadTest();
-        downloadUsingMaven("ext/org.jacoco.agent-0.8.0.jar",
-                "org.jacoco", "org.jacoco.agent", "0.8.0",
-                "f2748b949b5fc661e089e2eeef39891dfd10a7e5");
-        try (ZipFile zipFile = new ZipFile(new File("ext/org.jacoco.agent-0.8.0.jar"))) {
+        downloadUsingMaven("ext/org.jacoco.agent-0.8.2.jar",
+                "org.jacoco", "org.jacoco.agent", "0.8.2",
+                "1402427761df5c7601ff6e06280764833ed727b5");
+        try (ZipFile zipFile = new ZipFile(new File("ext/org.jacoco.agent-0.8.2.jar"))) {
             final Enumeration<? extends ZipEntry> e = zipFile.entries();
             while (e.hasMoreElements()) {
                 final ZipEntry zipEntry = e.nextElement();
@@ -154,21 +154,21 @@ public class Build extends BuildBase {
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
-        downloadUsingMaven("ext/org.jacoco.cli-0.8.0.jar",
-                "org.jacoco", "org.jacoco.cli", "0.8.0",
-                "69e55ba110e6ffa91d72ed3df8e09aecf043b0ab");
-        downloadUsingMaven("ext/org.jacoco.core-0.8.0.jar",
-                "org.jacoco", "org.jacoco.core", "0.8.0",
-                "cc2ebdc1da53665ec788903bad65ee64345e4455");
-        downloadUsingMaven("ext/org.jacoco.report-0.8.0.jar",
-                "org.jacoco", "org.jacoco.report", "0.8.0",
-                "1bcab2a451f5a382bc674857c8f3f6d3fa52151d");
-        downloadUsingMaven("ext/asm-commons-6.1.jar",
-                "org.ow2.asm", "asm-commons", "6.1",
-                "8a8d242d7ce00fc937a245fae5b65763d13f7cd1");
-        downloadUsingMaven("ext/asm-tree-6.1.jar",
-                "org.ow2.asm", "asm-tree", "6.1",
-                "701262d4b9bcbdc2d4b80617e82db9a2b7f4f088");
+        downloadUsingMaven("ext/org.jacoco.cli-0.8.2.jar",
+                "org.jacoco", "org.jacoco.cli", "0.8.2",
+                "9595c53358d0306900183b5a7e6a70c88171ab4c");
+        downloadUsingMaven("ext/org.jacoco.core-0.8.2.jar",
+                "org.jacoco", "org.jacoco.core", "0.8.2",
+                "977b33afe2344a9ee801fd3317c54d8e1f9d7a79");
+        downloadUsingMaven("ext/org.jacoco.report-0.8.2.jar",
+                "org.jacoco", "org.jacoco.report", "0.8.2",
+                "50e133cdfd2d31ca5702b73615be70f801d3ae26");
+        downloadUsingMaven("ext/asm-commons-7.0.jar",
+                "org.ow2.asm", "asm-commons", "7.0",
+                "478006d07b7c561ae3a92ddc1829bca81ae0cdd1");
+        downloadUsingMaven("ext/asm-tree-7.0.jar",
+                "org.ow2.asm", "asm-tree", "7.0",
+                "29bc62dcb85573af6e62e5b2d735ef65966c4180");
         downloadUsingMaven("ext/args4j-2.33.jar",
                 "args4j", "args4j", "2.33",
                 "bd87a75374a6d6523de82fef51fc3cfe9baf9fc9");
@@ -204,12 +204,12 @@ public class Build extends BuildBase {
         delete(files("coverage/bin/org/h2/sample"));
         // Generate report
         execJava(args("-cp",
-                "ext/org.jacoco.cli-0.8.0.jar" + File.pathSeparator
-                + "ext/org.jacoco.core-0.8.0.jar" + File.pathSeparator
-                + "ext/org.jacoco.report-0.8.0.jar" + File.pathSeparator
-                + "ext/asm-6.1.jar" + File.pathSeparator
-                + "ext/asm-commons-6.1.jar" + File.pathSeparator
-                + "ext/asm-tree-6.1.jar" + File.pathSeparator
+                "ext/org.jacoco.cli-0.8.2.jar" + File.pathSeparator
+                + "ext/org.jacoco.core-0.8.2.jar" + File.pathSeparator
+                + "ext/org.jacoco.report-0.8.2.jar" + File.pathSeparator
+                + "ext/asm-7.0.jar" + File.pathSeparator
+                + "ext/asm-commons-7.0.jar" + File.pathSeparator
+                + "ext/asm-tree-7.0.jar" + File.pathSeparator
                 + "ext/args4j-2.33.jar",
                 "org.jacoco.cli.internal.Main", "report", "coverage/jacoco.exec",
                 "--classfiles", "coverage/bin",
@@ -269,7 +269,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.15.0.jar" +
-                File.pathSeparator + "ext/asm-6.1.jar" +
+                File.pathSeparator + "ext/asm-7.0.jar" +
                 File.pathSeparator + javaToolsJar;
         FileList files;
         if (clientOnly) {
@@ -384,9 +384,9 @@ public class Build extends BuildBase {
         downloadOrVerify("ext/junit-4.12.jar",
                 "junit", "junit", "4.12",
                 "2973d150c0dc1fefe998f834810d68f278ea58ec", offline);
-        downloadUsingMaven("ext/asm-6.1.jar",
-                "org.ow2.asm", "asm", "6.1",
-                "94a0d17ba8eb24833cd54253ace9b053786a9571");
+        downloadUsingMaven("ext/asm-7.0.jar",
+                "org.ow2.asm", "asm", "7.0",
+                "d74d4ba0dee443f68fb2dcb7fcdb945a2cd89912");
     }
 
     private void downloadOrVerify(String target, String group, String artifact,
@@ -669,7 +669,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.15.0.jar" +
-                File.pathSeparator + "ext/asm-6.1.jar" +
+                File.pathSeparator + "ext/asm-7.0.jar" +
                 File.pathSeparator + "ext/junit-4.12.jar",
                 "-subpackages", "org.h2");
 
@@ -704,7 +704,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.15.0.jar" +
-                File.pathSeparator + "ext/asm-6.1.jar" +
+                File.pathSeparator + "ext/asm-7.0.jar" +
                 File.pathSeparator + "ext/junit-4.12.jar",
                 "-subpackages", "org.h2",
                 "-package",
@@ -967,7 +967,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/jts-core-1.15.0.jar" +
                 File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
                 File.pathSeparator + "ext/slf4j-nop-1.6.0.jar" +
-                File.pathSeparator + "ext/asm-6.1.jar" +
+                File.pathSeparator + "ext/asm-7.0.jar" +
                 File.pathSeparator + javaToolsJar;
         int version = getJavaVersion();
         if (version >= 9) {

--- a/h2/src/tools/org/h2/build/BuildBase.java
+++ b/h2/src/tools/org/h2/build/BuildBase.java
@@ -928,7 +928,7 @@ public class BuildBase {
      *
      * @return the Java version (7, 8, 9, 10, 11, etc)
      */
-    protected static int getJavaVersion() {
+    public static int getJavaVersion() {
         int version = 7;
         String v = getJavaSpecVersion();
         if (v != null) {


### PR DESCRIPTION
One test is disabled for Java 11+ due to issue #1303.

Some OpenJDK 11 distributions contain broken timezones that are not usable at all, they are now detected.

ASM and JaCoCo are updated to versions that support Java 11.

Travis builds are switched from 10 to 11, 7 and 8 are also preserved.