### PR TITLE
Fix sort order and ENUM data type in external results

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1707: Fix sort order and ENUM data type in external results
+</li>
 <li>PR #1706: Add hypothetical set functions
 </li>
 <li>PR #1705: Fix GROUP_CONCAT with variable separator

--- a/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPlainTempResult.java
@@ -59,8 +59,8 @@ class MVPlainTempResult extends MVTempResult {
      *            count of visible columns
      */
     MVPlainTempResult(Database database, Expression[] expressions, int visibleColumnCount) {
-        super(database, expressions.length, visibleColumnCount);
-        ValueDataType valueType = new ValueDataType(database, new int[columnCount]);
+        super(database, expressions, visibleColumnCount);
+        ValueDataType valueType = new ValueDataType(database, new int[expressions.length]);
         Builder<Long, ValueRow> builder = new MVMap.Builder<Long, ValueRow>()
                                                 .valueType(valueType).singleWriter();
         map = store.openMap("tmp", builder);
@@ -99,7 +99,11 @@ class MVPlainTempResult extends MVTempResult {
             return null;
         }
         cursor.next();
-        return cursor.getValue().getList();
+        Value[] currentRow = cursor.getValue().getList();
+        if (hasEnum) {
+            fixEnum(currentRow);
+        }
+        return currentRow;
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -136,9 +136,9 @@ public class ValueDataType implements DataType {
         if (a == b) {
             return 0;
         }
-        if (a instanceof ValueArray && b instanceof ValueArray) {
-            Value[] ax = ((ValueArray) a).getList();
-            Value[] bx = ((ValueArray) b).getList();
+        if (a instanceof ValueCollectionBase && b instanceof ValueCollectionBase) {
+            Value[] ax = ((ValueCollectionBase) a).getList();
+            Value[] bx = ((ValueCollectionBase) b).getList();
             int al = ax.length;
             int bl = bx.length;
             int len = Math.min(al, bl);

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -928,7 +928,6 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestCluster());
         addTest(new TestFileLockSerialized());
         addTest(new TestFileLockProcess());
-        addTest(new TestFileSystem());
         addTest(new TestDefrag());
         addTest(new TestTools());
         addTest(new TestSampleApps());
@@ -973,6 +972,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestDateIso8601());
         addTest(new TestDbException());
         addTest(new TestFile());
+        addTest(new TestFileSystem());
         addTest(new TestFtp());
         addTest(new TestGeometryUtils());
         addTest(new TestInterval());


### PR DESCRIPTION
1. Add support of row values to `ValueDataType`. Fixes a sorting regression with `DESC` / `NULLS …` order in `MVSortedTempResult`.

2. Add explicit type casts for `ENUM` values to external result. Before this change all implementations of external results returned them as integer values in some cases.