### PR TITLE
Invalidate PreparedStatement's result on rollback

### DIFF
--- a/h2/src/main/org/h2/value/CompareMode.java
+++ b/h2/src/main/org/h2/value/CompareMode.java
@@ -138,6 +138,8 @@ public class CompareMode implements Comparator<Value> {
             } else if (name.startsWith(DEFAULT)) {
                 useICU4J = false;
                 name = name.substring(DEFAULT.length());
+            } else if (name.startsWith(CHARSET)) {
+                useICU4J = false;
             } else {
                 useICU4J = CAN_USE_ICU4J;
             }


### PR DESCRIPTION
Fix for #1878. 
It is easy to just advance database's data modification counter (similar to commit), which is what I did, but this is definitely sub-optimal solution, because it affects every connection, instead of just a current one, as it should. 
Ideally, only last result of prepared statement(s) should be closed and ignored, not even recompilation is required. IMHO, we need to maintain session-level data and metadata modification counters separate from database, and pay attention to them in addition to ones from database. Database counters should only advance on transaction commit. The problem with doing all of this is a high risk of breaking pgstore codepath.