### PR TITLE
Reimplement MVStore.findOldChunks() with PriorityQueue

### DIFF
--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1816,7 +1816,10 @@ public class TestMVStore extends TestBase {
             for (int i = 0; i < 100; i++) {
                 m.put(j + i, "Hello " + j);
             }
+            trace("Before - fill rate: " + s.getFileStore().getFillRate() + "%, chunks fill rate: " + s.getChunksFillRate() + ", len: " + FileUtils.size(fileName));
             s.compact(80, 1024);
+            s.compactMoveChunks();
+            trace("After  - fill rate: " + s.getFileStore().getFillRate() + "%, chunks fill rate: " + s.getChunksFillRate() + ", len: " + FileUtils.size(fileName));
             s.close();
             long len = FileUtils.size(fileName);
             // System.out.println("   len:" + len);


### PR DESCRIPTION
To avoid sorting of a full chunk list, heap can be used here, since we are only looking for top N chunks. It will also reduce memory allocation.