### PR TITLE
Add limited support of EXEC(UTE) in MSSQLServer mode and some minor changes

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1900: Support SQLServer stored procedure execution syntax
+</li>
 <li>PR #1898: Add IS JSON predicate
 </li>
 <li>Issue #1896: MSSQLServer compatibility mode - GETDATE() incorrectly omits time

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2448,8 +2448,10 @@ public class Parser {
         }
         Expression[] args;
         ArrayList<Expression> argList = Utils.newSmallArrayList();
-        while (currentTokenType != SEMICOLON && currentTokenType != END) {
-            argList.add(readExpression());
+        if (currentTokenType != SEMICOLON && currentTokenType != END) {
+            do {
+                argList.add(readExpression());
+            } while (readIf(COMMA));
         }
         args = argList.toArray(new Expression[0]);
         command.setExpression(new JavaFunction(functionAlias, args));

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -102,11 +102,11 @@ public class Update extends Prepared {
             session.getUser().checkRight(table, Right.UPDATE);
             table.fire(session, Trigger.UPDATE, true);
             table.lock(session, true, false);
-            int columnCount = table.getColumns().length;
             // get the old rows, compute the new rows
             setCurrentRowNumber(0);
             int count = 0;
             Column[] columns = table.getColumns();
+            int columnCount = columns.length;
             int limitRows = -1;
             if (limitExpr != null) {
                 Value v = limitExpr.getValue(session);
@@ -137,8 +137,8 @@ public class Update extends Prepared {
                     Row newRow = table.getTemplateRow();
                     boolean setOnUpdate = false;
                     for (int i = 0; i < columnCount; i++) {
-                        Expression newExpr = setClauseMap.get(columns[i]);
-                        Column column = table.getColumn(i);
+                        Column column = columns[i];
+                        Expression newExpr = setClauseMap.get(column);
                         Value newValue;
                         if (newExpr == null) {
                             if (column.getOnUpdateExpression() != null) {
@@ -165,8 +165,8 @@ public class Update extends Prepared {
                         }
                         if (setOnUpdate) {
                             for (int i = 0; i < columnCount; i++) {
-                                if (setClauseMap.get(columns[i]) == null) {
-                                    Column column = table.getColumn(i);
+                                Column column = columns[i];
+                                if (setClauseMap.get(column) == null) {
                                     if (column.getOnUpdateExpression() != null) {
                                         newRow.setValue(i, table.getOnUpdateValue(session, column));
                                     }

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -5,9 +5,9 @@
  */
 package org.h2.command.dml;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
 import java.util.Objects;
 
 import org.h2.api.ErrorCode;
@@ -27,7 +27,6 @@ import org.h2.table.Column;
 import org.h2.table.PlanItem;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
-import org.h2.util.Utils;
 import org.h2.value.Value;
 import org.h2.value.ValueNull;
 
@@ -49,8 +48,7 @@ public class Update extends Prepared {
 
     private boolean updateToCurrentValuesReturnsZero;
 
-    private final ArrayList<Column> columns = Utils.newSmallArrayList();
-    private final HashMap<Column, Expression> expressionMap  = new HashMap<>();
+    private final LinkedHashMap<Column, Expression> setClauseMap  = new LinkedHashMap<>();
 
     private HashSet<Long> updatedKeysCollector;
 
@@ -77,12 +75,9 @@ public class Update extends Prepared {
      * @param expression the expression
      */
     public void setAssignment(Column column, Expression expression) {
-        if (expressionMap.containsKey(column)) {
-            throw DbException.get(ErrorCode.DUPLICATE_COLUMN_NAME_1, column
-                    .getName());
+        if (setClauseMap.put(column, expression) != null) {
+            throw DbException.get(ErrorCode.DUPLICATE_COLUMN_NAME_1, column.getName());
         }
-        columns.add(column);
-        expressionMap.put(column, expression);
         if (expression instanceof Parameter) {
             Parameter p = (Parameter) expression;
             p.setColumn(column);
@@ -142,7 +137,7 @@ public class Update extends Prepared {
                     Row newRow = table.getTemplateRow();
                     boolean setOnUpdate = false;
                     for (int i = 0; i < columnCount; i++) {
-                        Expression newExpr = expressionMap.get(columns[i]);
+                        Expression newExpr = setClauseMap.get(columns[i]);
                         Column column = table.getColumn(i);
                         Value newValue;
                         if (newExpr == null) {
@@ -170,7 +165,7 @@ public class Update extends Prepared {
                         }
                         if (setOnUpdate) {
                             for (int i = 0; i < columnCount; i++) {
-                                if (expressionMap.get(columns[i]) == null) {
+                                if (setClauseMap.get(columns[i]) == null) {
                                     Column column = table.getColumn(i);
                                     if (column.getOnUpdateExpression() != null) {
                                         newRow.setValue(i, table.getOnUpdateValue(session, column));
@@ -217,13 +212,14 @@ public class Update extends Prepared {
     public String getPlanSQL(boolean alwaysQuote) {
         StringBuilder builder = new StringBuilder("UPDATE ");
         targetTableFilter.getPlanSQL(builder, false, alwaysQuote).append("\nSET\n    ");
-        for (int i = 0, size = columns.size(); i < size; i++) {
-            if (i > 0) {
+        boolean f = false;
+        for (Entry<Column, Expression> entry : setClauseMap.entrySet()) {
+            if (f) {
                 builder.append(",\n    ");
             }
-            Column c = columns.get(i);
-            c.getSQL(builder, alwaysQuote).append(" = ");
-            expressionMap.get(c).getSQL(builder, alwaysQuote);
+            f = true;
+            entry.getKey().getSQL(builder, alwaysQuote).append(" = ");
+            entry.getValue().getSQL(builder, alwaysQuote);
         }
         if (condition != null) {
             builder.append("\nWHERE ");
@@ -243,13 +239,13 @@ public class Update extends Prepared {
             condition = condition.optimize(session);
             condition.createIndexConditions(session, targetTableFilter);
         }
-        for (Column c : columns) {
-            Expression e = expressionMap.get(c);
+        for (Entry<Column, Expression> entry : setClauseMap.entrySet()) {
+            Expression e = entry.getValue();
             e.mapColumns(targetTableFilter, 0, Expression.MAP_INITIAL);
             if (sourceTableFilter!=null){
                 e.mapColumns(sourceTableFilter, 0, Expression.MAP_INITIAL);
             }
-            expressionMap.put(c, e.optimize(session));
+            entry.setValue(e.optimize(session));
         }
         TableFilter[] filters;
         if(sourceTableFilter==null){

--- a/h2/src/main/org/h2/jmx/DatabaseInfo.java
+++ b/h2/src/main/org/h2/jmx/DatabaseInfo.java
@@ -11,7 +11,6 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import javax.management.JMException;
 import javax.management.MBeanServer;

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -304,6 +304,16 @@ public final class DataUtils {
      * Read a string.
      *
      * @param buff the source buffer
+     * @return the value
+     */
+    public static String readString(ByteBuffer buff) {
+        return readString(buff, readVarInt(buff));
+    }
+
+    /**
+     * Read a string.
+     *
+     * @param buff the source buffer
      * @param len the number of characters
      * @return the value
      */

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -5,6 +5,10 @@
  */
 package org.h2.mvstore.db;
 
+import static org.h2.mvstore.DataUtils.readString;
+import static org.h2.mvstore.DataUtils.readVarInt;
+import static org.h2.mvstore.DataUtils.readVarLong;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -14,7 +18,6 @@ import org.h2.api.IntervalQualifier;
 import org.h2.engine.Database;
 import org.h2.engine.Mode;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.WriteBuffer;
 import org.h2.mvstore.rtree.SpatialDataType;
 import org.h2.mvstore.rtree.SpatialKey;
@@ -714,23 +717,6 @@ public class ValueDataType implements DataType {
             }
             throw DbException.get(ErrorCode.FILE_CORRUPTED_1, "type: " + type);
         }
-    }
-
-    private static int readVarInt(ByteBuffer buff) {
-        return DataUtils.readVarInt(buff);
-    }
-
-    private static long readVarLong(ByteBuffer buff) {
-        return DataUtils.readVarLong(buff);
-    }
-
-    private static String readString(ByteBuffer buff, int len) {
-        return DataUtils.readString(buff, len);
-    }
-
-    private static String readString(ByteBuffer buff) {
-        int len = readVarInt(buff);
-        return DataUtils.readString(buff, len);
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/type/StringDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/StringDataType.java
@@ -42,8 +42,7 @@ public class StringDataType implements DataType {
 
     @Override
     public String read(ByteBuffer buff) {
-        int len = DataUtils.readVarInt(buff);
-        return DataUtils.readString(buff, len);
+        return DataUtils.readString(buff);
     }
 
     @Override

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -130,6 +130,7 @@ public class TestScript extends TestDb {
             testScript("testSimple.sql");
         }
         testScript("comments.sql");
+        testScript("compatibility.sql");
         testScript("derived-column-names.sql");
         testScript("distinct.sql");
         testScript("dual.sql");

--- a/h2/src/test/org/h2/test/scripts/compatibility.sql
+++ b/h2/src/test/org/h2/test/scripts/compatibility.sql
@@ -1,0 +1,52 @@
+-- Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+CREATE ALIAS MY_SQRT FOR "java.lang.Math.sqrt";
+> ok
+
+EXEC MY_SQRT 4;
+> exception SYNTAX_ERROR_2
+
+-- PostgreSQL-style EXECUTE doesn't work with MSSQLServer-style arguments
+EXECUTE MY_SQRT 4;
+> exception FUNCTION_ALIAS_NOT_FOUND_1
+
+SET MODE MSSQLServer;
+> ok
+
+-- PostgreSQL-style PREPARE is not available in MSSQLServer mode
+PREPARE TEST AS SELECT 1;
+> exception SYNTAX_ERROR_1
+
+-- PostgreSQL-style DEALLOCATE is not available in MSSQLServer mode
+DEALLOCATE TEST;
+> exception SYNTAX_ERROR_2
+
+EXEC MY_SQRT 4;
+>> 2.0
+
+EXECUTE MY_SQRT 4;
+>> 2.0
+
+EXEC PUBLIC.MY_SQRT 4;
+>> 2.0
+
+EXEC SCRIPT.PUBLIC.MY_SQRT 4;
+>> 2.0
+
+EXEC UNKNOWN_PROCEDURE;
+> exception FUNCTION_NOT_FOUND_1
+
+EXEC UNKNOWN_SCHEMA.MY_SQRT 4;
+> exception SCHEMA_NOT_FOUND_1
+
+EXEC UNKNOWN_DATABASE.PUBLIC.MY_SQRT 4;
+> exception DATABASE_NOT_FOUND_1
+
+SET MODE Regular;
+> ok
+
+DROP ALIAS MY_SQRT;
+> ok

--- a/h2/src/test/org/h2/test/scripts/compatibility.sql
+++ b/h2/src/test/org/h2/test/scripts/compatibility.sql
@@ -3,7 +3,13 @@
 -- Initial Developer: H2 Group
 --
 
+CREATE ALIAS MY_NO_ARG AS 'int f() { return 1; }';
+> ok
+
 CREATE ALIAS MY_SQRT FOR "java.lang.Math.sqrt";
+> ok
+
+CREATE ALIAS MY_REMAINDER FOR "java.lang.Math.IEEEremainder";
 > ok
 
 EXEC MY_SQRT 4;
@@ -24,8 +30,14 @@ PREPARE TEST AS SELECT 1;
 DEALLOCATE TEST;
 > exception SYNTAX_ERROR_2
 
+EXEC MY_NO_ARG;
+>> 1
+
 EXEC MY_SQRT 4;
 >> 2.0
+
+EXEC MY_REMAINDER 4, 3;
+>> 1.0
 
 EXECUTE MY_SQRT 4;
 >> 2.0
@@ -48,5 +60,11 @@ EXEC UNKNOWN_DATABASE.PUBLIC.MY_SQRT 4;
 SET MODE Regular;
 > ok
 
+DROP ALIAS MY_NO_ARG;
+> ok
+
 DROP ALIAS MY_SQRT;
+> ok
+
+DROP ALIAS MY_REMAINDER;
 > ok

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -812,4 +812,4 @@ isodow isoyear psql
 waiters reliably httpsdocs privileged narrow spending swallow locally uncomment builders
 setjava lift hyperlinks lazarevn nikita lazarev lvl ispras bias dbff fals tru dfff
 recognition spared hacky employing occupancy baos shifts littlejohn pushes scrub existent asterisked projections
-omits
+omits redefined


### PR DESCRIPTION
1. SQLServer-style `EXEC` and `EXECUTE` commands with unnamed parameters are supported now. Syntax with named parameters is not supported, because user-defined functions in H2 don't have names of parameters. Closes #1900.

2. `ArrayList` + `HashMap` combination in `Update` was replaced with `LinkedHashMap` that works faster and does not require data duplication in two objects.

3. Some tiny optimizations.