### PR TITLE
Reimplement Session.getLocks() in safer way

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,20 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1883: Suspicious code in Session.getLocks()
+</li>
+<li>Issue #1878: OPTIMIZE_REUSE_RESULTS causes incorrect result after rollback since 1.4.198
+</li>
+<li>PR #1880: Collation names like CHARSET_* recognition
+</li>
+<li>Issue #1844: MySQL Compatibility: create table error when primary key has comment
+</li>
+<li>PR #1873: Concurrency in database metadata
+</li>
+<li>Issue #1864: Failing to format NotSerializableException corrupting the database
+</li>
+<li>PR #1868: add more checking to TestFileLock
+</li>
 <li>Issue #1819: Trace.db file exceed file size limit (64MB)
 </li>
 <li>Issue #1861: Use COALESCE in named columns join for some data types

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -145,7 +145,7 @@ public class Database implements DataHandler {
     private final ConcurrentHashMap<String, Domain> domains = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, UserAggregate> aggregates = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Comment> comments = new ConcurrentHashMap<>();
-    
+
     private final HashMap<String, TableEngine> tableEngines = new HashMap<>();
 
     private final Set<Session> userSessions =

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -705,13 +705,11 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         }
 
         if (tablesToAnalyze != null) {
+            analyzeTables();
             if (database.isMVStore()) {
-                // table analysis will cause a new transaction(s) to be opened,
+                // table analysis opens a new transaction(s),
                 // so we need to commit afterwards whatever leftovers might be
-                analyzeTables();
                 commit(true);
-            } else {
-                analyzeTables();
             }
         }
         endTransaction();
@@ -1496,7 +1494,11 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
     public Set<Table> getLocks() {
         /*
          * This implementation needs to be lock-free.
-         *
+         */
+        if (locks.isEmpty()) {
+            return Collections.emptySet();
+        }
+        /*
          * Do not use ArrayList.toArray(T[]) here, its implementation is not
          * thread-safe.
          */

--- a/h2/src/main/org/h2/jmx/DatabaseInfo.java
+++ b/h2/src/main/org/h2/jmx/DatabaseInfo.java
@@ -11,6 +11,7 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import javax.management.JMException;
 import javax.management.MBeanServer;
@@ -257,18 +258,15 @@ public class DatabaseInfo implements DatabaseInfoMBean {
                         .append(session.getCurrentCommandStart().getString())
                         .append('\n');
             }
-            Table[] t = session.getLocks();
-            if (t.length > 0) {
-                for (Table table : session.getLocks()) {
-                    if (table.isLockedExclusivelyBy(session)) {
-                        buff.append("write lock on ");
-                    } else {
-                        buff.append("read lock on ");
-                    }
-                    buff.append(table.getSchema().getName()).
-                            append('.').append(table.getName()).
-                            append('\n');
+            for (Table table : session.getLocks()) {
+                if (table.isLockedExclusivelyBy(session)) {
+                    buff.append("write lock on ");
+                } else {
+                    buff.append("read lock on ");
                 }
+                buff.append(table.getSchema().getName()).
+                        append('.').append(table.getName()).
+                        append('\n');
             }
             buff.append('\n');
         }

--- a/h2/src/main/org/h2/message/TraceSystem.java
+++ b/h2/src/main/org/h2/message/TraceSystem.java
@@ -87,7 +87,7 @@ public class TraceSystem implements TraceWriter {
     private Writer fileWriter;
     private PrintWriter printWriter;
     /**
-     * Starts at -1 so that we check the filesize immediately upon open. This
+     * Starts at -1 so that we check the file size immediately upon open. This
      * Can be important if we open and close the trace file without managing to
      * have written CHECK_SIZE_EACH_WRITES bytes each time.
      */

--- a/h2/src/main/org/h2/result/SortOrder.java
+++ b/h2/src/main/org/h2/result/SortOrder.java
@@ -218,7 +218,7 @@ public class SortOrder implements Comparator<Value[]> {
      */
     public void sort(ArrayList<Value[]> rows, int offset, int limit) {
         int rowsSize = rows.size();
-        if (rows.isEmpty() || offset >= rowsSize || limit == 0) {
+        if (rowsSize == 0 || offset >= rowsSize || limit == 0) {
             return;
         }
         if (offset < 0) {

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -66,12 +66,12 @@ public abstract class RegularTable extends TableBase {
             builder.append("\nSession ").append(s.toString()).append(" on thread ").append(thread.getName())
                     .append(" is waiting to lock ").append(lock.toString())
                     .append(exclusive ? " (exclusive)" : " (shared)").append(" while locking ");
-            Table[] locks = s.getLocks();
-            for (int i = 0, length = locks.length; i < length; i++) {
-                Table t = locks[i];
-                if (i > 0) {
+            boolean addComma = false;
+            for (Table t : s.getLocks()) {
+                if (addComma) {
                     builder.append(", ");
                 }
+                addComma = true;
                 builder.append(t.toString());
                 if (t instanceof RegularTable) {
                     if (((RegularTable) t).lockExclusiveSession == s) {


### PR DESCRIPTION
Closes #1883.

`ArrayList` is really faster for this specific use case.

Old raw `Object[] ArrayList.toArray()` does not throw any exceptions, so it was used here.

New `T[] ArrayList.toArray(T[])` may throw exceptions during concurrent modification. I placed a comment to avoid accidental replacement to that method.

It's possible to use old one-by-one value reading with proper handling of exceptions, but `toArray()` looks like a more reliable method due to smaller window when concurrent modification can alter the result.

When there are multiple values, a `HashSet` is used a collector of values to remove unlikely, but possible duplicates. This method may return not incorrect snapshot of locked tables during concurrent modification, but I don't think that we should allow duplicate entries in it, some software may not expect such result.

However, I have a question about order of locked tables. Should we preserve it ? Maybe replace `HashSet` with `LinkedHashSet`?