### PR TITLE
Bug fix and tuneup for MVMap.tryLock()

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1755,10 +1755,9 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                         break;
                     }
                 }
-                p = replacePage(pos, p, unsavedMemoryHolder);
-                rootPage = p;
+                rootPage = replacePage(pos, p, unsavedMemoryHolder);
                 if (lockedRootReference == null) {
-                    if (!updateRoot(rootReference, p, attempt)) {
+                    if (!updateRoot(rootReference, rootPage, attempt)) {
                         decisionMaker.reset();
                         continue;
                     } else {


### PR DESCRIPTION
Fix for #1746 .
There is a problem with lock wait / notification in MVMap.operate():
Lucky thread may fail to notify waiters if it did go through the fast lane, without calling lockRoot(). And even after this fix, sleep interval should not be big, because there is a possibility for the last thread (or even few) not to get notified, because the lucky one failed to see their `notificationRequested` set.
Tuneup:
Change in use of `contention` variable as a sleep length ms and in upper bound for number of attempts without synchronization.
Also change `notifyAll()` to just `notify()`, because there is no point to wake up everybody.