### PR TITLE
Move commands to commands.html and other changes

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4810,7 +4810,7 @@ If specified field is a HOUR, MINUTE, SECOND, MILLISECOND, etc and value is a DA
 Fields DAY, MONTH, YEAR, WEEK, etc are not allowed for TIME values.
 Fields TIMEZONE_HOUR and TIMEZONE_MINUTE are only allowed for TIMESTAMP WITH TIME ZONE values.
 ","
-DATEADD('MONTH', 1, DATE '2001-01-31')
+DATEADD(MONTH, 1, DATE '2001-01-31')
 "
 
 "Functions (Time and Date)","DATEDIFF","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -1926,6 +1926,292 @@ Admin rights are required to execute this command.
 SHUTDOWN COMPACT
 "
 
+"Literals","Value","
+string | dollarQuotedString | numeric | dateAndTime | boolean | bytes
+    | interval | array | null
+","
+A literal value of any data type, or null.
+","
+10
+"
+
+"Literals","Array","
+ARRAY '[' [ expression, [,...] ] ']'
+","
+An array of values.
+","
+ARRAY[1, 2]
+ARRAY[1]
+ARRAY[]
+"
+
+"Literals","Boolean","
+TRUE | FALSE
+","
+A boolean value.
+","
+TRUE
+"
+
+"Literals","Bytes","
+X'hex'
+","
+A binary value. The hex value is not case sensitive.
+","
+X'01FF'
+"
+
+"Literals","Date","
+DATE 'yyyy-MM-dd'
+","
+A date literal. The limitations are the same as for the Java data type
+""java.sql.Date"", but for compatibility with other databases the suggested minimum
+and maximum years are 0001 and 9999.
+","
+DATE '2004-12-31'
+"
+
+"Literals","Date and time","
+date | time | timestamp | timestampWithTimeZone
+","
+A literal value of any date-time data type.
+","
+TIMESTAMP '1999-01-31 10:00:00'
+"
+
+"Literals","Decimal","
+[ + | - ] { { number [ . number ] } | { . number } }
+[ E [ + | - ] expNumber [...] ] ]
+","
+A decimal number with fixed precision and scale.
+Internally, ""java.lang.BigDecimal"" is used.
+To ensure the floating point representation is used, use CAST(X AS DOUBLE).
+There are some special decimal values: to represent positive infinity, use ""POWER(0, -1)"";
+for negative infinity, use ""(-POWER(0, -1))""; for -0.0, use ""(-CAST(0 AS DOUBLE))"";
+for ""NaN"" (not a number), use ""SQRT(-1)"".
+","
+SELECT -1600.05
+SELECT CAST(0 AS DOUBLE)
+SELECT -1.4e-10
+"
+
+"Literals","Dollar Quoted String","
+$$anythingExceptTwoDollarSigns$$
+","
+A string starts and ends with two dollar signs. Two dollar signs are not allowed
+within the text. A whitespace is required before the first set of dollar signs.
+No escaping is required within the text.
+","
+$$John's car$$
+"
+
+"Literals","Hex Number","
+[ + | - ] 0x hex
+","
+A number written in hexadecimal notation.
+","
+0xff
+"
+
+"Literals","Int","
+[ + | - ] number
+","
+The maximum integer number is 2147483647, the minimum is -2147483648.
+","
+10
+"
+
+"Literals","Long","
+[ + | - ] number
+","
+Long numbers are between -9223372036854775808 and 9223372036854775807.
+","
+100000
+"
+
+"Literals","Null","
+NULL
+","
+NULL is a value without data type and means 'unknown value'.
+","
+NULL
+"
+
+"Literals","Number","
+digit [...]
+","
+The maximum length of the number depends on the data type used.
+","
+100
+"
+
+"Literals","Numeric","
+decimal | int | long | hexNumber
+","
+The data type of a numeric value is always the lowest possible for the given value.
+If the number contains a dot this is decimal; otherwise it is int, long, or decimal (depending on the value).
+","
+SELECT -1600.05
+SELECT CAST(0 AS DOUBLE)
+SELECT -1.4e-10
+"
+
+"Literals","String","
+'anythingExceptSingleQuote'
+","
+A string starts and ends with a single quote. Two single quotes can be used to
+create a single quote inside a string.
+","
+'John''s car'
+"
+
+"Literals","Time","
+TIME [ WITHOUT TIME ZONE ] 'hh:mm:ss[.nnnnnnnnn]'
+","
+A time literal. A value is between 0:00:00 and 23:59:59.999999999
+and has nanosecond resolution.
+","
+TIME '23:59:59'
+"
+
+"Literals","Timestamp","
+TIMESTAMP [ WITHOUT TIME ZONE ] 'yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]'
+","
+A timestamp literal. The limitations are the same as for the Java data type
+""java.sql.Timestamp"", but for compatibility with other databases the suggested
+minimum and maximum years are 0001 and 9999.
+","
+TIMESTAMP '2005-12-31 23:59:59'
+"
+
+"Literals","Timestamp with time zone","
+TIMESTAMP WITH TIME ZONE 'yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]
+[Z | { - | + } timeZoneOffsetString | timeZoneNameString ]'
+","
+A timestamp with time zone literal.
+If name of time zone is specified it will be converted to time zone offset.
+","
+TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59Z'
+TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59-10:00'
+TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59.123+05'
+TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59.123456789 Europe/London'
+"
+
+"Literals","Interval","
+intervalYear | intervalMonth | intervalDay | intervalHour | intervalMinute
+    | intervalSecond | intervalYearToMonth | intervalDayToHour
+    | intervalDayToMinute | intervalDayToSecond | intervalHourToMinute
+    | intervalHourToSecond | intervalMinuteToSecond
+","
+An interval literal.
+","
+INTERVAL '1-2' YEAR TO MONTH
+"
+
+"Literals","INTERVAL YEAR","
+INTERVAL [-|+] '[-|+]yearInt' YEAR
+","
+An INTERVAL YEAR literal.
+","
+INTERVAL '10' YEAR
+"
+
+"Literals","INTERVAL MONTH","
+INTERVAL [-|+] '[-|+]monthInt' MONTH
+","
+An INTERVAL MONTH literal.
+","
+INTERVAL '10' MONTH
+"
+
+"Literals","INTERVAL DAY","
+INTERVAL [-|+] '[-|+]dayInt' DAY
+","
+An INTERVAL DAY literal.
+","
+INTERVAL '10' DAY
+"
+
+"Literals","INTERVAL HOUR","
+INTERVAL [-|+] '[-|+]hourInt' HOUR
+","
+An INTERVAL HOUR literal.
+","
+INTERVAL '10' HOUR
+"
+
+"Literals","INTERVAL MINUTE","
+INTERVAL [-|+] '[-|+]minuteInt' MINUTE
+","
+An INTERVAL MINUTE literal.
+","
+INTERVAL '10' MINUTE
+"
+
+"Literals","INTERVAL SECOND","
+INTERVAL [-|+] '[-|+]secondInt[.nnnnnnnnn]' SECOND
+","
+An INTERVAL SECOND literal.
+","
+INTERVAL '10.123' SECOND
+"
+
+"Literals","INTERVAL YEAR TO MONTH","
+INTERVAL [-|+] '[-|+]yearInt-monthInt' YEAR TO MONTH
+","
+An INTERVAL YEAR TO MONTH literal.
+","
+INTERVAL '1-6' YEAR TO MONTH
+"
+
+"Literals","INTERVAL DAY TO HOUR","
+INTERVAL [-|+] '[-|+]dayInt hoursInt' DAY TO HOUR
+","
+An INTERVAL DAY TO HOUR literal.
+","
+INTERVAL '10 11' DAY TO HOUR
+"
+
+"Literals","INTERVAL DAY TO MINUTE","
+INTERVAL [-|+] '[-|+]dayInt hh:mm' DAY TO MINUTE
+","
+An INTERVAL DAY TO MINUTE literal.
+","
+INTERVAL '10 11:12' DAY TO MINUTE
+"
+
+"Literals","INTERVAL DAY TO SECOND","
+INTERVAL [-|+] '[-|+]dayInt hh:mm:ss[.nnnnnnnnn]' DAY TO SECOND
+","
+An INTERVAL DAY TO SECOND literal.
+","
+INTERVAL '10 11:12:13.123' DAY TO SECOND
+"
+
+"Literals","INTERVAL HOUR TO MINUTE","
+INTERVAL [-|+] '[-|+]hh:mm' HOUR TO MINUTE
+","
+An INTERVAL HOUR TO MINUTE literal.
+","
+INTERVAL '10:11' HOUR TO MINUTE
+"
+
+"Literals","INTERVAL HOUR TO SECOND","
+INTERVAL [-|+] '[-|+]hh:mm:ss[.nnnnnnnnn]' HOUR TO SECOND
+","
+An INTERVAL HOUR TO SECOND literal.
+","
+INTERVAL '10:11:12.123' HOUR TO SECOND
+"
+
+"Literals","INTERVAL MINUTE TO SECOND","
+INTERVAL [-|+] '[-|+]mm:ss[.nnnnnnnnn]' MINUTE TO SECOND
+","
+An INTERVAL MINUTE TO SECOND literal.
+","
+INTERVAL '11:12.123' MINUTE TO SECOND
+"
+
 "Datetime fields","Datetime field","
 yearField | monthField | dayOfMonthField
     | hourField | minuteField | secondField
@@ -2113,32 +2399,6 @@ condition [ { AND condition } [...] ]
 Value or condition.
 ","
 ID=1 AND NAME='Hi'
-"
-
-"Other Grammar","Array","
-ARRAY '[' [ expression, [,...] ] ']'
-","
-An array of values.
-","
-ARRAY[1, 2]
-ARRAY[1]
-ARRAY[]
-"
-
-"Other Grammar","Boolean","
-TRUE | FALSE
-","
-A boolean value.
-","
-TRUE
-"
-
-"Other Grammar","Bytes","
-X'hex'
-","
-A binary value. The hex value is not case sensitive.
-","
-X'01FF'
 "
 
 "Other Grammar","Case","
@@ -2356,48 +2616,12 @@ A data type definition.
 INT
 "
 
-"Other Grammar","Date","
-DATE 'yyyy-MM-dd'
-","
-A date literal. The limitations are the same as for the Java data type
-""java.sql.Date"", but for compatibility with other databases the suggested minimum
-and maximum years are 0001 and 9999.
-","
-DATE '2004-12-31'
-"
-
-"Other Grammar","Decimal","
-[ + | - ] { { number [ . number ] } | { . number } }
-[ E [ + | - ] expNumber [...] ] ]
-","
-A decimal number with fixed precision and scale.
-Internally, ""java.lang.BigDecimal"" is used.
-To ensure the floating point representation is used, use CAST(X AS DOUBLE).
-There are some special decimal values: to represent positive infinity, use ""POWER(0, -1)"";
-for negative infinity, use ""(-POWER(0, -1))""; for -0.0, use ""(-CAST(0 AS DOUBLE))"";
-for ""NaN"" (not a number), use ""SQRT(-1)"".
-","
-SELECT -1600.05
-SELECT CAST(0 AS DOUBLE)
-SELECT -1.4e-10
-"
-
 "Other Grammar","Digit","
 0-9
 ","
 A digit.
 ","
 0
-"
-
-"Other Grammar","Dollar Quoted String","
-$$anythingExceptTwoDollarSigns$$
-","
-A string starts and ends with two dollar signs. Two dollar signs are not allowed
-within the text. A whitespace is required before the first set of dollar signs.
-No escaping is required within the text.
-","
-$$John's car$$
 "
 
 "Other Grammar","Expression","
@@ -2423,14 +2647,6 @@ The hexadecimal representation of a number or of bytes. Two characters are one
 byte.
 ","
 cafe
-"
-
-"Other Grammar","Hex Number","
-[ + | - ] 0x hex
-","
-A number written in hexadecimal notation.
-","
-0xff
 "
 
 "Other Grammar","Index Column","
@@ -2459,22 +2675,6 @@ VALUES { DEFAULT|expression | [ROW] ({DEFAULT|expression} [,...]) }, [,...]
 Values for INSERT statement.
 ","
 VALUES (1, 'Test')
-"
-
-"Other Grammar","Int","
-[ + | - ] number
-","
-The maximum integer number is 2147483647, the minimum is -2147483648.
-","
-10
-"
-
-"Other Grammar","Long","
-[ + | - ] number
-","
-Long numbers are between -9223372036854775808 and 9223372036854775807.
-","
-100000
 "
 
 "Other Grammar","Merge when clause","
@@ -2515,33 +2715,6 @@ WHEN NOT MATCHED THEN INSERT (ID, NAME) VALUES (S.ID, S.NAME)
 Names are not case sensitive. There is no maximum name length.
 ","
 TEST
-"
-
-"Other Grammar","Null","
-NULL
-","
-NULL is a value without data type and means 'unknown value'.
-","
-NULL
-"
-
-"Other Grammar","Number","
-digit [...]
-","
-The maximum length of the number depends on the data type used.
-","
-100
-"
-
-"Other Grammar","Numeric","
-decimal | int | long | hexNumber
-","
-The data type of a numeric value is always the lowest possible for the given value.
-If the number contains a dot this is decimal; otherwise it is int, long, or decimal (depending on the value).
-","
-SELECT -1600.05
-SELECT CAST(0 AS DOUBLE)
-SELECT -1.4e-10
 "
 
 "Other Grammar","Operand","
@@ -2652,15 +2825,6 @@ List of SET clauses.
 NAME = 'Test', VALUE = 2
 (A, B) = (1, 2)
 (A, B) = (SELECT X, Y FROM OTHER T2 WHERE T1.ID = T2.ID)
-"
-
-"Other Grammar","String","
-'anythingExceptSingleQuote'
-","
-A string starts and ends with a single quote. Two single quotes can be used to
-create a single quote inside a string.
-","
-'John''s car'
 "
 
 "Other Grammar","Summand","
@@ -2828,170 +2992,6 @@ A column name with optional table alias and schema.
 _ROWID_ can be used to access unique row identifier.
 ","
 ID
-"
-
-"Other Grammar","Time","
-TIME [ WITHOUT TIME ZONE ] 'hh:mm:ss[.nnnnnnnnn]'
-","
-A time literal. A value is between 0:00:00 and 23:59:59.999999999
-and has nanosecond resolution.
-","
-TIME '23:59:59'
-"
-
-"Other Grammar","Timestamp","
-TIMESTAMP [ WITHOUT TIME ZONE ] 'yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]'
-","
-A timestamp literal. The limitations are the same as for the Java data type
-""java.sql.Timestamp"", but for compatibility with other databases the suggested
-minimum and maximum years are 0001 and 9999.
-","
-TIMESTAMP '2005-12-31 23:59:59'
-"
-
-"Other Grammar","Timestamp with time zone","
-TIMESTAMP WITH TIME ZONE 'yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]
-[Z | { - | + } timeZoneOffsetString | timeZoneNameString ]'
-","
-A timestamp with time zone literal.
-If name of time zone is specified it will be converted to time zone offset.
-","
-TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59Z'
-TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59-10:00'
-TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59.123+05'
-TIMESTAMP WITH TIME ZONE '2005-12-31 23:59:59.123456789 Europe/London'
-"
-
-"Other Grammar","Date and time","
-date | time | timestamp | timestampWithTimeZone
-","
-A literal value of any date-time data type.
-","
-TIMESTAMP '1999-01-31 10:00:00'
-"
-
-"Other Grammar","INTERVAL YEAR","
-INTERVAL [-|+] '[-|+]yearInt' YEAR
-","
-An INTERVAL YEAR literal.
-","
-INTERVAL '10' YEAR
-"
-
-"Other Grammar","INTERVAL MONTH","
-INTERVAL [-|+] '[-|+]monthInt' MONTH
-","
-An INTERVAL MONTH literal.
-","
-INTERVAL '10' MONTH
-"
-
-"Other Grammar","INTERVAL DAY","
-INTERVAL [-|+] '[-|+]dayInt' DAY
-","
-An INTERVAL DAY literal.
-","
-INTERVAL '10' DAY
-"
-
-"Other Grammar","INTERVAL HOUR","
-INTERVAL [-|+] '[-|+]hourInt' HOUR
-","
-An INTERVAL HOUR literal.
-","
-INTERVAL '10' HOUR
-"
-
-"Other Grammar","INTERVAL MINUTE","
-INTERVAL [-|+] '[-|+]minuteInt' MINUTE
-","
-An INTERVAL MINUTE literal.
-","
-INTERVAL '10' MINUTE
-"
-
-"Other Grammar","INTERVAL SECOND","
-INTERVAL [-|+] '[-|+]secondInt[.nnnnnnnnn]' SECOND
-","
-An INTERVAL SECOND literal.
-","
-INTERVAL '10.123' SECOND
-"
-
-"Other Grammar","INTERVAL YEAR TO MONTH","
-INTERVAL [-|+] '[-|+]yearInt-monthInt' YEAR TO MONTH
-","
-An INTERVAL YEAR TO MONTH literal.
-","
-INTERVAL '1-6' YEAR TO MONTH
-"
-
-"Other Grammar","INTERVAL DAY TO HOUR","
-INTERVAL [-|+] '[-|+]dayInt hoursInt' DAY TO HOUR
-","
-An INTERVAL DAY TO HOUR literal.
-","
-INTERVAL '10 11' DAY TO HOUR
-"
-
-"Other Grammar","INTERVAL DAY TO MINUTE","
-INTERVAL [-|+] '[-|+]dayInt hh:mm' DAY TO MINUTE
-","
-An INTERVAL DAY TO MINUTE literal.
-","
-INTERVAL '10 11:12' DAY TO MINUTE
-"
-
-"Other Grammar","INTERVAL DAY TO SECOND","
-INTERVAL [-|+] '[-|+]dayInt hh:mm:ss[.nnnnnnnnn]' DAY TO SECOND
-","
-An INTERVAL DAY TO SECOND literal.
-","
-INTERVAL '10 11:12:13.123' DAY TO SECOND
-"
-
-"Other Grammar","INTERVAL HOUR TO MINUTE","
-INTERVAL [-|+] '[-|+]hh:mm' HOUR TO MINUTE
-","
-An INTERVAL HOUR TO MINUTE literal.
-","
-INTERVAL '10:11' HOUR TO MINUTE
-"
-
-"Other Grammar","INTERVAL HOUR TO SECOND","
-INTERVAL [-|+] '[-|+]hh:mm:ss[.nnnnnnnnn]' HOUR TO SECOND
-","
-An INTERVAL HOUR TO SECOND literal.
-","
-INTERVAL '10:11:12.123' HOUR TO SECOND
-"
-
-"Other Grammar","INTERVAL MINUTE TO SECOND","
-INTERVAL [-|+] '[-|+]mm:ss[.nnnnnnnnn]' MINUTE TO SECOND
-","
-An INTERVAL MINUTE TO SECOND literal.
-","
-INTERVAL '11:12.123' MINUTE TO SECOND
-"
-
-"Other Grammar","Interval","
-intervalYear | intervalMonth | intervalDay | intervalHour | intervalMinute
-    | intervalSecond | intervalYearToMonth | intervalDayToHour
-    | intervalDayToMinute | intervalDayToSecond | intervalHourToMinute
-    | intervalHourToSecond | intervalMinuteToSecond
-","
-An interval literal.
-","
-INTERVAL '1-2' YEAR TO MONTH
-"
-
-"Other Grammar","Value","
-string | dollarQuotedString | numeric | dateAndTime | boolean | bytes
-    | interval | array | null
-","
-A literal value of any data type, or null.
-","
-10
 "
 
 "Data Types","INT Type","

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -141,7 +141,7 @@ on the client side.
 <p>
 By default, this database stores large LOB (CLOB and BLOB) objects separate from the main table data.
 Small LOB objects are stored in-place, the threshold can be set using
-<a href="grammar.html#set_max_length_inplace_lob" class="notranslate" >MAX_LENGTH_INPLACE_LOB</a>,
+<a href="commands.html#set_max_length_inplace_lob" class="notranslate" >MAX_LENGTH_INPLACE_LOB</a>,
 but there is still an overhead to use CLOB/BLOB. Because of this, BLOB and CLOB
 should never be used for columns with a maximum size below about 200 bytes.
 The best threshold depends on the use case; reading in-place objects is faster
@@ -155,7 +155,7 @@ The following feature is only available for the PageStore storage engine.
 For the MVStore engine (the default for H2 version 1.4.x),
 append <code>;COMPRESS=TRUE</code> to the database URL instead.
 CLOB and BLOB values can be compressed by using
-<a href="grammar.html#set_compress_lob" class="notranslate" >SET COMPRESS_LOB</a>.
+<a href="commands.html#set_compress_lob" class="notranslate" >SET COMPRESS_LOB</a>.
 The LZF algorithm is faster but needs more disk space. By default compression is disabled, which usually speeds up write
 operations. If you store many large compressible values such as XML, HTML, text, and uncompressed binary files,
 then compressing can save a lot of disk space (sometimes more than 50%), and read operations may even be faster.
@@ -188,7 +188,7 @@ If multiple linked tables point to the same database (using the same database UR
 is shared. To disable this, set the system property <code>h2.shareLinkedConnections=false</code>.
 </p>
 <p>
-The statement <a href="grammar.html#create_linked_table" class="notranslate" >CREATE LINKED TABLE</a>
+The statement <a href="commands.html#create_linked_table" class="notranslate" >CREATE LINKED TABLE</a>
 supports an optional schema name parameter.
 </p>
 <p>
@@ -223,7 +223,7 @@ For details, see the sample application <code>org.h2.samples.UpdatableView</code
 <p>
 Please note that most data definition language (DDL) statements,
 such as "create table", commit the current transaction.
-See the <a href="grammar.html">Grammar</a> for details.
+See the <a href="commands.html">Commands</a> for details.
 </p>
 <p>
 Transaction isolation is provided for all data manipulation language (DML) statements.

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1791: Move commands to commands.html and other changes
+</li>
+<li>Issue #1774: H2 Browser configuration is unclear and fails on KUbuntu
+</li>
 <li>PR #1790: Do not convert standard TRIM function to non-standard functions
 </li>
 <li>Issue #1787: Non-standard MERGE throws LOCK_TIMEOUT_1 on violation of some constraints

--- a/h2/src/docsrc/html/commands.html
+++ b/h2/src/docsrc/html/commands.html
@@ -8,7 +8,7 @@ Initial Developer: H2 Group
 <head><meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>
-SQL Grammar
+Commands
 </title>
 <link rel="stylesheet" type="text/css" href="stylesheet.css" />
 <!-- [search] { -->
@@ -17,12 +17,12 @@ SQL Grammar
 <table class="content"><tr class="content"><td class="content"><div class="contentDiv">
 <!-- } -->
 
-<h1>SQL Grammar</h1>
-<h2 id="grammar_index">Index</h2>
-<h3>Literals</h3>
+<h1>Commands</h1>
+<h2 id="commands_index">Index</h2>
+<h3>Commands (Data Manipulation)</h3>
 <!-- syntax-start
 <p class="notranslate">
-<c:forEach var="item" items="literals">
+<c:forEach var="item" items="commandsDML">
     <a href="#${item.link}">${item.topic}</a><br />
 </c:forEach>
 </p>
@@ -31,15 +31,15 @@ syntax-end -->
 <table class="notranslate index">
     <tr>
         <td class="index">
-            <c:forEach var="item" items="literals-0">
+            <c:forEach var="item" items="commandsDML-0">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td><td class="index">
-            <c:forEach var="item" items="literals-1">
+            <c:forEach var="item" items="commandsDML-1">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td><td class="index">
-            <c:forEach var="item" items="literals-2">
+            <c:forEach var="item" items="commandsDML-2">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td>
@@ -47,10 +47,10 @@ syntax-end -->
 </table>
 <!-- railroad-end -->
 
-<h3>Datetime fields</h3>
+<h3>Commands (Data Definition)</h3>
 <!-- syntax-start
 <p class="notranslate">
-<c:forEach var="item" items="datetimeFields">
+<c:forEach var="item" items="commandsDDL">
     <a href="#${item.link}">${item.topic}</a><br />
 </c:forEach>
 </p>
@@ -59,15 +59,15 @@ syntax-end -->
 <table class="notranslate index">
     <tr>
         <td class="index">
-            <c:forEach var="item" items="datetimeFields-0">
+            <c:forEach var="item" items="commandsDDL-0">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td><td class="index">
-            <c:forEach var="item" items="datetimeFields-1">
+            <c:forEach var="item" items="commandsDDL-1">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td><td class="index">
-            <c:forEach var="item" items="datetimeFields-2">
+            <c:forEach var="item" items="commandsDDL-2">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td>
@@ -75,11 +75,11 @@ syntax-end -->
 </table>
 <!-- railroad-end -->
 
-<h3>Other Grammar</h3>
+<h3>Commands (Other)</h3>
 <!-- syntax-start
 <p class="notranslate">
-<c:forEach var="item" items="otherGrammar">
-    <a href="#${item.link}" >${item.topic}</a><br />
+<c:forEach var="item" items="commandsOther">
+    <a href="#${item.link}">${item.topic}</a><br />
 </c:forEach>
 </p>
 syntax-end -->
@@ -87,15 +87,15 @@ syntax-end -->
 <table class="notranslate index">
     <tr>
         <td class="index">
-            <c:forEach var="item" items="otherGrammar-0">
+            <c:forEach var="item" items="commandsOther-0">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td><td class="index">
-            <c:forEach var="item" items="otherGrammar-1">
+            <c:forEach var="item" items="commandsOther-1">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td><td class="index">
-            <c:forEach var="item" items="otherGrammar-2">
+            <c:forEach var="item" items="commandsOther-2">
                 <a href="#${item.link}" >${item.topic}</a><br />
             </c:forEach>
         </td>
@@ -108,8 +108,8 @@ syntax-end -->
 <p>Click on the header to switch between railroad diagram and BNF.</p>
 <!-- railroad-end -->
 
-<h2>Literals</h2>
-<c:forEach var="item" items="literals">
+<h2>Commands (Data Manipulation)</h2>
+<c:forEach var="item" items="commandsDML">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
 <pre name="bnf" style="display: none">
@@ -130,8 +130,8 @@ syntax-end -->
 ${item.example}</p>
 </c:forEach>
 
-<h2>Datetime fields</h2>
-<c:forEach var="item" items="datetimeFields">
+<h2>Commands (Data Definition)</h2>
+<c:forEach var="item" items="commandsDDL">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
 <pre name="bnf" style="display: none">
@@ -152,8 +152,8 @@ syntax-end -->
 ${item.example}</p>
 </c:forEach>
 
-<h2>Other Grammar</h2>
-<c:forEach var="item" items="otherGrammar">
+<h2>Commands (Other)</h2>
+<c:forEach var="item" items="commandsOther">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
 <pre name="bnf" style="display: none">
@@ -170,7 +170,8 @@ ${item.syntax}
 syntax-end -->
 <p>${item.text}</p>
 <p>Example:</p>
-<p class="notranslate">${item.example}</p>
+<p class="notranslate">
+${item.example}</p>
 </c:forEach>
 
 <!--[if lte IE 7]><script language="javascript">switchBnf(null);</script><![endif]-->

--- a/h2/src/docsrc/html/fragments.html
+++ b/h2/src/docsrc/html/fragments.html
@@ -75,9 +75,10 @@ translate -->
 <a href="advanced.html">Advanced</a><br />
 <br />
 <b>Reference</b><br />
-<a href="grammar.html">SQL Grammar</a><br />
+<a href="commands.html">Commands</a><br />
 <a href="functions.html">Functions</a><br />
 <a href="datatypes.html">Data Types</a><br />
+<a href="grammar.html">SQL Grammar</a><br />
 <a href="systemtables.html">System Tables</a><br />
 <a href="../javadoc/index.html">Javadoc</a><br />
 <a href="../h2.pdf">PDF (1.5 MB)</a><br />

--- a/h2/src/docsrc/html/functions.html
+++ b/h2/src/docsrc/html/functions.html
@@ -18,7 +18,7 @@ Functions
 <!-- } -->
 
 <h1>Functions</h1>
-<h2>Index</h2>
+<h2 id="functions_index">Index</h2>
 <h3>Aggregate Functions</h3>
 <!-- syntax-start
 <p class="notranslate">

--- a/h2/src/docsrc/html/grammar.html
+++ b/h2/src/docsrc/html/grammar.html
@@ -103,6 +103,34 @@ syntax-end -->
 </table>
 <!-- railroad-end -->
 
+<h3>Literals</h3>
+<!-- syntax-start
+<p class="notranslate">
+<c:forEach var="item" items="literals">
+    <a href="#${item.link}">${item.topic}</a><br />
+</c:forEach>
+</p>
+syntax-end -->
+<!-- railroad-start -->
+<table class="notranslate index">
+    <tr>
+        <td class="index">
+            <c:forEach var="item" items="literals-0">
+                <a href="#${item.link}" >${item.topic}</a><br />
+            </c:forEach>
+        </td><td class="index">
+            <c:forEach var="item" items="literals-1">
+                <a href="#${item.link}" >${item.topic}</a><br />
+            </c:forEach>
+        </td><td class="index">
+            <c:forEach var="item" items="literals-2">
+                <a href="#${item.link}" >${item.topic}</a><br />
+            </c:forEach>
+        </td>
+    </tr>
+</table>
+<!-- railroad-end -->
+
 <h3>Datetime fields</h3>
 <!-- syntax-start
 <p class="notranslate">
@@ -210,6 +238,28 @@ ${item.example}</p>
 
 <h2>Commands (Other)</h2>
 <c:forEach var="item" items="commandsOther">
+<h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
+<!-- railroad-start -->
+<pre name="bnf" style="display: none">
+${item.syntax}
+</pre>
+<div name="railroad">
+${item.railroad}
+</div>
+<!-- railroad-end -->
+<!-- syntax-start
+<pre>
+${item.syntax}
+</pre>
+syntax-end -->
+<p>${item.text}</p>
+<p>Example:</p>
+<p class="notranslate">
+${item.example}</p>
+</c:forEach>
+
+<h2>Literals</h2>
+<c:forEach var="item" items="literals">
 <h3 id="${item.link}" class="notranslate" onclick="switchBnf(this)">${item.topic}</h3>
 <!-- railroad-start -->
 <pre name="bnf" style="display: none">

--- a/h2/src/docsrc/html/mvstore.html
+++ b/h2/src/docsrc/html/mvstore.html
@@ -234,7 +234,7 @@ System.out.println(map.get(1));
 <p>
 To support multiple concurrent open transactions, a transaction utility is included,
 the <code>TransactionStore</code>.
-The tool supports PostgreSQL style "read committed" transaction isolation
+The tool supports "read committed" transaction isolation
 with savepoints, two-phase commit, and other features typically available in a database.
 There is no limit on the size of a transaction
 (the log is written to disk for large or long running transactions).

--- a/h2/src/docsrc/html/mvstore.html
+++ b/h2/src/docsrc/html/mvstore.html
@@ -466,8 +466,6 @@ For H2 version 1.4 and newer, the MVStore is the default storage engine
 For older versions, append
 <code>;MV_STORE=TRUE</code>
 to the database URL.
-Even though it can be used with the default table level locking,
-by default the MVCC mode is enabled when using the MVStore.
 </p>
 
 <h2 id="fileFormat">File Format</h2>
@@ -477,7 +475,7 @@ The file contains two file headers (for safety), and a number of chunks.
 The file headers are one block each; a block is 4096 bytes.
 Each chunk is at least one block, but typically 200 blocks or more.
 Data is stored in the chunks in the form of a
-<a href="http://en.wikipedia.org/wiki/Log-structured_file_system">log structured storage</a>.
+<a href="https://en.wikipedia.org/wiki/Log-structured_file_system">log structured storage</a>.
 There is one chunk for every version.
 </p>
 <pre>
@@ -539,14 +537,14 @@ Each value is stored as a hexadecimal number. The entries are:
 </li><li>block: The block number where one of the newest chunks starts
     (but not necessarily the newest).
 </li><li>blockSize: The block size of the file; currently always hex 1000, which is decimal 4096,
-    to match the <a href="http://en.wikipedia.org/wiki/Disk_sector">disk sector</a>
+    to match the <a href="https://en.wikipedia.org/wiki/Disk_sector">disk sector</a>
     length of modern hard disks.
 </li><li>chunk: The chunk id, which is normally the same value as the version;
     however, the chunk id might roll over to 0, while the version doesn't.
 </li><li>created: The number of milliseconds since 1970 when the file was created.
 </li><li>format: The file format number. Currently 1.
 </li><li>version: The version number of the chunk.
-</li><li>fletcher: The <a href="http://en.wikipedia.org/wiki/Fletcher's_checksum">
+</li><li>fletcher: The <a href="https://en.wikipedia.org/wiki/Fletcher's_checksum">
     Fletcher-32 checksum</a> of the header.
 </li></ul>
 <p>
@@ -603,7 +601,7 @@ plus all the parent nodes of those pages, recursively, up to the root page.
 If an entry in a map is changed, removed, or added, then the respective page is copied,
 modified, and stored in the next chunk, and the number of live pages in the old chunk is decremented.
 This mechanism is called copy-on-write, and is similar to how the
-<a href="http://en.wikipedia.org/wiki/Btrfs">Btrfs</a> file system works.
+<a href="https://en.wikipedia.org/wiki/Btrfs">Btrfs</a> file system works.
 Chunks without live pages are marked as free, so the space can be re-used by more recent chunks.
 Because not all chunks are of the same size, there can be a number of free blocks in front of a chunk
 for some time (until a small chunk is written or the chunks are compacted).
@@ -629,14 +627,14 @@ In any case, the file header is updated if the next chain gets longer than 20 ho
 
 <h3>Page Format</h3>
 <p>
-Each map is a <a href="http://en.wikipedia.org/wiki/B-tree">B-tree</a>,
+Each map is a <a href="https://en.wikipedia.org/wiki/B-tree">B-tree</a>,
 and the map data is stored in (B-tree-) pages.
 There are leaf pages that contain the key-value pairs of the map,
 and internal nodes, which only contain keys and pointers to leaf pages.
 The root of a tree is either a leaf or an internal node.
 Unlike file header and chunk header and footer, the page data is not human readable.
 Instead, it is stored as byte arrays, with long (8 bytes), int (4 bytes), short (2 bytes),
-and <a href="http://en.wikipedia.org/wiki/Variable-length_quantity">variable size int and long</a>
+and <a href="https://en.wikipedia.org/wiki/Variable-length_quantity">variable size int and long</a>
 (1 to 5 / 10 bytes). The page format is:
 </p>
 <ul><li>length (int): Length of the page in bytes.
@@ -680,7 +678,7 @@ This allows to estimate the amount of free space within a block, in addition to 
 <p>
 The total number of entries in child pages are kept to allow efficient range counting,
 lookup by index, and skip operations.
-The pages form a <a href="http://www.chiark.greenend.org.uk/~sgtatham/algorithms/cbtree.html">counted B-tree</a>.
+The pages form a <a href="https://www.chiark.greenend.org.uk/~sgtatham/algorithms/cbtree.html">counted B-tree</a>.
 </p>
 <p>
 Data compression: The data after the page type are optionally compressed using the LZF algorithm.

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -198,7 +198,6 @@ import org.h2.expression.condition.ConditionIn;
 import org.h2.expression.condition.ConditionInParameter;
 import org.h2.expression.condition.ConditionInSelect;
 import org.h2.expression.condition.ConditionNot;
-import org.h2.expression.function.DateTimeFunctions;
 import org.h2.expression.function.Function;
 import org.h2.expression.function.FunctionCall;
 import org.h2.expression.function.JavaFunction;
@@ -3521,8 +3520,7 @@ public class Parser {
             break;
         }
         case Function.EXTRACT: {
-            function.setParameter(0,
-                    ValueExpression.get(ValueString.get(currentToken)));
+            function.setParameter(0, ValueExpression.get(ValueString.get(currentToken)));
             read();
             read(FROM);
             function.setParameter(1, readExpression());
@@ -3531,13 +3529,12 @@ public class Parser {
         }
         case Function.DATE_ADD:
         case Function.DATE_DIFF: {
-            if (DateTimeFunctions.isDatePart(currentToken)) {
-                function.setParameter(0,
-                        ValueExpression.get(ValueString.get(currentToken)));
-                read();
+            if (currentTokenType == VALUE) {
+                function.setParameter(0, ValueExpression.get(currentValue.convertTo(Value.STRING)));
             } else {
-                function.setParameter(0, readExpression());
+                function.setParameter(0, ValueExpression.get(ValueString.get(currentToken)));
             }
+            read();
             read(COMMA);
             function.setParameter(1, readExpression());
             read(COMMA);

--- a/h2/src/main/org/h2/tools/Server.java
+++ b/h2/src/main/org/h2/tools/Server.java
@@ -719,7 +719,7 @@ public class Server extends Tool implements Runnable, ShutdownHandler {
                     // No success in detection.
                     throw new Exception(
                             "Browser detection failed, and java property 'h2.browser' " +
-                             "and environment variable BROWSER are not set to a browser executable.");
+                            "and environment variable BROWSER are not set to a browser executable.");
                 }
             }
         } catch (Exception e) {

--- a/h2/src/tools/org/h2/build/doc/BnfSyntax.java
+++ b/h2/src/tools/org/h2/build/doc/BnfSyntax.java
@@ -69,7 +69,9 @@ public class BnfSyntax implements BnfVisitor {
         }
         String page = "grammar.html";
         String section = found.getSection();
-        if (section.startsWith("Data Types") || section.startsWith("Interval Data Types")) {
+        if (section.startsWith("Commands")) {
+            page = "commands.html";
+        } if (section.startsWith("Data Types") || section.startsWith("Interval Data Types")) {
             page = "datatypes.html";
         } else if (section.startsWith("Functions")) {
             page = "functions.html";

--- a/h2/src/tools/org/h2/build/doc/GenerateDoc.java
+++ b/h2/src/tools/org/h2/build/doc/GenerateDoc.java
@@ -76,6 +76,8 @@ public class GenerateDoc {
                 help + "= 'Commands (DDL)' ORDER BY ID", true, false);
         map("commandsOther",
                 help + "= 'Commands (Other)' ORDER BY ID", true, false);
+        map("literals",
+                help + "= 'Literals' ORDER BY ID", true, false);
         map("datetimeFields",
                 help + "= 'Datetime fields' ORDER BY ID", true, false);
         map("otherGrammar",

--- a/h2/src/tools/org/h2/build/doc/LinkChecker.java
+++ b/h2/src/tools/org/h2/build/doc/LinkChecker.java
@@ -32,7 +32,9 @@ public class LinkChecker {
         "#build_index",
         "#datatypes_index",
         "#faq_index",
+        "#commands_index",
         "#grammar_index",
+        "#functions_index",
         "#tutorial_index"
     };
 

--- a/h2/src/tools/org/h2/build/doc/MergeDocs.java
+++ b/h2/src/tools/org/h2/build/doc/MergeDocs.java
@@ -31,8 +31,8 @@ public class MergeDocs {
         // the order of pages is important here
         String[] pages = { "quickstart.html", "installation.html",
                 "tutorial.html", "features.html", "performance.html",
-                "advanced.html", "grammar.html", "functions.html",
-                "datatypes.html", "systemtables.html",
+                "advanced.html", "commands.html", "functions.html",
+                "datatypes.html", "grammar.html", "systemtables.html",
                 "build.html", "history.html", "faq.html" };
         StringBuilder buff = new StringBuilder();
         for (String fileName : pages) {
@@ -100,7 +100,9 @@ public class MergeDocs {
                 .replaceAll("href=\"build.html\"", "href=\"#build_index\"")
                 .replaceAll("href=\"datatypes.html\"", "href=\"#datatypes_index\"")
                 .replaceAll("href=\"faq.html\"", "href=\"#faq_index\"")
+                .replaceAll("href=\"commands.html\"", "href=\"#commands_index\"")
                 .replaceAll("href=\"grammar.html\"", "href=\"#grammar_index\"")
+                .replaceAll("href=\"functions.html\"", "href=\"#functions_index\"")
                 .replaceAll("href=\"tutorial.html\"", "href=\"#tutorial_index\"");
     }
 

--- a/h2/src/tools/org/h2/build/i18n/PrepareTranslation.java
+++ b/h2/src/tools/org/h2/build/i18n/PrepareTranslation.java
@@ -33,7 +33,7 @@ import org.h2.util.StringUtils;
  */
 public class PrepareTranslation {
     private static final String MAIN_LANGUAGE = "en";
-    private static final String[] EXCLUDE = { "datatypes.html",
+    private static final String[] EXCLUDE = { "commands.html", "datatypes.html",
             "functions.html", "grammar.html" };
 
     /**


### PR DESCRIPTION
1. SQL commands are moved from `grammar.html` to own `commands.html`.

2. Literals are grouped into own subsection in `grammar.html`.

3. Reference to MVCC mode is removed from `mvstore.html`.

4. Parser does not try to parse any expressions during parsing of first argument of non-standard `DATE_ADD` and `DATE_DIFF` functions any more. SQL Server and H2 expect only a datetime unit here. We may allow dynamic specification of time units, but in this case we need to make all our datetime units a context-sensitive keywords to distinguish them from column names, I don't think that we want it. Also standard `EXTRACT` function supports only datetime units.