### PR TITLE
Fixbug - An IllegalStateException that wraps EOFException is thrown when partial writes happens

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -124,8 +124,9 @@ public class MVStoreTool {
                 block.rewind();
                 // Fixbug - An IllegalStateException that wraps EOFException is thrown when partial writes happens 
                 //in the case of power off or file system issues.
-                // So we should first check the read length of block, and skip the broken block at end of DB file.
+                // So we should first check the read length of block, and skip the broken block at end of the DB file.
                 if(pos + block.limit() > fileSize) {
+                    pw.printf("ERROR a broken block at end of the DB file %s, then skip it%n", fileName);
                     break;
                 }
                 DataUtils.readFully(file, pos, block);

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -122,6 +122,12 @@ public class MVStoreTool {
             long pageCount = 0;
             for (long pos = 0; pos < fileSize;) {
                 block.rewind();
+                // Fixbug - An IllegalStateException that wraps EOFException is thrown when partial writes happens 
+                //in the case of power off or file system issues.
+                // So we should first check the read length of block, and skip the broken block at end of DB file.
+                if(pos + block.limit() > fileSize) {
+                    break;
+                }
                 DataUtils.readFully(file, pos, block);
                 block.rewind();
                 int headerType = block.get();

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -124,12 +124,14 @@ public class MVStoreTool {
                 block.rewind();
                 // Fixbug - An IllegalStateException that wraps EOFException is thrown when partial writes happens 
                 //in the case of power off or file system issues.
-                // So we should first check the read length of block, and skip the broken block at end of the DB file.
-                if(pos + block.limit() > fileSize) {
-                    pw.printf("ERROR a broken block at end of the DB file %s, then skip it%n", fileName);
-                    break;
+                // So we should skip the broken block at end of the DB file.
+                try {
+                    DataUtils.readFully(file, pos, block);
+                } catch (IllegalStateException e){
+                    pos += blockSize;
+                    pw.printf("ERROR illegal position %d%n", pos);
+                    continue;
                 }
-                DataUtils.readFully(file, pos, block);
                 block.rewind();
                 int headerType = block.get();
                 if (headerType == 'H') {


### PR DESCRIPTION
An IllegalStateException that wraps EOFException is thrown in org.h2.mvstore.MVStoreTool.dump() method when partial writes happens in the case of power off or file system issues. So we should first check current file position and the read length of block, then skip the broken block at end of DB file.