### PR TITLE
Allow any expressions in window frames

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2709,7 +2709,7 @@ ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES
 UNBOUNDED PRECEDING|value PRECEDING|CURRENT ROW
 ","
 A window frame preceding clause.
-If value is specified it should be non-negative value or parameter.
+If value is specified it should not be negative.
 ","
 UNBOUNDED PRECEDING
 1 PRECEDING
@@ -2721,7 +2721,7 @@ UNBOUNDED PRECEDING|value PRECEDING|CURRENT ROW
     |value FOLLOWING|UNBOUNDED FOLLOWING
 ","
 A window frame bound clause.
-If value is specified it should be non-negative value or parameter.
+If value is specified it should not be negative.
 ","
 UNBOUNDED PRECEDING
 UNBOUNDED FOLLOWING

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1664: Allow any expressions in window frames
+</li>
 <li>Issue #1576: H2 Console should not display precision and scale for data types that don't have them
 </li>
 <li>PR #1662: Fix Alter Table Drop Column In View when table name is wrapped by Double Quotes

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3294,7 +3294,7 @@ public class Parser {
             read(ROW);
             return new WindowFrameBound(WindowFrameBoundType.CURRENT_ROW, null);
         }
-        Expression value = readValueOrParameter();
+        Expression value = readExpression();
         read("PRECEDING");
         return new WindowFrameBound(WindowFrameBoundType.PRECEDING, value);
     }
@@ -3311,22 +3311,12 @@ public class Parser {
             read(ROW);
             return new WindowFrameBound(WindowFrameBoundType.CURRENT_ROW, null);
         }
-        Expression value = readValueOrParameter();
+        Expression value = readExpression();
         if (readIf("PRECEDING")) {
             return new WindowFrameBound(WindowFrameBoundType.PRECEDING, value);
         }
         read("FOLLOWING");
         return new WindowFrameBound(WindowFrameBoundType.FOLLOWING, value);
-    }
-
-    private Expression readValueOrParameter() {
-        int index = parseIndex;
-        Expression value = readExpression();
-        if (!(value instanceof ValueExpression) && !(value instanceof Parameter)) {
-            parseIndex = index;
-            throw getSyntaxError();
-        }
-        return value;
     }
 
     private AggregateType getAggregateType(String name) {

--- a/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/AbstractAggregate.java
@@ -98,7 +98,9 @@ public abstract class AbstractAggregate extends DataAnalysisOperation {
             aggregateFastPartition(session, result, ordered, rowIdColumn, grouped);
             return;
         }
-        if (frame.getExclusion() == WindowFrameExclusion.EXCLUDE_NO_OTHERS) {
+        if (frame.isVariableBounds()) {
+            grouped = false;
+        } else if (frame.getExclusion() == WindowFrameExclusion.EXCLUDE_NO_OTHERS) {
             WindowFrameBound following = frame.getFollowing();
             boolean unboundedFollowing = following != null
                     && following.getType() == WindowFrameBoundType.UNBOUNDED_FOLLOWING;
@@ -117,10 +119,11 @@ public abstract class AbstractAggregate extends DataAnalysisOperation {
         }
         // All other types of frames (slow)
         int size = ordered.size();
+        int frameParametersOffset = getWindowFrameParametersOffset();
         for (int i = 0; i < size;) {
             Object aggregateData = createAggregateData();
-            for (Iterator<Value[]> iter = WindowFrame.iterator(over, session, ordered, getOverOrderBySort(), i,
-                    false); iter.hasNext();) {
+            for (Iterator<Value[]> iter = WindowFrame.iterator(over, session, ordered, getOverOrderBySort(),
+                    frameParametersOffset, i, false); iter.hasNext();) {
                 updateFromExpressions(session, aggregateData, iter.next());
             }
             Value r = getAggregatedValue(session, aggregateData);

--- a/h2/src/main/org/h2/expression/analysis/DataAnalysisOperation.java
+++ b/h2/src/main/org/h2/expression/analysis/DataAnalysisOperation.java
@@ -161,12 +161,19 @@ public abstract class DataAnalysisOperation extends Expression {
             }
             WindowFrame frame = over.getWindowFrame();
             if (frame != null) {
+                int index = getNumExpressions();
+                if (orderBy != null) {
+                    index += orderBy.size();
+                }
                 int n = 0;
-                if (frame.getStarting().isVariable()) {
+                WindowFrameBound bound = frame.getStarting();
+                if (bound.isVariable()) {
+                    bound.setExpressionIndex(index);
                     n++;
                 }
-                WindowFrameBound following = frame.getFollowing();
-                if (following != null && following.isVariable()) {
+                bound = frame.getFollowing();
+                if (bound != null && bound.isVariable()) {
+                    bound.setExpressionIndex(index + n);
                     n++;
                 }
                 numFrameExpressions = n;
@@ -356,20 +363,6 @@ public abstract class DataAnalysisOperation extends Expression {
         }
         return over == null ? getAggregatedValue(session, getGroupData(groupData, true))
                 : getWindowResult(session, groupData);
-    }
-
-    /**
-     * Returns offset of window frame parameters.
-     *
-     * @return offset of window frame parameters
-     */
-    protected final int getWindowFrameParametersOffset() {
-        int frameParametersOffset = getNumExpressions();
-        ArrayList<SelectOrderBy> orderBy = over.getOrderBy();
-        if (orderBy != null) {
-            frameParametersOffset += orderBy.size();
-        }
-        return frameParametersOffset;
     }
 
     /**

--- a/h2/src/main/org/h2/expression/analysis/Window.java
+++ b/h2/src/main/org/h2/expression/analysis/Window.java
@@ -66,7 +66,7 @@ public final class Window {
      * @param orderBy
      *            ORDER BY clause, or null
      * @param frame
-     *            window frame clause
+     *            window frame clause, or null
      */
     public Window(String parent, ArrayList<Expression> partitionBy, ArrayList<SelectOrderBy> orderBy,
             WindowFrame frame) {
@@ -96,6 +96,9 @@ public final class Window {
             for (SelectOrderBy o : orderBy) {
                 o.expression.mapColumns(resolver, level, Expression.MAP_IN_WINDOW);
             }
+        }
+        if (frame != null) {
+            frame.mapColumns(resolver, level, Expression.MAP_IN_WINDOW);
         }
     }
 
@@ -135,6 +138,9 @@ public final class Window {
             for (SelectOrderBy o : orderBy) {
                 o.expression = o.expression.optimize(session);
             }
+        }
+        if (frame != null) {
+            frame.optimize(session);
         }
     }
 
@@ -252,6 +258,9 @@ public final class Window {
             for (SelectOrderBy o : orderBy) {
                 o.expression.updateAggregate(session, stage);
             }
+        }
+        if (frame != null) {
+            frame.updateAggregate(session, stage);
         }
     }
 

--- a/h2/src/main/org/h2/expression/analysis/WindowFrame.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFrame.java
@@ -232,6 +232,8 @@ public final class WindowFrame {
      *            the session
      * @param orderedRows
      *            ordered rows
+     * @param frameParametersOffset
+     *            offset of window frame parameters
      * @param sortOrder
      *            sort order
      * @param currentRow
@@ -241,11 +243,11 @@ public final class WindowFrame {
      *             if over is not null and its exclusion clause is not EXCLUDE
      *             NO OTHERS
      */
-    public static int getEndIndex(Window over, Session session, ArrayList<Value[]> orderedRows, SortOrder sortOrder,
-            int currentRow) {
+    public static int getEndIndex(Window over, Session session, ArrayList<Value[]> orderedRows,
+            int frameParametersOffset, SortOrder sortOrder, int currentRow) {
         WindowFrame frame = over.getWindowFrame();
         if (frame != null) {
-            return frame.getEndIndex(session, orderedRows, sortOrder, currentRow);
+            return frame.getEndIndex(session, orderedRows, frameParametersOffset, sortOrder, currentRow);
         }
         int endIndex = orderedRows.size() - 1;
         return over.getOrderBy() == null ? endIndex : toGroupEnd(orderedRows, sortOrder, currentRow, endIndex);
@@ -505,6 +507,8 @@ public final class WindowFrame {
      *            the session
      * @param orderedRows
      *            ordered rows
+     * @param frameParametersOffset
+     *            offset of window frame parameters
      * @param sortOrder
      *            sort order
      * @param currentRow
@@ -513,11 +517,12 @@ public final class WindowFrame {
      * @throws UnsupportedOperationException
      *             if exclusion clause is not EXCLUDE NO OTHERS
      */
-    public int getStartIndex(Session session, ArrayList<Value[]> orderedRows, SortOrder sortOrder, int currentRow) {
+    public int getStartIndex(Session session, ArrayList<Value[]> orderedRows, int frameParametersOffset,
+            SortOrder sortOrder, int currentRow) {
         if (exclusion != WindowFrameExclusion.EXCLUDE_NO_OTHERS) {
             throw new UnsupportedOperationException();
         }
-        int startIndex = getIndex(session, orderedRows, sortOrder, currentRow, starting, -1, false);
+        int startIndex = getIndex(session, orderedRows, sortOrder, currentRow, starting, frameParametersOffset, false);
         if (startIndex < 0) {
             startIndex = 0;
         }
@@ -531,6 +536,8 @@ public final class WindowFrame {
      *            the session
      * @param orderedRows
      *            ordered rows
+     * @param frameParametersOffset
+     *            offset of window frame parameters
      * @param sortOrder
      *            sort order
      * @param currentRow
@@ -539,11 +546,17 @@ public final class WindowFrame {
      * @throws UnsupportedOperationException
      *             if exclusion clause is not EXCLUDE NO OTHERS
      */
-    private int getEndIndex(Session session, ArrayList<Value[]> orderedRows, SortOrder sortOrder, int currentRow) {
+    private int getEndIndex(Session session, ArrayList<Value[]> orderedRows, int frameParametersOffset,
+            SortOrder sortOrder, int currentRow) {
         if (exclusion != WindowFrameExclusion.EXCLUDE_NO_OTHERS) {
             throw new UnsupportedOperationException();
         }
-        int endIndex = following != null ? getIndex(session, orderedRows, sortOrder, currentRow, following, -1, true)
+        int followingOffset = frameParametersOffset;
+        if (starting.isVariable()) {
+            followingOffset++;
+        }
+        int endIndex = following != null
+                ? getIndex(session, orderedRows, sortOrder, currentRow, following, followingOffset, true)
                 : units == WindowFrameUnits.ROWS ? currentRow
                         : toGroupEnd(orderedRows, sortOrder, currentRow, orderedRows.size() - 1);
         int size = orderedRows.size();

--- a/h2/src/main/org/h2/expression/analysis/WindowFrameBound.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFrameBound.java
@@ -20,6 +20,8 @@ public class WindowFrameBound {
 
     private boolean isVariable;
 
+    private int expressionIndex = -1;
+
     /**
      * Creates new instance of window frame bound.
      *
@@ -63,6 +65,25 @@ public class WindowFrameBound {
      */
     public boolean isVariable() {
         return isVariable;
+    }
+
+    /**
+     * Returns the index of preserved expression.
+     *
+     * @return the index of preserved expression, or -1
+     */
+    public int getExpressionIndex() {
+        return expressionIndex;
+    }
+
+    /**
+     * Sets the index of preserved expression.
+     *
+     * @param expressionIndex
+     *            the index to set
+     */
+    void setExpressionIndex(int expressionIndex) {
+        this.expressionIndex = expressionIndex;
     }
 
     /**

--- a/h2/src/main/org/h2/expression/analysis/WindowFunction.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFunction.java
@@ -349,18 +349,19 @@ public class WindowFunction extends DataAnalysisOperation {
 
     private void getNth(Session session, HashMap<Integer, Value> result, ArrayList<Value[]> ordered, int rowIdColumn) {
         int size = ordered.size();
+        int frameParametersOffset = getWindowFrameParametersOffset();
         for (int i = 0; i < size; i++) {
             Value[] row = ordered.get(i);
             int rowId = row[rowIdColumn].getInt();
             Value v;
             switch (type) {
             case FIRST_VALUE:
-                v = getNthValue(WindowFrame.iterator(over, session, ordered, getOverOrderBySort(), i, false), 0,
-                        ignoreNulls);
+                v = getNthValue(WindowFrame.iterator(over, session, ordered, getOverOrderBySort(),
+                        frameParametersOffset, i, false), 0, ignoreNulls);
                 break;
             case LAST_VALUE:
-                v = getNthValue(WindowFrame.iterator(over, session, ordered, getOverOrderBySort(), i, true), 0,
-                        ignoreNulls);
+                v = getNthValue(WindowFrame.iterator(over, session, ordered, getOverOrderBySort(),
+                        frameParametersOffset, i, true), 0, ignoreNulls);
                 break;
             case NTH_VALUE: {
                 int n = row[1].getInt();
@@ -368,8 +369,8 @@ public class WindowFunction extends DataAnalysisOperation {
                     throw DbException.getInvalidValueException("nth row", n);
                 }
                 n--;
-                Iterator<Value[]> iter = WindowFrame.iterator(over, session, ordered, getOverOrderBySort(), i,
-                        fromLast);
+                Iterator<Value[]> iter = WindowFrame.iterator(over, session, ordered, getOverOrderBySort(),
+                        frameParametersOffset, i, fromLast);
                 v = getNthValue(iter, n, ignoreNulls);
                 break;
             }

--- a/h2/src/main/org/h2/expression/analysis/WindowFunction.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFunction.java
@@ -349,19 +349,18 @@ public class WindowFunction extends DataAnalysisOperation {
 
     private void getNth(Session session, HashMap<Integer, Value> result, ArrayList<Value[]> ordered, int rowIdColumn) {
         int size = ordered.size();
-        int frameParametersOffset = getWindowFrameParametersOffset();
         for (int i = 0; i < size; i++) {
             Value[] row = ordered.get(i);
             int rowId = row[rowIdColumn].getInt();
             Value v;
             switch (type) {
             case FIRST_VALUE:
-                v = getNthValue(WindowFrame.iterator(over, session, ordered, getOverOrderBySort(),
-                        frameParametersOffset, i, false), 0, ignoreNulls);
+                v = getNthValue(WindowFrame.iterator(over, session, ordered, getOverOrderBySort(), i, false), 0,
+                        ignoreNulls);
                 break;
             case LAST_VALUE:
-                v = getNthValue(WindowFrame.iterator(over, session, ordered, getOverOrderBySort(),
-                        frameParametersOffset, i, true), 0, ignoreNulls);
+                v = getNthValue(WindowFrame.iterator(over, session, ordered, getOverOrderBySort(), i, true), 0,
+                        ignoreNulls);
                 break;
             case NTH_VALUE: {
                 int n = row[1].getInt();
@@ -369,8 +368,8 @@ public class WindowFunction extends DataAnalysisOperation {
                     throw DbException.getInvalidValueException("nth row", n);
                 }
                 n--;
-                Iterator<Value[]> iter = WindowFrame.iterator(over, session, ordered, getOverOrderBySort(),
-                        frameParametersOffset, i, fromLast);
+                Iterator<Value[]> iter = WindowFrame.iterator(over, session, ordered, getOverOrderBySort(), i,
+                        fromLast);
                 v = getNthValue(iter, n, ignoreNulls);
                 break;
             }

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/array-agg.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/array-agg.sql
@@ -614,5 +614,25 @@ SELECT ID, VALUE,
 > 8  4     [1, 2, 3, 4, 5, 6, 7, 8] [4, 5, 6, 7, 8]          [1, 2, 3, 4, 5, 6, 7, 8] [4, 5, 6, 7, 8]
 > rows: 8
 
+SELECT ID, VALUE,
+    ARRAY_AGG(ID ORDER BY ID) OVER
+        (PARTITION BY VALUE ORDER BY ID ROWS BETWEEN VALUE / 3 PRECEDING AND VALUE / 3 FOLLOWING) A,
+    ARRAY_AGG(ID ORDER BY ID) OVER
+        (PARTITION BY VALUE ORDER BY ID ROWS BETWEEN UNBOUNDED PRECEDING AND VALUE / 3 FOLLOWING) AP,
+    ARRAY_AGG(ID ORDER BY ID) OVER
+        (PARTITION BY VALUE ORDER BY ID ROWS BETWEEN VALUE / 3 PRECEDING AND UNBOUNDED FOLLOWING) AF
+    FROM TEST;
+> ID VALUE A      AP     AF
+> -- ----- ------ ------ ------
+> 1  1     [1]    [1]    [1, 2]
+> 2  1     [2]    [1, 2] [2]
+> 3  2     [3]    [3]    [3, 4]
+> 4  2     [4]    [3, 4] [4]
+> 5  3     [5, 6] [5, 6] [5, 6]
+> 6  3     [5, 6] [5, 6] [5, 6]
+> 7  4     [7, 8] [7, 8] [7, 8]
+> 8  4     [7, 8] [7, 8] [7, 8]
+> rows: 8
+
 DROP TABLE TEST;
 > ok

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/array-agg.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/array-agg.sql
@@ -596,5 +596,23 @@ SELECT ID, VALUE,
 > 8  4     [1, 2, 3, 4, 5, 6, 7, 8] [8]                      [1, 2, 3, 4, 5, 6, 7, 8] [7, 8]                   [1, 2, 3, 4, 5, 6, 7, 8] [7, 8]
 > rows: 8
 
+SELECT ID, VALUE,
+    ARRAY_AGG(ID ORDER BY ID) OVER (ORDER BY ID RANGE BETWEEN UNBOUNDED PRECEDING AND VALUE FOLLOWING) RG,
+    ARRAY_AGG(ID ORDER BY ID) OVER (ORDER BY ID RANGE BETWEEN VALUE PRECEDING AND UNBOUNDED FOLLOWING) RGR,
+    ARRAY_AGG(ID ORDER BY ID) OVER (ORDER BY ID ROWS BETWEEN UNBOUNDED PRECEDING AND VALUE FOLLOWING) R,
+    ARRAY_AGG(ID ORDER BY ID) OVER (ORDER BY ID ROWS BETWEEN VALUE PRECEDING AND UNBOUNDED FOLLOWING) RR
+    FROM TEST;
+> ID VALUE RG                       RGR                      R                        RR
+> -- ----- ------------------------ ------------------------ ------------------------ ------------------------
+> 1  1     [1, 2]                   [1, 2, 3, 4, 5, 6, 7, 8] [1, 2]                   [1, 2, 3, 4, 5, 6, 7, 8]
+> 2  1     [1, 2, 3]                [1, 2, 3, 4, 5, 6, 7, 8] [1, 2, 3]                [1, 2, 3, 4, 5, 6, 7, 8]
+> 3  2     [1, 2, 3, 4, 5]          [1, 2, 3, 4, 5, 6, 7, 8] [1, 2, 3, 4, 5]          [1, 2, 3, 4, 5, 6, 7, 8]
+> 4  2     [1, 2, 3, 4, 5, 6]       [2, 3, 4, 5, 6, 7, 8]    [1, 2, 3, 4, 5, 6]       [2, 3, 4, 5, 6, 7, 8]
+> 5  3     [1, 2, 3, 4, 5, 6, 7, 8] [2, 3, 4, 5, 6, 7, 8]    [1, 2, 3, 4, 5, 6, 7, 8] [2, 3, 4, 5, 6, 7, 8]
+> 6  3     [1, 2, 3, 4, 5, 6, 7, 8] [3, 4, 5, 6, 7, 8]       [1, 2, 3, 4, 5, 6, 7, 8] [3, 4, 5, 6, 7, 8]
+> 7  4     [1, 2, 3, 4, 5, 6, 7, 8] [3, 4, 5, 6, 7, 8]       [1, 2, 3, 4, 5, 6, 7, 8] [3, 4, 5, 6, 7, 8]
+> 8  4     [1, 2, 3, 4, 5, 6, 7, 8] [4, 5, 6, 7, 8]          [1, 2, 3, 4, 5, 6, 7, 8] [4, 5, 6, 7, 8]
+> rows: 8
+
 DROP TABLE TEST;
 > ok

--- a/h2/src/test/org/h2/test/scripts/functions/window/nth_value.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/window/nth_value.sql
@@ -252,3 +252,13 @@ SELECT I, X, LAST_VALUE(I) OVER (ORDER BY X) L FROM VALUES (1, 1), (2, 1), (3, 2
 > 4 2 4
 > 5 3 5
 > rows: 5
+
+SELECT A, MAX(B) M, FIRST_VALUE(A) OVER (ORDER BY A ROWS BETWEEN MAX(B) - 1 FOLLOWING AND UNBOUNDED FOLLOWING) F
+    FROM VALUES (1, 1), (1, 1), (2, 1), (2, 2), (3, 1) V(A, B)
+    GROUP BY A;
+> A M F
+> - - -
+> 1 1 1
+> 2 2 3
+> 3 1 3
+> rows: 3

--- a/h2/src/test/org/h2/test/scripts/functions/window/nth_value.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/window/nth_value.sql
@@ -218,6 +218,28 @@ SELECT ID, CATEGORY,
 > 13 4        1  1  1  2  3  4
 > rows (ordered): 13
 
+SELECT ID, CATEGORY,
+    FIRST_VALUE(ID) OVER (ORDER BY ID ROWS BETWEEN CATEGORY FOLLOWING AND UNBOUNDED FOLLOWING) F,
+    LAST_VALUE(ID) OVER (ORDER BY ID ROWS BETWEEN CURRENT ROW AND CATEGORY FOLLOWING) L,
+    NTH_VALUE(ID, 2) OVER (ORDER BY ID ROWS BETWEEN CATEGORY FOLLOWING AND UNBOUNDED FOLLOWING) N
+    FROM TEST ORDER BY ID;
+> ID CATEGORY F    L  N
+> -- -------- ---- -- ----
+> 1  1        2    2  3
+> 2  1        3    3  4
+> 3  1        4    4  5
+> 4  1        5    5  6
+> 5  1        6    6  7
+> 6  1        7    7  8
+> 7  2        9    9  10
+> 8  2        10   10 11
+> 9  3        12   12 13
+> 10 3        13   13 null
+> 11 3        null 13 null
+> 12 4        null 13 null
+> 13 4        null 13 null
+> rows (ordered): 13
+
 DROP TABLE TEST;
 > ok
 

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -805,4 +805,4 @@ queryparser tokenized freeze factorings recompilation unenclosed rfe dsync
 econd irst bcef ordinality nord unnest
 analyst occupation distributive josaph aor engineer sajeewa isuru randil kevin doctor businessman artist ashan
 corrupts splitted disruption unintentional octets preconditions predicates subq objectweb insn opcodes
-preserves masking holder unboxing avert iae transformed subtle reevaluate exclusions subclause ftbl
+preserves masking holder unboxing avert iae transformed subtle reevaluate exclusions subclause ftbl rgr


### PR DESCRIPTION
Expressions in bounds of window frames were initially limited to direct values or parameters. This limitation is removed here.

For constant expressions behavior is the same.

For non-constant expressions their values are saved together with values of other expressions. If values are anyway the same within a partition all optimized implementations are available. If they are not the same within the partition all optimizations are disabled.
