### PR TITLE
Implement conversion from GEOMETRY to JSON

### DIFF
--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -71,7 +71,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Console: add accesskey to most important commands (A, AREA, BUTTON, INPUT, LABEL, LEGEND, TEXTAREA).
 </li><li>Test performance again with SQL Server, Oracle, DB2.
 </li><li>Test with Spatial DB in a box / JTS: http://www.opengeospatial.org/standards/sfs - OpenGIS Implementation Specification.
-</li><li>Improve documentation of MVCC (Multi Version Concurrency Control).
 </li><li>Find a tool to view large text file (larger than 100 MB), with find, page up and down (like less), truncate before / after.
 </li><li>Implement, test, document XAConnection and so on.
 </li><li>Pluggable data type (for streaming, hashing, compression, validation, conversion, encryption).
@@ -95,7 +94,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>iReport to support H2.
 </li><li>Include SMTP (mail) client (alert on cluster failure, low disk space,...).
 </li><li>Option for SCRIPT to append to a file.
-</li><li>JSON parser and functions.
+</li><li>JSON functions.
 </li><li>Copy database: tool with config GUI and batch mode, extensible (example: compare).
 </li><li>Document, implement tool for long running transactions using user-defined compensation statements.
 </li><li>Support SET TABLE DUAL READONLY.
@@ -121,7 +120,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>LIKE: improved version for larger texts (currently using naive search).
 </li><li>Throw an exception when the application calls getInt on a Long (optional).
 </li><li>Default date format for input and output (local date constants).
-</li><li>Document ROWNUM usage for reports: SELECT ROWNUM, * FROM (subquery).
 </li><li>File system that writes to two file systems (replication, replicating file system).
 </li><li>Standalone tool to get relevant system properties and add it to the trace output.
 </li><li>Support 'call proc(1=value)' (PostgreSQL, Oracle).
@@ -263,7 +261,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Test Eclipse DTP.
 </li><li>H2 Console: autocomplete: keep the previous setting
 </li><li>executeBatch: option to stop at the first failed statement.
-</li><li>Implement OLAP features as described here: http://www.devx.com/getHelpOn/10MinuteSolution/16573/0/page/5
 </li><li>Support Oracle ROWID (unique identifier for each row).
 </li><li>MySQL compatibility: alter table add index i(c), add constraint c foreign key(c) references t(c);
 </li><li>Server mode: improve performance for batch updates.

--- a/h2/src/main/org/h2/util/geometry/EWKBUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKBUtils.java
@@ -436,7 +436,7 @@ public final class EWKBUtils {
             for (int i = 0; i < numItems; i++) {
                 Target innerTarget = target.startCollectionItem(i, numItems);
                 parseEWKB(source, innerTarget, type);
-                target.endCollectionItem(innerTarget, i, numItems);
+                target.endCollectionItem(innerTarget, type, i, numItems);
             }
             target.endCollection(type);
             break;

--- a/h2/src/main/org/h2/util/geometry/EWKBUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKBUtils.java
@@ -438,12 +438,12 @@ public final class EWKBUtils {
                 parseEWKB(source, innerTarget, type);
                 target.endCollectionItem(innerTarget, type, i, numItems);
             }
-            target.endCollection(type);
             break;
         }
         default:
             throw new IllegalArgumentException();
         }
+        target.endObject(type);
     }
 
     private static void addRing(EWKBSource source, Target target, boolean useZ, boolean useM, int size) {

--- a/h2/src/main/org/h2/util/geometry/EWKTUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKTUtils.java
@@ -763,13 +763,9 @@ public final class EWKTUtils {
             break;
         }
         case MULTI_POINT:
-            parseCollection(source, target, MULTI_POINT, parentType, dimensionSystem);
-            break;
         case MULTI_LINE_STRING:
-            parseCollection(source, target, MULTI_LINE_STRING, parentType, dimensionSystem);
-            break;
         case MULTI_POLYGON:
-            parseCollection(source, target, MULTI_POLYGON, parentType, dimensionSystem);
+            parseCollection(source, target, type, parentType, dimensionSystem);
             break;
         case GEOMETRY_COLLECTION:
             parseCollection(source, target, GEOMETRY_COLLECTION, parentType, 0);

--- a/h2/src/main/org/h2/util/geometry/EWKTUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKTUtils.java
@@ -178,8 +178,11 @@ public final class EWKTUtils {
         }
 
         @Override
-        protected void endCollection(int type) {
-            if (type != GEOMETRY_COLLECTION) {
+        protected void endObject(int type) {
+            switch (type) {
+            case MULTI_POINT:
+            case MULTI_LINE_STRING:
+            case MULTI_POLYGON:
                 inMulti = false;
             }
         }
@@ -773,6 +776,7 @@ public final class EWKTUtils {
         default:
             throw new IllegalArgumentException();
         }
+        target.endObject(type);
         if (parentType == 0 && source.hasData()) {
             throw new IllegalArgumentException();
         }
@@ -802,7 +806,6 @@ public final class EWKTUtils {
                 source.read(')');
             }
         }
-        target.endCollection(type);
     }
 
     private static void parseMultiPointAlternative(EWKTSource source, Target target, int dimensionSystem) {

--- a/h2/src/main/org/h2/util/geometry/EWKTUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKTUtils.java
@@ -44,7 +44,7 @@ public final class EWKTUtils {
      * 0-based type names of geometries, subtract 1 from type code to get index
      * in this array.
      */
-    private static final String[] TYPES = { //
+    static final String[] TYPES = { //
             "POINT", //
             "LINESTRING", //
             "POLYGON", //
@@ -146,31 +146,7 @@ public final class EWKTUtils {
             if (inMulti) {
                 return;
             }
-            switch (type) {
-            case POINT:
-                output.append("POINT");
-                break;
-            case LINE_STRING:
-                output.append("LINESTRING");
-                break;
-            case POLYGON:
-                output.append("POLYGON");
-                break;
-            case MULTI_POINT:
-                output.append("MULTIPOINT");
-                break;
-            case MULTI_LINE_STRING:
-                output.append("MULTILINESTRING");
-                break;
-            case MULTI_POLYGON:
-                output.append("MULTIPOLYGON");
-                break;
-            case GEOMETRY_COLLECTION:
-                output.append("GEOMETRYCOLLECTION");
-                break;
-            default:
-                throw new IllegalArgumentException();
-            }
+            output.append(TYPES[type - 1]);
             switch (dimensionSystem) {
             case DIMENSION_SYSTEM_XYZ:
                 output.append(" Z");

--- a/h2/src/main/org/h2/util/geometry/EWKTUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKTUtils.java
@@ -171,7 +171,7 @@ public final class EWKTUtils {
         }
 
         @Override
-        protected void endCollectionItem(Target target, int index, int total) {
+        protected void endCollectionItem(Target target, int type, int index, int total) {
             if (index + 1 == total) {
                 output.append(')');
             }
@@ -801,7 +801,7 @@ public final class EWKTUtils {
                     }
                     Target innerTarget = target.startCollectionItem(i, numItems);
                     parseEWKT(source, innerTarget, type, dimensionSystem);
-                    target.endCollectionItem(innerTarget, i, numItems);
+                    target.endCollectionItem(innerTarget, type, i, numItems);
                 }
                 source.read(')');
             }
@@ -822,7 +822,7 @@ public final class EWKTUtils {
             target.startPoint();
             double[] c = points.get(i);
             target.addCoordinate(c[X], c[Y], c[Z], c[M], 0, 1);
-            target.endCollectionItem(innerTarget, i, numItems);
+            target.endCollectionItem(innerTarget, MULTI_POINT, i, numItems);
         }
     }
 

--- a/h2/src/main/org/h2/util/geometry/GeoJsonUtils.java
+++ b/h2/src/main/org/h2/util/geometry/GeoJsonUtils.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (http://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.util.geometry;
+
+import static org.h2.util.geometry.GeometryUtils.DIMENSION_SYSTEM_XYM;
+import static org.h2.util.geometry.GeometryUtils.DIMENSION_SYSTEM_XYZ;
+import static org.h2.util.geometry.GeometryUtils.GEOMETRY_COLLECTION;
+import static org.h2.util.geometry.GeometryUtils.LINE_STRING;
+import static org.h2.util.geometry.GeometryUtils.MULTI_LINE_STRING;
+import static org.h2.util.geometry.GeometryUtils.MULTI_POINT;
+import static org.h2.util.geometry.GeometryUtils.MULTI_POLYGON;
+import static org.h2.util.geometry.GeometryUtils.POINT;
+import static org.h2.util.geometry.GeometryUtils.POLYGON;
+
+import java.math.BigDecimal;
+
+import org.h2.api.ErrorCode;
+import org.h2.message.DbException;
+import org.h2.util.geometry.GeometryUtils.Target;
+import org.h2.util.json.JSONStringTarget;
+
+/**
+ * GeoJson format support for GEOMETRY data type.
+ */
+public final class GeoJsonUtils {
+
+    /**
+     * 0-based type names of geometries, subtract 1 from type code to get index
+     * in this array.
+     */
+    static final String[] TYPES = { //
+            "Point", //
+            "LineString", //
+            "Polygon", //
+            "MultiPoint", //
+            "MultiLineString", //
+            "MultiPolygon", //
+            "GeometryCollection", //
+    };
+
+    /**
+     * Converter output target that writes a GeoJson.
+     */
+    public static final class GeoJsonTarget extends Target {
+
+        private final JSONStringTarget output;
+
+        private final int dimensionSystem;
+
+        private int type;
+
+        private boolean inMulti, inMultiLine, wasEmpty;
+
+        /**
+         * Creates new GeoJson output target.
+         *
+         * @param output
+         *            output JSON target
+         * @param dimensionSystem
+         *            dimension system to use
+         */
+        public GeoJsonTarget(JSONStringTarget output, int dimensionSystem) {
+            if (dimensionSystem == DIMENSION_SYSTEM_XYM) {
+                throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1,
+                        "M (XYM) dimension system is not supported in GeoJson");
+            }
+            this.output = output;
+            this.dimensionSystem = dimensionSystem;
+        }
+
+        @Override
+        protected void startPoint() {
+            type = POINT;
+            wasEmpty = false;
+        }
+
+        @Override
+        protected void startLineString(int numPoints) {
+            writeHeader(LINE_STRING);
+            if (numPoints == 0) {
+                output.endArray();
+            }
+        }
+
+        @Override
+        protected void startPolygon(int numInner, int numPoints) {
+            writeHeader(POLYGON);
+            if (numPoints == 0) {
+                output.endArray();
+            } else {
+                output.startArray();
+            }
+        }
+
+        @Override
+        protected void startPolygonInner(int numInner) {
+            output.valueSeparator();
+            output.startArray();
+            if (numInner == 0) {
+                output.endArray();
+            }
+        }
+
+        @Override
+        protected void endNonEmptyPolygon() {
+            output.endArray();
+        }
+
+        @Override
+        protected void startCollection(int type, int numItems) {
+            writeHeader(type);
+            if (type != GEOMETRY_COLLECTION) {
+                inMulti = true;
+                if (type == MULTI_LINE_STRING || type == MULTI_POLYGON) {
+                    inMultiLine = true;
+                }
+            }
+        }
+
+        @Override
+        protected Target startCollectionItem(int index, int total) {
+            if (index != 0) {
+                output.valueSeparator();
+            }
+            if (inMultiLine) {
+                output.startArray();
+            }
+            return this;
+        }
+
+        @Override
+        protected void endObject(int type) {
+            switch (type) {
+            case MULTI_POINT:
+            case MULTI_LINE_STRING:
+            case MULTI_POLYGON:
+                inMultiLine = inMulti = false;
+                //$FALL-THROUGH$
+            case GEOMETRY_COLLECTION:
+                output.endArray();
+            }
+            if (!inMulti && !wasEmpty) {
+                output.endObject();
+            }
+        }
+
+        private void writeHeader(int type) {
+            this.type = type;
+            wasEmpty = false;
+            if (!inMulti) {
+                writeStartObject(type);
+            }
+        }
+
+        @Override
+        protected void addCoordinate(double x, double y, double z, double m, int index, int total) {
+            if (type == POINT) {
+                if (Double.isNaN(x) && Double.isNaN(y) && Double.isNaN(z) && Double.isNaN(m)) {
+                    wasEmpty = true;
+                    output.valueNull();
+                    return;
+                }
+                if (!inMulti) {
+                    writeStartObject(POINT);
+                }
+            }
+            if (index > 0) {
+                output.valueSeparator();
+            }
+            output.startArray();
+            writeDouble(x);
+            output.valueSeparator();
+            writeDouble(y);
+            if ((dimensionSystem & DIMENSION_SYSTEM_XYZ) != 0) {
+                output.valueSeparator();
+                writeDouble(z);
+            }
+            if ((dimensionSystem & DIMENSION_SYSTEM_XYM) != 0) {
+                output.valueSeparator();
+                writeDouble(m);
+            }
+            output.endArray();
+            if (type != POINT && index + 1 == total) {
+                output.endArray();
+            }
+        }
+
+        private void writeStartObject(int type) {
+            output.startObject();
+            output.member("type");
+            output.valueString(TYPES[type - 1]);
+            output.valueSeparator();
+            output.member(type != GEOMETRY_COLLECTION ? "coordinates" : "geometries");
+            if (type != POINT) {
+                output.startArray();
+            }
+        }
+
+        private void writeDouble(double v) {
+            output.valueNumber(BigDecimal.valueOf(GeometryUtils.checkFinite(v)).stripTrailingZeros());
+        }
+
+    }
+
+    /**
+     * Converts EWKB with known dimension system to GeoJson.
+     *
+     * @param ewkb
+     *            geometry object in EWKB format
+     * @param dimensionSystem
+     *            dimension system of the specified object, may be the same or
+     *            smaller than its real dimension system. M dimension system is
+     *            not supported.
+     * @return GeoJson representation of the specified geometry
+     * @throws DbException
+     *             on unsupported dimension system
+     */
+    public static String ewkbToGeoJson(byte[] ewkb, int dimensionSystem) {
+        JSONStringTarget output = new JSONStringTarget();
+        GeoJsonTarget target = new GeoJsonTarget(output, dimensionSystem);
+        EWKBUtils.parseEWKB(ewkb, target);
+        return output.getString();
+    }
+
+    private GeoJsonUtils() {
+    }
+
+}

--- a/h2/src/main/org/h2/util/geometry/GeoJsonUtils.java
+++ b/h2/src/main/org/h2/util/geometry/GeoJsonUtils.java
@@ -200,7 +200,9 @@ public final class GeoJsonUtils {
         }
 
         private void writeDouble(double v) {
-            output.valueNumber(BigDecimal.valueOf(GeometryUtils.checkFinite(v)).stripTrailingZeros());
+            BigDecimal d = BigDecimal.valueOf(GeometryUtils.checkFinite(v));
+            // stripTrailingZeros() does not work with 0.0 on Java 7
+            output.valueNumber(d.signum() != 0 ? d.stripTrailingZeros() : BigDecimal.ZERO);
         }
 
     }

--- a/h2/src/main/org/h2/util/geometry/GeometryUtils.java
+++ b/h2/src/main/org/h2/util/geometry/GeometryUtils.java
@@ -125,12 +125,12 @@ public final class GeometryUtils {
         }
 
         /**
-         * Invoked after writing of a collection.
+         * Invoked after writing of the object.
          *
          * @param type
-         *            type of collection, see {@link #startCollection(int, int)}
+         *            type of the object
          */
-        protected void endCollection(int type) {
+        protected void endObject(int type) {
         }
 
         /**

--- a/h2/src/main/org/h2/util/geometry/GeometryUtils.java
+++ b/h2/src/main/org/h2/util/geometry/GeometryUtils.java
@@ -114,12 +114,14 @@ public final class GeometryUtils {
          *
          * @param target
          *            the result of {@link #startCollectionItem(int, int)}
+         * @param type
+         *            type of collection
          * @param index
          *            0-based index of this item in the collection
          * @param total
          *            total number of items in the collection
          */
-        protected void endCollectionItem(Target target, int index, int total) {
+        protected void endCollectionItem(Target target, int type, int index, int total) {
         }
 
         /**

--- a/h2/src/main/org/h2/util/geometry/JTSUtils.java
+++ b/h2/src/main/org/h2/util/geometry/JTSUtils.java
@@ -171,7 +171,7 @@ public final class JTSUtils {
         }
 
         @Override
-        protected void endCollectionItem(Target target, int index, int total) {
+        protected void endCollectionItem(Target target, int type, int index, int total) {
             subgeometries[index] = ((GeometryTarget) target).getGeometry();
         }
 
@@ -413,7 +413,7 @@ public final class JTSUtils {
             for (int i = 0; i < numItems; i++) {
                 Target innerTarget = target.startCollectionItem(i, numItems);
                 parseGeometry(gc.getGeometryN(i), innerTarget, type);
-                target.endCollectionItem(innerTarget, i, numItems);
+                target.endCollectionItem(innerTarget, type, i, numItems);
             }
             target.endCollection(type);
         } else {

--- a/h2/src/main/org/h2/util/geometry/JTSUtils.java
+++ b/h2/src/main/org/h2/util/geometry/JTSUtils.java
@@ -341,6 +341,7 @@ public final class JTSUtils {
                 CoordinateSequence sequence = p.getCoordinateSequence();
                 addCoordinate(sequence, target, 0, 1, getMeasures(sequence));
             }
+            target.endObject(POINT);
         } else if (geometry instanceof LineString) {
             if (parentType != 0 && parentType != MULTI_LINE_STRING && parentType != GEOMETRY_COLLECTION) {
                 throw new IllegalArgumentException();
@@ -356,6 +357,7 @@ public final class JTSUtils {
             for (int i = 0; i < numPoints; i++) {
                 addCoordinate(cs, target, i, numPoints, measures);
             }
+            target.endObject(LINE_STRING);
         } else if (geometry instanceof Polygon) {
             if (parentType != 0 && parentType != MULTI_POLYGON && parentType != GEOMETRY_COLLECTION) {
                 throw new IllegalArgumentException();
@@ -390,6 +392,7 @@ public final class JTSUtils {
                 }
                 target.endNonEmptyPolygon();
             }
+            target.endObject(POLYGON);
         } else if (geometry instanceof GeometryCollection) {
             if (parentType != 0 && parentType != GEOMETRY_COLLECTION) {
                 throw new IllegalArgumentException();
@@ -415,11 +418,10 @@ public final class JTSUtils {
                 parseGeometry(gc.getGeometryN(i), innerTarget, type);
                 target.endCollectionItem(innerTarget, type, i, numItems);
             }
-            target.endCollection(type);
+            target.endObject(type);
         } else {
             throw new IllegalArgumentException();
         }
-
     }
 
     private static void addRing(CoordinateSequence sequence, Target target, int size, int measures) {

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -31,6 +31,7 @@ import org.h2.util.DateTimeUtils;
 import org.h2.util.IntervalUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.StringUtils;
+import org.h2.util.geometry.GeoJsonUtils;
 
 /**
  * This is the base class for all value classes.
@@ -1360,6 +1361,10 @@ public abstract class Value extends VersionedValue {
         case STRING_FIXED:
         case CLOB:
             return ValueJson.get(getString());
+        case GEOMETRY: {
+            ValueGeometry vg = (ValueGeometry) this;
+            return ValueJson.get(GeoJsonUtils.ewkbToGeoJson(vg.getBytesNoCopy(), vg.getDimensionSystem()));
+        }
         default:
             throw getDataConversionError(Value.JSON);
         }

--- a/h2/src/test/org/h2/test/scripts/datatypes/geometry.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/geometry.sql
@@ -98,3 +98,75 @@ SELECT CAST('POINT EMPTY' AS GEOMETRY(POLYGON));
 
 DROP TABLE TEST;
 > ok
+
+SELECT CAST('POINT EMPTY'::GEOMETRY AS JSON);
+>> null
+
+SELECT CAST('POINT (1 2)'::GEOMETRY AS JSON);
+>> {"type":"Point","coordinates":[1,2]}
+
+SELECT CAST('POINT Z (1 2 3)'::GEOMETRY AS JSON);
+>> {"type":"Point","coordinates":[1,2,3]}
+
+SELECT CAST('POINT ZM (1 2 3 4)'::GEOMETRY AS JSON);
+>> {"type":"Point","coordinates":[1,2,3,4]}
+
+SELECT CAST('POINT M (1 2 4)'::GEOMETRY AS JSON);
+> exception DATA_CONVERSION_ERROR_1
+
+SELECT CAST('LINESTRING EMPTY'::GEOMETRY AS JSON);
+>> {"type":"LineString","coordinates":[]}
+
+SELECT CAST('LINESTRING (1 2, 3 4)'::GEOMETRY AS JSON);
+>> {"type":"LineString","coordinates":[[1,2],[3,4]]}
+
+SELECT CAST('POLYGON EMPTY'::GEOMETRY AS JSON);
+>> {"type":"Polygon","coordinates":[]}
+
+SELECT CAST('POLYGON ((-1 -2, 10 1, 2 20, -1 -2))'::GEOMETRY AS JSON);
+>> {"type":"Polygon","coordinates":[[[-1,-2],[1E+1,1],[2,2E+1],[-1,-2]]]}
+
+SELECT CAST('POLYGON ((-1 -2, 10 1, 2 20, -1 -2), (0.5 0.5, 1 0.5, 1 1, 0.5 0.5))'::GEOMETRY AS JSON);
+>> {"type":"Polygon","coordinates":[[[-1,-2],[1E+1,1],[2,2E+1],[-1,-2]],[[0.5,0.5],[1,0.5],[1,1],[0.5,0.5]]]}
+
+SELECT CAST('MULTIPOINT EMPTY'::GEOMETRY AS JSON);
+>> {"type":"MultiPoint","coordinates":[]}
+
+SELECT CAST('MULTIPOINT ((1 2))'::GEOMETRY AS JSON);
+>> {"type":"MultiPoint","coordinates":[[1,2]]}
+
+SELECT CAST('MULTIPOINT ((1 2), (3 4))'::GEOMETRY AS JSON);
+>> {"type":"MultiPoint","coordinates":[[1,2],[3,4]]}
+
+SELECT CAST('MULTIPOINT ((1 0), EMPTY, EMPTY, (2 2))'::GEOMETRY AS JSON);
+>> {"type":"MultiPoint","coordinates":[[1,0],null,null,[2,2]]}
+
+SELECT CAST('MULTILINESTRING EMPTY'::GEOMETRY AS JSON);
+>> {"type":"MultiLineString","coordinates":[]}
+
+SELECT CAST('MULTILINESTRING ((1 2, 3 4, 5 7))'::GEOMETRY AS JSON);
+>> {"type":"MultiLineString","coordinates":[[[1,2],[3,4],[5,7]]]}
+
+SELECT CAST('MULTILINESTRING ((1 2, 3 4, 5 7), (-1 -1, 0 0, 2 2, 4 6.01))'::GEOMETRY AS JSON);
+>> {"type":"MultiLineString","coordinates":[[[1,2],[3,4],[5,7]],[[-1,-1],[0,0],[2,2],[4,6.01]]]}
+
+SELECT CAST('MULTIPOLYGON EMPTY'::GEOMETRY AS JSON);
+>> {"type":"MultiPolygon","coordinates":[]}
+
+SELECT CAST('MULTIPOLYGON (((-1 -2, 10 1, 2 20, -1 -2)))'::GEOMETRY AS JSON);
+>> {"type":"MultiPolygon","coordinates":[[[[-1,-2],[1E+1,1],[2,2E+1],[-1,-2]]]]}
+
+SELECT CAST('MULTIPOLYGON (((-1 -2, 10 1, 2 20, -1 -2)), ((1 2, 2 2, 3 3, 1 2)))'::GEOMETRY AS JSON);
+>> {"type":"MultiPolygon","coordinates":[[[[-1,-2],[1E+1,1],[2,2E+1],[-1,-2]]],[[[1,2],[2,2],[3,3],[1,2]]]]}
+
+SELECT CAST('MULTIPOLYGON (((-1 -2, 10 1, 2 20, -1 -2), (0.5 0.5, 1 0.5, 1 1, 0.5 0.5)))'::GEOMETRY AS JSON);
+>> {"type":"MultiPolygon","coordinates":[[[[-1,-2],[1E+1,1],[2,2E+1],[-1,-2]],[[0.5,0.5],[1,0.5],[1,1],[0.5,0.5]]]]}
+
+SELECT CAST('GEOMETRYCOLLECTION EMPTY'::GEOMETRY AS JSON);
+>> {"type":"GeometryCollection","geometries":[]}
+
+SELECT CAST('GEOMETRYCOLLECTION (POINT (1 2))'::GEOMETRY AS JSON);
+>> {"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[1,2]}]}
+
+SELECT CAST('GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (1 3)), MULTIPOINT ((4 8)))'::GEOMETRY AS JSON);
+>> {"type":"GeometryCollection","geometries":[{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[1,3]}]},{"type":"MultiPoint","coordinates":[[4,8]]}]}


### PR DESCRIPTION
An implementation of conversion from `GEOMETRY` data type to `JSON` data type using [GeoJson](https://tools.ietf.org/html/rfc7946) format. M dimension system is not supported (ZM is supported). Representation of empty geometries may be not fully compatible with other implementations, they are not standardized and existing implementations are different in that area.

Reverse conversion is not supported.