### PR TITLE
Raw error message is passed to DataUtils.newIllegalStateException()

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1230,7 +1230,7 @@ public class MVStore implements AutoCloseable {
                     } catch (IllegalStateException e) {
                         panic(e);
                     } catch (Throwable e) {
-                        panic(DataUtils.newIllegalStateException(DataUtils.ERROR_INTERNAL, e.toString(), e));
+                        panic(DataUtils.newIllegalStateException(DataUtils.ERROR_INTERNAL, "{0}", e.toString(), e));
                     }
                 }
             }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -541,7 +541,7 @@ public class Transaction {
                                     + " modified by transaction %s%n",
                             transactionId, blockingMap.getName(), blockingKey, toWaitFor));
                     if (isDeadlocked(toWaitFor)) {
-                        throw DataUtils.newIllegalStateException(DataUtils.ERROR_TRANSACTIONS_DEADLOCK,
+                        throw DataUtils.newIllegalStateException(DataUtils.ERROR_TRANSACTIONS_DEADLOCK, "{0}",
                                 details.toString());
                     }
                 }


### PR DESCRIPTION
Fix cases where raw error message is passed to DataUtils.newIllegalStateException() instead of format string, which may cause IAE