### PR TITLE
Add support of named columns joins

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2680,6 +2680,15 @@ Values for INSERT statement.
 VALUES (1, 'Test')
 "
 
+"Other Grammar","Join specification","
+ON expression | USING (columnName [,...])
+","
+Specifies a join condition or column names.
+","
+ON B.ID = A.PARENT_ID
+USING (ID)
+"
+
 "Other Grammar","Merge when clause","
 mergeWhenMatchedClause|mergeWhenNotMatchedClause
 ","
@@ -2858,13 +2867,13 @@ ID + 20
 [ [ AS ] newTableAlias [ ( columnName [,...] ) ] ]
 [ USE INDEX ([ indexName [,...] ]) ]
 [ { { LEFT | RIGHT } [ OUTER ] | [ INNER ] | CROSS | NATURAL }
-    JOIN tableExpression [ ON expression ] ]
+    JOIN tableExpression [ joinSpecification ] ]
 ","
-Joins a table. The join expression is not supported for cross and natural joins.
+Joins a table. The join specification is not supported for cross and natural joins.
 A natural join is an inner join, where the condition is automatically on the
 columns with the same name.
 ","
-TEST AS T LEFT JOIN TEST AS T1 ON T.ID = T1.ID
+TEST1 AS T1 LEFT JOIN TEST2 AS T2 ON T1.ID = T2.PARENT_ID
 "
 
 "Other Grammar","Within group specification","

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -636,6 +636,8 @@ The following tokens are keywords in H2:
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
 <tr><td>UNIQUE</td>
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
+<tr><td>USING</td>
+<td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
 <tr><td>VALUES</td>
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
 <tr><td>WHERE</td>

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -57,6 +57,7 @@ import static org.h2.util.ParserUtil.TABLE;
 import static org.h2.util.ParserUtil.TRUE;
 import static org.h2.util.ParserUtil.UNION;
 import static org.h2.util.ParserUtil.UNIQUE;
+import static org.h2.util.ParserUtil.USING;
 import static org.h2.util.ParserUtil.VALUES;
 import static org.h2.util.ParserUtil.WHERE;
 import static org.h2.util.ParserUtil.WINDOW;
@@ -525,6 +526,8 @@ public class Parser {
             "UNION",
             // UNIQUE
             "UNIQUE",
+            // USING
+            "USING",
             // VALUES
             "VALUES",
             // WHERE
@@ -1531,9 +1534,9 @@ public class Parser {
     private Prepared parseMerge() {
         int start = lastParseIndex;
         read("INTO");
-        List<String> excludeIdentifiers = Arrays.asList("USING", "KEY");
+        List<String> excludeIdentifiers = Collections.singletonList("KEY");
         TableFilter targetTableFilter = readSimpleTableFilter(0, excludeIdentifiers);
-        if (readIf("USING")) {
+        if (readIf(USING)) {
             return parseMergeUsing(targetTableFilter, start);
         }
         Merge command = new Merge(session);
@@ -2270,10 +2273,7 @@ public class Parser {
                 // the right hand side is the 'inner' table usually
                 join = readTableFilter();
                 join = readJoin(join);
-                Expression on = null;
-                if (readIf(ON)) {
-                    on = readExpression();
-                }
+                Expression on = readJoinSpecification(top, join);
                 addJoin(join, top, true, on);
                 top = join;
             } else if (readIf("LEFT")) {
@@ -2281,10 +2281,7 @@ public class Parser {
                 read(JOIN);
                 join = readTableFilter();
                 join = readJoin(join);
-                Expression on = null;
-                if (readIf(ON)) {
-                    on = readExpression();
-                }
+                Expression on = readJoinSpecification(top, join);
                 addJoin(top, join, true, on);
             } else if (readIf(FULL)) {
                 throw getSyntaxError();
@@ -2292,18 +2289,12 @@ public class Parser {
                 read(JOIN);
                 join = readTableFilter();
                 top = readJoin(top);
-                Expression on = null;
-                if (readIf(ON)) {
-                    on = readExpression();
-                }
+                Expression on = readJoinSpecification(top, join);
                 addJoin(top, join, false, on);
             } else if (readIf(JOIN)) {
                 join = readTableFilter();
                 top = readJoin(top);
-                Expression on = null;
-                if (readIf(ON)) {
-                    on = readExpression();
-                }
+                Expression on = readJoinSpecification(top, join);
                 addJoin(top, join, false, on);
             } else if (readIf(CROSS)) {
                 read(JOIN);
@@ -2312,32 +2303,17 @@ public class Parser {
             } else if (readIf(NATURAL)) {
                 read(JOIN);
                 join = readTableFilter();
-                Column[] tableCols = last.getTable().getColumns();
-                Column[] joinCols = join.getTable().getColumns();
-                String tableSchema = last.getTable().getSchema().getName();
-                String joinSchema = join.getTable().getSchema().getName();
+                Table table1 = last.getTable();
+                Table table2 = join.getTable();
+                String schema1 = table1.getSchema().getName();
+                String schema2 = table2.getSchema().getName();
                 Expression on = null;
-                for (Column tc : tableCols) {
-                    String tableColumnName = tc.getName();
-                    for (Column c : joinCols) {
-                        String joinColumnName = c.getName();
-                        if (equalsToken(tableColumnName, joinColumnName)) {
-                            join.addNaturalJoinColumn(c);
-                            Expression tableExpr = new ExpressionColumn(
-                                    database, tableSchema,
-                                    last.getTableAlias(), tableColumnName, false);
-                            Expression joinExpr = new ExpressionColumn(
-                                    database, joinSchema, join.getTableAlias(),
-                                    joinColumnName, false);
-                            Expression equal = new Comparison(session,
-                                    Comparison.EQUAL, tableExpr, joinExpr);
-                            if (on == null) {
-                                on = equal;
-                            } else {
-                                on = new ConditionAndOr(ConditionAndOr.AND, on,
-                                        equal);
-                            }
-                        }
+                for (Column column1 : table1.getColumns()) {
+                    String columnName1 = column1.getName();
+                    if (table2.doesColumnExist(columnName1)) {
+                        Column column2 = table2.getColumn(columnName1);
+                        join.addNaturalJoinColumn(column2);
+                        on = addJoinColumn(on, last, join, schema1, schema2, columnName1, column2.getName());
                     }
                 }
                 addJoin(top, join, false, on);
@@ -2347,6 +2323,38 @@ public class Parser {
             last = join;
         }
         return top;
+    }
+
+    private Expression readJoinSpecification(TableFilter filter1, TableFilter filter2) {
+        Expression on = null;
+        if (readIf(ON)) {
+            on = readExpression();
+        } else if (readIf(USING)) {
+            read(OPEN_PAREN);
+            Table table1 = filter1.getTable();
+            Table table2 = filter2.getTable();
+            String schema1 = table1.getSchema().getName();
+            String schema2 = table2.getSchema().getName();
+            do {
+                String columnName = readColumnIdentifier();
+                on = addJoinColumn(on, filter1, filter2, schema1, schema2, table1.getColumn(columnName).getName(),
+                        table2.getColumn(columnName).getName());
+            } while (readIfMore(true));
+        }
+        return on;
+    }
+
+    private Expression addJoinColumn(Expression on, TableFilter filter1, TableFilter filter2, String schema1,
+            String schema2, String columnName1, String columnName2) {
+        Expression tableExpr = new ExpressionColumn(database, schema1, filter1.getTableAlias(), columnName1, false);
+        Expression joinExpr = new ExpressionColumn(database, schema2, filter2.getTableAlias(), columnName2, false);
+        Expression equal = new Comparison(session, Comparison.EQUAL, tableExpr, joinExpr);
+        if (on == null) {
+            on = equal;
+        } else {
+            on = new ConditionAndOr(ConditionAndOr.AND, on, equal);
+        }
+        return on;
     }
 
     /**
@@ -5868,7 +5876,7 @@ public class Parser {
             read(OPEN_PAREN);
             command.setIndexColumns(parseIndexColumnList());
 
-            if (readIf("USING")) {
+            if (readIf(USING)) {
                 if (hash) {
                     throw getSyntaxError();
                 }
@@ -7675,7 +7683,7 @@ public class Parser {
             }
             command.setIndexColumns(parseIndexColumnList());
             // MySQL compatibility
-            if (readIf("USING")) {
+            if (readIf(USING)) {
                 read("BTREE");
             }
             return command;
@@ -7706,7 +7714,7 @@ public class Parser {
                 command.setIndex(getSchema().findIndex(session, indexName));
             }
             // MySQL compatibility
-            if (readIf("USING")) {
+            if (readIf(USING)) {
                 read("BTREE");
             }
         } else if (readIf(FOREIGN)) {

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -1572,7 +1572,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * RANGE, REGEXP, RIGHT, ROW, _ROWID_, ROWNUM, ROWS,
      * SELECT, SYSDATE, SYSTIME, SYSTIMESTAMP,
      * TABLE, TODAY, TOP, TRAILING, TRUE,
-     * UNION, UNIQUE,
+     * UNION, UNIQUE, USING
      * VALUES,
      * WHERE, WINDOW, WITH
      * </pre>

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -263,9 +263,14 @@ public class ParserUtil {
     public static final int UNIQUE = UNION + 1;
 
     /**
+     * The token "USING".
+     */
+    public static final int USING = UNIQUE + 1;
+
+    /**
      * The token "VALUES".
      */
-    public static final int VALUES = UNIQUE + 1;
+    public static final int VALUES = USING + 1;
 
     /**
      * The token "WHERE".
@@ -609,6 +614,8 @@ public class ParserUtil {
                 return UNIQUE;
             } else if (eq("UNION", s, ignoreCase, start, end)) {
                 return UNION;
+            } else if (eq("USING", s, ignoreCase, start, end)) {
+                return USING;
             }
             return IDENTIFIER;
         case 'V':

--- a/h2/src/test/org/h2/test/scripts/joins.sql
+++ b/h2/src/test/org/h2/test/scripts/joins.sql
@@ -799,6 +799,9 @@ SELECT T1.X1, T2.X2, T3.X3, T4.X4, T5.X5 FROM (
 > 1  1  1  1  1
 > rows: 1
 
+DROP TABLE T1, T2, T3, T4, T5;
+> ok
+
 CREATE TABLE A(X INT);
 > ok
 
@@ -825,4 +828,27 @@ SELECT * FROM TEST X LEFT OUTER JOIN TEST Y ON Y.A = X.A || '1';
 > rows: 0
 
 DROP TABLE TEST;
+> ok
+
+CREATE TABLE T1(A INT, B INT) AS VALUES (1, 10), (2, 20), (4, 40), (6, 6);
+> ok
+
+CREATE TABLE T2(A INT, B INT) AS VALUES (1, 100), (2, 200), (5, 500), (6, 6);
+> ok
+
+SELECT T1.B, T2.B FROM T1 INNER JOIN T2 USING (A);
+> B  B
+> -- ---
+> 10 100
+> 20 200
+> 6  6
+> rows: 3
+
+SELECT T1.B, T2.B FROM T1 INNER JOIN T2 USING (A, B);
+> B B
+> - -
+> 6 6
+> rows: 1
+
+DROP TABLE T1, T2;
 > ok


### PR DESCRIPTION
Support of standard named columns joins is implemented here.

Closes #1843.

A new keyword `USING` was introduced here due to problems in parser when this token is not a keyword. `USING` is a standard reserved word too.