### PR TITLE
Deadlock on MVStore closure due to OOM

### DIFF
--- a/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
+++ b/h2/src/test/org/h2/test/db/TestAnalyzeTableTx.java
@@ -25,31 +25,35 @@ public class TestAnalyzeTableTx extends TestDb {
 
     @Override
     public boolean isEnabled() {
-        if (config.networked || config.big) {
-            return false;
-        }
-        return true;
+        return !config.networked && !config.big;
     }
 
     @Override
     public void test() throws Exception {
         deleteDb(getTestName());
-        Connection shared = getConnection(getTestName());
-        Statement statement = shared.createStatement();
-        statement.executeUpdate("DROP TABLE IF EXISTS TEST");
-        statement.executeUpdate("CREATE TABLE TEST(ID INT PRIMARY KEY)");
         Connection[] connections = new Connection[C];
-        for (int i = 0; i < C; i++) {
-            Connection c = getConnection(getTestName());
-            c.createStatement().executeUpdate("INSERT INTO TEST VALUES (" + i + ')');
-            connections[i] = c;
-        }
-        try (ResultSet rs = statement.executeQuery("SELECT * FROM TEST")) {
+        try (Connection shared = getConnection(getTestName())) {
+            Statement statement = shared.createStatement();
+            statement.executeUpdate("DROP TABLE IF EXISTS TEST");
+            statement.executeUpdate("CREATE TABLE TEST(ID INT PRIMARY KEY)");
             for (int i = 0; i < C; i++) {
-                if (!rs.next())
-                    throw new Exception("next");
-                if (rs.getInt(1) != i)
-                    throw new Exception(Integer.toString(i));
+                Connection c = getConnection(getTestName());
+                c.createStatement().executeUpdate("INSERT INTO TEST VALUES (" + i + ')');
+                connections[i] = c;
+            }
+            try (ResultSet rs = statement.executeQuery("SELECT * FROM TEST")) {
+                for (int i = 0; i < C; i++) {
+                    if (!rs.next())
+                        throw new Exception("next");
+                    if (rs.getInt(1) != i)
+                        throw new Exception(Integer.toString(i));
+                }
+            }
+        } finally {
+            for (Connection connection : connections) {
+                if (connection != null) {
+                    try { connection.close(); } catch (Throwable ignore) {/**/}
+                }
             }
         }
     }


### PR DESCRIPTION
Fix for Issue #1672. 
MVStore.state is switched back to volatile from Atomic because any changes are made under storeLock.
isClosed() is waiting for storeLock as well, instead of sleeping.

Also unrelated minor tests changes.