### PR TITLE
Add RATIO_TO_REPORT window function

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -5552,7 +5552,7 @@ RATIO_TO_REPORT(value)
 OVER windowNameOrSpecification
 ","
 Returns the ratio of a value to the sum of all values.
-Is argument is NULL or sum of all values is 0, then the value of function is NULL.
+If argument is NULL or sum of all values is 0, then the value of function is NULL.
 
 Window functions are currently experimental in H2 and should be used with caution.
 They also may require a lot of memory for large queries.

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -5547,6 +5547,19 @@ SELECT NTH_VALUE(X) IGNORE NULLS OVER (
 ), * FROM TEST;
 "
 
+"Functions (Window)","RATIO_TO_REPORT","
+RATIO_TO_REPORT(value)
+OVER windowNameOrSpecification
+","
+Returns the ratio of a value to the sum of all values.
+Is argument is NULL or sum of all values is 0, then the value of function is NULL.
+
+Window functions are currently experimental in H2 and should be used with caution.
+They also may require a lot of memory for large queries.
+","
+SELECT X, RATIO_TO_REPORT(X) OVER (PARTITION BY CATEGORY), CATEGORY FROM TEST;
+"
+
 "System Tables","Information Schema","
 INFORMATION_SCHEMA
 ","

--- a/h2/src/main/org/h2/expression/analysis/WindowFunctionType.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFunctionType.java
@@ -65,6 +65,11 @@ public enum WindowFunctionType {
      */
     NTH_VALUE,
 
+    /**
+     * The type for RATIO_TO_REPORT() window function.
+     */
+    RATIO_TO_REPORT,
+
     ;
 
     /**
@@ -98,6 +103,8 @@ public enum WindowFunctionType {
             return LAST_VALUE;
         case "NTH_VALUE":
             return NTH_VALUE;
+        case "RATIO_TO_REPORT":
+            return RATIO_TO_REPORT;
         default:
             return null;
         }

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -204,7 +204,7 @@ public class TestScript extends TestDb {
                 "parsedatetime", "quarter", "second", "truncate", "week", "year", "date_trunc" }) {
             testScript("functions/timeanddate/" + s + ".sql");
         }
-        for (String s : new String[] { "lead", "nth_value", "ntile", "row_number" }) {
+        for (String s : new String[] { "lead", "nth_value", "ntile", "ratio_to_report", "row_number" }) {
             testScript("functions/window/" + s + ".sql");
         }
 

--- a/h2/src/test/org/h2/test/scripts/functions/window/ratio_to_report.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/window/ratio_to_report.sql
@@ -1,0 +1,35 @@
+-- Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (http://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+CREATE TABLE TEST(ID INT PRIMARY KEY, N NUMERIC);
+> ok
+
+INSERT INTO TEST VALUES(1, 1), (2, 2), (3, NULL), (4, 5);
+> update count: 4
+
+SELECT ID, N, RATIO_TO_REPORT(N) OVER() R2R FROM TEST;
+> ID N    R2R
+> -- ---- -----
+> 1  1    0.125
+> 2  2    0.25
+> 3  null null
+> 4  5    0.625
+> rows: 4
+
+INSERT INTO TEST VALUES (5, -8);
+> update count: 1
+
+SELECT ID, N, RATIO_TO_REPORT(N) OVER() R2R FROM TEST;
+> ID N    R2R
+> -- ---- ----
+> 1  1    null
+> 2  2    null
+> 3  null null
+> 4  5    null
+> 5  -8   null
+> rows: 5
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
This window function is not standard, but it's useful for some reports.

It's supported by some databases, a couple of examples below, and there are some others.
https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/RATIO_TO_REPORT.html
https://www.ibm.com/support/knowledgecenter/en/SSGU8G_12.1.0/com.ibm.sqls.doc/ids_sqs_2595.htm