### PR TITLE
Extract OFFSET / FETCH handling from Select and SelectUnion to Query

### DIFF
--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -307,6 +307,11 @@ public abstract class Query extends Prepared {
      */
     public abstract boolean isEverything(ExpressionVisitor visitor);
 
+    @Override
+    public boolean isReadOnly() {
+        return isEverything(ExpressionVisitor.READONLY_VISITOR);
+    }
+
     /**
      * Update all aggregate function values.
      *

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -1821,11 +1821,6 @@ public class Select extends Query {
         return true;
     }
 
-    @Override
-    public boolean isReadOnly() {
-        return isEverything(ExpressionVisitor.READONLY_VISITOR);
-    }
-
 
     @Override
     public boolean isCacheable() {

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -56,7 +56,6 @@ import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 import org.h2.value.DataType;
 import org.h2.value.Value;
-import org.h2.value.ValueNull;
 import org.h2.value.ValueRow;
 
 /**
@@ -804,40 +803,13 @@ public class Select extends Query {
     @Override
     protected ResultInterface queryWithoutCache(int maxRows, ResultTarget target) {
         disableLazyForJoinSubqueries(topTableFilter);
-
-        int limitRows = maxRows == 0 ? -1 : maxRows;
-        if (limitExpr != null) {
-            Value v = limitExpr.getValue(session);
-            int l = v == ValueNull.INSTANCE ? -1 : v.getInt();
-            if (limitRows < 0) {
-                limitRows = l;
-            } else if (l >= 0) {
-                limitRows = Math.min(l, limitRows);
-            }
-        }
-        boolean fetchPercent = this.fetchPercent;
-        if (fetchPercent) {
-            // Need to check it now, because negative limit has special treatment later
-            if (limitRows < 0 || limitRows > 100) {
-                throw DbException.getInvalidValueException("FETCH PERCENT", limitRows);
-            }
-            // 0 PERCENT means 0
-            if (limitRows == 0) {
-                fetchPercent = false;
-            }
-        }
-        long offset;
-        if (offsetExpr != null) {
-            offset = offsetExpr.getValue(session).getLong();
-            if (offset < 0) {
-                offset = 0;
-            }
-        } else {
-            offset = 0;
-        }
+        OffsetFetch offsetFetch = getOffsetFetch(maxRows);
+        long offset = offsetFetch.offset;
+        int fetch = offsetFetch.fetch;
+        boolean fetchPercent = offsetFetch.fetchPercent;
         boolean lazy = session.isLazyQueryExecution() &&
                 target == null && !isForUpdate && !isQuickAggregateQuery &&
-                limitRows != 0 && !fetchPercent && !withTies && offset == 0 && isReadOnly();
+                fetch != 0 && !fetchPercent && !withTies && offset == 0 && isReadOnly();
         int columnCount = expressions.size();
         LocalResult result = null;
         if (!lazy && (target == null ||
@@ -867,7 +839,7 @@ public class Select extends Query {
         if (isWindowQuery || isGroupQuery && !isGroupSortedQuery) {
             result = createLocalResult(result);
         }
-        if (!lazy && (limitRows >= 0 || offset > 0)) {
+        if (!lazy && (fetch >= 0 || offset > 0)) {
             result = createLocalResult(result);
         }
         topTableFilter.startQuery(session);
@@ -877,9 +849,9 @@ public class Select extends Query {
         ResultTarget to = result != null ? result : target;
         lazy &= to == null;
         LazyResult lazyResult = null;
-        if (limitRows != 0) {
+        if (fetch != 0) {
             // Cannot apply limit now if percent is specified
-            int limit = fetchPercent ? -1 : limitRows;
+            int limit = fetchPercent ? -1 : fetch;
             try {
                 if (isQuickAggregateQuery) {
                     queryQuick(columnCount, to, quickOffset && offset > 0);
@@ -909,10 +881,10 @@ public class Select extends Query {
                 }
             }
         }
-        assert lazy == (lazyResult != null): lazy;
+        assert lazy == (lazyResult != null) : lazy;
         if (lazyResult != null) {
-            if (limitRows > 0) {
-                lazyResult.setLimit(limitRows);
+            if (fetch > 0) {
+                lazyResult.setLimit(fetch);
             }
             if (randomAccessResult) {
                 return convertToDistinct(lazyResult);
@@ -920,21 +892,8 @@ public class Select extends Query {
                 return lazyResult;
             }
         }
-        if (offset != 0) {
-            if (offset > Integer.MAX_VALUE) {
-                throw DbException.getInvalidValueException("OFFSET", offset);
-            }
-            result.setOffset((int) offset);
-        }
-        if (limitRows >= 0) {
-            result.setLimit(limitRows);
-            result.setFetchPercent(fetchPercent);
-            if (withTies) {
-                result.setWithTies(sort);
-            }
-        }
         if (result != null) {
-            result.done();
+            finishResult(result, offset, fetch, fetchPercent);
             if (randomAccessResult && !distinct) {
                 result = convertToDistinct(result);
             }

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -407,11 +407,6 @@ public class SelectUnion extends Query {
     }
 
     @Override
-    public boolean isReadOnly() {
-        return left.isReadOnly() && right.isReadOnly();
-    }
-
-    @Override
     public void updateAggregate(Session s, int stage) {
         left.updateAggregate(s, stage);
         right.updateAggregate(s, stage);

--- a/h2/src/main/org/h2/command/dml/SelectUnion.java
+++ b/h2/src/main/org/h2/command/dml/SelectUnion.java
@@ -16,7 +16,6 @@ import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.Parameter;
-import org.h2.expression.ValueExpression;
 import org.h2.message.DbException;
 import org.h2.result.LazyResult;
 import org.h2.result.LocalResult;
@@ -28,8 +27,6 @@ import org.h2.table.Table;
 import org.h2.table.TableFilter;
 import org.h2.util.ColumnNamer;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
-import org.h2.value.ValueNull;
 
 /**
  * Represents a union SELECT statement.
@@ -141,28 +138,14 @@ public class SelectUnion extends Query {
 
     @Override
     protected ResultInterface queryWithoutCache(int maxRows, ResultTarget target) {
-        if (maxRows != 0) {
-            // maxRows is set (maxRows 0 means no limit)
-            int l;
-            if (limitExpr == null) {
-                l = -1;
-            } else {
-                Value v = limitExpr.getValue(session);
-                l = v == ValueNull.INSTANCE ? -1 : v.getInt();
-            }
-            if (l < 0) {
-                // for limitExpr, 0 means no rows, and -1 means no limit
-                l = maxRows;
-            } else {
-                l = Math.min(l, maxRows);
-            }
-            limitExpr = ValueExpression.get(ValueInt.get(l));
-        }
+        OffsetFetch offsetFetch = getOffsetFetch(maxRows);
+        long offset = offsetFetch.offset;
+        int fetch = offsetFetch.fetch;
+        boolean fetchPercent = offsetFetch.fetchPercent;
         Database db = session.getDatabase();
         if (db.getSettings().optimizeInsertFromSelect) {
             if (unionType == UnionType.UNION_ALL && target != null) {
-                if (sort == null && !distinct && maxRows == 0 &&
-                        offsetExpr == null && limitExpr == null) {
+                if (sort == null && !distinct && fetch < 0 && offset == 0) {
                     left.query(0, target);
                     right.query(0, target);
                     return null;
@@ -172,19 +155,12 @@ public class SelectUnion extends Query {
         int columnCount = left.getColumnCount();
         if (session.isLazyQueryExecution() && unionType == UnionType.UNION_ALL && !distinct &&
                 sort == null && !randomAccessResult && !isForUpdate &&
-                offsetExpr == null && !fetchPercent && !withTies && isReadOnly()) {
-            int limit = -1;
-            if (limitExpr != null) {
-                Value v = limitExpr.getValue(session);
-                if (v != ValueNull.INSTANCE) {
-                    limit = v.getInt();
-                }
-            }
+                offset == 0 && !fetchPercent && !withTies && isReadOnly()) {
             // limit 0 means no rows
-            if (limit != 0) {
+            if (fetch != 0) {
                 LazyResultUnion lazyResult = new LazyResultUnion(expressionArray, columnCount);
-                if (limit > 0) {
-                    lazyResult.setLimit(limit);
+                if (fetch > 0) {
+                    lazyResult.setLimit(fetch);
                 }
                 return lazyResult;
             }
@@ -256,22 +232,9 @@ public class SelectUnion extends Query {
         default:
             DbException.throwInternalError("type=" + unionType);
         }
-        if (offsetExpr != null) {
-            result.setOffset(offsetExpr.getValue(session).getInt());
-        }
-        if (limitExpr != null) {
-            Value v = limitExpr.getValue(session);
-            if (v != ValueNull.INSTANCE) {
-                result.setLimit(v.getInt());
-                result.setFetchPercent(fetchPercent);
-                if (withTies) {
-                    result.setWithTies(sort);
-                }
-            }
-        }
         l.close();
         r.close();
-        result.done();
+        finishResult(result, offset, fetch, fetchPercent);
         if (target != null) {
             while (result.next()) {
                 target.addRow(result.currentRow());


### PR DESCRIPTION
`Select` and `SelectUnion` had own copies of `OFFSET` and `FETCH`-related code. This code is extracted into two new methods in the parent `Query` class to reduce code duplication and possible inconsistencies. A version from `Select` class was used, because it was tested better with different edge cases.

`isReadOnly()` is also extracted into `Query`.