### PR TITLE
Fix concurrent deletion handling in SELECT FOR UPDATE

### DIFF
--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -35,6 +35,7 @@ import org.h2.result.LazyResult;
 import org.h2.result.LocalResult;
 import org.h2.result.ResultInterface;
 import org.h2.result.ResultTarget;
+import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.result.SortOrder;
 import org.h2.table.Column;
@@ -429,7 +430,11 @@ public class Select extends Query {
             int count = filters.size();
             for (int i = 0; i < count; i++) {
                 TableFilter tableFilter = filters.get(i);
-                tableFilter.set(tableFilter.getTable().lockRow(session, tableFilter.get()));
+                Row row = tableFilter.getTable().lockRow(session, tableFilter.get());
+                if (row == null) {
+                    return false;
+                }
+                tableFilter.set(row);
             }
             return isConditionMet();
         }


### PR DESCRIPTION
Additional fix for issue #1759.

Row may be deleted concurrently, this situation was not handled and an invalid obscure error was thrown.