### PR TITLE
Fix for issue #1864 - Proper handling of NotSerializableException

### DIFF
--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -920,12 +920,12 @@ public final class DataUtils {
             }
         }
 
-        if (Pattern.matches(".*\\{\\d+,.*}.*", message)) {
+        try {
             return MessageFormat.format(message, arguments) +
                     " [" + Constants.VERSION_MAJOR + "." +
                     Constants.VERSION_MINOR + "." + Constants.BUILD_ID +
                     "/" + errorCode + "]";
-        } else {
+        } catch (IllegalArgumentException iae) {
             return message;
         }
     }

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -15,6 +15,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.h2.engine.Constants;
 import org.h2.util.StringUtils;
@@ -918,10 +919,15 @@ public final class DataUtils {
                 arguments[i] = s;
             }
         }
-        return MessageFormat.format(message, arguments) +
-                " [" + Constants.VERSION_MAJOR + "." +
-                Constants.VERSION_MINOR + "." + Constants.BUILD_ID +
-                "/" + errorCode + "]";
+
+        if (Pattern.matches(".*\\{\\d+,.*}.*", message)) {
+            return MessageFormat.format(message, arguments) +
+                    " [" + Constants.VERSION_MAJOR + "." +
+                    Constants.VERSION_MINOR + "." + Constants.BUILD_ID +
+                    "/" + errorCode + "]";
+        } else {
+            return message;
+        }
     }
 
     /**


### PR DESCRIPTION
`DataUtils.formatMessage()` was failing to format the error message and throwing `NumberFormatException` and ultimately corrupting the database file.

The reason is that the error message contains strings like - **Could not serialize {field = [..**, which is already formatted. Due to the **{** character, `MessageFormat` is expecting a trailing number, which it cannot find as the message is already formatted.

So an error checking has been introduced in `DataUtils.formatMessage()`. If `IllegalArgumentException` is thrown while executing `MessageFormat.format()`, raw message will be returned instead assuming the message is already formatted.