### PR TITLE
Store changes in pure append mode case

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1232,6 +1232,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                         }
                     }
                 } else {
+                    tip = tip.parent;
                     page = Page.createLeaf(this,
                             Arrays.copyOf(keysBuffer, keyCount),
                             Arrays.copyOf(valuesBuffer, keyCount),
@@ -1323,6 +1324,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @param value to be appended
      */
     public void append(K key, V value) {
+        beforeWrite();
         RootReference rootReference = lockRoot(getRoot(), 1);
         int appendCounter = rootReference.getAppendCounter();
         try {

--- a/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
@@ -62,14 +62,14 @@ class MVPlainTempResult extends MVTempResult {
         super(database, expressions.length, visibleColumnCount);
         ValueDataType valueType = new ValueDataType(database, new int[columnCount]);
         Builder<Long, ValueRow> builder = new MVMap.Builder<Long, ValueRow>()
-                                                .valueType(valueType);
+                                                .valueType(valueType).singleWriter();
         map = store.openMap("tmp", builder);
     }
 
     @Override
     public int addRow(Value[] values) {
         assert parent == null;
-        map.put(counter++, ValueRow.get(values));
+        map.append(counter++, ValueRow.get(values));
         return ++rowCount;
     }
 


### PR DESCRIPTION
This is fix for #1691. OOME was triggered by the fact that changes were never stored on disk, because in pure append mode check for unsaved memory was left out. This deficiency did not manifest itself in other uses of append mode, because store action was triggered by some other activities in the same MVStore.

- Invoke beforeWrite() in append mode
- Fix unsaved memory accounting in flushAppendBuffer
- Switched MVPlainTempResult back to append mode use.