### PR TITLE
#1935: Improve file locking on shared filesystems like SMB

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1935: Improve file locking on shared filesystems like SMB
+</li>
 <li>Issue #1942: MySQL Mode: convertInsertNullToZero should be turned off by default?
 </li>
 <li>Issue #1940: MySQL Mode: Modify column from NOT NULL to NULL syntax

--- a/h2/src/main/org/h2/store/FileLock.java
+++ b/h2/src/main/org/h2/store/FileLock.java
@@ -5,8 +5,10 @@
  */
 package org.h2.store;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.net.BindException;
 import java.net.ConnectException;
 import java.net.InetAddress;
@@ -187,7 +189,7 @@ public class FileLock implements Runnable {
             try (OutputStream out = FileUtils.newOutputStream(fileName, false)) {
                 properties.store(out, MAGIC);
             }
-            lastWrite = FileUtils.lastModified(fileName);
+            lastWrite = aggressiveLastModified(fileName);
             if (trace.isDebugEnabled()) {
                 trace.debug("save " + properties);
             }
@@ -196,7 +198,30 @@ public class FileLock implements Runnable {
             throw getExceptionFatal("Could not save properties " + fileName, e);
         }
     }
-
+    
+    /**
+     * Aggressively read last modified time, to work-around remote filesystems.
+     * 
+     * @param filename file name to check
+     * @return last modified date/time in milliseconds UTC
+     */
+    private static long aggressiveLastModified(String fileName) {
+        /*
+         * Some remote filesystem, e.g. SMB on Windows, can cache metadata for
+         * 5-10 seconds. To work around that, do a one-byte read from the
+         * underlying file, which has the effect of invalidating the metadata
+         * cache.
+         */
+        try {
+            try (RandomAccessFile raRD = new RandomAccessFile(fileName, "rws")) {
+                raRD.seek(0);
+                byte b[] = new byte[1];
+                raRD.read(b);
+            }
+        } catch (IOException ignoreEx) {}
+        return FileUtils.lastModified(fileName);
+    }
+      
     private void checkServer() {
         Properties prop = load();
         String server = prop.getProperty("server");
@@ -257,7 +282,7 @@ public class FileLock implements Runnable {
 
     private void waitUntilOld() {
         for (int i = 0; i < 2 * TIME_GRANULARITY / SLEEP_GAP; i++) {
-            long last = FileUtils.lastModified(fileName);
+            long last = aggressiveLastModified(fileName);
             long dist = System.currentTimeMillis() - last;
             if (dist < -TIME_GRANULARITY) {
                 // lock file modified in the future -
@@ -354,7 +379,7 @@ public class FileLock implements Runnable {
         FileUtils.createDirectories(FileUtils.getParent(fileName));
         if (!FileUtils.createFile(fileName)) {
             waitUntilOld();
-            long read = FileUtils.lastModified(fileName);
+            long read = aggressiveLastModified(fileName);
             Properties p2 = load();
             String m2 = p2.getProperty("method", SOCKET);
             if (m2.equals(FILE)) {
@@ -388,7 +413,7 @@ public class FileLock implements Runnable {
                     throw getExceptionFatal("IOException", null);
                 }
             }
-            if (read != FileUtils.lastModified(fileName)) {
+            if (read != aggressiveLastModified(fileName)) {
                 throw getExceptionFatal("Concurrent update", null);
             }
             FileUtils.delete(fileName);
@@ -482,7 +507,7 @@ public class FileLock implements Runnable {
                 // trace.debug("watchdog check");
                 try {
                     if (!FileUtils.exists(fileName) ||
-                            FileUtils.lastModified(fileName) != lastWrite) {
+                            aggressiveLastModified(fileName) != lastWrite) {
                         save();
                     }
                     Thread.sleep(sleep);


### PR DESCRIPTION
Use suggested technique (1-byte file read) to force OS to update cached metadata