### PR TITLE
Detect unsupported URLs for the driver in JdbcUtils.getConnection()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1730: console can no longer connect to psql dbs in v1.4.197 (works in v1.4.196)
+</li>
 <li>Issue #1590: Error on executing "DELETE FROM table1 WHERE ID = ?; DELETE FROM table2 WHERE ID = ?;"
 </li>
 <li>Issue #1727: Support ISODOW as identifier for the extract function additional to ISO_DAY_OF_WEEK

--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -724,7 +724,6 @@ public class WebServer implements Service {
             String password) throws SQLException {
         driver = driver.trim();
         databaseUrl = databaseUrl.trim();
-        org.h2.Driver.load();
         Properties p = new Properties();
         p.setProperty("user", user.trim());
         // do not trim the password, otherwise an
@@ -734,19 +733,7 @@ public class WebServer implements Service {
             if (ifExists) {
                 databaseUrl += ";IFEXISTS=TRUE";
             }
-            // PostgreSQL would throw a NullPointerException
-            // if it is loaded before the H2 driver
-            // because it can't deal with non-String objects in the connection
-            // Properties
-            return org.h2.Driver.load().connect(databaseUrl, p);
         }
-//            try {
-//                Driver dr = (Driver) urlClassLoader.
-//                        loadClass(driver).newInstance();
-//                return dr.connect(url, p);
-//            } catch(ClassNotFoundException e2) {
-//                throw e2;
-//            }
         return JdbcUtils.getConnection(driver, databaseUrl, p);
     }
 

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -300,10 +300,7 @@ public class JdbcUtils {
                     if (connection != null) {
                         return connection;
                     }
-                    /*
-                     * URL is not valid for the specified driver, fallback to
-                     * default.
-                     */
+                    throw new SQLException("Driver " + driver + " is not suitable for " + url, "08001");
                 } else if (javax.naming.Context.class.isAssignableFrom(d)) {
                     // JNDI context
                     Context context = (Context) d.getDeclaredConstructor().newInstance();

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -288,17 +288,24 @@ public class JdbcUtils {
             JdbcUtils.load(url);
         } else {
             Class<?> d = loadUserClass(driver);
-            if (java.sql.Driver.class.isAssignableFrom(d)) {
-                try {
+            try {
+                if (java.sql.Driver.class.isAssignableFrom(d)) {
                     Driver driverInstance = (Driver) d.getDeclaredConstructor().newInstance();
-                    return driverInstance.connect(url, prop); /*fix issue #695 with drivers with the same
-                    jdbc subprotocol in classpath of jdbc drivers (as example redshift and postgresql drivers)*/
-                } catch (Exception e) {
-                    throw DbException.toSQLException(e);
-                }
-            } else if (javax.naming.Context.class.isAssignableFrom(d)) {
-                // JNDI context
-                try {
+                    /*
+                     * fix issue #695 with drivers with the same jdbc
+                     * subprotocol in classpath of jdbc drivers (as example
+                     * redshift and postgresql drivers)
+                     */
+                    Connection connection = driverInstance.connect(url, prop);
+                    if (connection != null) {
+                        return connection;
+                    }
+                    /*
+                     * URL is not valid for the specified driver, fallback to
+                     * default.
+                     */
+                } else if (javax.naming.Context.class.isAssignableFrom(d)) {
+                    // JNDI context
                     Context context = (Context) d.getDeclaredConstructor().newInstance();
                     DataSource ds = (DataSource) context.lookup(url);
                     String user = prop.getProperty("user");
@@ -307,13 +314,11 @@ public class JdbcUtils {
                         return ds.getConnection();
                     }
                     return ds.getConnection(user, password);
-                } catch (Exception e) {
-                    throw DbException.toSQLException(e);
                 }
-            } else {
-                // don't know, but maybe it loaded a JDBC Driver
-                return DriverManager.getConnection(url, prop);
+            } catch (Exception e) {
+                throw DbException.toSQLException(e);
             }
+            // don't know, but maybe it loaded a JDBC Driver
         }
         return DriverManager.getConnection(url, prop);
     }

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -510,12 +510,15 @@ public class TestTools extends TestDb {
     }
 
     private void testJdbcDriverUtils() {
-        assertEquals("org.h2.Driver",
-                JdbcUtils.getDriver("jdbc:h2:~/test"));
-        assertEquals("org.postgresql.Driver",
-                JdbcUtils.getDriver("jdbc:postgresql:test"));
-        assertEquals(null,
-                JdbcUtils.getDriver("jdbc:unknown:test"));
+        assertEquals("org.h2.Driver", JdbcUtils.getDriver("jdbc:h2:~/test"));
+        assertEquals("org.postgresql.Driver", JdbcUtils.getDriver("jdbc:postgresql:test"));
+        assertEquals(null, JdbcUtils.getDriver("jdbc:unknown:test"));
+        try {
+            JdbcUtils.getConnection("org.h2.Driver", "jdbc:h2x:test", "sa", "");
+            fail("Expected SQLException: No suitable driver found");
+        } catch (SQLException e) {
+            // OK
+        }
     }
 
     private void testWrongServer() throws Exception {

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -515,9 +515,9 @@ public class TestTools extends TestDb {
         assertEquals(null, JdbcUtils.getDriver("jdbc:unknown:test"));
         try {
             JdbcUtils.getConnection("org.h2.Driver", "jdbc:h2x:test", "sa", "");
-            fail("Expected SQLException: No suitable driver found");
+            fail("Expected SQLException: 08001");
         } catch (SQLException e) {
-            // OK
+            assertEquals("08001", e.getSQLState());
         }
     }
 

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -807,4 +807,4 @@ analyst occupation distributive josaph aor engineer sajeewa isuru randil kevin d
 corrupts splitted disruption unintentional octets preconditions predicates subq objectweb insn opcodes
 preserves masking holder unboxing avert iae transformed subtle reevaluate exclusions subclause ftbl rgr
 presorted inclusion contexts aax mwd percentile cont interpolate mwa hypothetical regproc childed listagg foreground
-isodow isoyear
+isodow isoyear psql


### PR DESCRIPTION
Fixes #1730.

`Driver.connect()` implementations return `null` when URL is not supported by the driver.