### PR TITLE
Assorted changes

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -615,12 +615,10 @@ CREATE AGGREGATE SIMPLE_MEDIAN FOR ""com.acme.db.Median""
 
 "Commands (DDL)","CREATE ALIAS","
 CREATE ALIAS [ IF NOT EXISTS ] newFunctionAliasName [ DETERMINISTIC ]
-[ NOBUFFER ] { FOR classAndMethodName | AS sourceCodeString }
+{ FOR classAndMethodName | AS sourceCodeString }
 ","
 Creates a new function alias. If this is a ResultSet returning function,
 by default the return value is cached in a local temporary file.
-
-NOBUFFER - disables caching of ResultSet return value to temporary file.
 
 DETERMINISTIC - Deterministic functions must always return the same value for the same parameters.
 

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6455,7 +6455,8 @@ public class Parser {
         command.setAliasName(aliasName);
         command.setIfNotExists(ifNotExists);
         command.setDeterministic(readIf("DETERMINISTIC"));
-        command.setBufferResultSetToLocalTemp(!readIf("NOBUFFER"));
+        // Compatibility with old versions of H2
+        readIf("NOBUFFER");
         if (readIf("AS")) {
             command.setSource(readString());
         } else {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4163,24 +4163,16 @@ public class Parser {
             break;
         case IDENTIFIER:
             String name = currentToken;
-            if (currentTokenQuoted) {
-                read();
-                if (readIf(OPEN_PAREN)) {
-                    r = readFunction(null, name);
-                } else if (readIf(DOT)) {
-                    r = readTermObjectDot(name);
-                } else {
-                    r = new ExpressionColumn(database, null, null, name, false);
-                }
+            boolean quoted = currentTokenQuoted;
+            read();
+            if (readIf(OPEN_PAREN)) {
+                r = readFunction(null, name);
+            } else if (readIf(DOT)) {
+                r = readTermObjectDot(name);
+            } else if (quoted) {
+                r = new ExpressionColumn(database, null, null, name, false);
             } else {
-                read();
-                if (readIf(DOT)) {
-                    r = readTermObjectDot(name);
-                } else if (readIf(OPEN_PAREN)) {
-                    r = readFunction(null, name);
-                } else {
-                    r = readTermWithIdentifier(name);
-                }
+                r = readTermWithIdentifier(name);
             }
             break;
         case MINUS_SIGN:

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -203,7 +203,7 @@ import org.h2.expression.condition.ConditionAndOr;
 import org.h2.expression.condition.ConditionExists;
 import org.h2.expression.condition.ConditionIn;
 import org.h2.expression.condition.ConditionInParameter;
-import org.h2.expression.condition.ConditionInSelect;
+import org.h2.expression.condition.ConditionInQuery;
 import org.h2.expression.condition.ConditionNot;
 import org.h2.expression.condition.IsJsonPredicate;
 import org.h2.expression.condition.TypePredicate;
@@ -3033,8 +3033,7 @@ public class Parser {
                 } else {
                     if (isSelect()) {
                         Query query = parseSelect();
-                        r = new ConditionInSelect(database, r, query, false,
-                                Comparison.EQUAL);
+                        r = new ConditionInQuery(database, r, query, false, Comparison.EQUAL);
                     } else {
                         ArrayList<Expression> v = Utils.newSmallArrayList();
                         Expression last;
@@ -3045,8 +3044,7 @@ public class Parser {
                         if (v.size() == 1 && (last instanceof Subquery)) {
                             Subquery s = (Subquery) last;
                             Query q = s.getQuery();
-                            r = new ConditionInSelect(database, r, q, false,
-                                    Comparison.EQUAL);
+                            r = new ConditionInQuery(database, r, q, false, Comparison.EQUAL);
                         } else {
                             r = new ConditionIn(database, r, v);
                         }
@@ -3076,7 +3074,7 @@ public class Parser {
                     read(OPEN_PAREN);
                     if (isSelect()) {
                         Query query = parseSelect();
-                        r = new ConditionInSelect(database, r, query, true, compareType);
+                        r = new ConditionInQuery(database, r, query, true, compareType);
                         read(CLOSE_PAREN);
                     } else {
                         parseIndex = start;
@@ -3091,7 +3089,7 @@ public class Parser {
                         read(CLOSE_PAREN);
                     } else if (isSelect()) {
                         Query query = parseSelect();
-                        r = new ConditionInSelect(database, r, query, false, compareType);
+                        r = new ConditionInQuery(database, r, query, false, compareType);
                         read(CLOSE_PAREN);
                     } else {
                         parseIndex = start;

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4190,11 +4190,9 @@ public class Parser {
                 if (readIfMore(true)) {
                     ArrayList<Expression> list = Utils.newSmallArrayList();
                     list.add(r);
-                    if (!readIf(CLOSE_PAREN)) {
-                        do {
-                            list.add(readExpression());
-                        } while (readIfMore(false));
-                    }
+                    do {
+                        list.add(readExpression());
+                    } while (readIfMore(true));
                     r = new ExpressionList(list.toArray(new Expression[0]), false);
                 }
             }
@@ -4206,10 +4204,9 @@ public class Parser {
                 r = ValueExpression.get(ValueArray.getEmpty());
             } else {
                 ArrayList<Expression> list = Utils.newSmallArrayList();
-                list.add(readExpression());
-                while (readIf(COMMA)) {
+                do {
                     list.add(readExpression());
-                }
+                } while (readIf(COMMA));
                 read(CLOSE_BRACKET);
                 r = new ExpressionList(list.toArray(new Expression[0]), true);
             }

--- a/h2/src/main/org/h2/command/ddl/CreateFunctionAlias.java
+++ b/h2/src/main/org/h2/command/ddl/CreateFunctionAlias.java
@@ -26,7 +26,6 @@ public class CreateFunctionAlias extends SchemaCommand {
     private boolean ifNotExists;
     private boolean force;
     private String source;
-    private boolean bufferResultSetToLocalTemp = true;
 
     public CreateFunctionAlias(Session session, Schema schema) {
         super(session, schema);
@@ -46,13 +45,9 @@ public class CreateFunctionAlias extends SchemaCommand {
             int id = getObjectId();
             FunctionAlias functionAlias;
             if (javaClassMethod != null) {
-                functionAlias = FunctionAlias.newInstance(getSchema(), id,
-                        aliasName, javaClassMethod, force,
-                        bufferResultSetToLocalTemp);
+                functionAlias = FunctionAlias.newInstance(getSchema(), id, aliasName, javaClassMethod, force);
             } else {
-                functionAlias = FunctionAlias.newInstanceFromSource(
-                        getSchema(), id, aliasName, source, force,
-                        bufferResultSetToLocalTemp);
+                functionAlias = FunctionAlias.newInstanceFromSource(getSchema(), id, aliasName, source, force);
             }
             functionAlias.setDeterministic(deterministic);
             db.addSchemaObject(session, functionAlias);
@@ -83,15 +78,6 @@ public class CreateFunctionAlias extends SchemaCommand {
 
     public void setDeterministic(boolean deterministic) {
         this.deterministic = deterministic;
-    }
-
-    /**
-     * Should the return value ResultSet be buffered in a local temporary file?
-     *
-     * @param b the new value
-     */
-    public void setBufferResultSetToLocalTemp(boolean b) {
-        this.bufferResultSetToLocalTemp = b;
     }
 
     public void setSource(String source) {

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -990,13 +990,11 @@ public class Select extends Query {
                             e = new ExpressionColumn(database, replacementSchema, replacementAlias,
                                     replacementFilter.getColumnName(right), false);
                         } else {
-                            Function f = Function.getFunction(database, Function.COALESCE);
-                            f.setParameter(0, new ExpressionColumn(database, schema, alias,
-                                    filter.getColumnName(left), false));
-                            f.setParameter(1, new ExpressionColumn(database, replacementSchema, replacementAlias,
-                                    replacementFilter.getColumnName(right), false));
-                            f.doneWithParameters();
-                            e = new Alias(f, left.getName(), true);
+                            e = new Alias(Function.getFunctionWithArgs(database, Function.COALESCE,
+                                    new ExpressionColumn(database, schema, alias, filter.getColumnName(left), false),
+                                    new ExpressionColumn(database, replacementSchema, replacementAlias,
+                                            replacementFilter.getColumnName(right), false)), //
+                                    left.getName(), true);
                         }
                         expressions.add(index++, e);
                     }

--- a/h2/src/main/org/h2/command/dml/Select.java
+++ b/h2/src/main/org/h2/command/dml/Select.java
@@ -426,19 +426,6 @@ public class Select extends Query {
         return true;
     }
 
-    private int getGroupByExpressionCount() {
-        if (groupByExpression == null) {
-            return 0;
-        }
-        int count = 0;
-        for (boolean b : groupByExpression) {
-            if (b) {
-                ++count;
-            }
-        }
-        return count;
-    }
-
     boolean isConditionMetForUpdate() {
         if (isConditionMet()) {
             int count = filters.size();
@@ -1312,14 +1299,14 @@ public class Select extends Query {
                 sortUsingIndex = false;
             }
         }
-        if (!isQuickAggregateQuery && isGroupQuery &&
-                getGroupByExpressionCount() > 0) {
+        if (!isQuickAggregateQuery && isGroupQuery) {
             Index index = getGroupSortedIndex();
-            Index current = topTableFilter.getIndex();
-            if (index != null && current != null && (current.getIndexType().isScan() ||
-                    current == index)) {
-                topTableFilter.setIndex(index);
-                isGroupSortedQuery = true;
+            if (index != null) {
+                Index current = topTableFilter.getIndex();
+                if (current != null && (current.getIndexType().isScan() || current == index)) {
+                    topTableFilter.setIndex(index);
+                    isGroupSortedQuery = true;
+                }
             }
         }
         expressionArray = expressions.toArray(new Expression[0]);

--- a/h2/src/main/org/h2/engine/FunctionAlias.java
+++ b/h2/src/main/org/h2/engine/FunctionAlias.java
@@ -43,7 +43,6 @@ public class FunctionAlias extends SchemaObjectBase {
     private String source;
     private JavaMethod[] javaMethods;
     private boolean deterministic;
-    private boolean bufferResultSetToLocalTemp = true;
 
     private FunctionAlias(Schema schema, int id, String name) {
         super(schema, id, name, Trace.FUNCTION);
@@ -57,12 +56,11 @@ public class FunctionAlias extends SchemaObjectBase {
      * @param name the name
      * @param javaClassMethod the class and method name
      * @param force create the object even if the class or method does not exist
-     * @param bufferResultSetToLocalTemp whether the result should be buffered
      * @return the database object
      */
     public static FunctionAlias newInstance(
             Schema schema, int id, String name, String javaClassMethod,
-            boolean force, boolean bufferResultSetToLocalTemp) {
+            boolean force) {
         FunctionAlias alias = new FunctionAlias(schema, id, name);
         int paren = javaClassMethod.indexOf('(');
         int lastDot = javaClassMethod.lastIndexOf('.', paren < 0 ?
@@ -72,7 +70,6 @@ public class FunctionAlias extends SchemaObjectBase {
         }
         alias.className = javaClassMethod.substring(0, lastDot);
         alias.methodName = javaClassMethod.substring(lastDot + 1);
-        alias.bufferResultSetToLocalTemp = bufferResultSetToLocalTemp;
         alias.init(force);
         return alias;
     }
@@ -85,15 +82,12 @@ public class FunctionAlias extends SchemaObjectBase {
      * @param name the name
      * @param source the source code
      * @param force create the object even if the class or method does not exist
-     * @param bufferResultSetToLocalTemp whether the result should be buffered
      * @return the database object
      */
     public static FunctionAlias newInstanceFromSource(
-            Schema schema, int id, String name, String source, boolean force,
-            boolean bufferResultSetToLocalTemp) {
+            Schema schema, int id, String name, String source, boolean force) {
         FunctionAlias alias = new FunctionAlias(schema, id, name);
         alias.source = source;
-        alias.bufferResultSetToLocalTemp = bufferResultSetToLocalTemp;
         alias.init(force);
         return alias;
     }
@@ -221,9 +215,6 @@ public class FunctionAlias extends SchemaObjectBase {
         if (deterministic) {
             buff.append(" DETERMINISTIC");
         }
-        if (!bufferResultSetToLocalTemp) {
-            buff.append(" NOBUFFER");
-        }
         if (source != null) {
             buff.append(" AS ");
             StringUtils.quoteStringSQL(buff, source);
@@ -302,15 +293,6 @@ public class FunctionAlias extends SchemaObjectBase {
 
     public String getSource() {
         return source;
-    }
-
-    /**
-     * Should the return value ResultSet be buffered in a local temporary file?
-     *
-     * @return true if yes
-     */
-    public boolean isBufferResultSetToLocalTemp() {
-        return bufferResultSetToLocalTemp;
     }
 
     /**

--- a/h2/src/main/org/h2/expression/BinaryOperation.java
+++ b/h2/src/main/org/h2/expression/BinaryOperation.java
@@ -260,25 +260,17 @@ public class BinaryOperation extends Expression {
             switch (l) {
             case Value.INT: {
                 // Oracle date add
-                Function f = Function.getFunction(session.getDatabase(), Function.DATEADD);
-                f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));
-                f.setParameter(1, left);
-                f.setParameter(2, right);
-                f.doneWithParameters();
-                return f.optimize(session);
+                return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
+                        ValueExpression.get(ValueString.get("DAY")), left, right).optimize(session);
             }
             case Value.DECIMAL:
             case Value.FLOAT:
             case Value.DOUBLE: {
                 // Oracle date add
-                Function f = Function.getFunction(session.getDatabase(), Function.DATEADD);
-                f.setParameter(0, ValueExpression.get(ValueString.get("SECOND")));
-                left = new BinaryOperation(OpType.MULTIPLY, ValueExpression.get(ValueInt
-                        .get(60 * 60 * 24)), left);
-                f.setParameter(1, left);
-                f.setParameter(2, right);
-                f.doneWithParameters();
-                return f.optimize(session);
+                return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
+                        ValueExpression.get(ValueString.get("SECOND")),
+                        new BinaryOperation(OpType.MULTIPLY, ValueExpression.get(ValueInt.get(60 * 60 * 24)), left),
+                        right).optimize(session);
             }
             case Value.TIME:
                 if (r == Value.TIME || r == Value.TIMESTAMP_TZ) {
@@ -298,29 +290,20 @@ public class BinaryOperation extends Expression {
                 switch (r) {
                 case Value.INT: {
                     // Oracle date subtract
-                    Function f = Function.getFunction(session.getDatabase(), Function.DATEADD);
-                    f.setParameter(0, ValueExpression.get(ValueString.get("DAY")));
-                    right = new UnaryOperation(right);
-                    right = right.optimize(session);
-                    f.setParameter(1, right);
-                    f.setParameter(2, left);
-                    f.doneWithParameters();
-                    return f.optimize(session);
+                    return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
+                            ValueExpression.get(ValueString.get("DAY")), //
+                            new UnaryOperation(right), //
+                            left).optimize(session);
                 }
                 case Value.DECIMAL:
                 case Value.FLOAT:
                 case Value.DOUBLE: {
                     // Oracle date subtract
-                    Function f = Function.getFunction(session.getDatabase(), Function.DATEADD);
-                    f.setParameter(0, ValueExpression.get(ValueString.get("SECOND")));
-                    right = new BinaryOperation(OpType.MULTIPLY, ValueExpression.get(ValueInt
-                            .get(60 * 60 * 24)), right);
-                    right = new UnaryOperation(right);
-                    right = right.optimize(session);
-                    f.setParameter(1, right);
-                    f.setParameter(2, left);
-                    f.doneWithParameters();
-                    return f.optimize(session);
+                    return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
+                                ValueExpression.get(ValueString.get("SECOND")),
+                                new UnaryOperation(new BinaryOperation(OpType.MULTIPLY, //
+                                        ValueExpression.get(ValueInt.get(60 * 60 * 24)), right)), //
+                                left).optimize(session);
                 }
                 case Value.TIME:
                     type = TypeInfo.TYPE_TIMESTAMP;

--- a/h2/src/main/org/h2/expression/condition/ConditionInQuery.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInQuery.java
@@ -26,9 +26,9 @@ import org.h2.value.ValueNull;
 import org.h2.value.ValueRow;
 
 /**
- * An 'in' condition with a subquery, as in WHERE ID IN(SELECT ...)
+ * An IN() condition with a subquery, as in WHERE ID IN(SELECT ...)
  */
-public class ConditionInSelect extends Condition {
+public class ConditionInQuery extends Condition {
 
     private final Database database;
     private Expression left;
@@ -36,8 +36,7 @@ public class ConditionInSelect extends Condition {
     private final boolean all;
     private final int compareType;
 
-    public ConditionInSelect(Database database, Expression left, Query query,
-            boolean all, int compareType) {
+    public ConditionInQuery(Database database, Expression left, Query query, boolean all, int compareType) {
         this.database = database;
         this.left = left;
         this.query = query;

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -452,9 +452,9 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunction("ARRAY_APPEND", ARRAY_APPEND, 2, Value.ARRAY);
         addFunction("ARRAY_SLICE", ARRAY_SLICE, 3, Value.ARRAY);
         addFunction("CSVREAD", CSVREAD,
-                VAR_ARGS, Value.RESULT_SET, false, false, false, true, false);
+                VAR_ARGS, Value.RESULT_SET, false, false, true, false);
         addFunction("CSVWRITE", CSVWRITE,
-                VAR_ARGS, Value.INT, false, false, true, true, false);
+                VAR_ARGS, Value.INT, false, false, true, false);
         addFunctionNotDeterministic("MEMORY_FREE", MEMORY_FREE,
                 0, Value.INT);
         addFunctionNotDeterministic("MEMORY_USED", MEMORY_USED,
@@ -476,11 +476,11 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunctionNotDeterministic("CANCEL_SESSION", CANCEL_SESSION,
                 1, Value.BOOLEAN);
         addFunction("SET", SET,
-                2, Value.NULL, false, false, true, true, false);
+                2, Value.NULL, false, false, true, false);
         addFunction("FILE_READ", FILE_READ,
-                VAR_ARGS, Value.NULL, false, false, true, true, false);
+                VAR_ARGS, Value.NULL, false, false, true, false);
         addFunction("FILE_WRITE", FILE_WRITE,
-                2, Value.LONG, false, false, true, true, false);
+                2, Value.LONG, false, false, true, false);
         addFunctionNotDeterministic("TRANSACTION_ID", TRANSACTION_ID,
                 0, Value.STRING);
         addFunctionWithNull("DECODE", DECODE,
@@ -497,10 +497,10 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunctionWithNull("UNNEST", UNNEST, VAR_ARGS, Value.RESULT_SET);
 
         // ON DUPLICATE KEY VALUES function
-        addFunction("VALUES", VALUES, 1, Value.NULL, false, true, false, true, false);
+        addFunction("VALUES", VALUES, 1, Value.NULL, false, true, true, false);
 
-        addFunction("JSON_ARRAY", JSON_ARRAY, VAR_ARGS, Value.JSON, false, true, true, true, true);
-        addFunction("JSON_OBJECT", JSON_OBJECT, VAR_ARGS, Value.JSON, false, true, true, true, true);
+        addFunction("JSON_ARRAY", JSON_ARRAY, VAR_ARGS, Value.JSON, false, true, true, true);
+        addFunction("JSON_OBJECT", JSON_OBJECT, VAR_ARGS, Value.JSON, false, true, true, true);
     }
 
     /**
@@ -521,9 +521,9 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
 
     private static void addFunction(String name, int type, int parameterCount,
             int returnDataType, boolean nullIfParameterIsNull, boolean deterministic,
-            boolean bufferResultSetToLocalTemp, boolean requireParentheses, boolean specialArguments) {
+            boolean requireParentheses, boolean specialArguments) {
         FunctionInfo info = new FunctionInfo(name, type, parameterCount, returnDataType, nullIfParameterIsNull,
-                deterministic, bufferResultSetToLocalTemp, requireParentheses, specialArguments);
+                deterministic, requireParentheses, specialArguments);
         if (FUNCTIONS_BY_ID[type] == null) {
             FUNCTIONS_BY_ID[type] = info;
         }
@@ -537,17 +537,17 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
 
     private static void addFunctionNotDeterministic(String name, int type,
             int parameterCount, int returnDataType, boolean requireParentheses) {
-        addFunction(name, type, parameterCount, returnDataType, true, false, true, requireParentheses, false);
+        addFunction(name, type, parameterCount, returnDataType, true, false, requireParentheses, false);
     }
 
     private static void addFunction(String name, int type, int parameterCount,
             int returnDataType) {
-        addFunction(name, type, parameterCount, returnDataType, true, true, true, true, false);
+        addFunction(name, type, parameterCount, returnDataType, true, true, true, false);
     }
 
     private static void addFunctionWithNull(String name, int type,
             int parameterCount, int returnDataType) {
-        addFunction(name, type, parameterCount, returnDataType, false, true, true, true, false);
+        addFunction(name, type, parameterCount, returnDataType, false, true, true, false);
     }
 
     /**
@@ -3074,11 +3074,6 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
     @Override
     public boolean isDeterministic() {
         return info.deterministic;
-    }
-
-    @Override
-    public boolean isBufferResultSetToLocalTemp() {
-        return info.bufferResultSetToLocalTemp;
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/function/FunctionCall.java
+++ b/h2/src/main/org/h2/expression/function/FunctionCall.java
@@ -69,11 +69,4 @@ public interface FunctionCall {
      */
     boolean isDeterministic();
 
-    /**
-     * Should the return value ResultSet be buffered in a local temporary file?
-     *
-     * @return true if it should be.
-     */
-    boolean isBufferResultSetToLocalTemp();
-
 }

--- a/h2/src/main/org/h2/expression/function/FunctionInfo.java
+++ b/h2/src/main/org/h2/expression/function/FunctionInfo.java
@@ -41,11 +41,6 @@ public final class FunctionInfo {
     public final boolean deterministic;
 
     /**
-     * Should the return value ResultSet be buffered in a local temporary file?
-     */
-    final boolean bufferResultSetToLocalTemp;
-
-    /**
      * Should the no-arg function require parentheses.
      */
     final boolean requireParentheses;
@@ -73,9 +68,6 @@ public final class FunctionInfo {
      * @param deterministic
      *            if this function always returns the same value for the same
      *            parameters
-     * @param bufferResultSetToLocalTemp
-     *            should the return value ResultSet be buffered in a local
-     *            temporary file?
      * @param requireParentheses
      *            should the no-arg function require parentheses
      * @param specialArguments
@@ -83,15 +75,13 @@ public final class FunctionInfo {
      *            {@link org.h2.expression.Expression#getValue(org.h2.engine.Session)}.
      */
     public FunctionInfo(String name, int type, int parameterCount, int returnDataType, boolean nullIfParameterIsNull,
-            boolean deterministic, boolean bufferResultSetToLocalTemp, boolean requireParentheses,
-            boolean specialArguments) {
+            boolean deterministic, boolean requireParentheses, boolean specialArguments) {
         this.name = name;
         this.type = type;
         this.parameterCount = parameterCount;
         this.returnDataType = returnDataType;
         this.nullIfParameterIsNull = nullIfParameterIsNull;
         this.deterministic = deterministic;
-        this.bufferResultSetToLocalTemp = bufferResultSetToLocalTemp;
         this.requireParentheses = requireParentheses;
         this.specialArguments = specialArguments;
     }
@@ -112,7 +102,6 @@ public final class FunctionInfo {
         parameterCount = source.parameterCount;
         nullIfParameterIsNull = source.nullIfParameterIsNull;
         deterministic = source.deterministic;
-        bufferResultSetToLocalTemp = source.bufferResultSetToLocalTemp;
         requireParentheses = true;
         specialArguments = source.specialArguments;
     }

--- a/h2/src/main/org/h2/expression/function/JavaFunction.java
+++ b/h2/src/main/org/h2/expression/function/JavaFunction.java
@@ -168,11 +168,6 @@ public class JavaFunction extends Expression implements FunctionCall {
     }
 
     @Override
-    public boolean isBufferResultSetToLocalTemp() {
-        return functionAlias.isBufferResultSetToLocalTemp();
-    }
-
-    @Override
     public int getSubexpressionCount() {
         return args.length;
     }

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -40,13 +40,13 @@ public class FunctionsMySQL extends FunctionsBase {
 
     static {
         FUNCTIONS.put("UNIX_TIMESTAMP", new FunctionInfo("UNIX_TIMESTAMP", UNIX_TIMESTAMP,
-                VAR_ARGS, Value.INT, false, false, false, true, false));
+                VAR_ARGS, Value.INT, false, false, true, false));
         FUNCTIONS.put("FROM_UNIXTIME", new FunctionInfo("FROM_UNIXTIME", FROM_UNIXTIME,
-                VAR_ARGS, Value.STRING, false, true, false, true, false));
+                VAR_ARGS, Value.STRING, false, true, true, false));
         FUNCTIONS.put("DATE", new FunctionInfo("DATE", DATE,
-                1, Value.DATE, false, true, false, true, false));
+                1, Value.DATE, false, true, true, false));
         FUNCTIONS.put("LAST_INSERT_ID", new FunctionInfo("LAST_INSERT_ID", LAST_INSERT_ID,
-                VAR_ARGS, Value.LONG, false, false, true, true, false));
+                VAR_ARGS, Value.LONG, false, false, true, false));
 
     }
 

--- a/h2/src/test/org/h2/test/scripts/datatypes/row.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/row.sql
@@ -3,6 +3,18 @@
 -- Initial Developer: H2 Group
 --
 
+SELECT ();
+>> ROW ()
+
+SELECT (1,);
+> exception SYNTAX_ERROR_2
+
+SELECT ROW ();
+>> ROW ()
+
+SELECT ROW (1,);
+> exception SYNTAX_ERROR_2
+
 SELECT ROW (10);
 >> ROW (10)
 

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -364,18 +364,6 @@ select * from dual where cast('xx' as varchar_ignorecase(1)) = 'X' and cast('x x
 explain select -cast(0 as real), -cast(0 as double);
 >> SELECT 0.0, 0.0 FROM SYSTEM_RANGE(1, 1) /* PUBLIC.RANGE_INDEX */
 
-select () empty;
-> EMPTY
-> ------
-> ROW ()
-> rows: 1
-
-select (1,) one_element;
-> ONE_ELEMENT
-> -----------
-> ROW (1)
-> rows: 1
-
 select (1) one;
 > ONE
 > ---


### PR DESCRIPTION
1. `Parser.readTerm()` is now a little bit shorter.

2. `NOBUFFER` flag in functions is removed from documentation, but still accepted and ignored. It was used for user-defined table value functions, but it is useless now. (`ValueResultSet` needs some buffering, but it does not know its source function, so such buffering should be performed automatically depending on data size.)

3. `Function` now can accept arguments during its creation. If arguments weren't specified, they now can be specified without calculation of their indexes.

4. **Incompatible change.** Support for the old-style `(value,)` array syntax is removed. H2 accepts only standard array literals since 1.4.198 as arrays. Old-style literals are parsed as row values. In some places they can be implicitly converted to arrays, in others they can't and code needs to be adjusted. 1.4.198 and 1.4.199 parse `(value,)` as a row value too, but this syntax is not valid and I don't see any good reasons to accept it. Note that 1.4.197 and older versions may export such literals to SQL, but `ARRAY` data type is not used too often, and such scripts usually can be loaded to 1.4.198 and 1.4.199 directly and these versions already use standard array literals during export, so they can be used in the middle if some database has such values.

5. `Select.getGroupByExpressionCount()` is removed. It was used only in one place to check presence of group by expressions (actual count was ignored), but the next method quickly checks their presence by itself.

6. `ConditionInSelect` is renamed to `ConditionInQuery`, because any query expression can be used as its argument.

@grandinj