### PR TITLE
Fix issues with getSchema() and setSchema()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1952: Connection.setSchema doesn't work with query cache
+</li>
+<li>PR #1951: Assorted changes
+</li>
 <li>PR #1950: Fix NULL handling in ARRAY_AGG
 </li>
 <li>PR #1949: Extract aggregate and window functions into own pages in documentation

--- a/h2/src/main/org/h2/command/CommandInterface.java
+++ b/h2/src/main/org/h2/command/CommandInterface.java
@@ -13,7 +13,7 @@ import org.h2.result.ResultWithGeneratedKeys;
 /**
  * Represents a SQL statement.
  */
-public interface CommandInterface {
+public interface CommandInterface extends AutoCloseable {
 
     /**
      * The type for unknown statement.
@@ -536,6 +536,7 @@ public interface CommandInterface {
     /**
      * Close the statement.
      */
+    @Override
     void close();
 
     /**

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -847,7 +847,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         // Because cache may have captured query result (in Query.lastResult),
         // which is based on data from uncommitted transaction.,
         // It is not valid after rollback, therefore cache has to be cleared.
-        if(queryCache != null) {
+        if (queryCache != null) {
             queryCache.clear();
         }
     }
@@ -1326,6 +1326,9 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
 
     public void setCurrentSchema(Schema schema) {
         modificationId++;
+        if (queryCache != null) {
+            queryCache.clear();
+        }
         this.currentSchemaName = schema.getName();
     }
 

--- a/h2/src/test/org/h2/test/jdbc/TestConnection.java
+++ b/h2/src/test/org/h2/test/jdbc/TestConnection.java
@@ -115,9 +115,6 @@ public class TestConnection extends TestDb {
     }
 
     private void testSetGetSchema() throws SQLException {
-        if (config.networked) {
-            return;
-        }
         deleteDb("schemaSetGet");
         Connection conn = getConnection("schemaSetGet");
         Statement s = conn.createStatement();
@@ -146,7 +143,10 @@ public class TestConnection extends TestDb {
             assertEquals("b", rs.getString(2));
             assertFalse(rs.next());
         }
+        s.execute("SET SCHEMA \"MY_TEST_SCHEMA\"");
+        assertEquals("MY_TEST_SCHEMA", conn.getSchema());
         s.close();
         conn.close();
+        deleteDb("schemaSetGet");
     }
 }

--- a/h2/src/test/org/h2/test/jdbc/TestConnection.java
+++ b/h2/src/test/org/h2/test/jdbc/TestConnection.java
@@ -10,6 +10,7 @@ import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -121,18 +122,30 @@ public class TestConnection extends TestDb {
         Connection conn = getConnection("schemaSetGet");
         Statement s = conn.createStatement();
         s.executeUpdate("create schema my_test_schema");
-        s.executeUpdate("create table my_test_schema.my_test_table(id uuid, nave varchar)");
+        s.executeUpdate("create table my_test_schema.my_test_table(id int, nave varchar) as values (1, 'a')");
         assertEquals("PUBLIC", conn.getSchema());
         assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, s, "select * from my_test_table");
         assertThrows(ErrorCode.SCHEMA_NOT_FOUND_1, conn).setSchema("my_test_table");
         conn.setSchema("MY_TEST_SCHEMA");
         assertEquals("MY_TEST_SCHEMA", conn.getSchema());
-        s.executeQuery("select * from my_test_table");
+        try (ResultSet rs = s.executeQuery("select * from my_test_table")) {
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertEquals("a", rs.getString(2));
+            assertFalse(rs.next());
+        }
         assertThrows(ErrorCode.SCHEMA_NOT_FOUND_1, conn).setSchema("NON_EXISTING_SCHEMA");
         assertEquals("MY_TEST_SCHEMA", conn.getSchema());
         s.executeUpdate("create schema \"otheR_schEma\"");
+        s.executeUpdate("create table \"otheR_schEma\".my_test_table(id int, nave varchar) as values (2, 'b')");
         conn.setSchema("otheR_schEma");
         assertEquals("otheR_schEma", conn.getSchema());
+        try (ResultSet rs = s.executeQuery("select * from my_test_table")) {
+            assertTrue(rs.next());
+            assertEquals(2, rs.getInt(1));
+            assertEquals("b", rs.getString(2));
+            assertFalse(rs.next());
+        }
         s.close();
         conn.close();
     }


### PR DESCRIPTION
1. Closes #1952.

2. `getSchema()` and `setSchema()` are implemented for remote connections.