### PR TITLE
Fix GROUP_CONCAT with variable separator

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3545,6 +3545,7 @@ GROUP_CONCAT ( [ DISTINCT|ALL ] string
 [FILTER (WHERE expression)] [OVER windowNameOrSpecification]
 ","
 Concatenates strings with a separator.
+Separator must be the same for all rows in the same group.
 The default separator is a ',' (without space).
 This method returns a string.
 If no rows are selected, the result is NULL.

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -181,6 +181,10 @@ public class Aggregate extends AbstractAggregate {
             if (v != ValueNull.INSTANCE) {
                 v = updateCollecting(session, v.convertTo(Value.STRING), remembered);
             }
+            if (args.length >= 2) {
+                ((AggregateDataCollecting) data).setSharedArgument(
+                        remembered != null ? remembered[1] : args[1].getValue(session));
+            }
             break;
         case ARRAY_AGG:
             if (v != ValueNull.INSTANCE) {
@@ -415,7 +419,8 @@ public class Aggregate extends AbstractAggregate {
     }
 
     private Value getGroupConcat(Session session, AggregateData data) {
-        Value[] array = ((AggregateDataCollecting) data).getArray();
+        AggregateDataCollecting collectingData = (AggregateDataCollecting) data;
+        Value[] array = collectingData.getArray();
         if (array == null) {
             return ValueNull.INSTANCE;
         }
@@ -423,7 +428,7 @@ public class Aggregate extends AbstractAggregate {
             sortWithOrderBy(array);
         }
         StatementBuilder buff = new StatementBuilder();
-        String sep = args.length < 2 ? "," : args[1].getValue(session).getString();
+        String sep = args.length < 2 ? "," : collectingData.getSharedArgument().getString();
         for (Value val : array) {
             String s;
             if (val.getValueType() == Value.ARRAY) {

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/group-concat.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/group-concat.sql
@@ -67,3 +67,32 @@ select group_concat(distinct v order by v desc) from test;
 
 drop table test;
 > ok
+
+create table test(g varchar, v int) as values ('-', 1), ('-', 2), ('-', 3), ('|', 4), ('|', 5), ('|', 6), ('*', null);
+> ok
+
+select g, group_concat(v separator g) from test group by g;
+> G GROUP_CONCAT(V SEPARATOR G)
+> - ---------------------------
+> * null
+> - 1-2-3
+> | 4|5|6
+> rows: 3
+
+select g, group_concat(v separator g) over (partition by g) from test order by v;
+> G GROUP_CONCAT(V SEPARATOR G) OVER (PARTITION BY G)
+> - -------------------------------------------------
+> * null
+> - 1-2-3
+> - 1-2-3
+> - 1-2-3
+> | 4|5|6
+> | 4|5|6
+> | 4|5|6
+> rows (ordered): 7
+
+select g, group_concat(v separator v) from test group by g;
+> exception INVALID_VALUE_2
+
+drop table test;
+> ok


### PR DESCRIPTION
`GROUP_CONCAT` wasn't able to handle non-constant `SEPARATOR` properly. This issue is fixed.

Other changes, especially a replacement of `Aggregate.on` with `AbstractAggregate.args[]`, are preparation work for hypothetical set functions that may have multiple arguments.

Special field for `GROUP_CONCAT` is also replaced with the second argument in array.