### PR TITLE
Additional fix for deadlock on shutdown (exclusively in pgstore mode)

### DIFF
--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1512,7 +1512,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         if (database.getLobSession() == this) {
             return;
         }
-        while (true) {
+        while (!isClosed()) {
             Session exclusive = database.getExclusiveSession();
             if (exclusive == null || exclusive == this) {
                 break;


### PR DESCRIPTION
This PR is an additional (to #1842) fix for issue #1841.
Before the fix it use to stuck (in pgstore mode only) in my tests on every 3th-7th run. After this fix it hasn't stuck once after 200 runs.
