### PR TITLE
Backward compatibility patch for #1952

### DIFF
--- a/h2/src/main/org/h2/mvstore/Cursor.java
+++ b/h2/src/main/org/h2/mvstore/Cursor.java
@@ -154,7 +154,6 @@ public class Cursor<K, V> implements Iterator<K> {
     private static CursorPos traverseDown(Page p, Object key) {
         CursorPos cursorPos = null;
         while (!p.isLeaf()) {
-            assert p.getKeyCount() > 0;
             int index = 0;
             if(key != null) {
                 index = p.binarySearch(key) + 1;

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -294,7 +294,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
     @SuppressWarnings("unchecked")
     private K getFirstLast(boolean first) {
         Page p = getRootPage();
-        if (p.getKeyCount() == 0) {
+        if (p.getTotalCount() == 0) {
             return null;
         }
         while (true) {


### PR DESCRIPTION
This PR addresses issue #1592.
B-Tree internal nodes with single child and no keys, which can be produced by versions up to 1.4.197, should be processed correctly on get/cursor and eliminated on updates