### PR TITLE
Basis for implementation of SQL/JSON standard

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -41,6 +41,7 @@ import org.h2.value.ValueGeometry;
 import org.h2.value.ValueInt;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueJavaObject;
+import org.h2.value.ValueJson;
 import org.h2.value.ValueLobDb;
 import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
@@ -101,6 +102,7 @@ public class ValueDataType implements DataType {
     private static final int BYTES_0_31 = 100;
     private static final int SPATIAL_KEY_2D = 132;
     private static final int CUSTOM_DATA_TYPE = 133;
+    private static final int JSON = 134;
 
     final DataHandler handler;
     final CompareMode compareMode;
@@ -500,6 +502,12 @@ public class ValueDataType implements DataType {
                 putVarLong(interval.getRemaining());
             break;
         }
+        case Value.JSON:{
+            String s = v.getString();
+            buff.put((byte) JSON);
+            writeString(buff, s);
+            break;
+        }
         default:
             if (JdbcUtils.customDataTypesHandler != null) {
                 byte[] b = v.getBytesNoCopy();
@@ -686,6 +694,10 @@ public class ValueDataType implements DataType {
             }
             throw DbException.get(ErrorCode.UNKNOWN_DATA_TYPE_1,
                     "No CustomDataTypesHandler has been set up");
+        }
+        case JSON: {
+            String str = readString(buff);
+            return ValueJson.get(str);
         }
         default:
             if (type >= INT_0_15 && type < INT_0_15 + 16) {

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -42,6 +42,7 @@ import org.h2.value.ValueGeometry;
 import org.h2.value.ValueInt;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueJavaObject;
+import org.h2.value.ValueJson;
 import org.h2.value.ValueLob;
 import org.h2.value.ValueLobDb;
 import org.h2.value.ValueLong;
@@ -119,6 +120,7 @@ public class Data {
     private static final int LOCAL_DATE = 133;
     private static final int LOCAL_TIMESTAMP = 134;
     private static final int CUSTOM_DATA_TYPE = 135;
+    private static final int JSON = 136;
 
     private static final long MILLIS_PER_MINUTE = 1000 * 60;
 
@@ -754,6 +756,11 @@ public class Data {
             writeVarLong(interval.getRemaining());
             break;
         }
+        case Value.JSON: {
+            writeByte((byte) JSON);
+            writeString(v.getString());
+            break;
+        }
         default:
             if (JdbcUtils.customDataTypesHandler != null) {
                 byte[] b = v.getBytesNoCopy();
@@ -961,6 +968,10 @@ public class Data {
             }
             throw DbException.get(ErrorCode.UNKNOWN_DATA_TYPE_1,
                     "No CustomDataTypesHandler has been set up");
+        }
+        case JSON: {
+            String s = readString();
+            return ValueJson.get(s);
         }
         default:
             if (type >= INT_0_15 && type < INT_0_15 + 16) {
@@ -1225,6 +1236,9 @@ public class Data {
             ValueInterval interval = (ValueInterval) v;
             return 2 + getVarLongLen(interval.getLeading()) + getVarLongLen(interval.getRemaining());
         }
+        case Value.JSON:
+            String s = v.getString();
+            return 1 + getStringLen(s);
         default:
             if (JdbcUtils.customDataTypesHandler != null) {
                 byte[] b = v.getBytesNoCopy();

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -784,6 +784,10 @@ public class Transfer {
             return ValueInterval.from(IntervalQualifier.valueOf(ordinal), negative, readLong(),
                     ordinal < 5 ? 0 : readLong());
         }
+        case JSON: {
+            String s = readString();
+            return ValueJson.get(s);
+        }
         default:
             if (JdbcUtils.customDataTypesHandler != null) {
                 return JdbcUtils.customDataTypesHandler.convert(

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -69,6 +69,7 @@ public class Transfer {
     private static final int ENUM = 25;
     private static final int INTERVAL = 26;
     private static final int ROW = 27;
+    private static final int JSON = 28;
 
     private Socket socket;
     private DataInputStream in;
@@ -606,6 +607,11 @@ public class Transfer {
                 writeString(v.getString());
             }
             break;
+        case Value.JSON: {
+            writeInt(JSON);
+            writeString(v.getString());
+            break;
+        }
         default:
             if (JdbcUtils.customDataTypesHandler != null) {
                 writeInt(type);

--- a/h2/src/main/org/h2/value/TypeInfo.java
+++ b/h2/src/main/org/h2/value/TypeInfo.java
@@ -146,6 +146,11 @@ public class TypeInfo {
      * ROW (row value) type with parameters.
      */
     public static final TypeInfo TYPE_ROW;
+    
+    /**
+     * JSON type.
+     */
+    public static final TypeInfo TYPE_JSON;
 
     private static final TypeInfo[] TYPE_INFOS_BY_VALUE_TYPE;
 
@@ -215,6 +220,7 @@ public class TypeInfo {
         TYPE_INTERVAL_DAY_TO_SECOND = infos[Value.INTERVAL_DAY_TO_SECOND];
         TYPE_INTERVAL_HOUR_TO_SECOND = infos[Value.INTERVAL_HOUR_TO_SECOND];
         infos[Value.ROW] = TYPE_ROW = new TypeInfo(Value.ROW, Integer.MAX_VALUE, 0, Integer.MAX_VALUE, null);
+        infos[Value.JSON] = TYPE_JSON = new TypeInfo(Value.JSON, Integer.MAX_VALUE, 0, Integer.MAX_VALUE, null); 
         TYPE_INFOS_BY_VALUE_TYPE = infos;
     }
 
@@ -276,6 +282,7 @@ public class TypeInfo {
         case Value.JAVA_OBJECT:
         case Value.UUID:
         case Value.ROW:
+        case Value.JSON:
             return TYPE_INFOS_BY_VALUE_TYPE[type];
         case Value.UNKNOWN:
             return TYPE_UNKNOWN;

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -245,11 +245,16 @@ public abstract class Value extends VersionedValue {
      * The value type for ROW values.
      */
     public static final int ROW = 39;
+    
+    /**
+     * The value type for JSON values.
+     */
+    public static final int JSON = 40;
 
     /**
      * The number of value types.
      */
-    public static final int TYPE_COUNT = ROW + 1;
+    public static final int TYPE_COUNT = JSON + 1;
 
     private static SoftReference<Value[]> softCache;
 
@@ -441,6 +446,8 @@ public abstract class Value extends VersionedValue {
             return 44_000;
         case ENUM:
             return 45_000;
+        case JSON:
+            return 46_000;
         case ARRAY:
             return 50_000;
         case ROW:
@@ -813,6 +820,8 @@ public abstract class Value extends VersionedValue {
             case Value.INTERVAL_HOUR_TO_SECOND:
             case Value.INTERVAL_MINUTE_TO_SECOND:
                 return convertToIntervalDayTime(targetType);
+            case Value.JSON:
+                return new ValueJson(getString());
             case ARRAY:
                 return convertToArray();
             case ROW:

--- a/h2/src/main/org/h2/value/ValueJson.java
+++ b/h2/src/main/org/h2/value/ValueJson.java
@@ -1,0 +1,78 @@
+package org.h2.value;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import org.h2.util.StringUtils;
+
+public class ValueJson extends Value {
+    
+    private String value;
+    
+    ValueJson (String s) {
+        this.value = s;
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder) {
+        return StringUtils.quoteStringSQL(builder, value).append("::JSON");
+    }
+
+    @Override
+    public TypeInfo getType() {
+        return TypeInfo.TYPE_JSON;
+    }
+
+    @Override
+    public int getValueType() {
+        return Value.JSON;
+    }
+
+    @Override
+    public String getString() {
+        return value;
+    }
+
+    @Override
+    public Object getObject() {
+        return value;
+    }
+    
+    @Override
+    public int getMemory() {
+        return value.length() * 2 + 94;
+    }
+
+    @Override
+    public void set(PreparedStatement prep, int parameterIndex) throws SQLException {
+        prep.setString(parameterIndex, value);
+    }
+
+    /*
+     * The simplest version
+     * In fact {"foo":1,"bar":2} must be equal to {"bar":2, "foo":1}
+     */
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    /*
+     * Similar to hashCode()
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ValueJson &&
+                this.value.equals(((ValueJson) other).value);
+    }
+
+    @Override
+    public int compareTypeSafe(Value v, CompareMode mode) {
+        String other = ((ValueJson) v).value;
+        return mode.compareString(value, other, false);
+    }
+    
+    public static Value get(String s) {
+        return new ValueJson(s);
+    }
+
+}

--- a/h2/src/main/org/h2/value/ValueJson.java
+++ b/h2/src/main/org/h2/value/ValueJson.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: Lazarev Nikita <lazarevn@ispras.ru>
+ */
 package org.h2.value;
 
 import java.sql.PreparedStatement;

--- a/h2/src/main/org/h2/value/ValueJson.java
+++ b/h2/src/main/org/h2/value/ValueJson.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
- * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
  * Initial Developer: Lazarev Nikita <lazarevn@ispras.ru>
  */
 package org.h2.value;

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -151,7 +151,7 @@ public class TestScript extends TestDb {
 
         for (String s : new String[] { "array", "bigint", "binary", "blob",
                 "boolean", "char", "clob", "date", "decimal", decimal2, "double", "enum",
-                "geometry", "identity", "int", "interval", "other", "real", "row", "smallint",
+                "geometry", "identity", "int", "json", "interval", "other", "real", "row", "smallint",
                 "time", "timestamp-with-timezone", "timestamp", "tinyint",
                 "uuid", "varchar", "varchar-ignorecase" }) {
             testScript("datatypes/" + s + ".sql");

--- a/h2/src/test/org/h2/test/scripts/datatypes/json.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/json.sql
@@ -1,0 +1,23 @@
+SELECT CAST('{"tag1":"simple string"}' AS JSON);
+>> {"tag1":"simple string"}
+
+SELECT '{"tag1":"simple string"}'::JSON;
+>> {"tag1":"simple string"}
+
+CREATE TABLE TEST (ID INT, DATA JSON);
+> ok
+
+INSERT INTO TEST VALUES
+(1, '{"tag1":"simple string", "tag2": 333, "tag3":[1, 2, 3]}'::json),
+(2, '{"tag1":"another string", "tag4":{"lvl1":"lvl2"}}'::json),
+(3, '["string", 5555, {"arr":"yes"}]'::json),
+(4, '{"1":"val1"}'::json);
+> update count: 4 
+
+@reconnect
+
+SELECT ID, DATA FROM TEST;
+>> <4 rows>
+
+DROP TABLE TEST IF EXISTS;
+> ok

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -585,6 +585,9 @@ public class TestValue extends TestDb {
         testTypeInfoInterval1(Value.INTERVAL_HOUR_TO_MINUTE);
         testTypeInfoInterval2(Value.INTERVAL_HOUR_TO_SECOND);
         testTypeInfoInterval2(Value.INTERVAL_MINUTE_TO_SECOND);
+        
+        testTypeInfoCheck(Value.JSON, Integer.MAX_VALUE, 0, Integer.MAX_VALUE, TypeInfo.TYPE_JSON,
+                TypeInfo.getTypeInfo(Value.JSON));
     }
 
     private void testTypeInfoInterval1(int type) {

--- a/h2/src/test/org/h2/test/unit/TestValueMemory.java
+++ b/h2/src/test/org/h2/test/unit/TestValueMemory.java
@@ -40,6 +40,7 @@ import org.h2.value.ValueGeometry;
 import org.h2.value.ValueInt;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueJavaObject;
+import org.h2.value.ValueJson;
 import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueResultSet;
@@ -246,6 +247,8 @@ public class TestValueMemory extends TestBase implements DataHandler {
         case Value.INTERVAL_HOUR_TO_MINUTE:
             return ValueInterval.from(IntervalQualifier.valueOf(type - Value.INTERVAL_YEAR),
                     random.nextBoolean(), random.nextInt(Integer.MAX_VALUE), random.nextInt(12));
+        case Value.JSON:
+            return ValueJson.get("{\"key\":\"value\"}");
         default:
             throw new AssertionError("type=" + type);
         }


### PR DESCRIPTION
So, here is required minimum, I think.
According to standard (as I found  [here](https://www.wiscorp.com/pub/DM32.2-2014-00024R1_JSON-SQL-Proposal-1.pdf) and [here](https://www.wiscorp.com/pub/DM32.2-2014-00025r1-sql-json-part-2.pdf) ) also required:

1. IS_JSON function
2. JSON_OBJECT[AGG], JSON_ARRAY[AGG] functions
3. JSON_VALUE, JSON_QUERY, JSON_EXISTS functions with specific SQL/JSON path language support.

Looks like some JSON parser is needed. I would like to discuss possibility of using any third-party library or its code (under license).

In addition, it seems interesting to develop a way to store JSON:
- With preservation of information about the type of document (primitive, object, array)
- For objects and arrays - producing some kind of structure mapping

What do you think about it?

And there is the PostgreSQL dialect different from the standard. I would be glad to discuss the features for its (at least) partial support.