### PR TITLE
Deadlock on concurrent shutdown

### DIFF
--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -280,13 +280,19 @@ public class Set extends Prepared {
             int value = getIntValue();
             switch (value) {
             case 0:
-                database.unsetExclusiveSession(session);
+                if (!database.unsetExclusiveSession(session)) {
+                    throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
+                }
                 break;
             case 1:
-                database.setExclusiveSession(session, false);
+                if (!database.setExclusiveSession(session, false)) {
+                    throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
+                }
                 break;
             case 2:
-                database.setExclusiveSession(session, true);
+                if (!database.setExclusiveSession(session, true)) {
+                    throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
+                }
                 break;
             default:
                 throw DbException.getInvalidValueException("EXCLUSIVE", value);

--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -280,7 +280,7 @@ public class Set extends Prepared {
             int value = getIntValue();
             switch (value) {
             case 0:
-                database.setExclusiveSession(null, false);
+                database.unsetExclusiveSession(session);
                 break;
             case 1:
                 database.setExclusiveSession(session, false);

--- a/h2/src/main/org/h2/command/dml/TransactionCommand.java
+++ b/h2/src/main/org/h2/command/dml/TransactionCommand.java
@@ -86,15 +86,14 @@ public class TransactionCommand extends Prepared {
             // execution of shutdown and query
             session.throttle();
             Database db = session.getDatabase();
-            if (db.setExclusiveSession(session, true)) {
-                if (type == CommandInterface.SHUTDOWN_COMPACT ||
-                        type == CommandInterface.SHUTDOWN_DEFRAG) {
-                    db.setCompactMode(type);
-                }
-                // close the database, but don't update the persistent setting
-                db.setCloseDelay(0);
-                session.close();
+            db.setExclusiveSession(session, true);
+            if (type == CommandInterface.SHUTDOWN_COMPACT ||
+                    type == CommandInterface.SHUTDOWN_DEFRAG) {
+                db.setCompactMode(type);
             }
+            // close the database, but don't update the persistent setting
+            db.setCloseDelay(0);
+            session.close();
             break;
         }
         default:

--- a/h2/src/main/org/h2/command/dml/TransactionCommand.java
+++ b/h2/src/main/org/h2/command/dml/TransactionCommand.java
@@ -93,22 +93,8 @@ public class TransactionCommand extends Prepared {
             // execution of shutdown and query
             session.throttle();
             for (Session s : db.getSessions(false)) {
-                if (db.isMultiThreaded()) {
-                    synchronized (s) {
-                        s.rollback();
-                    }
-                } else {
-                    // if not multi-threaded, the session could already own
-                    // the lock, which would result in a deadlock
-                    // the other session can not concurrently do anything
-                    // because the current session has locked the database
-                    s.rollback();
-                }
-                if (s != session) {
-                    s.close();
-                }
+                s.close();
             }
-            session.close();
             break;
         }
         default:

--- a/h2/src/main/org/h2/command/dml/TransactionCommand.java
+++ b/h2/src/main/org/h2/command/dml/TransactionCommand.java
@@ -86,14 +86,15 @@ public class TransactionCommand extends Prepared {
             // execution of shutdown and query
             session.throttle();
             Database db = session.getDatabase();
-            db.setExclusiveSession(session, true);
-            if (type == CommandInterface.SHUTDOWN_COMPACT ||
-                    type == CommandInterface.SHUTDOWN_DEFRAG) {
-                db.setCompactMode(type);
+            if (db.setExclusiveSession(session, true)) {
+                if (type == CommandInterface.SHUTDOWN_COMPACT ||
+                        type == CommandInterface.SHUTDOWN_DEFRAG) {
+                    db.setCompactMode(type);
+                }
+                // close the database, but don't update the persistent setting
+                db.setCloseDelay(0);
+                session.close();
             }
-            // close the database, but don't update the persistent setting
-            db.setCloseDelay(0);
-            session.close();
             break;
         }
         default:

--- a/h2/src/main/org/h2/command/dml/TransactionCommand.java
+++ b/h2/src/main/org/h2/command/dml/TransactionCommand.java
@@ -82,18 +82,18 @@ public class TransactionCommand extends Prepared {
         case CommandInterface.SHUTDOWN_DEFRAG: {
             session.getUser().checkAdmin();
             session.commit(false);
-            if (type == CommandInterface.SHUTDOWN_COMPACT ||
-                    type == CommandInterface.SHUTDOWN_DEFRAG) {
-                session.getDatabase().setCompactMode(type);
-            }
-            // close the database, but don't update the persistent setting
-            session.getDatabase().setCloseDelay(0);
-            Database db = session.getDatabase();
             // throttle, to allow testing concurrent
             // execution of shutdown and query
             session.throttle();
-            for (Session s : db.getSessions(false)) {
-                s.close();
+            Database db = session.getDatabase();
+            if (db.setExclusiveSession(session, true)) {
+                if (type == CommandInterface.SHUTDOWN_COMPACT ||
+                        type == CommandInterface.SHUTDOWN_DEFRAG) {
+                    db.setCompactMode(type);
+                }
+                // close the database, but don't update the persistent setting
+                db.setCloseDelay(0);
+                session.close();
             }
             break;
         }

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2655,25 +2655,26 @@ public class Database implements DataHandler {
      *
      * @param session the session
      * @param closeOthers whether other sessions are closed
+     * @return true if success, false otherwise
      */
-    public void setExclusiveSession(Session session, boolean closeOthers) {
+    public boolean setExclusiveSession(Session session, boolean closeOthers) {
         if (!exclusiveSession.compareAndSet(null, session)) {
-            throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
+            return false;
         }
         if (closeOthers) {
             closeAllSessionsException(session);
         }
+        return true;
     }
 
     /**
      * Stop exclusiv access the database by provided session.
      *
      * @param session the session
+     * @return true if success, false otherwise
      */
-    public void unsetExclusiveSession(Session session) {
-        if (!exclusiveSession.compareAndSet(session, null)) {
-            throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
-        }
+    public boolean unsetExclusiveSession(Session session) {
+        return exclusiveSession.compareAndSet(session, null);
     }
 
     @Override

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2655,12 +2655,26 @@ public class Database implements DataHandler {
      *
      * @param session the session
      * @param closeOthers whether other sessions are closed
+     * @return true if success, false otherwise
      */
-    public void setExclusiveSession(Session session, boolean closeOthers) {
-        this.exclusiveSession.set(session);
+    public boolean setExclusiveSession(Session session, boolean closeOthers) {
+        if (!exclusiveSession.compareAndSet(null, session)) {
+            return false;
+        }
         if (closeOthers) {
             closeAllSessionsException(session);
         }
+        return true;
+    }
+
+    /**
+     * Stop exclusiv access the database by provided session.
+     *
+     * @param session the session
+     * @return true if success, false otherwise
+     */
+    public boolean unsetExclusiveSession(Session session) {
+        return exclusiveSession.compareAndSet(session, null);
     }
 
     @Override

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2655,26 +2655,25 @@ public class Database implements DataHandler {
      *
      * @param session the session
      * @param closeOthers whether other sessions are closed
-     * @return true if success, false otherwise
      */
-    public boolean setExclusiveSession(Session session, boolean closeOthers) {
+    public void setExclusiveSession(Session session, boolean closeOthers) {
         if (!exclusiveSession.compareAndSet(null, session)) {
-            return false;
+            throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
         }
         if (closeOthers) {
             closeAllSessionsException(session);
         }
-        return true;
     }
 
     /**
      * Stop exclusiv access the database by provided session.
      *
      * @param session the session
-     * @return true if success, false otherwise
      */
-    public boolean unsetExclusiveSession(Session session) {
-        return exclusiveSession.compareAndSet(session, null);
+    public void unsetExclusiveSession(Session session) {
+        if (!exclusiveSession.compareAndSet(session, null)) {
+            throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR adds test for and fixes issue #1841.
Since life cycle state of the session is changed with CAS operation now, to prevent race on session closure, synchronization on session to be closed is redundant.
Call to rollback() there is part of the closure procedure anyway, so code can be simplified.
