### PR TITLE
Fix NPE with ENUM in SelectUnion

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1665: TestCrashAPI: NPE with ENUM in MINUS operator
+</li>
+<li>Issue #1602: Combine type, precision, scale, display size and extTypeInfo into one object
+</li>
+<li>PR #1671: Assorted changes
+</li>
 <li>Issue #1668: MySQL compatibility DATE() function should return NULL on error
 </li>
 <li>Issue #1604: TestCrashAPI: PreparedStatement.getGeneratedKeys() is already closed

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -27,7 +27,6 @@ import org.h2.table.ColumnResolver;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
 import org.h2.util.ColumnNamer;
-import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueInt;
 import org.h2.value.ValueNull;
@@ -122,7 +121,7 @@ public class SelectUnion extends Query {
         Mode mode = session.getDatabase().getMode();
         for (int i = 0; i < columnCount; i++) {
             Expression e = expressions.get(i);
-            newValues[i] = values[i].convertTo(e.getType().getValueType(), mode);
+            newValues[i] = values[i].convertTo(e.getType(), mode, null);
         }
         return newValues;
     }
@@ -329,13 +328,8 @@ public class SelectUnion extends Query {
         for (int i = 0; i < len; i++) {
             Expression l = le.get(i);
             Expression r = re.get(i);
-            TypeInfo lType = l.getType(), rType = r.getType();
-            int type = Value.getHigherOrder(lType.getValueType(), rType.getValueType());
-            long prec = Math.max(lType.getPrecision(), rType.getPrecision());
-            int scale = Math.max(lType.getScale(), rType.getScale());
-            int displaySize = Math.max(lType.getDisplaySize(), rType.getDisplaySize());
-            String columnName = columnNamer.getColumnName(l,i,l.getAlias());
-            Column col = new Column(columnName, type, prec, scale, displaySize);
+            String columnName = columnNamer.getColumnName(l, i, l.getAlias());
+            Column col = new Column(columnName, Value.getHigherType(l.getType(), r.getType()));
             Expression e = new ExpressionColumn(session.getDatabase(), col);
             expressions.add(e);
         }

--- a/h2/src/main/org/h2/expression/BinaryOperation.java
+++ b/h2/src/main/org/h2/expression/BinaryOperation.java
@@ -202,7 +202,6 @@ public class BinaryOperation extends Expression {
                 int dataType = Value.getHigherOrder(l, r);
                 if (dataType == Value.ENUM) {
                     type = TypeInfo.TYPE_INT;
-                    dataType = Value.INT;
                 } else {
                     type = TypeInfo.getTypeInfo(dataType);
                     if (DataType.isStringType(dataType) && session.getDatabase().getMode().allowPlusForStringConcat) {

--- a/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/enum.sql
@@ -284,5 +284,20 @@ CREATE TABLE TEST(E ENUM('a', 'b'));
 EXPLAIN SELECT * FROM TEST WHERE E = 'a';
 >> SELECT TEST.E FROM PUBLIC.TEST /* PUBLIC.TEST.tableScan */ WHERE E = 'a'
 
+INSERT INTO TEST VALUES ('a');
+> update count: 1
+
+(SELECT * FROM TEST A) UNION ALL (SELECT * FROM TEST A);
+> E
+> -
+> a
+> a
+> rows: 2
+
+(SELECT * FROM TEST A) MINUS (SELECT * FROM TEST A);
+> E
+> -
+> rows: 0
+
 DROP TABLE TEST;
 > ok


### PR DESCRIPTION
Fixes #1665.

Some typos are fixed, useless assignment is removed, `Parser.parseValuesTable()` does not calculate upper type of two same types in the first row any more.