### PR TITLE
Improve parsing of MySQL table options and restrict it to MySQL compatibility mode

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1918: MySQL: CREATE TABLE with both CHARSET and COMMENT failed
+</li>
 <li>Issue #1913: MySQL: auto_increment changing SQL not supported
 </li>
 <li>Issue #1585: The translate function on DB2 mode could have parameters order changed

--- a/h2/src/main/org/h2/command/ddl/CommandWithColumns.java
+++ b/h2/src/main/org/h2/command/ddl/CommandWithColumns.java
@@ -158,4 +158,8 @@ public abstract class CommandWithColumns extends SchemaCommand {
         return false;
     }
 
+    public AlterTableAddConstraint getPrimaryKey() {
+        return primaryKey;
+    }
+
 }

--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -61,6 +61,10 @@ public class CreateTable extends CommandWithColumns {
         data.columns.add(column);
     }
 
+    public ArrayList<Column> getColumns() {
+        return data.columns;
+    }
+
     public void setIfNotExists(boolean ifNotExists) {
         this.ifNotExists = ifNotExists;
     }

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -626,6 +626,15 @@ public class Column {
         }
     }
 
+    /**
+     * Returns autoincrement options, or {@code null}.
+     *
+     * @return autoincrement options, or {@code null}
+     */
+    public SequenceOptions getAutoIncrementOptions() {
+        return autoIncrementOptions;
+    }
+
     public void setConvertNullToDefault(boolean convert) {
         this.convertNullToDefault = convert;
     }

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -411,13 +411,23 @@ public class TestCompatibility extends TestDb {
         stat.execute("CREATE TABLE TEST_4" +
                 "(ID INT PRIMARY KEY) charset=UTF8");
         stat.execute("CREATE TABLE TEST_5" +
-                "(ID INT PRIMARY KEY) ENGINE=InnoDb auto_increment=3 default charset=UTF8");
+                "(ID INT AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDb auto_increment=3 default charset=UTF8");
         stat.execute("CREATE TABLE TEST_6" +
-                "(ID INT PRIMARY KEY) ENGINE=InnoDb auto_increment=3 charset=UTF8");
+                "(ID INT AUTO_INCREMENT PRIMARY KEY) ENGINE=MyISAM default character set UTF8MB4, auto_increment 3");
         stat.execute("CREATE TABLE TEST_7" +
-                "(ID INT, KEY TEST_7_IDX(ID) USING BTREE)");
+                "(ID INT AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDb auto_increment=3 charset=UTF8 comment 'text'");
         stat.execute("CREATE TABLE TEST_8" +
-                "(ID INT, UNIQUE KEY TEST_8_IDX(ID) USING BTREE)");
+                "(ID INT AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDb auto_increment=3 character set=UTF8");
+        stat.execute("CREATE TABLE TEST_9" +
+                "(ID INT, KEY TEST_7_IDX(ID) USING BTREE)");
+        stat.execute("CREATE TABLE TEST_10" +
+                "(ID INT, UNIQUE KEY TEST_10_IDX(ID) USING BTREE)");
+        assertThrows(ErrorCode.SYNTAX_ERROR_2, stat).execute("CREATE TABLE TEST_99" +
+                "(ID INT PRIMARY KEY) CHARSET UTF8,");
+        assertThrows(ErrorCode.COLUMN_NOT_FOUND_1, stat).execute("CREATE TABLE TEST_99" +
+                "(ID INT PRIMARY KEY) AUTO_INCREMENT 100");
+        assertThrows(ErrorCode.COLUMN_NOT_FOUND_1, stat).execute("CREATE TABLE TEST_99" +
+                "(ID INT) AUTO_INCREMENT 100");
 
         // this maps to SET REFERENTIAL_INTEGRITY TRUE/FALSE
         stat.execute("SET foreign_key_checks = 0");


### PR DESCRIPTION
Closes #1918.

1. MySQL table options are now only parsed in MySQL compatibility mode. They aren't compatible with anything else anyway.

2. These options now can be specified in any order. Optional comma between options is allowed. Missing optional `=` between names and values is now handled properly.

3. Names of table engines are not restricted to `InnoDb` and `MyISAM` any more, MySQL and its forks have too many different engines. I don't see any reason in validation of their names.

4. `COMMENT` and `AUTO_INCREMENT` values are now passed to `CreateTable` command. They were ignored earlier.

5. `AUTO_INCREMENT` is not accepted any more if primary key does not have an auto-increment column. This is a side effect of (4).