### PR TITLE
Fix Alter Table Drop Column In View when table name is wrapped by Double Quotes

### DIFF
--- a/h2/src/main/org/h2/command/ddl/AlterTableAlterColumn.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAlterColumn.java
@@ -296,7 +296,7 @@ public class AlterTableAlterColumn extends CommandWithColumns {
             // (because the column to drop is referenced or so)
             checkViews(table, newTable);
         } catch (DbException e) {
-            execute("DROP TABLE " + newTable.getName(), true);
+            execute("DROP TABLE " + newTable.getSQL(), true);
             throw e;
         }
         String tableName = table.getName();

--- a/h2/src/test/org/h2/test/db/TestViewAlterTable.java
+++ b/h2/src/test/org/h2/test/db/TestViewAlterTable.java
@@ -46,6 +46,7 @@ public class TestViewAlterTable extends TestDb {
         testJoinAndAlias();
         testSubSelect();
         testForeignKey();
+        testAlterTableDropColumnInViewWithDoubleQuotes();
 
         conn.close();
         deleteDb(getTestName());
@@ -196,5 +197,19 @@ public class TestViewAlterTable extends TestDb {
                     "INFORMATION_SCHEMA", rs.getString(2));
         }
 
+    }
+
+    // original error: table "XX_COPY_xx_xx" not found
+    private void testAlterTableDropColumnInViewWithDoubleQuotes() throws SQLException{
+        // simple
+        stat.execute("create table \"test\"(id identity, name varchar) " +
+                "as select x, 'Hello'");
+        stat.execute("create view test_view as select * from \"test\"");
+        assertThrows(ErrorCode.COLUMN_IS_REFERENCED_1, stat).
+                execute("alter table \"test\" drop name");
+        ResultSet rs = stat.executeQuery("select * from test_view");
+        assertTrue(rs.next());
+        stat.execute("drop view test_view");
+        stat.execute("drop table \"test\"");
     }
 }


### PR DESCRIPTION
Hi,
The included test cases illustrate the use case the cases the bug. 

Before this fix, h2 was failing to delete the copy table because if deserves the old name and irrelevant error was reported.