### PR TITLE
Reduce code duplication and remove h2.mixedGeometries

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1807: Reduce code duplication and remove h2.mixedGeometries
+</li>
 <li>PR #1806: Improve SELECT FOR UPDATE documentation
 </li>
 <li>PR #1804: Lift limit of 10 characters on enum value (1.4.198 regression)

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -567,18 +567,6 @@ public class SysProperties {
     public static final String AUTH_CONFIG_FILE =
             Utils.getProperty("h2.authConfigFile", null);
 
-    /**
-     * System property {@code h2.mixedGeometries}, {@code false} by default.
-     * <p>
-     * If {@code true} illegal geometries with mixed XY/XYZ dimensionality like
-     * {@code 'LINESTRING (1 2, 3 4 5)'} are accepted.
-     * </p>
-     * <p>
-     * If {@code false} such geometries are rejected with data conversion error.
-     * </p>
-     */
-    public static final boolean MIXED_GEOMETRIES = Utils.getProperty("h2.mixedGeometries", false);
-
     private static final String H2_BASE_DIR = "h2.baseDir";
 
     private SysProperties() {

--- a/h2/src/main/org/h2/index/HashIndex.java
+++ b/h2/src/main/org/h2/index/HashIndex.java
@@ -18,7 +18,7 @@ import org.h2.result.SearchRow;
 import org.h2.result.SortOrder;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.TableFilter;
 import org.h2.value.DataType;
 import org.h2.value.Value;
@@ -34,11 +34,11 @@ public class HashIndex extends BaseIndex {
      */
     private final int indexColumn;
     private final boolean totalOrdering;
-    private final RegularTable tableData;
+    private final PageStoreTable tableData;
     private Map<Value, Long> rows;
     private final ArrayList<Long> nullRows = new ArrayList<>();
 
-    public HashIndex(RegularTable table, int id, String indexName, IndexColumn[] columns, IndexType indexType) {
+    public HashIndex(PageStoreTable table, int id, String indexName, IndexColumn[] columns, IndexType indexType) {
         super(table, id, indexName, columns, indexType);
         Column column = columns[0].column;
         indexColumn = column.getColumnId();

--- a/h2/src/main/org/h2/index/NonUniqueHashCursor.java
+++ b/h2/src/main/org/h2/index/NonUniqueHashCursor.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import org.h2.engine.Session;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 
 /**
  * Cursor implementation for non-unique hash index
@@ -20,11 +20,11 @@ public class NonUniqueHashCursor implements Cursor {
 
     private final Session session;
     private final ArrayList<Long> positions;
-    private final RegularTable tableData;
+    private final PageStoreTable tableData;
 
     private int index = -1;
 
-    public NonUniqueHashCursor(Session session, RegularTable tableData,
+    public NonUniqueHashCursor(Session session, PageStoreTable tableData,
             ArrayList<Long> positions) {
         this.session = session;
         this.tableData = tableData;

--- a/h2/src/main/org/h2/index/NonUniqueHashIndex.java
+++ b/h2/src/main/org/h2/index/NonUniqueHashIndex.java
@@ -18,7 +18,7 @@ import org.h2.result.SearchRow;
 import org.h2.result.SortOrder;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.TableFilter;
 import org.h2.util.Utils;
 import org.h2.value.DataType;
@@ -37,10 +37,10 @@ public class NonUniqueHashIndex extends BaseIndex {
     private final int indexColumn;
     private final boolean totalOrdering;
     private Map<Value, ArrayList<Long>> rows;
-    private final RegularTable tableData;
+    private final PageStoreTable tableData;
     private long rowCount;
 
-    public NonUniqueHashIndex(RegularTable table, int id, String indexName,
+    public NonUniqueHashIndex(PageStoreTable table, int id, String indexName,
             IndexColumn[] columns, IndexType indexType) {
         super(table, id, indexName, columns, indexType);
         Column column = columns[0].column;

--- a/h2/src/main/org/h2/index/PageBtreeIndex.java
+++ b/h2/src/main/org/h2/index/PageBtreeIndex.java
@@ -19,7 +19,7 @@ import org.h2.store.Page;
 import org.h2.store.PageStore;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.TableFilter;
 import org.h2.util.MathUtils;
 import org.h2.value.Value;
@@ -34,13 +34,13 @@ public class PageBtreeIndex extends PageIndex {
     private static int memoryChangeRequired;
 
     private final PageStore store;
-    private final RegularTable tableData;
+    private final PageStoreTable tableData;
     private final boolean needRebuild;
     private long rowCount;
     private int memoryPerPage;
     private int memoryCount;
 
-    public PageBtreeIndex(RegularTable table, int id, String indexName,
+    public PageBtreeIndex(PageStoreTable table, int id, String indexName,
             IndexColumn[] columns,
             IndexType indexType, boolean create, Session session) {
         super(table, id, indexName, columns, indexType);

--- a/h2/src/main/org/h2/index/PageDataIndex.java
+++ b/h2/src/main/org/h2/index/PageDataIndex.java
@@ -18,7 +18,7 @@ import org.h2.store.Page;
 import org.h2.store.PageStore;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.TableFilter;
 import org.h2.util.MathUtils;
 import org.h2.value.Value;
@@ -32,7 +32,7 @@ import org.h2.value.ValueNull;
 public class PageDataIndex extends PageIndex {
 
     private final PageStore store;
-    private final RegularTable tableData;
+    private final PageStoreTable tableData;
     private long lastKey;
     private long rowCount;
     private int mainIndexColumn = -1;
@@ -45,7 +45,7 @@ public class PageDataIndex extends PageIndex {
     private int memoryPerPage;
     private int memoryCount;
 
-    public PageDataIndex(RegularTable table, int id, IndexColumn[] columns,
+    public PageDataIndex(PageStoreTable table, int id, IndexColumn[] columns,
             IndexType indexType, boolean create, Session session) {
         super(table, id, table.getName() + "_DATA", columns, indexType);
 

--- a/h2/src/main/org/h2/index/PageDelegateIndex.java
+++ b/h2/src/main/org/h2/index/PageDelegateIndex.java
@@ -14,7 +14,7 @@ import org.h2.result.SortOrder;
 import org.h2.store.PageStore;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.TableFilter;
 
 /**
@@ -24,7 +24,7 @@ public class PageDelegateIndex extends PageIndex {
 
     private final PageDataIndex mainIndex;
 
-    public PageDelegateIndex(RegularTable table, int id, String name,
+    public PageDelegateIndex(PageStoreTable table, int id, String name,
             IndexType indexType, PageDataIndex mainIndex, boolean create,
             Session session) {
         super(table, id, name,

--- a/h2/src/main/org/h2/index/ScanIndex.java
+++ b/h2/src/main/org/h2/index/ScanIndex.java
@@ -17,7 +17,7 @@ import org.h2.result.SearchRow;
 import org.h2.result.SortOrder;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.TableFilter;
 import org.h2.util.Utils;
 
@@ -30,10 +30,10 @@ import org.h2.util.Utils;
 public class ScanIndex extends BaseIndex {
     private long firstFree = -1;
     private ArrayList<Row> rows = Utils.newSmallArrayList();
-    private final RegularTable tableData;
+    private final PageStoreTable tableData;
     private long rowCount;
 
-    public ScanIndex(RegularTable table, int id, IndexColumn[] columns,
+    public ScanIndex(PageStoreTable table, int id, IndexColumn[] columns,
             IndexType indexType) {
         super(table, id, table.getName() + "_DATA", columns, indexType);
         tableData = table;

--- a/h2/src/main/org/h2/index/TreeIndex.java
+++ b/h2/src/main/org/h2/index/TreeIndex.java
@@ -12,7 +12,7 @@ import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.result.SortOrder;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.TableFilter;
 import org.h2.value.Value;
 import org.h2.value.ValueNull;
@@ -23,11 +23,11 @@ import org.h2.value.ValueNull;
 public class TreeIndex extends BaseIndex {
 
     private TreeNode root;
-    private final RegularTable tableData;
+    private final PageStoreTable tableData;
     private long rowCount;
     private boolean closed;
 
-    public TreeIndex(RegularTable table, int id, String indexName,
+    public TreeIndex(PageStoreTable table, int id, String indexName,
             IndexColumn[] columns, IndexType indexType) {
         super(table, id, indexName, columns, indexType);
         tableData = table;

--- a/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
@@ -75,8 +75,8 @@ public class JdbcConnectionPool implements DataSource, ConnectionEventListener,
     private PrintWriter logWriter;
     private volatile int maxConnections = DEFAULT_MAX_CONNECTIONS;
     private volatile int timeout = DEFAULT_TIMEOUT;
-    private AtomicInteger activeConnections = new AtomicInteger(0);
-    private AtomicBoolean isDisposed = new AtomicBoolean(false);
+    private AtomicInteger activeConnections = new AtomicInteger();
+    private AtomicBoolean isDisposed = new AtomicBoolean();
 
     protected JdbcConnectionPool(ConnectionPoolDataSource dataSource) {
         this.dataSource = dataSource;

--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -27,22 +27,22 @@ public class FileStore {
     /**
      * The number of read operations.
      */
-    protected final AtomicLong readCount = new AtomicLong(0);
+    protected final AtomicLong readCount = new AtomicLong();
 
     /**
      * The number of read bytes.
      */
-    protected final AtomicLong readBytes = new AtomicLong(0);
+    protected final AtomicLong readBytes = new AtomicLong();
 
     /**
      * The number of write operations.
      */
-    protected final AtomicLong writeCount = new AtomicLong(0);
+    protected final AtomicLong writeCount = new AtomicLong();
 
     /**
      * The number of written bytes.
      */
-    protected final AtomicLong writeBytes = new AtomicLong(0);
+    protected final AtomicLong writeBytes = new AtomicLong();
 
     /**
      * The free spaces between the chunks. The first block to use is block 2

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1445,7 +1445,7 @@ public class MVStore implements AutoCloseable {
         assert lastChunk != null;
         final ThreadPoolExecutor executorService = new ThreadPoolExecutor(10, 10, 10L, TimeUnit.SECONDS,
                 new ArrayBlockingQueue<Runnable>(keysPerPage + 1));
-        final AtomicInteger executingThreadCounter = new AtomicInteger(0);
+        final AtomicInteger executingThreadCounter = new AtomicInteger();
         try {
             ChunkIdsCollector collector = new ChunkIdsCollector(meta.getId());
             long oldestVersionToKeep = getOldestVersionToKeep();

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -40,7 +40,7 @@ public class MVPrimaryIndex extends BaseIndex {
     private final MVTable mvTable;
     private final String mapName;
     private final TransactionMap<Value, Value> dataMap;
-    private final AtomicLong lastKey = new AtomicLong(0);
+    private final AtomicLong lastKey = new AtomicLong();
     private int mainIndexColumn = SearchRow.ROWID_INDEX;
 
     public MVPrimaryIndex(Database db, MVTable table, int id,

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -7,11 +7,6 @@ package org.h2.mvstore.db;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -19,8 +14,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.command.ddl.CreateTableData;
-import org.h2.constraint.Constraint;
-import org.h2.constraint.ConstraintReferential;
 import org.h2.engine.Constants;
 import org.h2.engine.DbObject;
 import org.h2.engine.Session;
@@ -39,19 +32,15 @@ import org.h2.result.SearchRow;
 import org.h2.schema.SchemaObject;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.Table;
-import org.h2.table.TableBase;
-import org.h2.table.TableType;
+import org.h2.table.RegularTable;
 import org.h2.util.DebuggingThreadLocal;
 import org.h2.util.MathUtils;
 import org.h2.util.Utils;
-import org.h2.value.DataType;
-import org.h2.value.Value;
 
 /**
  * A table stored in a MVStore.
  */
-public class MVTable extends TableBase {
+public class MVTable extends RegularTable {
     /**
      * The table name this thread is waiting to lock.
      */
@@ -107,11 +96,6 @@ public class MVTable extends TableBase {
     private MVPrimaryIndex primaryIndex;
     private final ArrayList<Index> indexes = Utils.newSmallArrayList();
     private final AtomicLong lastModificationId = new AtomicLong();
-    private volatile Session lockExclusiveSession;
-
-    // using a ConcurrentHashMap as a set
-    private final ConcurrentHashMap<Session, Session> lockSharedSessions =
-            new ConcurrentHashMap<>();
 
     /**
      * The queue of sessions waiting to lock the table. It is a FIFO queue to
@@ -121,8 +105,6 @@ public class MVTable extends TableBase {
     private final Trace traceLock;
     private final AtomicInteger changesUntilAnalyze;
     private int nextAnalyze;
-    private final boolean containsLargeObject;
-    private Column rowIdColumn;
 
     private final MVTableEngine.Store store;
     private final TransactionStore transactionStore;
@@ -133,15 +115,6 @@ public class MVTable extends TableBase {
         changesUntilAnalyze = nextAnalyze <= 0 ? null : new AtomicInteger(nextAnalyze);
         this.store = store;
         this.transactionStore = store.getTransactionStore();
-        this.isHidden = data.isHidden;
-        boolean b = false;
-        for (Column col : getColumns()) {
-            if (DataType.isLargeObject(col.getType().getValueType())) {
-                b = true;
-                break;
-            }
-        }
-        containsLargeObject = b;
         traceLock = database.getTrace(Trace.LOCK);
 
         primaryIndex = new MVPrimaryIndex(database, this, getId(),
@@ -317,104 +290,12 @@ public class MVTable extends TableBase {
         return false;
     }
 
-    private static String getDeadlockDetails(ArrayList<Session> sessions, boolean exclusive) {
-        // We add the thread details here to make it easier for customers to
-        // match up these error messages with their own logs.
-        StringBuilder buff = new StringBuilder();
-        for (Session s : sessions) {
-            Table lock = s.getWaitForLock();
-            Thread thread = s.getWaitForLockThread();
-            buff.append("\nSession ").append(s.toString())
-                    .append(" on thread ").append(thread.getName())
-                    .append(" is waiting to lock ").append(lock.toString())
-                    .append(exclusive ? " (exclusive)" : " (shared)")
-                    .append(" while locking ");
-            int i = 0;
-            for (Table t : s.getLocks()) {
-                if (i++ > 0) {
-                    buff.append(", ");
-                }
-                buff.append(t.toString());
-                if (t instanceof MVTable) {
-                    if (t.isLockedExclusivelyBy(s)) {
-                        buff.append(" (exclusive)");
-                    } else {
-                        buff.append(" (shared)");
-                    }
-                }
-            }
-            buff.append('.');
-        }
-        return buff.toString();
-    }
-
-    @Override
-    public ArrayList<Session> checkDeadlock(Session session, Session clash,
-            Set<Session> visited) {
-        // only one deadlock check at any given time
-        synchronized (MVTable.class) {
-            if (clash == null) {
-                // verification is started
-                clash = session;
-                visited = new HashSet<>();
-            } else if (clash == session) {
-                // we found a circle where this session is involved
-                return new ArrayList<>(0);
-            } else if (visited.contains(session)) {
-                // we have already checked this session.
-                // there is a circle, but the sessions in the circle need to
-                // find it out themselves
-                return null;
-            }
-            visited.add(session);
-            ArrayList<Session> error = null;
-            for (Session s : lockSharedSessions.keySet()) {
-                if (s == session) {
-                    // it doesn't matter if we have locked the object already
-                    continue;
-                }
-                Table t = s.getWaitForLock();
-                if (t != null) {
-                    error = t.checkDeadlock(s, clash, visited);
-                    if (error != null) {
-                        error.add(session);
-                        break;
-                    }
-                }
-            }
-            // take a local copy so we don't see inconsistent data, since we are
-            // not locked while checking the lockExclusiveSession value
-            Session copyOfLockExclusiveSession = lockExclusiveSession;
-            if (error == null && copyOfLockExclusiveSession != null) {
-                Table t = copyOfLockExclusiveSession.getWaitForLock();
-                if (t != null) {
-                    error = t.checkDeadlock(copyOfLockExclusiveSession, clash,
-                            visited);
-                    if (error != null) {
-                        error.add(session);
-                    }
-                }
-            }
-            return error;
-        }
-    }
-
     private void traceLock(Session session, boolean exclusive, TraceLockEvent eventEnum, String extraInfo) {
         if (traceLock.isDebugEnabled()) {
             traceLock.debug("{0} {1} {2} {3} {4}", session.getId(),
                     exclusive ? "exclusive write lock" : "shared read lock", eventEnum.getEventText(),
                     getName(), extraInfo);
         }
-    }
-
-    @Override
-    public boolean isLockedExclusively() {
-        return lockExclusiveSession != null;
-    }
-
-    @Override
-    public boolean isLockedExclusivelyBy(Session session) {
-        return lockExclusiveSession == session;
     }
 
     @Override
@@ -445,26 +326,6 @@ public class MVTable extends TableBase {
                 }
             }
         }
-    }
-
-    @Override
-    public boolean canTruncate() {
-        if (getCheckForeignKeyConstraints() &&
-                database.getReferentialIntegrity()) {
-            ArrayList<Constraint> constraints = getConstraints();
-            if (constraints != null) {
-                for (Constraint c : constraints) {
-                    if (c.getConstraintType() != Constraint.Type.REFERENTIAL) {
-                        continue;
-                    }
-                    ConstraintReferential ref = (ConstraintReferential) c;
-                    if (ref.getRefTable() == this) {
-                        return false;
-                    }
-                }
-            }
-        }
-        return true;
     }
 
     @Override
@@ -642,24 +503,6 @@ public class MVTable extends TableBase {
         }
     }
 
-    private static void addRowsToIndex(Session session, ArrayList<Row> list,
-            Index index) {
-        sortRows(list, index);
-        for (Row row : list) {
-            index.add(session, row);
-        }
-        list.clear();
-    }
-
-    private static void sortRows(ArrayList<? extends SearchRow> list, final Index index) {
-        Collections.sort(list, new Comparator<SearchRow>() {
-            @Override
-            public int compare(SearchRow r1, SearchRow r2) {
-                return index.compareRows(r1, r2);
-            }
-        });
-    }
-
     @Override
     public void removeRow(Session session, Row row) {
         syncLastModificationIdWithDatabase();
@@ -752,16 +595,6 @@ public class MVTable extends TableBase {
     }
 
     @Override
-    public void checkSupportAlter() {
-        // ok
-    }
-
-    @Override
-    public TableType getTableType() {
-        return TableType.TABLE;
-    }
-
-    @Override
     public Index getScanIndex(Session session) {
         return primaryIndex;
     }
@@ -779,25 +612,6 @@ public class MVTable extends TableBase {
     @Override
     public long getMaxDataModificationId() {
         return lastModificationId.get();
-    }
-
-    public boolean getContainsLargeObject() {
-        return containsLargeObject;
-    }
-
-    @Override
-    public boolean isDeterministic() {
-        return true;
-    }
-
-    @Override
-    public boolean canGetRowCount() {
-        return true;
-    }
-
-    @Override
-    public boolean canDrop() {
-        return true;
     }
 
     @Override
@@ -851,11 +665,6 @@ public class MVTable extends TableBase {
         return primaryIndex.getDiskSpaceUsed();
     }
 
-    @Override
-    public void checkRename() {
-        // ok
-    }
-
     /**
      * Get a new transaction.
      *
@@ -864,21 +673,6 @@ public class MVTable extends TableBase {
     Transaction getTransactionBegin() {
         // TODO need to commit/rollback the transaction
         return transactionStore.begin();
-    }
-
-    @Override
-    public Column getRowIdColumn() {
-        if (rowIdColumn == null) {
-            rowIdColumn = new Column(Column.ROWID, Value.LONG);
-            rowIdColumn.setTable(this, SearchRow.ROWID_INDEX);
-            rowIdColumn.setRowId(true);
-        }
-        return rowIdColumn;
-    }
-
-    @Override
-    public String toString() {
-        return getSQL(false);
     }
 
     @Override

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -28,7 +28,7 @@ import org.h2.index.Index;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.mvstore.db.MVTableEngine;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.Table;
 import org.h2.table.TableLink;
 import org.h2.table.TableSynonym;
@@ -705,7 +705,7 @@ public class Schema extends DbObjectBase {
                 }
                 return database.getTableEngine(data.tableEngine).createTable(data);
             }
-            return new RegularTable(data);
+            return new PageStoreTable(data);
         }
     }
 

--- a/h2/src/main/org/h2/store/PageStore.java
+++ b/h2/src/main/org/h2/store/PageStore.java
@@ -40,7 +40,7 @@ import org.h2.schema.Schema;
 import org.h2.store.fs.FileUtils;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.Table;
 import org.h2.table.TableType;
 import org.h2.util.Cache;
@@ -159,7 +159,7 @@ public class PageStore implements CacheWriter {
 
     private PageLog log;
     private Schema metaSchema;
-    private RegularTable metaTable;
+    private PageStoreTable metaTable;
     private PageDataIndex metaIndex;
     private final IntIntHashMap metaRootPageId = new IntIntHashMap();
     private final HashMap<Integer, PageIndex> metaObjects = new HashMap<>();
@@ -1602,7 +1602,7 @@ public class PageStore implements CacheWriter {
         data.persistIndexes = true;
         data.create = false;
         data.session = pageStoreSession;
-        metaTable = new RegularTable(data);
+        metaTable = new PageStoreTable(data);
         metaIndex = (PageDataIndex) metaTable.getScanIndex(
                 pageStoreSession);
         metaObjects.clear();
@@ -1683,7 +1683,7 @@ public class PageStore implements CacheWriter {
             data.persistIndexes = true;
             data.create = false;
             data.session = session;
-            RegularTable table = new RegularTable(data);
+            PageStoreTable table = new PageStoreTable(data);
             boolean binaryUnsigned = SysProperties.SORT_BINARY_UNSIGNED;
             if (options.length > 3) {
                 binaryUnsigned = Boolean.parseBoolean(options[3]);
@@ -1702,7 +1702,7 @@ public class PageStore implements CacheWriter {
                 throw DbException.get(ErrorCode.FILE_CORRUPTED_1,
                         "Table not found:" + parent + " for " + row + " meta:" + metaObjects);
             }
-            RegularTable table = (RegularTable) p.getTable();
+            PageStoreTable table = (PageStoreTable) p.getTable();
             Column[] tableCols = table.getColumns();
             int len = columns.length;
             IndexColumn[] cols = new IndexColumn[len];

--- a/h2/src/main/org/h2/table/PageStoreTable.java
+++ b/h2/src/main/org/h2/table/PageStoreTable.java
@@ -44,11 +44,9 @@ import org.h2.value.DataType;
 import org.h2.value.Value;
 
 /**
- * Most tables are an instance of this class. For this table, the data is stored
- * in the database. The actual data is not kept here, instead it is kept in the
- * indexes. There is at least one index, the scan index.
+ * A table store in a PageStore.
  */
-public class RegularTable extends TableBase {
+public class PageStoreTable extends TableBase {
 
     private Index scanIndex;
     private long rowCount;
@@ -72,7 +70,7 @@ public class RegularTable extends TableBase {
     private int nextAnalyze;
     private Column rowIdColumn;
 
-    public RegularTable(CreateTableData data) {
+    public PageStoreTable(CreateTableData data) {
         super(data);
         nextAnalyze = database.getSettings().analyzeAuto;
         this.isHidden = data.isHidden;
@@ -515,8 +513,8 @@ public class RegularTable extends TableBase {
                     buff.append(", ");
                 }
                 buff.append(t.toString());
-                if (t instanceof RegularTable) {
-                    if (((RegularTable) t).lockExclusiveSession == s) {
+                if (t instanceof PageStoreTable) {
+                    if (((PageStoreTable) t).lockExclusiveSession == s) {
                         buff.append(" (exclusive)");
                     } else {
                         buff.append(" (shared)");
@@ -532,7 +530,7 @@ public class RegularTable extends TableBase {
     public ArrayList<Session> checkDeadlock(Session session, Session clash,
             Set<Session> visited) {
         // only one deadlock check at any given time
-        synchronized (RegularTable.class) {
+        synchronized (PageStoreTable.class) {
             if (clash == null) {
                 // verification is started
                 clash = session;

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.table;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.h2.command.ddl.CreateTableData;
+import org.h2.constraint.Constraint;
+import org.h2.constraint.ConstraintReferential;
+import org.h2.engine.Session;
+import org.h2.index.Index;
+import org.h2.result.Row;
+import org.h2.result.SearchRow;
+import org.h2.value.DataType;
+import org.h2.value.Value;
+
+/**
+ * Most tables are an instance of this class. For this table, the data is stored
+ * in the database. The actual data is not kept here, instead it is kept in the
+ * indexes. There is at least one index, the scan index.
+ */
+public abstract class RegularTable extends TableBase {
+
+    /**
+     * Appends the specified rows to the specified index.
+     *
+     * @param session
+     *            the session
+     * @param list
+     *            the rows, list is cleared on completion
+     * @param index
+     *            the index to append to
+     */
+    protected static void addRowsToIndex(Session session, ArrayList<Row> list, Index index) {
+        sortRows(list, index);
+        for (Row row : list) {
+            index.add(session, row);
+        }
+        list.clear();
+    }
+
+    /**
+     * Formats details of a deadlock.
+     *
+     * @param sessions
+     *            the list of sessions
+     * @param exclusive
+     *            true if waiting for exclusive lock, false otherwise
+     * @return formatted details of a deadlock
+     */
+    protected static String getDeadlockDetails(ArrayList<Session> sessions, boolean exclusive) {
+        // We add the thread details here to make it easier for customers to
+        // match up these error messages with their own logs.
+        StringBuilder builder = new StringBuilder();
+        for (Session s : sessions) {
+            Table lock = s.getWaitForLock();
+            Thread thread = s.getWaitForLockThread();
+            builder.append("\nSession ").append(s.toString()).append(" on thread ").append(thread.getName())
+                    .append(" is waiting to lock ").append(lock.toString())
+                    .append(exclusive ? " (exclusive)" : " (shared)").append(" while locking ");
+            Table[] locks = s.getLocks();
+            for (int i = 0, length = locks.length; i < length; i++) {
+                Table t = locks[i];
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                builder.append(t.toString());
+                if (t instanceof RegularTable) {
+                    if (((RegularTable) t).lockExclusiveSession == s) {
+                        builder.append(" (exclusive)");
+                    } else {
+                        builder.append(" (shared)");
+                    }
+                }
+            }
+            builder.append('.');
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Sorts the specified list of rows for a specified index.
+     *
+     * @param list
+     *            the list of rows
+     * @param index
+     *            the index to sort for
+     */
+    protected static void sortRows(ArrayList<? extends SearchRow> list, final Index index) {
+        Collections.sort(list, new Comparator<SearchRow>() {
+            @Override
+            public int compare(SearchRow r1, SearchRow r2) {
+                return index.compareRows(r1, r2);
+            }
+        });
+    }
+
+    protected final boolean containsLargeObject;
+
+    protected volatile Session lockExclusiveSession;
+
+    // using a ConcurrentHashMap as a set
+    protected final ConcurrentHashMap<Session, Session> lockSharedSessions = new ConcurrentHashMap<>();
+
+    private Column rowIdColumn;
+
+    protected RegularTable(CreateTableData data) {
+        super(data);
+        this.isHidden = data.isHidden;
+        boolean b = false;
+        for (Column col : getColumns()) {
+            if (DataType.isLargeObject(col.getType().getValueType())) {
+                b = true;
+                break;
+            }
+        }
+        containsLargeObject = b;
+    }
+
+    @Override
+    public boolean canDrop() {
+        return true;
+    }
+
+    @Override
+    public boolean canGetRowCount() {
+        return true;
+    }
+
+    @Override
+    public boolean canTruncate() {
+        if (getCheckForeignKeyConstraints() && database.getReferentialIntegrity()) {
+            ArrayList<Constraint> constraints = getConstraints();
+            if (constraints != null) {
+                for (Constraint c : constraints) {
+                    if (c.getConstraintType() != Constraint.Type.REFERENTIAL) {
+                        continue;
+                    }
+                    ConstraintReferential ref = (ConstraintReferential) c;
+                    if (ref.getRefTable() == this) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public ArrayList<Session> checkDeadlock(Session session, Session clash, Set<Session> visited) {
+        // only one deadlock check at any given time
+        synchronized (getClass()) {
+            if (clash == null) {
+                // verification is started
+                clash = session;
+                visited = new HashSet<>();
+            } else if (clash == session) {
+                // we found a cycle where this session is involved
+                return new ArrayList<>(0);
+            } else if (visited.contains(session)) {
+                // we have already checked this session.
+                // there is a cycle, but the sessions in the cycle need to
+                // find it out themselves
+                return null;
+            }
+            visited.add(session);
+            ArrayList<Session> error = null;
+            for (Session s : lockSharedSessions.keySet()) {
+                if (s == session) {
+                    // it doesn't matter if we have locked the object already
+                    continue;
+                }
+                Table t = s.getWaitForLock();
+                if (t != null) {
+                    error = t.checkDeadlock(s, clash, visited);
+                    if (error != null) {
+                        error.add(session);
+                        break;
+                    }
+                }
+            }
+            // take a local copy so we don't see inconsistent data, since we are
+            // not locked while checking the lockExclusiveSession value
+            Session copyOfLockExclusiveSession = lockExclusiveSession;
+            if (error == null && copyOfLockExclusiveSession != null) {
+                Table t = copyOfLockExclusiveSession.getWaitForLock();
+                if (t != null) {
+                    error = t.checkDeadlock(copyOfLockExclusiveSession, clash, visited);
+                    if (error != null) {
+                        error.add(session);
+                    }
+                }
+            }
+            return error;
+        }
+    }
+
+    @Override
+    public void checkRename() {
+        // ok
+    }
+
+    @Override
+    public void checkSupportAlter() {
+        // ok
+    }
+
+    public boolean getContainsLargeObject() {
+        return containsLargeObject;
+    }
+
+    @Override
+    public Column getRowIdColumn() {
+        if (rowIdColumn == null) {
+            rowIdColumn = new Column(Column.ROWID, Value.LONG);
+            rowIdColumn.setTable(this, SearchRow.ROWID_INDEX);
+            rowIdColumn.setRowId(true);
+        }
+        return rowIdColumn;
+    }
+
+    @Override
+    public TableType getTableType() {
+        return TableType.TABLE;
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return true;
+    }
+
+    @Override
+    public boolean isLockedExclusively() {
+        return lockExclusiveSession != null;
+    }
+
+    @Override
+    public boolean isLockedExclusivelyBy(Session session) {
+        return lockExclusiveSession == session;
+    }
+
+    @Override
+    public String toString() {
+        return getSQL(false);
+    }
+
+}

--- a/h2/src/main/org/h2/table/TableBase.java
+++ b/h2/src/main/org/h2/table/TableBase.java
@@ -72,8 +72,7 @@ public abstract class TableBase extends Table {
             this.tableEngineParams = Collections.emptyList();
         }
         setTemporary(data.temporary);
-        Column[] cols = data.columns.toArray(new Column[0]);
-        setColumns(cols);
+        setColumns(data.columns.toArray(new Column[0]));
     }
 
     @Override

--- a/h2/src/main/org/h2/util/geometry/EWKBUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKBUtils.java
@@ -24,7 +24,6 @@ import static org.h2.util.geometry.GeometryUtils.toCanonicalDouble;
 
 import java.io.ByteArrayOutputStream;
 
-import org.h2.engine.SysProperties;
 import org.h2.util.Bits;
 import org.h2.util.StringUtils;
 import org.h2.util.geometry.GeometryUtils.DimensionSystemTarget;
@@ -146,7 +145,7 @@ public final class EWKBUtils {
             writeDouble(x);
             writeDouble(y);
             if ((dimensionSystem & DIMENSION_SYSTEM_XYZ) != 0) {
-                writeDouble(!SysProperties.MIXED_GEOMETRIES && check ? checkFinite(z) : z);
+                writeDouble(check ? checkFinite(z) : z);
             }
             if ((dimensionSystem & DIMENSION_SYSTEM_XYM) != 0) {
                 writeDouble(check ? checkFinite(m) : m);

--- a/h2/src/main/org/h2/util/geometry/EWKTUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKTUtils.java
@@ -24,7 +24,6 @@ import static org.h2.util.geometry.GeometryUtils.Z;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 
-import org.h2.engine.SysProperties;
 import org.h2.util.geometry.EWKBUtils.EWKBTarget;
 import org.h2.util.geometry.GeometryUtils.DimensionSystemTarget;
 import org.h2.util.geometry.GeometryUtils.Target;
@@ -223,15 +222,7 @@ public final class EWKTUtils {
             writeDouble(x);
             output.append(' ');
             writeDouble(y);
-            dimensionZ: if ((dimensionSystem & DIMENSION_SYSTEM_XYZ) != 0) {
-                if (SysProperties.MIXED_GEOMETRIES) {
-                    if (Double.isNaN(z)) {
-                        if ((dimensionSystem & DIMENSION_SYSTEM_XYM) != 0) {
-                            throw new IllegalArgumentException();
-                        }
-                        break dimensionZ;
-                    }
-                }
+            if ((dimensionSystem & DIMENSION_SYSTEM_XYZ) != 0) {
                 output.append(' ');
                 writeDouble(z);
             }

--- a/h2/src/main/org/h2/util/geometry/JTSUtils.java
+++ b/h2/src/main/org/h2/util/geometry/JTSUtils.java
@@ -24,7 +24,6 @@ import static org.h2.util.geometry.GeometryUtils.toCanonicalDouble;
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Method;
 
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.util.geometry.EWKBUtils.EWKBTarget;
 import org.h2.util.geometry.GeometryUtils.DimensionSystemTarget;
@@ -206,8 +205,7 @@ public final class JTSUtils {
             coordinates.setOrdinate(index, X, checkFinite(x));
             coordinates.setOrdinate(index, Y, checkFinite(y));
             coordinates.setOrdinate(index, Z,
-                    (dimensionSystem & DIMENSION_SYSTEM_XYZ) != 0 ? SysProperties.MIXED_GEOMETRIES ? z : checkFinite(z)
-                            : Double.NaN);
+                    (dimensionSystem & DIMENSION_SYSTEM_XYZ) != 0 ? checkFinite(z) : Double.NaN);
             if ((dimensionSystem & DIMENSION_SYSTEM_XYM) != 0) {
                 coordinates.setOrdinate(index, M, checkFinite(m));
             }

--- a/h2/src/test/org/h2/test/bench/Database.java
+++ b/h2/src/test/org/h2/test/bench/Database.java
@@ -46,7 +46,7 @@ class Database {
     private final ArrayList<Object[]> results = new ArrayList<>();
     private int totalTime;
     private int totalGCTime;
-    private final AtomicInteger executedStatements = new AtomicInteger(0);
+    private final AtomicInteger executedStatements = new AtomicInteger();
     private int threadCount;
 
     private Server serverH2;

--- a/h2/src/test/org/h2/test/db/TestExclusive.java
+++ b/h2/src/test/org/h2/test/db/TestExclusive.java
@@ -42,7 +42,7 @@ public class TestExclusive extends TestDb {
         Connection conn2 = getConnection("exclusive");
         final Statement stat2 = conn2.createStatement();
         stat.execute("set exclusive true");
-        final AtomicInteger state = new AtomicInteger(0);
+        final AtomicInteger state = new AtomicInteger();
         Task task = new Task() {
             @Override
             public void call() throws SQLException {

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -43,7 +43,7 @@ import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.result.SortOrder;
 import org.h2.table.IndexColumn;
-import org.h2.table.RegularTable;
+import org.h2.table.PageStoreTable;
 import org.h2.table.SubQueryInfo;
 import org.h2.table.Table;
 import org.h2.table.TableBase;
@@ -1143,7 +1143,7 @@ public class TestTableEngines extends TestDb {
         /**
          * A table able to handle affinity indexes.
          */
-        private static class AffinityTable extends RegularTable {
+        private static class AffinityTable extends PageStoreTable {
 
             /**
              * A (no-op) affinity index.

--- a/h2/src/test/org/h2/test/unit/TestGeometryUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestGeometryUtils.java
@@ -20,7 +20,6 @@ import static org.h2.util.geometry.GeometryUtils.Y;
 import static org.h2.util.geometry.GeometryUtils.Z;
 
 import java.io.ByteArrayOutputStream;
-import java.lang.ProcessBuilder.Redirect;
 import java.util.Random;
 
 import org.h2.test.TestBase;
@@ -41,7 +40,6 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.WKBWriter;
 import org.locationtech.jts.io.WKTReader;
@@ -80,8 +78,6 @@ public class TestGeometryUtils extends TestBase {
 
     private static final String MIXED_WKT = "LINESTRING (1 2, 3 4 5)";
 
-    private static final String MIXED_WKT_Z = "LINESTRING Z (1 2, 3 4 5)";
-
     private static final byte[] MIXED_WKB = StringUtils.convertHexToBytes(""
             // BOM (BigEndian)
             + "00"
@@ -103,19 +99,13 @@ public class TestGeometryUtils extends TestBase {
             + "4014000000000000");
 
     /**
-     * May be used to run only this test and may be launched by this test in a
-     * subprocess.
+     * Run just this test.
      *
      * @param a
-     *            if empty run this test only
+     *            ignored
      */
     public static void main(String... a) throws Exception {
-        TestGeometryUtils test = (TestGeometryUtils) TestBase.createCaller().init();
-        if (a.length == 0) {
-            test.test();
-        } else {
-            test.testMixedGeometriesAcceptImpl();
-        }
+        TestBase.createCaller().init().test();
     }
 
     @Override
@@ -134,7 +124,6 @@ public class TestGeometryUtils extends TestBase {
         testSRID();
         testIntersectionAndUnion();
         testMixedGeometries();
-        testMixedGeometriesAccept();
     }
 
     private void testPoint() throws Exception {
@@ -500,29 +489,6 @@ public class TestGeometryUtils extends TestBase {
         } catch (IllegalArgumentException ex) {
             // Expected
         }
-    }
-
-    private void testMixedGeometriesAccept() throws Exception {
-        ProcessBuilder pb = new ProcessBuilder().redirectError(Redirect.INHERIT);
-        pb.command(getJVM(), "-cp", getClassPath(), "-ea", "-Dh2.mixedGeometries=true", getClass().getName(), "dummy");
-        assertEquals(0, pb.start().waitFor());
-    }
-
-    private void testMixedGeometriesAcceptImpl() throws Exception {
-        assertEquals(MIXED_WKB, EWKTUtils.ewkt2ewkb(MIXED_WKT));
-        assertEquals(MIXED_WKT_Z, EWKTUtils.ewkb2ewkt(MIXED_WKB));
-        Geometry g = new WKTReader().read(MIXED_WKT);
-        assertEquals(MIXED_WKB, JTSUtils.geometry2ewkb(g));
-        LineString ls = (LineString) JTSUtils.ewkb2geometry(MIXED_WKB);
-        CoordinateSequence cs = ls.getCoordinateSequence();
-        assertEquals(2, cs.size());
-        assertEquals(3, cs.getDimension());
-        assertEquals(1, cs.getOrdinate(0, X));
-        assertEquals(2, cs.getOrdinate(0, Y));
-        assertEquals(Double.NaN, cs.getOrdinate(0, Z));
-        assertEquals(3, cs.getOrdinate(1, X));
-        assertEquals(4, cs.getOrdinate(1, Y));
-        assertEquals(5, cs.getOrdinate(1, Z));
     }
 
 }


### PR DESCRIPTION
1. `h2.mixedGeometries` was added for H2GIS, but H2GIS does not need it, they decided not to support invalid geometries. This setting is removed.

2. `RegularTable` is renamed to `PageStoreTable`. Shared code from new `PageStoreTable` and `MVTable` is extracted back to `RegularTable`.

3. No-arg constructors of `AtomicLong`, `AtomicInt`, and `AtomicBoolean` are used where possible (0 / false).