### PR TITLE
Add standard LOG() function with two arguments

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4235,20 +4235,31 @@ FLOOR(A)
 "
 
 "Functions (Numeric)","LN","
-{LN|LOG}(numeric)
+LN(numeric)
 ","
 Calculates the natural (base e) logarithm as a double value.
-In the PostgreSQL mode, LOG(x) is base 10.
-See also Java ""Math.log"".
+Argument must be a positive numeric value.
 ","
 LN(A)
+"
+
+"Functions (Numeric)","LOG","
+LOG([baseNumeric,] numeric)
+","
+Calculates the logarithm with specified base as a double value.
+Argument and base must be positive numeric values.
+Base cannot be equal to 1.
+The default base is e (natural logarithm), in the PostgreSQL mode the default base is base 10.
+In MSSQLServer mode the optional base is specified after the argument.
+","
+LOG(2, A)
 "
 
 "Functions (Numeric)","LOG10","
 LOG10(numeric)
 ","
 Calculates the base 10 logarithm as a double value.
-See also Java ""Math.log10"".
+Argument must be a positive numeric value.
 ","
 LOG10(A)
 "

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,7 +21,13 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #1948: Add standard LOG() function with two arguments
+</li>
 <li>Issue #1935: Improve file locking on shared filesystems like SMB
+</li>
+<li>PR #1946: Reimplement table value constructor on top of Query
+</li>
+<li>PR #1945: Fix IN (SELECT UNION with OFFSET/FETCH)
 </li>
 <li>Issue #1942: MySQL Mode: convertInsertNullToZero should be turned off by default?
 </li>

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -888,6 +888,7 @@ or the SQL statement <code>SET MODE MSSQLServer</code>.
 </li><li>Concatenating <code>NULL</code> with another value
     results in the other value.
 </li><li>Text can be concatenated using '+'.
+</li><li>Arguments of LOG() function are swapped.
 </li><li>MONEY data type is treated like NUMERIC(19, 4) data type. SMALLMONEY data type is treated like NUMERIC(10, 4)
     data type.
 </li><li><code>IDENTITY</code> can be used for automatic id generation on column level.

--- a/h2/src/main/org/h2/command/dml/TableValueConstructor.java
+++ b/h2/src/main/org/h2/command/dml/TableValueConstructor.java
@@ -131,7 +131,8 @@ public class TableValueConstructor extends Query {
      * @param rows
      *            the values
      */
-    public static void getValuesSQL(StringBuilder builder, boolean alwaysQuote, ArrayList<ArrayList<Expression>> rows) {
+    public static void getValuesSQL(StringBuilder builder, boolean alwaysQuote, //
+            ArrayList<ArrayList<Expression>> rows) {
         builder.append("VALUES ");
         int rowCount = rows.size();
         for (int i = 0; i < rowCount; i++) {

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -119,9 +119,14 @@ public class Mode {
     public boolean allowPlusForStringConcat;
 
     /**
-     * The function LOG() uses base 10 instead of E.
+     * The single-argument function LOG() uses base 10 instead of E.
      */
     public boolean logIsLogBase10;
+
+    /**
+     * Swap the parameters of LOG() function.
+     */
+    public boolean swapLogFunctionParameters;
 
     /**
      * The function REGEXP_REPLACE() uses \ for back-references.
@@ -270,6 +275,7 @@ public class Mode {
         mode.squareBracketQuotedNames = true;
         mode.uniqueIndexNullsHandling = UniqueIndexNullsHandling.FORBID_ANY_DUPLICATES;
         mode.allowPlusForStringConcat = true;
+        mode.swapLogFunctionParameters = true;
         mode.swapConvertFunctionParameters = true;
         mode.supportPoundSymbolForColumnNames = true;
         mode.discardWithTableHints = true;

--- a/h2/src/main/org/h2/store/FileLock.java
+++ b/h2/src/main/org/h2/store/FileLock.java
@@ -5,7 +5,6 @@
  */
 package org.h2.store;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
@@ -198,10 +197,10 @@ public class FileLock implements Runnable {
             throw getExceptionFatal("Could not save properties " + fileName, e);
         }
     }
-    
+
     /**
      * Aggressively read last modified time, to work-around remote filesystems.
-     * 
+     *
      * @param filename file name to check
      * @return last modified date/time in milliseconds UTC
      */
@@ -221,7 +220,7 @@ public class FileLock implements Runnable {
         } catch (IOException ignoreEx) {}
         return FileUtils.lastModified(fileName);
     }
-      
+
     private void checkServer() {
         Properties prop = load();
         String server = prop.getProperty("server");

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/log.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/log.sql
@@ -3,26 +3,92 @@
 -- Initial Developer: H2 Group
 --
 
-create memory table test(id int primary key, name varchar(255));
+SELECT LN(NULL), LOG(NULL, NULL), LOG(NULL, 2), LOG(2, NULL), LOG10(NULL), LOG(NULL);
+> NULL NULL NULL NULL NULL NULL
+> ---- ---- ---- ---- ---- ----
+> null null null null null null
+> rows: 1
+
+SELECT LN(0);
+> exception INVALID_VALUE_2
+
+SELECT LN(-1);
+> exception INVALID_VALUE_2
+
+SELECT LOG(0, 2);
+> exception INVALID_VALUE_2
+
+SELECT LOG(-1, 2);
+> exception INVALID_VALUE_2
+
+SELECT LOG(1, 2);
+> exception INVALID_VALUE_2
+
+SELECT LOG(2, 0);
+> exception INVALID_VALUE_2
+
+SELECT LOG(2, -1);
+> exception INVALID_VALUE_2
+
+SELECT LOG(0);
+> exception INVALID_VALUE_2
+
+SELECT LOG(-1);
+> exception INVALID_VALUE_2
+
+SELECT LOG10(0);
+> exception INVALID_VALUE_2
+
+SELECT LOG10(-1);
+> exception INVALID_VALUE_2
+
+SELECT LN(0.5) VH, LN(1) V1, LN(2) V2, LN(3) V3, LN(10) V10;
+> VH                  V1  V2                 V3                 V10
+> ------------------- --- ------------------ ------------------ -----------------
+> -0.6931471805599453 0.0 0.6931471805599453 1.0986122886681098 2.302585092994046
+> rows: 1
+
+SELECT LOG(2, 0.5) VH, LOG(2, 1) V1, LOG(2, 2) V2, LOG(2, 3) V3, LOG(2, 10) V10, LOG(2, 64) V64;
+> VH   V1  V2  V3                 V10                V64
+> ---- --- --- ------------------ ------------------ ---
+> -1.0 0.0 1.0 1.5849625007211563 3.3219280948873626 6.0
+> rows: 1
+
+SELECT LOG(2.7182818284590452, 10);
+>> 2.302585092994046
+
+SELECT LOG(10, 3);
+>> 0.47712125471966244
+
+SELECT LOG(0.5) VH, LOG(1) V1, LOG(2) V2, LOG(3) V3, LOG(10) V10;
+> VH                  V1  V2                 V3                 V10
+> ------------------- --- ------------------ ------------------ -----------------
+> -0.6931471805599453 0.0 0.6931471805599453 1.0986122886681098 2.302585092994046
+> rows: 1
+
+SELECT LOG10(0.5) VH, LOG10(1) V1, LOG10(2) V2, LOG10(3) V3, LOG10(10) V10, LOG10(100) V100;
+> VH                  V1  V2                 V3                  V10 V100
+> ------------------- --- ------------------ ------------------- --- ----
+> -0.3010299956639812 0.0 0.3010299956639812 0.47712125471966244 1.0 2.0
+> rows: 1
+
+SET MODE PostgreSQL;
 > ok
 
-insert into test values(1, 'Hello');
-> update count: 1
-
-select log(null) vn, log(1) v1, ln(1.1) v2, log(-1.1) v3, log(1.9) v4, log(-1.9) v5 from test;
-> VN   V1  V2                  V3  V4                 V5
-> ---- --- ------------------- --- ------------------ ---
-> null 0.0 0.09531017980432493 NaN 0.6418538861723947 NaN
+SELECT LOG(0.5) VH, LOG(1) V1, LOG(2) V2, LOG(3) V3, LOG(10) V10, LOG(100) V100;
+> VH                  V1  V2                 V3                  V10 V100
+> ------------------- --- ------------------ ------------------- --- ----
+> -0.3010299956639812 0.0 0.3010299956639812 0.47712125471966244 1.0 2.0
 > rows: 1
 
-select log10(null) vn, log10(0) v1, log10(10) v2, log10(0.0001) v3, log10(1000000) v4, log10(1) v5 from test;
-> VN   V1        V2  V3   V4  V5
-> ---- --------- --- ---- --- ---
-> null -Infinity 1.0 -4.0 6.0 0.0
+SET MODE MSSQLServer;
+> ok
+
+SELECT LOG(0.5, 2) VH, LOG(1, 2) V1, LOG(2, 2) V2, LOG(3, 2) V3, LOG(10, 2) V10, LOG(64, 2) V64;
+> VH   V1  V2  V3                 V10                V64
+> ---- --- --- ------------------ ------------------ ---
+> -1.0 0.0 1.0 1.5849625007211563 3.3219280948873626 6.0
 > rows: 1
 
-select log(null) vn, log(1) v1, log(1.1) v2, log(-1.1) v3, log(1.9) v4, log(-1.9) v5 from test;
-> VN   V1  V2                  V3  V4                 V5
-> ---- --- ------------------- --- ------------------ ---
-> null 0.0 0.09531017980432493 NaN 0.6418538861723947 NaN
-> rows: 1
+SET MODE Regular;
+> ok

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -812,4 +812,4 @@ isodow isoyear psql
 waiters reliably httpsdocs privileged narrow spending swallow locally uncomment builders
 setjava lift hyperlinks lazarevn nikita lazarev lvl ispras bias dbff fals tru dfff
 recognition spared hacky employing occupancy baos shifts littlejohn pushes scrub existent asterisked projections
-omits redefined ensured arrayagg objectagg bmp uabcd prefixed incoherence
+omits redefined ensured arrayagg objectagg bmp uabcd prefixed incoherence aggressively smb invalidating filesystems


### PR DESCRIPTION
SQL:2016 `LOG()` function with two arguments is implemented.

SQL:2003 `LN()` and SQL:2016 `LOG10()` are changed to throw exception on invalid arguments as required by the standard.

Non-standard `LOG()` function with the one arguments is still works as `LN()` by default and as `LOG10()` in PostrgreSQL compatibility mode. But now it also throws exception on invalid argument (PostgreSQL throws it too).

In MSSQLServer compatibility mode the new standard function accepts arguments in reverse order for compatibility with SQL Server.