### PR TITLE
Fix ExpressionColumn.getSQL() for DATABASE_TO_UPPER=FALSE

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1735: Creating views with DATABASE_TO_UPPER=FALSE fails
+</li>
 <li>Issue #1732: source.html does not work
 </li>
 <li>Issue #1730: Show error in H2 Console if specified driver is not compatible with URL

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -59,22 +59,11 @@ public class ExpressionColumn extends Expression {
 
     @Override
     public StringBuilder getSQL(StringBuilder builder) {
-        boolean quote = database.getSettings().databaseToUpper;
         if (schemaName != null) {
-            if (quote) {
-                Parser.quoteIdentifier(builder, schemaName);
-            } else {
-                builder.append(schemaName);
-            }
-            builder.append('.');
+            Parser.quoteIdentifier(builder, schemaName).append('.');
         }
         if (tableAlias != null) {
-            if (quote) {
-                Parser.quoteIdentifier(builder, tableAlias);
-            } else {
-                builder.append(tableAlias);
-            }
-            builder.append('.');
+            Parser.quoteIdentifier(builder, tableAlias).append('.');
         }
         if (column != null) {
             if (derivedName != null) {
@@ -82,10 +71,8 @@ public class ExpressionColumn extends Expression {
             } else {
                 builder.append(column.getSQL());
             }
-        } else if (quote) {
-            Parser.quoteIdentifier(builder, columnName);
         } else {
-            builder.append(columnName);
+            Parser.quoteIdentifier(builder, columnName);
         }
         return builder;
     }

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -117,6 +117,13 @@ public class TestCompatibility extends TestDb {
         assertEquals(1000000000000000000000e10, rs.getDouble(2));
         assertEquals(0xfafbL, rs.getLong(3));
         assertFalse(rs.next());
+
+        stat.execute("create table \"t 1\" (a int, b int)");
+        stat.execute("create view v as select * from \"t 1\"");
+        stat.executeQuery("select * from v").close();
+        stat.execute("drop view v");
+        stat.execute("drop table \"t 1\"");
+
         c.close();
     }
 


### PR DESCRIPTION
Closes #1735.

`ExpressionColumn.getSQL()` did not quote names if and only if `DATABASE_TO_UPPER=FALSE`. Perhaps such trick was introduced because `Parser.quoteIdentifier()` quotes lower case names unconditionally, but some names must be quoted.

If unquoted lower case identifiers will be required in generated SQL it should be implemented in some safe way. Personally I think that unquoted names in generated SQL is always a bad idea, because unquoted name may be parsed by another database or by different version of H2 as some reserved word.