### PR TITLE
Fix derived column list in complex queries

### DIFF
--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -39,6 +39,7 @@ public class ExpressionColumn extends Expression {
     private ColumnResolver columnResolver;
     private int queryLevel;
     private Column column;
+    private String derivedName;
 
     public ExpressionColumn(Database database, Column column) {
         this.database = database;
@@ -76,7 +77,11 @@ public class ExpressionColumn extends Expression {
             builder.append('.');
         }
         if (column != null) {
-            builder.append(column.getSQL());
+            if (derivedName != null) {
+                Parser.quoteIdentifier(builder, derivedName);
+            } else {
+                builder.append(column.getSQL());
+            }
         } else if (quote) {
             Parser.quoteIdentifier(builder, columnName);
         } else {
@@ -101,11 +106,18 @@ public class ExpressionColumn extends Expression {
         }
         for (Column col : resolver.getColumns()) {
             String n = resolver.getDerivedColumnName(col);
+            boolean derived;
             if (n == null) {
                 n = col.getName();
+                derived  = false;
+            } else {
+                derived = true;
             }
             if (database.equalsIdentifiers(columnName, n)) {
                 mapColumn(resolver, col, level);
+                if (derived) {
+                    derivedName = n;
+                }
                 return;
             }
         }

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -7,6 +7,7 @@ package org.h2.table;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import org.h2.api.ErrorCode;
 import org.h2.command.Parser;
@@ -122,7 +123,7 @@ public class TableFilter implements ColumnResolver {
     private final int hashCode;
     private final int orderInFrom;
 
-    private HashMap<Column, String> derivedColumnMap;
+    private LinkedHashMap<Column, String> derivedColumnMap;
 
     /**
      * Create a new table filter object.
@@ -801,6 +802,18 @@ public class TableFilter implements ColumnResolver {
         if (alias != null) {
             builder.append(' ');
             Parser.quoteIdentifier(builder, alias);
+            if (derivedColumnMap != null) {
+                builder.append('(');
+                boolean f = false;
+                for (String name : derivedColumnMap.values()) {
+                    if (f) {
+                        builder.append(", ");
+                    }
+                    f = true;
+                    Parser.quoteIdentifier(builder, name);
+                }
+                builder.append(')');
+            }
         }
         if (indexHints != null) {
             builder.append(" USE INDEX (");
@@ -1091,7 +1104,7 @@ public class TableFilter implements ColumnResolver {
         if (count != derivedColumnNames.size()) {
             throw DbException.get(ErrorCode.COLUMN_COUNT_DOES_NOT_MATCH);
         }
-        HashMap<Column, String> map = new HashMap<>();
+        LinkedHashMap<Column, String> map = new LinkedHashMap<>();
         for (int i = 0; i < count; i++) {
             String alias = derivedColumnNames.get(i);
             for (int j = 0; j < i; j++) {

--- a/h2/src/test/org/h2/test/scripts/dml/select.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/select.sql
@@ -602,3 +602,26 @@ FROM (SELECT 1 X), (VALUES (1, 2), (2, 1), (3, 3)) T(A, B);
 > 1 2 1
 > 1 3 3
 > rows: 3
+
+SELECT A, B, C FROM (SELECT A, B, C FROM (VALUES (1, 2, 3)) V(A, B, C));
+> A B C
+> - - -
+> 1 2 3
+> rows: 1
+
+SELECT * FROM (SELECT * FROM (VALUES (1, 2, 3)) V(A, B, C));
+> A B C
+> - - -
+> 1 2 3
+> rows: 1
+
+SELECT * FROM
+    (SELECT X * X, Y FROM
+        (SELECT A + 5, B FROM
+            (VALUES (1, 2)) V(A, B)
+        ) T(X, Y)
+    );
+> X * X Y
+> ----- -
+> 36    2
+> rows: 1

--- a/h2/src/test/org/h2/test/scripts/dml/select.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/select.sql
@@ -603,6 +603,14 @@ FROM (SELECT 1 X), (VALUES (1, 2), (2, 1), (3, 3)) T(A, B);
 > 1 3 3
 > rows: 3
 
+SELECT A, SUM(S) OVER (ORDER BY S) FROM
+    (SELECT A, SUM(B) FROM (VALUES (1, 2), (1, 3), (3, 5), (3, 10)) V(A, B) GROUP BY A) S(A, S);
+> A SUM(S) OVER (ORDER BY S)
+> - ------------------------
+> 1 5
+> 3 20
+> rows: 2
+
 SELECT A, B, C FROM (SELECT A, B, C FROM (VALUES (1, 2, 3)) V(A, B, C));
 > A B C
 > - - -

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/histogram.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/histogram.sql
@@ -4,20 +4,20 @@
 --
 
 SELECT HISTOGRAM(X), HISTOGRAM(DISTINCT X) FROM VALUES (1), (2), (3), (1), (2), (NULL), (5) T(X);
-> HISTOGRAM(C1)                               HISTOGRAM(DISTINCT C1)
+> HISTOGRAM(X)                                HISTOGRAM(DISTINCT X)
 > ------------------------------------------- -------------------------------------------
 > [[null, 1], [1, 2], [2, 2], [3, 1], [5, 1]] [[null, 1], [1, 1], [2, 1], [3, 1], [5, 1]]
 > rows: 1
 
 SELECT HISTOGRAM(X) FILTER (WHERE X > 1), HISTOGRAM(DISTINCT X) FILTER (WHERE X > 1)
     FROM VALUES (1), (2), (3), (1), (2), (NULL), (5) T(X);
-> HISTOGRAM(C1) FILTER (WHERE (C1 > 1)) HISTOGRAM(DISTINCT C1) FILTER (WHERE (C1 > 1))
-> ------------------------------------- ----------------------------------------------
-> [[2, 2], [3, 1], [5, 1]]              [[2, 1], [3, 1], [5, 1]]
+> HISTOGRAM(X) FILTER (WHERE (X > 1)) HISTOGRAM(DISTINCT X) FILTER (WHERE (X > 1))
+> ----------------------------------- --------------------------------------------
+> [[2, 2], [3, 1], [5, 1]]            [[2, 1], [3, 1], [5, 1]]
 > rows: 1
 
-SELECT HISTOGRAM(X) FILTER (WHERE X > 0), HISTOGRAM(DISTINCT X) FILTER (WHERE X > 0)  FROM VALUES (0) T(X);
-> HISTOGRAM(C1) FILTER (WHERE (C1 > 0)) HISTOGRAM(DISTINCT C1) FILTER (WHERE (C1 > 0))
-> ------------------------------------- ----------------------------------------------
-> []                                    []
+SELECT HISTOGRAM(X) FILTER (WHERE X > 0), HISTOGRAM(DISTINCT X) FILTER (WHERE X > 0) FROM VALUES (0) T(X);
+> HISTOGRAM(X) FILTER (WHERE (X > 0)) HISTOGRAM(DISTINCT X) FILTER (WHERE (X > 0))
+> ----------------------------------- --------------------------------------------
+> []                                  []
 > rows: 1


### PR DESCRIPTION
1. Standard derived column list syntax didn't work when query was nested into another query and so on. Also derived names of columns weren't returned in metadata.

2. A fix for issue #1718 is reimplemented to avoid additional field reads in non-grouped non-window queries. A new test case also ensures that subqueries with own grouping scope do not interact with outer query.