### PR TITLE
Improve isSimpleIdentifier() and enquoteIdentifier()

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -8106,7 +8106,7 @@ public class Parser {
         if (s == null) {
             return "\"\"";
         }
-        if (ParserUtil.isSimpleIdentifier(s)) {
+        if (ParserUtil.isSimpleIdentifier(s, true, false)) {
             return s;
         }
         return StringUtils.quoteIdentifier(s);
@@ -8124,7 +8124,7 @@ public class Parser {
         if (s == null) {
             return builder.append("\"\"");
         }
-        if (ParserUtil.isSimpleIdentifier(s)) {
+        if (ParserUtil.isSimpleIdentifier(s, true, false)) {
             return builder.append(s);
         }
         return StringUtils.quoteIdentifier(builder, s);

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -1383,17 +1383,35 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
 
     /**
      * @param identifier
-     *            identifier to quote if required
+     *            identifier to quote if required, may be quoted or unquoted
      * @param alwaysQuote
      *            if {@code true} identifier will be quoted unconditionally
-     * @return specified identifier quoted if required or explicitly requested
+     * @return specified identifier quoted if required, explicitly requested, or
+     *         if it was already quoted
+     * @throws SQLException
+     *             if identifier is not a valid identifier
      */
     @Override
     public String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException {
-        if (alwaysQuote || !isSimpleIdentifier(identifier)) {
-            return StringUtils.quoteIdentifier(identifier);
+        if (isSimpleIdentifier(identifier)) {
+            return alwaysQuote ? '"' + identifier + '"': identifier;
         }
-        return identifier;
+        int length = identifier.length();
+        if (length > 0 && identifier.charAt(0) == '"') {
+            boolean quoted = true;
+            for (int i = 1; i < length; i++) {
+                if (identifier.charAt(i) == '"') {
+                    quoted = !quoted;
+                } else if (!quoted) {
+                    throw new SQLException();
+                }
+            }
+            if (quoted) {
+                throw new SQLException();
+            }
+            return identifier;
+        }
+        return StringUtils.quoteIdentifier(identifier);
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -1403,7 +1403,8 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
      */
     @Override
     public boolean isSimpleIdentifier(String identifier) throws SQLException {
-        return ParserUtil.isSimpleIdentifier(identifier);
+        JdbcConnection.Settings settings = conn.getSettings();
+        return ParserUtil.isSimpleIdentifier(identifier, settings.databaseToUpper, settings.databaseToLower);
     }
 
     /**

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -484,6 +484,15 @@ public class TestStatement extends TestDb {
         assertEquals("\"Test\"", stat.enquoteIdentifier("Test", false));
         assertEquals("\"test\"", stat.enquoteIdentifier("test", false));
         assertEquals("\"TODAY\"", stat.enquoteIdentifier("TODAY", false));
+        assertEquals("\"Test\"", stat.enquoteIdentifier("\"Test\"", false));
+        assertEquals("\"Test\"", stat.enquoteIdentifier("\"Test\"", true));
+        assertEquals("\"\"\"Test\"", stat.enquoteIdentifier("\"\"\"Test\"", true));
+        try {
+            stat.enquoteIdentifier("\"Test", true);
+            fail();
+        } catch (SQLException ex) {
+            // OK
+        }
         // Other lower case characters don't have upper case mappings
         assertEquals("\u02B0", stat.enquoteIdentifier("\u02B0", false));
 

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -53,6 +53,7 @@ public class TestStatement extends TestDb {
         testIdentityMerge();
         testIdentity();
         conn.close();
+        testIdentifiers();
         deleteDb("statement");
     }
 
@@ -330,23 +331,6 @@ public class TestStatement extends TestDb {
         assertNull(stat.getWarnings());
         assertTrue(conn == stat.getConnection());
 
-        assertEquals("SOME_ID", statBC.enquoteIdentifier("SOME_ID", false));
-        assertEquals("\"SOME ID\"", statBC.enquoteIdentifier("SOME ID", false));
-        assertEquals("\"SOME_ID\"", statBC.enquoteIdentifier("SOME_ID", true));
-        assertEquals("\"FROM\"", statBC.enquoteIdentifier("FROM", false));
-        assertEquals("\"Test\"", statBC.enquoteIdentifier("Test", false));
-        assertEquals("\"TODAY\"", statBC.enquoteIdentifier("TODAY", false));
-        // Other lower case characters don't have upper case mappings
-        assertEquals("\u02B0", statBC.enquoteIdentifier("\u02B0", false));
-
-        assertTrue(statBC.isSimpleIdentifier("SOME_ID"));
-        assertFalse(statBC.isSimpleIdentifier("SOME ID"));
-        assertFalse(statBC.isSimpleIdentifier("FROM"));
-        assertFalse(statBC.isSimpleIdentifier("Test"));
-        assertFalse(statBC.isSimpleIdentifier("TODAY"));
-        // Other lower case characters don't have upper case mappings
-        assertTrue(statBC.isSimpleIdentifier("\u02B0"));
-
         stat.close();
     }
 
@@ -487,6 +471,77 @@ public class TestStatement extends TestDb {
         assertEquals(1, ((JdbcPreparedStatementBackwardsCompat) ps).executeLargeUpdate());
         assertEquals(1, ((JdbcStatementBackwardsCompat) ps).getLargeUpdateCount());
         stat.execute("drop table test");
+    }
+
+    private void testIdentifiers() throws SQLException {
+        Connection conn = getConnection("statement");
+
+        JdbcStatement stat = (JdbcStatement) conn.createStatement();
+        assertEquals("SOME_ID", stat.enquoteIdentifier("SOME_ID", false));
+        assertEquals("\"SOME ID\"", stat.enquoteIdentifier("SOME ID", false));
+        assertEquals("\"SOME_ID\"", stat.enquoteIdentifier("SOME_ID", true));
+        assertEquals("\"FROM\"", stat.enquoteIdentifier("FROM", false));
+        assertEquals("\"Test\"", stat.enquoteIdentifier("Test", false));
+        assertEquals("\"test\"", stat.enquoteIdentifier("test", false));
+        assertEquals("\"TODAY\"", stat.enquoteIdentifier("TODAY", false));
+        // Other lower case characters don't have upper case mappings
+        assertEquals("\u02B0", stat.enquoteIdentifier("\u02B0", false));
+
+        assertTrue(stat.isSimpleIdentifier("SOME_ID"));
+        assertFalse(stat.isSimpleIdentifier("SOME ID"));
+        assertFalse(stat.isSimpleIdentifier("FROM"));
+        assertFalse(stat.isSimpleIdentifier("Test"));
+        assertFalse(stat.isSimpleIdentifier("test"));
+        assertFalse(stat.isSimpleIdentifier("TODAY"));
+        // Other lower case characters don't have upper case mappings
+        assertTrue(stat.isSimpleIdentifier("\u02B0"));
+
+        conn.close();
+        conn = getConnection("statement;DATABASE_TO_LOWER=TRUE");
+
+        stat = (JdbcStatement) conn.createStatement();
+        assertEquals("some_id", stat.enquoteIdentifier("some_id", false));
+        assertEquals("\"some id\"", stat.enquoteIdentifier("some id", false));
+        assertEquals("\"some_id\"", stat.enquoteIdentifier("some_id", true));
+        assertEquals("\"from\"", stat.enquoteIdentifier("from", false));
+        assertEquals("\"Test\"", stat.enquoteIdentifier("Test", false));
+        assertEquals("\"TEST\"", stat.enquoteIdentifier("TEST", false));
+        assertEquals("\"today\"", stat.enquoteIdentifier("today", false));
+
+        assertTrue(stat.isSimpleIdentifier("some_id"));
+        assertFalse(stat.isSimpleIdentifier("some id"));
+        assertFalse(stat.isSimpleIdentifier("from"));
+        assertFalse(stat.isSimpleIdentifier("Test"));
+        assertFalse(stat.isSimpleIdentifier("TEST"));
+        assertFalse(stat.isSimpleIdentifier("today"));
+
+        conn.close();
+        conn = getConnection("statement;DATABASE_TO_UPPER=FALSE");
+
+        stat = (JdbcStatement) conn.createStatement();
+        assertEquals("SOME_ID", stat.enquoteIdentifier("SOME_ID", false));
+        assertEquals("some_id", stat.enquoteIdentifier("some_id", false));
+        assertEquals("\"SOME ID\"", stat.enquoteIdentifier("SOME ID", false));
+        assertEquals("\"some id\"", stat.enquoteIdentifier("some id", false));
+        assertEquals("\"SOME_ID\"", stat.enquoteIdentifier("SOME_ID", true));
+        assertEquals("\"some_id\"", stat.enquoteIdentifier("some_id", true));
+        assertEquals("\"FROM\"", stat.enquoteIdentifier("FROM", false));
+        assertEquals("\"from\"", stat.enquoteIdentifier("from", false));
+        assertEquals("Test", stat.enquoteIdentifier("Test", false));
+        assertEquals("\"TODAY\"", stat.enquoteIdentifier("TODAY", false));
+        assertEquals("\"today\"", stat.enquoteIdentifier("today", false));
+
+        assertTrue(stat.isSimpleIdentifier("SOME_ID"));
+        assertTrue(stat.isSimpleIdentifier("some_id"));
+        assertFalse(stat.isSimpleIdentifier("SOME ID"));
+        assertFalse(stat.isSimpleIdentifier("some id"));
+        assertFalse(stat.isSimpleIdentifier("FROM"));
+        assertFalse(stat.isSimpleIdentifier("from"));
+        assertTrue(stat.isSimpleIdentifier("Test"));
+        assertFalse(stat.isSimpleIdentifier("TODAY"));
+        assertFalse(stat.isSimpleIdentifier("today"));
+
+        conn.close();
     }
 
 }


### PR DESCRIPTION
These two methods from JDBC 4.3 are now use values of `DATABASE_TO_UPPER` and `DATABASE_TO_LOWER` settings.

`enquoteIdentifier()` now supports already quoted identifiers.

Identifiers with title-case letters are now quoted for safety if either of that two settings is set to `true`, it's an obscure character class that can have conversions to upper or lower case.