### PR TITLE
Improve DATABASE_TO_LOWER handling

### DIFF
--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -338,7 +338,7 @@ This is achieved using different database URLs. Settings in the URLs are not cas
     <td><a href="#compatibility">Compatibility mode</a></td>
     <td class="notranslate">
         jdbc:h2:&lt;url&gt;;MODE=&lt;databaseType&gt;<br />
-        jdbc:h2:~/test;MODE=MYSQL
+        jdbc:h2:~/test;MODE=MYSQL;DATABASE_TO_LOWER=TRUE
     </td>
 </tr>
 <tr>
@@ -894,8 +894,9 @@ or the SQL statement <code>SET MODE MSSQLServer</code>.
 
 <h3>MySQL Compatibility Mode</h3>
 <p>
-To use the MySQL mode, use the database URL <code>jdbc:h2:~/test;MODE=MySQL</code>
-or the SQL statement <code>SET MODE MySQL</code>. Use this mode for compatibility with MariaDB too.
+To use the MySQL mode, use the database URL <code>jdbc:h2:~/test;MODE=MySQL;DATABASE_TO_LOWER=TRUE</code>.
+Use this mode for compatibility with MariaDB too.
+When case-insensitive identifiers are needed append <code>;CASE_INSENSITIVE_IDENTIFIERS=TRUE</code> to URL.
 </p>
 <ul><li>When inserting data, if a column is defined to be <code>NOT NULL</code>
     and <code>NULL</code> is inserted,
@@ -904,7 +905,6 @@ or the SQL statement <code>SET MODE MySQL</code>. Use this mode for compatibilit
 </li><li>Creating indexes in the <code>CREATE TABLE</code> statement is allowed using
     <code>INDEX(..)</code> or <code>KEY(..)</code>.
     Example: <code>create table test(id int primary key, name varchar(255), key idx_name(name));</code>
-</li><li>Meta data calls return identifiers in lower case.
 </li><li>When converting a floating point number to an integer, the fractional
     digits are not truncated, but the value is rounded.
 </li><li>Concatenating <code>NULL</code> with another value
@@ -944,8 +944,7 @@ or the SQL statement <code>SET MODE Oracle</code>.
 
 <h3>PostgreSQL Compatibility Mode</h3>
 <p>
-To use the PostgreSQL mode, use the database URL <code>jdbc:h2:~/test;MODE=PostgreSQL</code>
-or the SQL statement <code>SET MODE PostgreSQL</code>.
+To use the PostgreSQL mode, use the database URL <code>jdbc:h2:~/test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE</code>.
 </p>
 <ul><li>For aliased columns, <code>ResultSetMetaData.getColumnName()</code>
     returns the alias name and <code>getTableName()</code> returns

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1275,7 +1275,7 @@ public class Database implements DataHandler {
      * @return the role or null
      */
     public Role findRole(String roleName) {
-        return roles.get(roleName);
+        return roles.get(StringUtils.toUpperEnglish(roleName));
     }
 
     /**
@@ -1309,7 +1309,7 @@ public class Database implements DataHandler {
      * @return the user or null
      */
     public User findUser(String name) {
-        return users.get(name);
+        return users.get(StringUtils.toUpperEnglish(name));
     }
 
     /**

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -357,6 +357,9 @@ public class DbSettings extends SettingsBase {
         }
         databaseToLower = lower;
         databaseToUpper = upper;
+        HashMap<String, String> settings = getSettings();
+        settings.put("DATABASE_TO_LOWER", Boolean.toString(lower));
+        settings.put("DATABASE_TO_UPPER", Boolean.toString(upper));
     }
 
     /**

--- a/h2/src/main/org/h2/engine/RightOwner.java
+++ b/h2/src/main/org/h2/engine/RightOwner.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import org.h2.table.Table;
+import org.h2.util.StringUtils;
 
 /**
  * A right owner (sometimes called principal).
@@ -27,9 +28,13 @@ public abstract class RightOwner extends DbObjectBase {
      */
     private HashMap<DbObject, Right> grantedRights;
 
-    protected RightOwner(Database database, int id, String name,
-            int traceModuleId) {
-        super(database, id, name, traceModuleId);
+    protected RightOwner(Database database, int id, String name, int traceModuleId) {
+        super(database, id, StringUtils.toUpperEnglish(name), traceModuleId);
+    }
+
+    @Override
+    public void rename(String newName) {
+        super.rename(StringUtils.toUpperEnglish(newName));
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -16,7 +16,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.h2.engine.Constants;
-import org.h2.engine.Mode.ModeEnum;
 import org.h2.engine.SessionInterface;
 import org.h2.engine.SessionRemote;
 import org.h2.engine.SysProperties;
@@ -1539,7 +1538,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
 
     /**
      * Gets the comma-separated list of all SQL keywords that are not supported as
-     * table/column/index name, in addition to the SQL-2003 keywords. The list
+     * table/column/index name, in addition to the SQL:2003 keywords. The list
      * returned is:
      * <pre>
      * IF,ILIKE,INTERSECTS,
@@ -1551,7 +1550,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * SYSDATE,SYSTIME,SYSTIMESTAMP,
      * TODAY,TOP
      * </pre>
-     * The complete list of keywords (including SQL-2003 keywords) is:
+     * The complete list of keywords (including SQL:2003 keywords) is:
      * <pre>
      * ALL, AND, ARRAY, AS,
      * BETWEEN,
@@ -2594,98 +2593,100 @@ public class JdbcDatabaseMetaData extends TraceObject implements
 
     /**
      * Checks if for CREATE TABLE Test(ID INT), getTables returns Test as the
-     * table name.
+     * table name and identifiers are case sensitive.
      *
-     * @return false
+     * @return true is so, false otherwise
      */
     @Override
-    public boolean supportsMixedCaseIdentifiers() {
+    public boolean supportsMixedCaseIdentifiers() throws SQLException{
         debugCodeCall("supportsMixedCaseIdentifiers");
-        return false;
-    }
-
-    /**
-     * Checks if a table created with CREATE TABLE "Test"(ID INT) is a different
-     * table than a table created with CREATE TABLE TEST(ID INT).
-     *
-     * @return true usually, and false in MySQL mode
-     */
-    @Override
-    public boolean supportsMixedCaseQuotedIdentifiers() throws SQLException {
-        debugCodeCall("supportsMixedCaseQuotedIdentifiers");
-        return conn.getMode().getEnum() != ModeEnum.MySQL;
+        JdbcConnection.Settings settings = conn.getSettings();
+        return !settings.databaseToUpper && !settings.databaseToLower && !settings.caseInsensitiveIdentifiers;
     }
 
     /**
      * Checks if for CREATE TABLE Test(ID INT), getTables returns TEST as the
      * table name.
      *
-     * @return true usually, and false in MySQL mode
+     * @return true is so, false otherwise
      */
     @Override
     public boolean storesUpperCaseIdentifiers() throws SQLException {
         debugCodeCall("storesUpperCaseIdentifiers");
-        return conn.getMode().getEnum() != ModeEnum.MySQL;
+        return conn.getSettings().databaseToUpper;
     }
 
     /**
      * Checks if for CREATE TABLE Test(ID INT), getTables returns test as the
      * table name.
      *
-     * @return false usually, and true in MySQL mode
+     * @return true is so, false otherwise
      */
     @Override
     public boolean storesLowerCaseIdentifiers() throws SQLException {
         debugCodeCall("storesLowerCaseIdentifiers");
-        return conn.getMode().getEnum() == ModeEnum.MySQL;
+        return conn.getSettings().databaseToLower;
     }
 
     /**
      * Checks if for CREATE TABLE Test(ID INT), getTables returns Test as the
-     * table name.
+     * table name and identifiers are not case sensitive.
      *
-     * @return false
+     * @return true is so, false otherwise
      */
     @Override
-    public boolean storesMixedCaseIdentifiers() {
+    public boolean storesMixedCaseIdentifiers() throws SQLException {
         debugCodeCall("storesMixedCaseIdentifiers");
-        return false;
+        JdbcConnection.Settings settings = conn.getSettings();
+        return !settings.databaseToUpper && !settings.databaseToLower && settings.caseInsensitiveIdentifiers;
+    }
+
+    /**
+     * Checks if a table created with CREATE TABLE "Test"(ID INT) is a different
+     * table than a table created with CREATE TABLE "TEST"(ID INT).
+     *
+     * @return true is so, false otherwise
+     */
+    @Override
+    public boolean supportsMixedCaseQuotedIdentifiers() throws SQLException {
+        debugCodeCall("supportsMixedCaseQuotedIdentifiers");
+        return !conn.getSettings().caseInsensitiveIdentifiers;
     }
 
     /**
      * Checks if for CREATE TABLE "Test"(ID INT), getTables returns TEST as the
      * table name.
      *
-     * @return false usually, and true in MySQL mode
+     * @return false
      */
     @Override
     public boolean storesUpperCaseQuotedIdentifiers() throws SQLException {
         debugCodeCall("storesUpperCaseQuotedIdentifiers");
-        return conn.getMode().getEnum() == ModeEnum.MySQL;
+        return false;
     }
 
     /**
      * Checks if for CREATE TABLE "Test"(ID INT), getTables returns test as the
      * table name.
      *
-     * @return false usually, and true in MySQL mode
+     * @return false
      */
     @Override
     public boolean storesLowerCaseQuotedIdentifiers() throws SQLException {
         debugCodeCall("storesLowerCaseQuotedIdentifiers");
-        return conn.getMode().getEnum() == ModeEnum.MySQL;
+        return false;
     }
 
     /**
      * Checks if for CREATE TABLE "Test"(ID INT), getTables returns Test as the
-     * table name.
+     * table name and identifiers are case insensitive.
      *
-     * @return true usually, and false in MySQL mode
+     * @return true is so, false otherwise
      */
     @Override
     public boolean storesMixedCaseQuotedIdentifiers() throws SQLException {
         debugCodeCall("storesMixedCaseQuotedIdentifiers");
-        return conn.getMode().getEnum() != ModeEnum.MySQL;
+        return conn.getSettings().caseInsensitiveIdentifiers;
     }
 
     /**

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -705,9 +705,6 @@ public class MetaTable extends Table {
     }
 
     private ArrayList<Table> getTablesByName(Session session, String tableName) {
-        if (database.getMode().lowerCaseIdentifiers) {
-            tableName = StringUtils.toUpperEnglish(tableName);
-        }
         ArrayList<Table> tables = database.getTableOrViewByName(tableName);
         for (Table temp : session.getLocalTempTables()) {
             if (temp.getName().equals(tableName)) {
@@ -769,12 +766,12 @@ public class MetaTable extends Table {
         }
 
         ArrayList<Row> rows = Utils.newSmallArrayList();
-        String catalog = identifier(database.getShortName());
+        String catalog = database.getShortName();
         boolean admin = session.getUser().isAdmin();
         switch (type) {
         case TABLES: {
             for (Table table : getAllTables(session)) {
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -803,7 +800,7 @@ public class MetaTable extends Table {
                         // TABLE_CATALOG
                         catalog,
                         // TABLE_SCHEMA
-                        identifier(table.getSchema().getName()),
+                        table.getSchema().getName(),
                         // TABLE_NAME
                         tableName,
                         // TABLE_TYPE
@@ -833,7 +830,7 @@ public class MetaTable extends Table {
             // 10x faster
             final ArrayList<Table> tablesToList;
             if (indexFrom != null && indexFrom.equals(indexTo)) {
-                String tableName = identifier(indexFrom.getString());
+                String tableName = indexFrom.getString();
                 if (tableName == null) {
                     break;
                 }
@@ -842,7 +839,7 @@ public class MetaTable extends Table {
                 tablesToList = getAllTables(session);
             }
             for (Table table : tablesToList) {
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -880,11 +877,11 @@ public class MetaTable extends Table {
                             // TABLE_CATALOG
                             catalog,
                             // TABLE_SCHEMA
-                            identifier(table.getSchema().getName()),
+                            table.getSchema().getName(),
                             // TABLE_NAME
                             tableName,
                             // COLUMN_NAME
-                            identifier(c.getName()),
+                            c.getName(),
                             // ORDINAL_POSITION
                             ValueInt.get(j + 1),
                             // DOMAIN_CATALOG
@@ -953,7 +950,7 @@ public class MetaTable extends Table {
             // 10x faster
             final ArrayList<Table> tablesToList;
             if (indexFrom != null && indexFrom.equals(indexTo)) {
-                String tableName = identifier(indexFrom.getString());
+                String tableName = indexFrom.getString();
                 if (tableName == null) {
                     break;
                 }
@@ -962,7 +959,7 @@ public class MetaTable extends Table {
                 tablesToList = getAllTables(session);
             }
             for (Table table : tablesToList) {
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -998,17 +995,17 @@ public class MetaTable extends Table {
                                 // TABLE_CATALOG
                                 catalog,
                                 // TABLE_SCHEMA
-                                identifier(table.getSchema().getName()),
+                                table.getSchema().getName(),
                                 // TABLE_NAME
                                 tableName,
                                 // NON_UNIQUE
                                 ValueBoolean.get(!index.getIndexType().isUnique()),
                                 // INDEX_NAME
-                                identifier(index.getName()),
+                                index.getName(),
                                 // ORDINAL_POSITION
                                 ValueShort.get((short) (k + 1)),
                                 // COLUMN_NAME
-                                identifier(column.getName()),
+                                column.getName(),
                                 // CARDINALITY
                                 ValueInt.get(0),
                                 // PRIMARY_KEY
@@ -1220,9 +1217,9 @@ public class MetaTable extends Table {
                         // SEQUENCE_CATALOG
                         catalog,
                         // SEQUENCE_SCHEMA
-                        identifier(s.getSchema().getName()),
+                        s.getSchema().getName(),
                         // SEQUENCE_NAME
-                        identifier(s.getName()),
+                        s.getName(),
                         // CURRENT_VALUE
                         ValueLong.get(s.getCurrentValue()),
                         // INCREMENT
@@ -1295,8 +1292,8 @@ public class MetaTable extends Table {
                                 schema = table.getSchema();
                             }
                         }
-                        String tableName = (table != null) ? identifier(table.getName()) : "";
-                        String schemaName = (schema != null) ? identifier(schema.getName()) : "";
+                        String tableName = (table != null) ? table.getName() : "";
+                        String schemaName = (schema != null) ? schema.getName() : "";
                         if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                             continue;
                         }
@@ -1355,7 +1352,7 @@ public class MetaTable extends Table {
                             // ALIAS_SCHEMA
                             alias.getSchema().getName(),
                             // ALIAS_NAME
-                            identifier(alias.getName()),
+                            alias.getName(),
                             // JAVA_CLASS
                             alias.getJavaClassName(),
                             // JAVA_METHOD
@@ -1387,7 +1384,7 @@ public class MetaTable extends Table {
                         // ALIAS_SCHEMA
                         database.getMainSchema().getName(),
                         // ALIAS_NAME
-                        identifier(agg.getName()),
+                        agg.getName(),
                         // JAVA_CLASS
                         agg.getJavaClassName(),
                         // JAVA_METHOD
@@ -1431,7 +1428,7 @@ public class MetaTable extends Table {
                                 // ALIAS_SCHEMA
                                 alias.getSchema().getName(),
                                 // ALIAS_NAME
-                                identifier(alias.getName()),
+                                alias.getName(),
                                 // JAVA_CLASS
                                 alias.getJavaClassName(),
                                 // JAVA_METHOD
@@ -1476,7 +1473,7 @@ public class MetaTable extends Table {
                                 // ALIAS_SCHEMA
                                 alias.getSchema().getName(),
                                 // ALIAS_NAME
-                                identifier(alias.getName()),
+                                alias.getName(),
                                 // JAVA_CLASS
                                 alias.getJavaClassName(),
                                 // JAVA_METHOD
@@ -1520,7 +1517,7 @@ public class MetaTable extends Table {
                         // CATALOG_NAME
                         catalog,
                         // SCHEMA_NAME
-                        identifier(schema.getName()),
+                        schema.getName(),
                         // SCHEMA_OWNER
                         identifier(schema.getOwner().getName()),
                         // DEFAULT_CHARACTER_SET_NAME
@@ -1547,7 +1544,7 @@ public class MetaTable extends Table {
                 if (hideTable(table, session)) {
                     continue;
                 }
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -1566,7 +1563,7 @@ public class MetaTable extends Table {
                 if (hideTable(table, session)) {
                     continue;
                 }
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -1595,7 +1592,7 @@ public class MetaTable extends Table {
                 if (table.getTableType() != TableType.VIEW) {
                     continue;
                 }
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -1604,7 +1601,7 @@ public class MetaTable extends Table {
                         // TABLE_CATALOG
                         catalog,
                         // TABLE_SCHEMA
-                        identifier(table.getSchema().getName()),
+                        table.getSchema().getName(),
                         // TABLE_NAME
                         tableName,
                         // VIEW_DEFINITION
@@ -1649,7 +1646,7 @@ public class MetaTable extends Table {
                 IndexColumn[] refCols = ref.getRefColumns();
                 Table tab = ref.getTable();
                 Table refTab = ref.getRefTable();
-                String tableName = identifier(refTab.getName());
+                String tableName = refTab.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -1660,19 +1657,19 @@ public class MetaTable extends Table {
                             // PKTABLE_CATALOG
                             catalog,
                             // PKTABLE_SCHEMA
-                            identifier(refTab.getSchema().getName()),
+                            refTab.getSchema().getName(),
                             // PKTABLE_NAME
-                            identifier(refTab.getName()),
+                            refTab.getName(),
                             // PKCOLUMN_NAME
-                            identifier(refCols[j].column.getName()),
+                            refCols[j].column.getName(),
                             // FKTABLE_CATALOG
                             catalog,
                             // FKTABLE_SCHEMA
-                            identifier(tab.getSchema().getName()),
+                            tab.getSchema().getName(),
                             // FKTABLE_NAME
-                            identifier(tab.getName()),
+                            tab.getName(),
                             // FKCOLUMN_NAME
-                            identifier(cols[j].column.getName()),
+                            cols[j].column.getName(),
                             // ORDINAL_POSITION
                             ValueShort.get((short) (j + 1)),
                             // UPDATE_RULE
@@ -1680,9 +1677,9 @@ public class MetaTable extends Table {
                             // DELETE_RULE
                             delete,
                             // FK_NAME
-                            identifier(ref.getName()),
+                            ref.getName(),
                             // PK_NAME
-                            identifier(ref.getUniqueIndex().getName()),
+                            ref.getUniqueIndex().getName(),
                             // DEFERRABILITY
                             ValueShort.get((short) DatabaseMetaData.importedKeyNotDeferrable)
                     );
@@ -1706,7 +1703,7 @@ public class MetaTable extends Table {
                 if (index != null) {
                     uniqueIndexName = index.getName();
                 }
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -1731,16 +1728,16 @@ public class MetaTable extends Table {
                         // CONSTRAINT_CATALOG
                         catalog,
                         // CONSTRAINT_SCHEMA
-                        identifier(constraint.getSchema().getName()),
+                        constraint.getSchema().getName(),
                         // CONSTRAINT_NAME
-                        identifier(constraint.getName()),
+                        constraint.getName(),
                         // CONSTRAINT_TYPE
                         constraintType == Constraint.Type.PRIMARY_KEY ?
                                 constraintType.getSqlName() : constraintType.name(),
                         // TABLE_CATALOG
                         catalog,
                         // TABLE_SCHEMA
-                        identifier(table.getSchema().getName()),
+                        table.getSchema().getName(),
                         // TABLE_NAME
                         tableName,
                         // UNIQUE_INDEX_NAME
@@ -1768,9 +1765,9 @@ public class MetaTable extends Table {
                         // CONSTANT_CATALOG
                         catalog,
                         // CONSTANT_SCHEMA
-                        identifier(constant.getSchema().getName()),
+                        constant.getSchema().getName(),
                         // CONSTANT_NAME
-                        identifier(constant.getName()),
+                        constant.getName(),
                         // DATA_TYPE
                         ValueInt.get(DataType.convertTypeToSQLType(expr.getType().getValueType())),
                         // REMARKS
@@ -1792,7 +1789,7 @@ public class MetaTable extends Table {
                         // DOMAIN_SCHEMA
                         database.getMainSchema().getName(),
                         // DOMAIN_NAME
-                        identifier(dt.getName()),
+                        dt.getName(),
                         // COLUMN_DEFAULT
                         col.getDefaultSQL(),
                         // IS_NULLABLE
@@ -1828,17 +1825,17 @@ public class MetaTable extends Table {
                         // TRIGGER_CATALOG
                         catalog,
                         // TRIGGER_SCHEMA
-                        identifier(trigger.getSchema().getName()),
+                        trigger.getSchema().getName(),
                         // TRIGGER_NAME
-                        identifier(trigger.getName()),
+                        trigger.getName(),
                         // TRIGGER_TYPE
                         trigger.getTypeNameList(),
                         // TABLE_CATALOG
                         catalog,
                         // TABLE_SCHEMA
-                        identifier(table.getSchema().getName()),
+                        table.getSchema().getName(),
                         // TABLE_NAME
-                        identifier(table.getName()),
+                        table.getName(),
                         // BEFORE
                         ValueBoolean.get(trigger.isBefore()),
                         // JAVA_CLASS
@@ -1989,9 +1986,9 @@ public class MetaTable extends Table {
                         // SYNONYM_CATALOG
                         catalog,
                         // SYNONYM_SCHEMA
-                        identifier(synonym.getSchema().getName()),
+                        synonym.getSchema().getName(),
                         // SYNONYM_NAME
-                        identifier(synonym.getName()),
+                        synonym.getName(),
                         // SYNONYM_FOR
                         synonym.getSynonymForName(),
                         // SYNONYM_FOR_SCHEMA
@@ -2016,7 +2013,7 @@ public class MetaTable extends Table {
                 if (hideTable(table, session)) {
                     continue;
                 }
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -2024,15 +2021,15 @@ public class MetaTable extends Table {
                         // CONSTRAINT_CATALOG
                         catalog,
                         // CONSTRAINT_SCHEMA
-                        identifier(constraint.getSchema().getName()),
+                        constraint.getSchema().getName(),
                         // CONSTRAINT_NAME
-                        identifier(constraint.getName()),
+                        constraint.getName(),
                         // CONSTRAINT_TYPE
                         constraintType.getSqlName(),
                         // TABLE_CATALOG
                         catalog,
                         // TABLE_SCHEMA
-                        identifier(table.getSchema().getName()),
+                        table.getSchema().getName(),
                         // TABLE_NAME
                         tableName,
                         // IS_DEFERRABLE
@@ -2052,7 +2049,7 @@ public class MetaTable extends Table {
                 if (hideTable(table, session)) {
                     continue;
                 }
-                String tableName = identifier(table.getName());
+                String tableName = table.getName();
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
@@ -2094,13 +2091,13 @@ public class MetaTable extends Table {
                             // CONSTRAINT_CATALOG
                             catalog,
                             // CONSTRAINT_SCHEMA
-                            identifier(constraint.getSchema().getName()),
+                            constraint.getSchema().getName(),
                             // CONSTRAINT_NAME
-                            identifier(constraint.getName()),
+                            constraint.getName(),
                             // TABLE_CATALOG
                             catalog,
                             // TABLE_SCHEMA
-                            identifier(table.getSchema().getName()),
+                            table.getSchema().getName(),
                             // TABLE_NAME
                             tableName,
                             // COLUMN_NAME
@@ -2135,13 +2132,13 @@ public class MetaTable extends Table {
                         // CONSTRAINT_CATALOG
                         catalog,
                         // CONSTRAINT_SCHEMA
-                        identifier(constraint.getSchema().getName()),
+                        constraint.getSchema().getName(),
                         // CONSTRAINT_NAME
-                        identifier(constraint.getName()),
+                        constraint.getName(),
                         // UNIQUE_CONSTRAINT_CATALOG
                         catalog,
                         // UNIQUE_CONSTRAINT_SCHEMA
-                        identifier(unique.getSchema().getName()),
+                        unique.getSchema().getName(),
                         // UNIQUE_CONSTRAINT_NAME
                         unique.getName(),
                         // MATCH_OPTION
@@ -2248,9 +2245,9 @@ public class MetaTable extends Table {
                     // TABLE_CATALOG
                     catalog,
                     // TABLE_SCHEMA
-                    identifier(table.getSchema().getName()),
+                    table.getSchema().getName(),
                     // TABLE_NAME
-                    identifier(table.getName()),
+                    table.getName(),
                     // PRIVILEGE_TYPE
                     right,
                     // IS_GRANTABLE
@@ -2265,11 +2262,11 @@ public class MetaTable extends Table {
                     // TABLE_CATALOG
                     catalog,
                     // TABLE_SCHEMA
-                    identifier(table.getSchema().getName()),
+                    table.getSchema().getName(),
                     // TABLE_NAME
-                    identifier(table.getName()),
+                    table.getName(),
                     // COLUMN_NAME
-                    identifier(column),
+                    column,
                     // PRIVILEGE_TYPE
                     right,
                     // IS_GRANTABLE

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -527,7 +527,7 @@ public class TestMetaData extends TestDb {
         assertFalse(meta.storesLowerCaseIdentifiers());
         assertFalse(meta.storesLowerCaseQuotedIdentifiers());
         assertFalse(meta.storesMixedCaseIdentifiers());
-        assertTrue(meta.storesMixedCaseQuotedIdentifiers());
+        assertFalse(meta.storesMixedCaseQuotedIdentifiers());
         assertTrue(meta.storesUpperCaseIdentifiers());
         assertFalse(meta.storesUpperCaseQuotedIdentifiers());
         assertTrue(meta.supportsAlterTableWithAddColumn());

--- a/h2/src/test/org/h2/test/unit/TestBnf.java
+++ b/h2/src/test/org/h2/test/unit/TestBnf.java
@@ -39,7 +39,7 @@ public class TestBnf extends TestDb {
             testModes(conn);
             testProcedures(conn, false);
         }
-        try (Connection conn = getConnection("bnf;mode=mysql")) {
+        try (Connection conn = getConnection("bnf;mode=mysql;database_to_lower=true")) {
             testProcedures(conn, true);
         }
     }


### PR DESCRIPTION
1. `DatabaseMetaData` methods now return correct information about identifiers' case handling.

2. Documentation of `MySQL` and `PostgreSQL` compatibility modes now suggests `DATABASE_TO_LOWER=TRUE`.

3. Many conversions to lower case in `INFORMATION_SCHEMA` in MySQL mode were removed, because identifiers should be in lower case already, and when they aren't in lower case for some reason they shouldn't be returned in lower case. The only exceptions are names of users and roles, they are still converted to lower case in this mode.

4. Names of users and roles are now converted to upper case. Documentation says that user names should be in upper case, but H2 converts them to upper case only in connection code. When `DATABASE_TO_LOWER` is enabled unquoted user names are converted to lower case by parser. We need to convert them to upper case, otherwise users are created with lowercase names and there is no way to login under such name. For example, it was not possible to reconnect to database that was created with `DATABASE_TO_LOWER=TRUE`.

These changes may affect compatibility modes somehow.

@grandinj