### PR TITLE
Ask password in Shell in secure way and improve database creation information in tutorial

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1794: Ask password in Shell in secure way and improve database creation information in tutorial
+</li>
 <li>PR #1791: Move commands to commands.html and other changes
 </li>
 <li>Issue #1774: H2 Browser configuration is unclear and fails on KUbuntu

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -428,8 +428,9 @@ and the file password (in addition to the user password) when connecting to the 
 
 <h3>Creating a New Database with File Encryption</h3>
 <p>
-By default, a new database is automatically created if it does not exist yet.
-To create an encrypted database, connect to it as it would already exist.
+By default, a new database is automatically created if it does not exist yet
+when the <a href="#database_url">embedded</a> url is used.
+To create an encrypted database, connect to it as it would already exist locally using the embedded URL.
 </p>
 
 <h3>Connecting to an Encrypted Database</h3>

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -490,9 +490,51 @@ Auto-creation of databases can be disabled, see
 <a href="features.html#database_only_if_exists">Opening a Database Only if it Already Exists</a>.
 </p>
 <p>
-H2 Console does not allow creation of databases by default unless a browser window is opened by Console during its
+H2 Console does not allow creation of databases unless a browser window is opened by Console during its
 startup or from its icon in the system tray and remote access is not enabled.
 A context menu of the tray icon can also be used to create a new database.
+</p>
+<p>
+You can also create a new local database from a command line with a Shell tool:
+</p>
+<pre>
+&gt; java -cp h2-*.jar org.h2.tools.Shell
+
+Welcome to H2 Shell
+Exit with Ctrl+C
+[Enter]   jdbc:h2:mem:2
+URL       jdbc:h2:./path/to/database
+[Enter]   org.h2.Driver
+Driver
+[Enter]   sa
+User      your_username
+Password  (hidden)
+Type the same password again to confirm database creation.
+Password  (hidden)
+Connected
+
+sql&gt; quit
+Connection closed
+</pre>
+<p>
+By default remote creation of databases from a TCP connection or a web interface is not allowed.
+It's not recommended to enable remote creation of databases due to security reasons.
+User who creates a new database becomes its administrator and therefore gets the same access to your JVM as H2 has
+and the same access to your operating system as Java and your system account allows.
+It's recommended to create all databases locally using an embedded URL, local H2 Console, or the Shell tool.
+</p>
+<p>
+If you really need to allow remote database creation, you can pass <code>-ifNotExists</code> parameter to
+TCP, PG, or Web servers (but not to the Console tool).
+Its combination with <code>-tcpAllowOthers</code>, <code>-pgAllowOthers</code>, or <code>-webAllowOthers</code>
+effectively creates a remote security hole in your system, if you use it, always guard your ports with a firewall
+or some other solution and use such combination of settings only in trusted networks.
+</p>
+<p>
+H2 Servlet also supports such option.
+When you use it always protect the servlet with security constraints,
+see <a href="#usingH2ConsoleServlet">Using the H2 Console Servlet</a> for example;
+don't forget to uncomment and adjust security configuration for your needs.
 </p>
 
 <h2 id="using_server">Using the Server</h2>
@@ -788,7 +830,7 @@ When the web application is stopped, the database connection will be closed auto
 If the TCP server is started within the <code>DbStarter</code>, it will also be stopped automatically.
 </p>
 
-<h3>Using the H2 Console Servlet</h3>
+<h3 id="usingH2ConsoleServlet">Using the H2 Console Servlet</h3>
 <p>
 The H2 Console is a standalone application and includes its own web server, but it can be
 used as a servlet as well. To do that, include the <code>h2*.jar</code> file in your application, and
@@ -814,6 +856,20 @@ add the following configuration to your <code>web.xml</code>:
     &lt;servlet-name&gt;H2Console&lt;/servlet-name&gt;
     &lt;url-pattern&gt;/console/*&lt;/url-pattern&gt;
 &lt;/servlet-mapping&gt;
+&lt;!--
+&lt;security-role&gt;
+    &lt;role-name&gt;admin&lt;/role-name&gt;
+&lt;/security-role&gt;
+&lt;security-constraint&gt;
+    &lt;web-resource-collection&gt;
+        &lt;web-resource-name&gt;H2 Console&lt;/web-resource-name&gt;
+        &lt;url-pattern&gt;/console/*&lt;/url-pattern&gt;
+    &lt;/web-resource-collection&gt;
+    &lt;auth-constraint&gt;
+        &lt;role-name&gt;admin&lt;/role-name&gt;
+    &lt;/auth-constraint&gt;
+&lt;/security-constraint&gt;
+--&gt;
 </pre>
 <p>
 For details, see also <code>src/tools/WEB-INF/web.xml</code>.

--- a/h2/src/main/org/h2/tools/GUIConsole.java
+++ b/h2/src/main/org/h2/tools/GUIConsole.java
@@ -51,7 +51,7 @@ public class GUIConsole extends Console implements ActionListener, MouseListener
     private Button startBrowser;
 
     private Frame createFrame;
-    private TextField pathField, userField, passwordField;
+    private TextField pathField, userField, passwordField, passwordConfirmationField;
     private Button createButton;
     private TextArea errorArea;
 
@@ -318,6 +318,7 @@ public class GUIConsole extends Console implements ActionListener, MouseListener
 
         constraints = new GridBagConstraints();
         constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.insets = new Insets(10, 0, 0, 0);
         constraints.gridx = 0;
         constraints.gridy = 0;
         Label urlLabel = new Label("Database path:", Label.LEFT);
@@ -328,7 +329,7 @@ public class GUIConsole extends Console implements ActionListener, MouseListener
         constraints.fill = GridBagConstraints.HORIZONTAL;
         constraints.gridy = 0;
         constraints.weightx = 1d;
-        constraints.insets = new Insets(0, 5, 0, 0);
+        constraints.insets = new Insets(10, 5, 0, 0);
         constraints.gridx = 1;
         pathField = new TextField();
         pathField.setFont(font);
@@ -370,13 +371,33 @@ public class GUIConsole extends Console implements ActionListener, MouseListener
         constraints.gridx = 1;
         passwordField = new TextField();
         passwordField.setFont(font);
+        passwordField.setEchoChar('*');
         mainPanel.add(passwordField, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.gridx = 0;
+        constraints.gridy = 3;
+        Label passwordConfirmationLabel = new Label("Password confirmation:", Label.LEFT);
+        passwordConfirmationLabel.setFont(font);
+        mainPanel.add(passwordConfirmationLabel, constraints);
+
+        constraints = new GridBagConstraints();
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.gridy = 3;
+        constraints.weightx = 1d;
+        constraints.insets = new Insets(0, 5, 0, 0);
+        constraints.gridx = 1;
+        passwordConfirmationField = new TextField();
+        passwordConfirmationField.setFont(font);
+        passwordConfirmationField.setEchoChar('*');
+        mainPanel.add(passwordConfirmationField, constraints);
 
         constraints = new GridBagConstraints();
         constraints.gridx = 0;
         constraints.gridwidth = 2;
         constraints.insets = new Insets(10, 0, 0, 0);
-        constraints.gridy = 3;
+        constraints.gridy = 4;
         constraints.anchor = GridBagConstraints.EAST;
         createButton = new Button("Create");
         createButton.setFocusable(false);
@@ -387,7 +408,7 @@ public class GUIConsole extends Console implements ActionListener, MouseListener
 
         constraints = new GridBagConstraints();
         constraints.fill = GridBagConstraints.HORIZONTAL;
-        constraints.gridy = 4;
+        constraints.gridy = 5;
         constraints.weightx = 1d;
         constraints.insets = new Insets(10, 0, 0, 0);
         constraints.gridx = 0;
@@ -406,11 +427,10 @@ public class GUIConsole extends Console implements ActionListener, MouseListener
         constraints.gridy = 0;
         createFrame.add(mainPanel, constraints);
 
-        int width = 300, height = 300;
+        int width = 400, height = 400;
         createFrame.setSize(width, height);
-        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        createFrame.setLocation((screenSize.width - width) / 2,
-                (screenSize.height - height) / 2);
+        createFrame.pack();
+        createFrame.setLocationRelativeTo(null);
         try {
             createFrame.setVisible(true);
         } catch (Throwable t) {
@@ -431,7 +451,13 @@ public class GUIConsole extends Console implements ActionListener, MouseListener
         if (web == null || createFrame == null) {
             return;
         }
-        String path = pathField.getText(), user = userField.getText(), password = passwordField.getText();
+        String path = pathField.getText(), user = userField.getText(), password = passwordField.getText(),
+                passwordConfirmation = passwordConfirmationField.getText();
+        if (!password.equals(passwordConfirmation)) {
+            errorArea.setForeground(Color.RED);
+            errorArea.setText("Passwords don't match");
+            return;
+        }
         if (password.isEmpty()) {
             errorArea.setForeground(Color.RED);
             errorArea.setText("Specify a password");

--- a/h2/src/test/org/h2/test/unit/TestShell.java
+++ b/h2/src/test/org/h2/test/unit/TestShell.java
@@ -107,8 +107,9 @@ public class TestShell extends TestBase {
             testOut.println("");
             read("Driver");
             testOut.println("sa");
-            read("User");
             testOut.println("sa");
+            testOut.println("sa");
+            read("User");
             read("Password");
         }
         read("Commands are case insensitive");

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -809,4 +809,4 @@ preserves masking holder unboxing avert iae transformed subtle reevaluate exclus
 presorted inclusion contexts aax mwd percentile cont interpolate mwa hypothetical regproc childed listagg foreground
 isodow isoyear psql
 
-waiters reliably httpsdocs privileged narrow spending swallow
+waiters reliably httpsdocs privileged narrow spending swallow locally uncomment


### PR DESCRIPTION
Related with #1792.

1. Obscure password hiding logic in `Shell` is removed and replaced with password confirmation (for database creation only).

2. Database creation information in Tutorial is improved. Now it includes command-line instructions, applicability and security notes about `-ifNotExists` flags, and sample security configuration for a web servlet.