### PR TITLE
issue#1787: Non-standard MERGE throws LOCK_TIMEOUT_1

### DIFF
--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -182,14 +182,17 @@ public class Merge extends CommandWithValues {
                     if (index != null) {
                         // verify the index columns match the key
                         Column[] indexColumns = index.getColumns();
-                        boolean indexMatchesKeys = true;
+                        boolean indexMatchesKeys;
                         if (indexColumns.length <= keys.length) {
+                            indexMatchesKeys = true;
                             for (int i = 0; i < indexColumns.length; i++) {
                                 if (indexColumns[i] != keys[i]) {
                                     indexMatchesKeys = false;
                                     break;
                                 }
                             }
+                        } else {
+                            indexMatchesKeys = false;
                         }
                         if (indexMatchesKeys) {
                             throw DbException.get(ErrorCode.CONCURRENT_UPDATE_1, targetTable.getName());

--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -6,7 +6,6 @@
 package org.h2.command.dml;
 
 import java.util.ArrayList;
-
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.command.Command;
@@ -21,9 +20,11 @@ import org.h2.expression.Expression;
 import org.h2.expression.Parameter;
 import org.h2.index.Index;
 import org.h2.message.DbException;
+import org.h2.mvstore.db.MVPrimaryIndex;
 import org.h2.result.ResultInterface;
 import org.h2.result.Row;
 import org.h2.table.Column;
+import org.h2.table.IndexColumn;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
 import org.h2.value.Value;
@@ -181,7 +182,14 @@ public class Merge extends CommandWithValues {
                     Index index = (Index) e.getSource();
                     if (index != null) {
                         // verify the index columns match the key
-                        Column[] indexColumns = index.getColumns();
+                        Column[] indexColumns;
+                        if (index instanceof MVPrimaryIndex) {
+                            MVPrimaryIndex foundMV = (MVPrimaryIndex) index;
+                            indexColumns = new Column[] {
+                                    foundMV.getIndexColumns()[foundMV.getMainIndexColumn()].column };
+                        } else {
+                            indexColumns = index.getColumns();
+                        }
                         boolean indexMatchesKeys;
                         if (indexColumns.length <= keys.length) {
                             indexMatchesKeys = true;

--- a/h2/src/test/org/h2/test/scripts/dml/merge.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/merge.sql
@@ -46,13 +46,13 @@ EXPLAIN MERGE INTO TEST(ID, NAME) KEY(ID) VALUES(3, 'How do you do');
 >> MERGE INTO PUBLIC.TEST(ID, NAME) KEY(ID) VALUES (3, 'How do you do')
 
 MERGE INTO TEST(ID, NAME) KEY(NAME) VALUES(3, 'Fine');
-> exception LOCK_TIMEOUT_1
+> exception DUPLICATE_KEY_1
 
 MERGE INTO TEST(ID, NAME) KEY(NAME) VALUES(4, 'Fine!');
 > update count: 1
 
 MERGE INTO TEST(ID, NAME) KEY(NAME) VALUES(4, 'Fine! And you');
-> exception LOCK_TIMEOUT_1
+> exception DUPLICATE_KEY_1
 
 MERGE INTO TEST(ID, NAME) KEY(NAME, ID) VALUES(5, 'I''m ok');
 > update count: 1
@@ -91,6 +91,17 @@ SELECT * FROM TEST;
 > 8  Fine!
 > 9  I'm ok
 > rows: 10
+
+DROP TABLE TEST;
+> ok
+
+-- Test for the index matching logic in org.h2.command.dml.Merge
+
+CREATE TABLE TEST(ID INT PRIMARY KEY, VALUE1 INT, VALUE2 INT, UNIQUE(VALUE1, VALUE2));
+> ok
+
+MERGE INTO TEST KEY (ID) VALUES (1, 2, 3), (2, 2, 3);
+> exception DUPLICATE_KEY_1
 
 DROP TABLE TEST;
 > ok


### PR DESCRIPTION
the match-index-to-key logic was wrong when there are more key columns than index columns