### PR TITLE
Failure to stop background thread

### DIFF
--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -186,11 +186,10 @@ public class FileStore {
      * Close this store.
      */
     public void close() {
-        if(file != null) {
+        if(file != null && file.isOpen()) {
             try {
-                if (fileLock != null) {
+                if (fileLock != null && fileLock.isValid()) {
                     fileLock.release();
-                    fileLock = null;
                 }
                 file.close();
                 freeSpace.clear();
@@ -199,6 +198,7 @@ public class FileStore {
                         DataUtils.ERROR_WRITING_FAILED,
                         "Closing failed for file {0}", fileName, e);
             } finally {
+                fileLock = null;
                 file = null;
             }
         }

--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -186,21 +186,20 @@ public class FileStore {
      * Close this store.
      */
     public void close() {
-        if(file != null && file.isOpen()) {
-            try {
-                if (fileLock != null && fileLock.isValid()) {
+        try {
+            if(file != null && file.isOpen()) {
+                if (fileLock != null) {
                     fileLock.release();
                 }
                 file.close();
-                freeSpace.clear();
-            } catch (Exception e) {
-                throw DataUtils.newIllegalStateException(
-                        DataUtils.ERROR_WRITING_FAILED,
-                        "Closing failed for file {0}", fileName, e);
-            } finally {
-                fileLock = null;
-                file = null;
             }
+        } catch (Exception e) {
+            throw DataUtils.newIllegalStateException(
+                    DataUtils.ERROR_WRITING_FAILED,
+                    "Closing failed for file {0}", fileName, e);
+        } finally {
+            fileLock = null;
+            file = null;
         }
     }
 

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2845,19 +2845,20 @@ public class MVStore implements AutoCloseable {
         // which should not happen with non-weak flavour of CAS operation,
         // but I've seen it, so just to be safe...
         BackgroundWriterThread t;
-        while ((t = backgroundWriterThread.get()) != null &&
-                // if called from within the thread itself - can not join
-                t != Thread.currentThread()) {
+        while ((t = backgroundWriterThread.get()) != null) {
             if (backgroundWriterThread.compareAndSet(t, null)) {
-                synchronized (t.sync) {
-                    t.sync.notifyAll();
-                }
+                // if called from within the thread itself - can not join
+                if (t != Thread.currentThread()) {
+                    synchronized (t.sync) {
+                        t.sync.notifyAll();
+                    }
 
-                if (waitForIt) {
-                    try {
-                        t.join();
-                    } catch (Exception e) {
-                        // ignore
+                    if (waitForIt) {
+                        try {
+                            t.join();
+                        } catch (Exception e) {
+                            // ignore
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
PR #1650 has a bug which fail to stop background thread after panic exception happened in background thread itself.
This behavior can be seen as leftover thread after TestMVStore run.

BTW, @katzyn "async:" file system uses default execution service and it also leaves behind bunch of dormant threads. Can custom thread pool be used there instead and be shutdown on FileStore closure? It's not big deal really, but surprising a bit.