### PR TITLE
WIP: Add LSHIFT and RSHIFT bitwise operations

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4084,6 +4084,28 @@ See also Java operator ^.
 BITXOR(A, B)
 "
 
+"Functions (Numeric)","LSHIFT","
+LSHIFT(long, int)
+","
+The bitwise left shift operation.
+Shifts the first argument by the number of bits given by the second argument.
+This method returns a long.
+See also Java operator <<.
+","
+LSHIFT(A, B)
+"
+
+"Functions (Numeric)","RSHIFT","
+RSHIFT(long, int)
+","
+The bitwise right shift operation.
+Shifts the first argument by the number of bits given by the second argument.
+This method returns a long.
+See also Java operator >>.
+","
+RSHIFT(A, B)
+"
+
 "Functions (Numeric)","MOD","
 MOD(long, long)
 ","

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1833: Add LSHIFT and RSHIFT function
+</li>
 <li>PR #1833: Add BITNOT function
 </li>
 <li>PR #1832: JSON validation and normalization

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,7 +21,7 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
-<li>PR #1833: Add LSHIFT and RSHIFT function
+<li>PR #1836: Add LSHIFT and RSHIFT function
 </li>
 <li>PR #1833: Add BITNOT function
 </li>

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -91,7 +91,7 @@ public class Function extends Expression implements FunctionCall {
             TRUNCATE = 27, SECURE_RAND = 28, HASH = 29, ENCRYPT = 30,
             DECRYPT = 31, COMPRESS = 32, EXPAND = 33, ZERO = 34,
             RANDOM_UUID = 35, COSH = 36, SINH = 37, TANH = 38, LN = 39,
-            BITGET = 40, ORA_HASH = 41, BITNOT = 42;
+            BITGET = 40, ORA_HASH = 41, BITNOT = 42, LSHIFT = 43, RSHIFT = 44;
 
     public static final int ASCII = 50, BIT_LENGTH = 51, CHAR = 52,
             CHAR_LENGTH = 53, CONCAT = 54, DIFFERENCE = 55, HEXTORAW = 56,
@@ -213,6 +213,7 @@ public class Function extends Expression implements FunctionCall {
         addFunction("LOG", LOG, 1, Value.DOUBLE);
         addFunction("LN", LN, 1, Value.DOUBLE);
         addFunction("LOG10", LOG10, 1, Value.DOUBLE);
+        addFunction("LSHIFT", LSHIFT, 2, Value.LONG);
         addFunction("MOD", MOD, 2, Value.LONG);
         addFunction("PI", PI, 0, Value.DOUBLE);
         addFunction("POWER", POWER, 2, Value.DOUBLE);
@@ -223,6 +224,7 @@ public class Function extends Expression implements FunctionCall {
         addFunctionNotDeterministic("RANDOM", RAND, VAR_ARGS, Value.DOUBLE);
         addFunction("ROUND", ROUND, VAR_ARGS, Value.DOUBLE);
         addFunction("ROUNDMAGIC", ROUNDMAGIC, 1, Value.DOUBLE);
+        addFunction("RSHIFT", RSHIFT, 2, Value.LONG);
         addFunction("SIGN", SIGN, 1, Value.INT);
         addFunction("SIN", SIN, 1, Value.DOUBLE);
         addFunction("SINH", SINH, 1, Value.DOUBLE);
@@ -1247,6 +1249,12 @@ public class Function extends Expression implements FunctionCall {
             break;
         case BITXOR:
             result = ValueLong.get(v0.getLong() ^ v1.getLong());
+            break;
+        case LSHIFT:
+            result = ValueLong.get(v0.getLong() << v1.getInt());
+            break;
+        case RSHIFT:
+            result = ValueLong.get(v0.getLong() >> v1.getInt());
             break;
         case MOD: {
             long x = v1.getLong();

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/lshift.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/lshift.sql
@@ -1,0 +1,16 @@
+-- Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+create memory table test(id int primary key, name varchar(255));
+> ok
+
+insert into test values(1, 'Hello');
+> update count: 1
+
+select lshift(null, 1) vn, lshift(1, null) vn1, lshift(null, null) vn2, lshift(3, 6) v1, lshift(3,0) v2 from test;
+> VN   VN1  VN2  V1  V2
+> ---- ---- ---- --- --
+> null null null 192 3
+> rows: 1

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/rshift.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/rshift.sql
@@ -1,0 +1,16 @@
+-- Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+create memory table test(id int primary key, name varchar(255));
+> ok
+
+insert into test values(1, 'Hello');
+> update count: 1
+
+select rshift(null, 1) vn, rshift(1, null) vn1, rshift(null, null) vn2, rshift(3, 6) v1, rshift(1024,3) v2 from test;
+> VN   VN1  VN2  V1 V2
+> ---- ---- ---- -- ---
+> null null null 0  128
+> rows: 1

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -379,7 +379,7 @@ longblob longer longest longitude longnvarchar longs longtext longvarbinary long
 look lookahead looking looks lookup lookups lookupswitch loop loopback looping
 loops loose lor lore lose losing loss losses lossless losslessly lost lot lots
 low lowast lower lowercase lowercased lowest loz lpad lrem lreturn lrm lru lsaquo
-lshl lshr lsm lsquo lstore lsub lte ltrim lucene lucerne lugano lukas lumber
+lshift lshl lshr lsm lsquo lstore lsub lte ltrim lucene lucerne lugano lukas lumber
 lumberjack luntbuild lushr lutin lxabcdef lxor lying lynx lzf mac macdonald
 machine machines maciej macr macro macromedia macros made magic magnolia magyar
 mahon mail mailing main mainly maintain maintained maintaining maintains
@@ -556,7 +556,7 @@ rmd rmdir rmerr rmi rmiregistry rnd rnfr rnto road roadmap roads robert roc rogu
 rojas role roles roll rollback rollbacks rolled rolling rollover rolls roman room
 root rooted roots rot rotate round rounded rounding roundmagic rounds routine routinely
 routines row rowcount rowid rowlock rownum rows rowscn rowsize roy royalty rpad rpm rsa
-rsaquo rsquo rss rtree rtrim ruby ruebezahl rule rules run rund rundll runnable
+rsaquo rshift rsquo rss rtree rtrim ruby ruebezahl rule rules run rund rundll runnable
 runner runners running runs runscript runtime rwd rws sabine safari safe safely
 safes safety said sainsbury salary sale sales saload salt salz sam same
 sameorigin samp sample samples sanitize sanity sans sastore sat satisfy saturday sauce


### PR DESCRIPTION
Add `LSHIFT` and `RSHIFT` that take two arguments and perform bitwise shifts. Java equivalents are `<<` and `>>`.

I'm having some trouble running the test suite so please ignore this PR and I will fix up any problems shown by Travis CI before removing the *WIP:* prefix.