### PR TITLE
MVStore chunks occupancy rate calculation fixes

### DIFF
--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -99,6 +99,12 @@ public class Chunk {
     public long unused;
 
     /**
+     * Version of the store at which chunk become unused and therefore can be
+     * considered "dead" and collected after this version is no longer in use.
+     */
+    public long unusedAtVersion;
+
+    /**
      * The last used map id.
      */
     public int mapId;
@@ -193,6 +199,7 @@ public class Chunk {
         c.metaRootPos = DataUtils.readHexLong(map, "root", 0);
         c.time = DataUtils.readHexLong(map, "time", 0);
         c.unused = DataUtils.readHexLong(map, "unused", 0);
+        c.unusedAtVersion = DataUtils.readHexLong(map, "unusedAtVersion", 0);
         c.version = DataUtils.readHexLong(map, "version", id);
         c.next = DataUtils.readHexLong(map, "next", 0);
         return c;
@@ -248,6 +255,9 @@ public class Chunk {
         DataUtils.appendMap(buff, "time", time);
         if (unused != 0) {
             DataUtils.appendMap(buff, "unused", unused);
+        }
+        if (unusedAtVersion != 0) {
+            DataUtils.appendMap(buff, "unusedAtVersion", unusedAtVersion);
         }
         DataUtils.appendMap(buff, "version", version);
         return buff.toString();

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1078,6 +1078,8 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                 return rootReference;
             } else if (isClosed()) {
                 if (rootReference.version < store.getOldestVersionToKeep()) {
+                    clear();
+                    store.deregisterMapRoot(id);
                     return null;
                 }
                 return rootReference;

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1114,12 +1114,6 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @param sourceMap the source map
      */
     final void copyFrom(MVMap<K, V> sourceMap) {
-        // We are going to cheat a little bit in the copy()
-        // by temporary setting map's root to some arbitrary nodes.
-        // This will allow for newly created ones to be saved.
-        // That's why it's important to preserve all chunks
-        // created in the process, especially if retention time
-        // is set to a lower value, or even 0.
         MVStore.TxCounter txCounter = store.registerVersionUsage();
         try {
             beforeWrite();
@@ -1129,7 +1123,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         }
     }
 
-    private Page copy(Page source, Page parent, int index) {
+    private void copy(Page source, Page parent, int index) {
         Page target = source.copy(this);
         if (parent == null) {
             setInitialRoot(target, INITIAL_VERSION);
@@ -1151,7 +1145,6 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         if (store.isSaveNeeded()) {
             store.commit();
         }
-        return target;
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -974,6 +974,7 @@ public class MVStore implements AutoCloseable {
                             if (normalShutdown && fileStore != null && !fileStore.isReadOnly()) {
                                 for (MVMap<?, ?> map : maps.values()) {
                                     if (map.isClosed()) {
+                                        map.clear();
                                         if (meta.remove(MVMap.getMapRootKey(map.getId())) != null) {
                                             markMetaChanged();
                                         }
@@ -1108,6 +1109,7 @@ public class MVStore implements AutoCloseable {
             if (map.setWriteVersion(version) == null) {
                 assert map.isClosed();
                 assert map.getVersion() < getOldestVersionToKeep();
+                map.clear();
                 meta.remove(MVMap.getMapRootKey(map.getId()));
                 markMetaChanged();
                 iter.remove();
@@ -1258,6 +1260,7 @@ public class MVStore implements AutoCloseable {
             if (rootReference == null) {
                 assert map.isClosed();
                 assert map.getVersion() < getOldestVersionToKeep();
+                map.clear();
                 meta.remove(MVMap.getMapRootKey(map.getId()));
                 iter.remove();
             } else if (map.getCreateVersion() <= storeVersion && // if map was created after storing started, skip it
@@ -1292,7 +1295,7 @@ public class MVStore implements AutoCloseable {
                 meta.put(key, Long.toHexString(root));
             }
         }
-        applyFreedSpace();
+        applyFreedSpace(storeVersion);
         RootReference metaRootReference = meta.setWriteVersion(version);
         assert metaRootReference != null;
         assert metaRootReference.version == version : metaRootReference.version + " != " + version;
@@ -1404,33 +1407,45 @@ public class MVStore implements AutoCloseable {
     private void freeUnusedChunks(boolean fast) {
         assert storeLock.isHeldByCurrentThread();
         if (lastChunk != null && reuseSpace) {
+            long oldestVersionToKeep = getOldestVersionToKeep();
             Set<Integer> referenced = collectReferencedChunks(fast);
             long time = getTimeSinceCreation();
 
-            for (Iterator<Chunk> iterator = chunks.values().iterator(); iterator.hasNext(); ) {
-                Chunk c = iterator.next();
-                if (c.block != Long.MAX_VALUE && !referenced.contains(c.id)) {
-                    if (canOverwriteChunk(c, time)) {
-                        iterator.remove();
-                        if (meta.remove(Chunk.getMetaKey(c.id)) != null) {
-                            markMetaChanged();
-                        }
-                        long start = c.block * BLOCK_SIZE;
-                        int length = c.len * BLOCK_SIZE;
-                        fileStore.free(start, length);
-                        assert fileStore.getFileLengthInUse() == measureFileLengthInUse() :
-                                fileStore.getFileLengthInUse() + " != " + measureFileLengthInUse();
-                    } else {
-                        if (c.unused == 0) {
-                            c.unused = time;
-                            meta.put(Chunk.getMetaKey(c.id), c.asString());
-                            markMetaChanged();
+            long currentStoreVersionBackup = currentStoreVersion;
+            try {
+                // to block re-entrance into commit() / tryCommit(), which is otherwise be possible
+                // due to meta.remove() and meta.put(), we set the following field
+                currentStoreVersion = currentVersion;
+                reuseSpace = false;     // to block possible re-entrance into this method
+                for (Iterator<Chunk> iterator = chunks.values().iterator(); iterator.hasNext(); ) {
+                    Chunk c = iterator.next();
+                    if (c.block != Long.MAX_VALUE && c.version < oldestVersionToKeep && !referenced.contains(c.id)) {
+                        assert c.unusedAtVersion > 0 : c;
+                        if (canOverwriteChunk(c, time, oldestVersionToKeep)) {
+                            iterator.remove();
+                            if (meta.remove(Chunk.getMetaKey(c.id)) != null) {
+                                markMetaChanged();
+                            }
+                            long start = c.block * BLOCK_SIZE;
+                            int length = c.len * BLOCK_SIZE;
+                            fileStore.free(start, length);
+                            assert fileStore.getFileLengthInUse() == measureFileLengthInUse() :
+                                    fileStore.getFileLengthInUse() + " != " + measureFileLengthInUse();
+                        } else {
+                            if (c.unused == 0) {
+                                c.unused = time;
+                                meta.put(Chunk.getMetaKey(c.id), c.asString());
+                                markMetaChanged();
+                            }
                         }
                     }
                 }
+            } finally {
+                // set it here, to avoid calling it often if it was slow
+                lastFreeUnusedChunks = getTimeSinceCreation();
+                reuseSpace = true;
+                currentStoreVersion = currentStoreVersionBackup;
             }
-            // set it here, to avoid calling it often if it was slow
-            lastFreeUnusedChunks = getTimeSinceCreation();
         }
     }
 
@@ -1662,7 +1677,7 @@ public class MVStore implements AutoCloseable {
         }
     }
 
-    private boolean canOverwriteChunk(Chunk c, long time) {
+    private boolean canOverwriteChunk(Chunk c, long time, long oldestVersionToKeep) {
         if (retentionTime >= 0) {
             if (c.time + retentionTime > time) {
                 return false;
@@ -1671,7 +1686,7 @@ public class MVStore implements AutoCloseable {
                 return false;
             }
         }
-        return true;
+        return c.unusedAtVersion > 0 && oldestVersionToKeep > c.unusedAtVersion;
     }
 
     private long getTimeSinceCreation() {
@@ -1696,7 +1711,7 @@ public class MVStore implements AutoCloseable {
      * completely free chunks are not removed from the set of chunks, and the
      * disk space is not yet marked as free.
      */
-    private void applyFreedSpace() {
+    private void applyFreedSpace(long storeVersion) {
         while (true) {
             ArrayList<Chunk> modified = new ArrayList<>();
             synchronized (freedPageSpace) {
@@ -1712,6 +1727,10 @@ public class MVStore implements AutoCloseable {
                         if (c.maxLenLive < 0 && c.maxLenLive > -MARKED_FREE) {
                             // can happen after a rollback
                             c.maxLenLive = 0;
+                        }
+                        assert (c.pageCountLive == 0) == (c.maxLenLive == 0) : c;
+                        if (c.pageCountLive == 0 && c.maxLenLive == 0) {
+                            c.unusedAtVersion = storeVersion;
                         }
                         modified.add(c);
                     }
@@ -1924,6 +1943,10 @@ public class MVStore implements AutoCloseable {
     }
 
     private void compactMoveChunks(ArrayList<Chunk> move) {
+        // this will ensure better recognition of the last chunk
+        // in case of pwer failure, since we are going to move older chunks
+        // to the end of the file
+        writeStoreHeader();
         for (Chunk c : move) {
             moveChunk(c, true);
         }
@@ -2693,6 +2716,9 @@ public class MVStore implements AutoCloseable {
 
             int id = map.getId();
             String name = getMapName(id);
+            if (!delayed) {
+                map.clear();
+            }
             removeMap(name, id, delayed);
         } finally {
             storeLock.unlock();
@@ -2722,6 +2748,11 @@ public class MVStore implements AutoCloseable {
     public void removeMap(String name) {
         int id = getMapId(name);
         if(id > 0) {
+            MVMap map = getMap(id);
+            if (map == null) {
+                map = openMap(name);
+            }
+            map.clear();
             removeMap(name, id, false);
         }
     }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1413,7 +1413,6 @@ public class MVStore implements AutoCloseable {
                 for (Iterator<Chunk> iterator = chunks.values().iterator(); iterator.hasNext(); ) {
                     Chunk c = iterator.next();
                     if (c.block != Long.MAX_VALUE && c.version < oldestVersionToKeep && !referenced.contains(c.id)) {
-                        assert c.unusedAtVersion > 0 : c;
                         if (canOverwriteChunk(c, time, oldestVersionToKeep)) {
                             iterator.remove();
                             if (meta.remove(Chunk.getMetaKey(c.id)) != null) {
@@ -1702,21 +1701,17 @@ public class MVStore implements AutoCloseable {
             synchronized (freedPageSpace) {
                 for (Chunk f : freedPageSpace.values()) {
                     Chunk c = chunks.get(f.id);
-                    assert c != null : f.id;
                     if (c != null) { // skip if was already removed
                         c.maxLenLive += f.maxLenLive;
                         c.pageCountLive += f.pageCountLive;
-                        assert c.pageCountLive >= 0 : c;
                         if (c.pageCountLive < 0 && c.pageCountLive > -MARKED_FREE) {
                             // can happen after a rollback
                             c.pageCountLive = 0;
                         }
-                        assert c.maxLenLive >= 0 : c;
                         if (c.maxLenLive < 0 && c.maxLenLive > -MARKED_FREE) {
                             // can happen after a rollback
                             c.maxLenLive = 0;
                         }
-                        assert (c.pageCountLive == 0) == (c.maxLenLive == 0) : c;
                         if (c.pageCountLive == 0 && c.maxLenLive == 0) {
                             c.unusedAtVersion = storeVersion;
                         }

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -1035,7 +1035,7 @@ public abstract class Page implements Cloneable
         public String toString() {
             return "Cnt:" + count + ", pos:" + DataUtils.getPageChunkId(pos) +
                     "-" + DataUtils.getPageOffset(pos) + ":" + DataUtils.getPageMaxLength(pos) +
-                    (page == null ? DataUtils.getPageType(pos) == 0 : page.isLeaf() ? " leaf" : " node") + ", " + page;
+                    ((page == null ? DataUtils.getPageType(pos) == 0 : page.isLeaf()) ? " leaf" : " node") + ", " + page;
         }
     }
 

--- a/h2/src/test/org/h2/test/store/TestDefrag.java
+++ b/h2/src/test/org/h2/test/store/TestDefrag.java
@@ -45,13 +45,15 @@ public class TestDefrag  extends TestDb
                             " AS SELECT x, x || SPACE(200) FROM SYSTEM_RANGE(1,10000000)");
             }
             long origSize = dbFile.length();
+            trace("before defrag: " + origSize);
             assertTrue(origSize > 4_000_000_000L);
             try (Statement st = c.createStatement()) {
                 st.execute("shutdown defrag");
             }
-            long compactedSize = dbFile.length();
-            assertTrue(compactedSize < 400_000_000);
         }
+        long compactedSize = dbFile.length();
+        trace("after defrag: " + compactedSize);
+        assertTrue(compactedSize < 400_000_000);
 
         try (Connection c = getConnection(dbName + ";LAZY_QUERY_EXECUTION=1")) {
             try (Statement st = c.createStatement()) {


### PR DESCRIPTION
This PR fixes the following bugs:
During de-fragmentation procedure on shutdown re-entrance into the MVStore.commit() is possible when meta map is modified within freeUnusedChunks(). This may disrupt FileStore's free space accounting.
When map gets removed it is not cleared, therefore pages it contains are not released from store's perspective and will lead to incorrect chunk's occupancy calculations.
MVStore.freeUnusedChunks() should always work in "fast" mode - only one version of the store is scanned for reachable pages, while all recent  chunks are implicitely considered as being in-use.
