### PR TITLE
Suggest ANY(?) instead of variable IN() again

### DIFF
--- a/h2/src/docsrc/html/performance.html
+++ b/h2/src/docsrc/html/performance.html
@@ -490,7 +490,7 @@ Instead, use a prepared statement with arrays as in the following example:
 </p>
 <pre>
 PreparedStatement prep = conn.prepareStatement(
-    "SELECT * FROM TEST WHERE ID IN(UNNEST(?))");
+    "SELECT * FROM TEST WHERE ID = ANY(?)");
 prep.setObject(1, new Object[] { "1", "2" });
 ResultSet rs = prep.executeQuery();
 </pre>

--- a/h2/src/main/org/h2/expression/condition/ConditionInParameter.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInParameter.java
@@ -24,7 +24,7 @@ import org.h2.value.ValueBoolean;
 import org.h2.value.ValueNull;
 
 /**
- * A condition with parameter as {@code IN(UNNEST(?))}.
+ * A condition with parameter as {@code = ANY(?)}.
  */
 public class ConditionInParameter extends Condition {
     private static final class ParameterList extends AbstractList<Expression> {
@@ -104,12 +104,12 @@ public class ConditionInParameter extends Condition {
     }
 
     /**
-     * Create a new {@code IN(UNNEST(?))} condition.
+     * Create a new {@code = ANY(?)} condition.
      *
      * @param database
      *            the database
      * @param left
-     *            the expression before {@code IN(UNNEST(?))}
+     *            the expression before {@code = ANY(?)}
      * @param parameter
      *            parameter
      */
@@ -162,8 +162,8 @@ public class ConditionInParameter extends Condition {
     @Override
     public StringBuilder getSQL(StringBuilder builder) {
         builder.append('(');
-        left.getSQL(builder).append(" IN(UNNEST(");
-        return parameter.getSQL(builder).append(")))");
+        left.getSQL(builder).append(" = ANY(");
+        return parameter.getSQL(builder).append("))");
     }
 
     @Override

--- a/h2/src/test/org/h2/test/scripts/functions/system/unnest.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/unnest.sql
@@ -60,8 +60,8 @@ SELECT X, X IN(UNNEST(ARRAY[2, 4])) FROM SYSTEM_RANGE(1, 5);
 SELECT X, X IN(UNNEST(?)) FROM SYSTEM_RANGE(1, 5);
 {
 2
-> X X IN(UNNEST(?1))
-> - ----------------
+> X X = ANY(?1)
+> - -----------
 > 1 FALSE
 > 2 TRUE
 > 3 FALSE


### PR DESCRIPTION
Usage of PostgreSQL-style `= ANY(?)` was suggested in 1.4.197 instead of more complicated syntax with H2-specific `TABLE` function.

Due to conflict with aggregate functions support of `ANY` was limited some time ago and this example was replaced with `IN(UNNEST(?))` construction. In uses standard `UNNEST` function, but without a `SELECT` statement, so this syntax is not fully standard too (H2 accepts table functions as argument of `IN`).

Some time ago this conflict was resolved by suggesting usage of parentheses when necessary and `= ANY(…)` construction is now always parsed as quantified comparison, so it is safe to recommend `= ANY(?)` again.