### PR TITLE
Collation names like CHARSET_* recognition

### DIFF
--- a/h2/src/main/org/h2/value/CompareMode.java
+++ b/h2/src/main/org/h2/value/CompareMode.java
@@ -138,6 +138,8 @@ public class CompareMode implements Comparator<Value> {
             } else if (name.startsWith(DEFAULT)) {
                 useICU4J = false;
                 name = name.substring(DEFAULT.length());
+            } else if (name.startsWith(CHARSET)) {
+                useICU4J = false;
             } else {
                 useICU4J = CAN_USE_ICU4J;
             }


### PR DESCRIPTION
In presence of `com.ibm.icu.text.Collator` class on a classpath, collation names like CHARSET_* are not recognized anymore by SET COLLATION command, i.e TestSetCollation start failing.