### PR TITLE
Do not allow DELETE without FROM in modes that don't support it

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1889: Do not allow DELETE without FROM in modes that don't support it
+</li>
+<li>Issue #308: Mode MySQL and LAST_INSERT_ID with argument
+</li>
 <li>Issue #1883: Suspicious code in Session.getLocks()
 </li>
 <li>Issue #1878: OPTIMIZE_REUSE_RESULTS causes incorrect result after rollback since 1.4.198

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -892,6 +892,7 @@ or the SQL statement <code>SET MODE MSSQLServer</code>.
 </li><li><code>IDENTITY</code> can be used for automatic id generation on column level.
 </li><li>Table hints are discarded. Example: <code>SELECT * FROM table WITH (NOLOCK)</code>.
 </li><li>Datetime value functions return the same value within a command.
+</li><li>FROM keyword is optional in DELETE command.
 </li></ul>
 
 <h3>MySQL Compatibility Mode</h3>
@@ -943,6 +944,7 @@ or the SQL statement <code>SET MODE Oracle</code>.
 </li><li>REGEXP_REPLACE() uses \ for back-references.
 </li><li>DATE data type is treated like TIMESTAMP(0) data type.
 </li><li>Datetime value functions return the same value within a command.
+</li><li>FROM keyword is optional in DELETE command.
 </li></ul>
 
 <h3>PostgreSQL Compatibility Mode</h3>

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1300,9 +1300,14 @@ public class Parser {
         }
         currentPrepared = command;
         int start = lastParseIndex;
-        if (!readIf(FROM) && database.getMode().getEnum() == ModeEnum.MySQL) {
-            readIdentifierWithSchema();
-            read(FROM);
+        Mode mode = database.getMode();
+        if (!mode.deleteWithoutFrom && !readIf(FROM)) {
+            if (mode.getEnum() == ModeEnum.MySQL) {
+                readIdentifierWithSchema();
+                read(FROM);
+            } else {
+                throw getSyntaxError();
+            }
         }
         TableFilter filter = readSimpleTableFilter(0, null);
         command.setTableFilter(filter);

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -210,6 +210,11 @@ public class Mode {
     public boolean dateTimeValueWithinTransaction;
 
     /**
+     * If {@code true}, FROM is optional in DELETE statement.
+     */
+    public boolean deleteWithoutFrom;
+
+    /**
      * An optional Set of hidden/disallowed column types.
      * Certain DBMSs don't support all column types provided by H2, such as
      * "NUMBER" when using PostgreSQL mode.
@@ -279,6 +284,7 @@ public class Mode {
         // MS SQL Server does not support client info properties. See
         // https://msdn.microsoft.com/en-Us/library/dd571296%28v=sql.110%29.aspx
         mode.supportedClientInfoPropertiesRegEx = null;
+        mode.deleteWithoutFrom = true;
         DataType dt = DataType.createNumeric(19, 4, false);
         dt.type = Value.DECIMAL;
         dt.sqlType = Types.NUMERIC;
@@ -320,6 +326,7 @@ public class Mode {
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile(".*\\..*");
         mode.prohibitEmptyInPredicate = true;
+        mode.deleteWithoutFrom = true;
         dt = DataType.createDate(/* 2001-01-01 23:59:59 */ 19, 19, "DATE", false, 0, 0);
         dt.type = Value.TIMESTAMP;
         dt.sqlType = Types.TIMESTAMP;

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -221,7 +221,7 @@ public class TestLob extends TestDb {
         Statement stat2 = conn2.createStatement();
         ResultSet rs = stat2.executeQuery("select data from lob");
         rs.next();
-        stat.execute("delete lob");
+        stat.execute("delete from lob");
         InputStream in = rs.getBinaryStream(1);
         in.read();
         conn2.close();

--- a/h2/src/test/org/h2/test/scripts/dml/delete.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/delete.sql
@@ -6,8 +6,8 @@
 CREATE TABLE TEST(ID INT);
 > ok
 
-INSERT INTO TEST VALUES (1), (2), (3);
-> update count: 3
+INSERT INTO TEST VALUES 1, 2, 3, 4, 5, 6, 7, 8;
+> update count: 8
 
 DELETE FROM TEST WHERE EXISTS (SELECT X FROM SYSTEM_RANGE(1, 3) WHERE X = ID) AND ROWNUM() = 1;
 > update count: 1
@@ -17,7 +17,90 @@ SELECT ID FROM TEST;
 > --
 > 2
 > 3
-> rows: 2
+> 4
+> 5
+> 6
+> 7
+> 8
+> rows: 7
+
+DELETE TEST WHERE ID = 2;
+> exception SYNTAX_ERROR_2
+
+SET MODE DB2;
+> ok
+
+DELETE TEST WHERE ID = 2;
+> exception SYNTAX_ERROR_2
+
+SET MODE Derby;
+> ok
+
+DELETE TEST WHERE ID = 2;
+> exception SYNTAX_ERROR_2
+
+SET MODE HSQLDB;
+> ok
+
+DELETE TEST WHERE ID = 2;
+> exception SYNTAX_ERROR_2
+
+SET MODE MySQL;
+> ok
+
+DELETE TEST WHERE ID = 2;
+> exception SYNTAX_ERROR_2
+
+DELETE TEST FROM TEST WHERE ID = 4;
+> update count: 1
+
+SET MODE PostgreSQL;
+> ok
+
+DELETE TEST WHERE ID = 2;
+> exception SYNTAX_ERROR_2
+
+SET MODE Ignite;
+> ok
+
+DELETE TEST WHERE ID = 2;
+> exception SYNTAX_ERROR_2
+
+SET MODE MSSQLServer;
+> ok
+
+DELETE TEST WHERE ID = 3;
+> update count: 1
+
+SET MODE Oracle;
+> ok
+
+DELETE TEST WHERE ID = 5;
+> update count: 1
+
+SET MODE Regular;
+> ok
+
+SELECT * FROM TEST;
+> ID
+> --
+> 2
+> 6
+> 7
+> 8
+> rows: 4
+
+DELETE TOP 1 FROM TEST;
+> update count: 1
+
+DELETE FROM TEST LIMIT 1;
+> update count: 1
+
+DELETE TOP 1 FROM TEST LIMIT 1;
+> exception SYNTAX_ERROR_1
+
+SELECT COUNT(*) FROM TEST;
+>> 2
 
 DROP TABLE TEST;
 > ok


### PR DESCRIPTION
A fix for issue #585 contains an incorrect condition that additionally allows to use `DELETE` without `FROM` in all modes with exception for MySQL one. Actually only Oracle and MSSQLServer compatibility modes should allow it.

https://docs.microsoft.com/sql/t-sql/statements/delete-transact-sql?view=sql-server-2017
https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/DELETE.html

Others don't support it:
https://www.ibm.com/support/knowledgecenter/en/SSEPEK_12.0.0/apsg/src/tpc/db2z_deletedatatables.html
https://db.apache.org/derby/docs/10.15/ref/rrefsqlj35981.html
http://hsqldb.org/doc/guide/dataaccess-chapt.html#dac_delete_statement
https://dev.mysql.com/doc/refman/8.0/en/delete.html
https://www.postgresql.org/docs/11/sql-delete.html

See also discussion in the mailing list:
https://groups.google.com/forum/#!topic/h2-database/nuesopBwIcI
It was suggested to make it optional for all modes, but I don't think that it is a good idea, it may lead to accidental usage of such statements. SQL Standard also does not allow `DELETE` without `FROM`:
```SQL
DELETE FROM <target table>
    [ FOR PORTION OF <application time period name>
    FROM <point in time 1> TO <point in time 2> ]
    [ [ AS ] <correlation name> ]
    [ WHERE <search condition> ]
```
@grandinj