### PR TITLE
Ignore errors in MySQL compatibility DATE() function

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1668: MySQL compatibility DATE() function should return NULL on error
+</li>
 <li>Issue #1604: TestCrashAPI: PreparedStatement.getGeneratedKeys() is already closed
 </li>
 <li>PR #1667: Detect NULL values and overflow in window frame bounds

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -22,6 +22,7 @@ import org.h2.util.StringUtils;
 import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueInt;
+import org.h2.value.ValueNull;
 import org.h2.value.ValueString;
 
 /**
@@ -229,7 +230,11 @@ public class FunctionsMySQL extends FunctionsBase {
                 result = v0;
                 break;
             default:
-                v0 = v0.convertTo(Value.TIMESTAMP);
+                try {
+                    v0 = v0.convertTo(Value.TIMESTAMP);
+                } catch (DbException ex) {
+                    v0 = ValueNull.INSTANCE;
+                }
                 //$FALL-THROUGH$
             case Value.TIMESTAMP:
             case Value.TIMESTAMP_TZ:

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -312,16 +312,12 @@ public class TestCompatibility extends TestDb {
         stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR)");
         stat.execute("INSERT INTO TEST VALUES(1, 'Hello'), (2, 'World')");
         assertResult("0", stat, "SELECT UNIX_TIMESTAMP('1970-01-01 00:00:00Z')");
-        assertResult("1196418619", stat,
-                "SELECT UNIX_TIMESTAMP('2007-11-30 10:30:19Z')");
-        assertResult("1196418619", stat,
-                "SELECT UNIX_TIMESTAMP(FROM_UNIXTIME(1196418619))");
-        assertResult("2007 November", stat,
-                "SELECT FROM_UNIXTIME(1196300000, '%Y %M')");
-        assertResult("2003-12-31", stat,
-                "SELECT DATE('2003-12-31 11:02:03')");
-        assertResult("2003-12-31", stat,
-                "SELECT DATE('2003-12-31 11:02:03')");
+        assertResult("1196418619", stat, "SELECT UNIX_TIMESTAMP('2007-11-30 10:30:19Z')");
+        assertResult("1196418619", stat, "SELECT UNIX_TIMESTAMP(FROM_UNIXTIME(1196418619))");
+        assertResult("2007 November", stat, "SELECT FROM_UNIXTIME(1196300000, '%Y %M')");
+        assertResult("2003-12-31", stat, "SELECT DATE('2003-12-31 11:02:03')");
+        assertResult("2003-12-31", stat, "SELECT DATE('2003-12-31 11:02:03')");
+        assertResult(null, stat, "SELECT DATE('100')");
         // check the weird MySQL variant of DELETE
         stat.execute("DELETE TEST FROM TEST WHERE 1=2");
 


### PR DESCRIPTION
A trivial fix for issue #1668.