### PR TITLE
Optimize window aggregates with ORDER BY + UNBOUNDED PRECEDING + no exclusions

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1656: Optimize window aggregates with ORDER BY + UNBOUNDED PRECEDING + no exclusions
+</li>
 <li>Issue #1654: OOM in TestMemoryUsage, in big mode
 </li>
 <li>Issue #1651: TIMESTAMP values near DST may be changed in MVStore database due to UTC-based PageStore format in some

--- a/h2/src/main/org/h2/api/Aggregate.java
+++ b/h2/src/main/org/h2/api/Aggregate.java
@@ -44,7 +44,9 @@ public interface Aggregate {
     void add(Object value) throws SQLException;
 
     /**
-     * This method returns the computed aggregate value.
+     * This method returns the computed aggregate value. This method must
+     * preserve previously added values and must be able to reevaluate result if
+     * more values were added since its previous invocation.
      *
      * @return the aggregated value
      */

--- a/h2/src/main/org/h2/api/AggregateFunction.java
+++ b/h2/src/main/org/h2/api/AggregateFunction.java
@@ -47,7 +47,9 @@ public interface AggregateFunction {
     void add(Object value) throws SQLException;
 
     /**
-     * This method returns the computed aggregate value.
+     * This method returns the computed aggregate value. This method must
+     * preserve previously added values and must be able to reevaluate result if
+     * more values were added since its previous invocation.
      *
      * @return the aggregated value
      */

--- a/h2/src/main/org/h2/expression/analysis/WindowFrameExclusion.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFrameExclusion.java
@@ -39,6 +39,17 @@ public enum WindowFrameExclusion {
     }
 
     /**
+     * Returns true if this exclusion clause excludes or includes the whole
+     * group.
+     *
+     * @return true if this exclusion clause is {@link #EXCLUDE_GROUP} or
+     *         {@link #EXCLUDE_NO_OTHERS}
+     */
+    public boolean isGroupOrNoOthers() {
+        return this == WindowFrameExclusion.EXCLUDE_GROUP || this == EXCLUDE_NO_OTHERS;
+    }
+
+    /**
      * Returns SQL representation.
      *
      * @return SQL representation.

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -805,4 +805,4 @@ queryparser tokenized freeze factorings recompilation unenclosed rfe dsync
 econd irst bcef ordinality nord unnest
 analyst occupation distributive josaph aor engineer sajeewa isuru randil kevin doctor businessman artist ashan
 corrupts splitted disruption unintentional octets preconditions predicates subq objectweb insn opcodes
-preserves masking holder unboxing avert iae transformed subtle
+preserves masking holder unboxing avert iae transformed subtle reevaluate exclusions


### PR DESCRIPTION
I removed buggy optimization in #1486 due to issue #1485 and added different test cases to prevent possible regressions.

In this PR this optimization is reimplemented properly.

Window aggregate functions with `ORDER BY` and without window frame clause or with window frame clause with `UNBOUNDED PRECEDING` and no excluding clause or `EXCLUDE NO OTHERS` clause are optimized to collect values only once for each partition.

Old buggy implementation (that was removed) always worked as for `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`. New implementation correctly checks last row that should be aggregated. In this special case rows can be only appended to aggregation. The only difference is that last appended row is not necessary the current row. For example, with `ORDER BY` and without window frame clause all rows with the same order must be appended to aggregation at once.