### PR TITLE
Add standard CURRENT_SCHEMA function

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -347,7 +347,7 @@ ALTER INDEX IDXNAME RENAME TO IDX_TEST_NAME
 "
 
 "Commands (DDL)","ALTER SCHEMA RENAME","
-ALTER SCHEMA [ IF EXISTS ] schema RENAME TO newSchemaName
+ALTER SCHEMA [ IF EXISTS ] schemaName RENAME TO newSchemaName
 ","
 Renames a schema.
 This command commits an open transaction in this connection.
@@ -4980,6 +4980,14 @@ CALL CSVWRITE('data/test2.csv', 'SELECT * FROM TEST', 'charset=UTF-8 fieldSepara
 CALL CSVWRITE('data/test.tsv', 'SELECT * FROM TEST', 'charset=UTF-8 fieldSeparator=' || CHAR(9));
 "
 
+"Functions (System)","CURRENT_SCHEMA","
+CURRENT_SCHEMA | SCHEMA()
+","
+Returns the name of the default schema for this session.
+","
+CALL CURRENT_SCHEMA
+"
+
 "Functions (System)","DATABASE","
 DATABASE()
 ","
@@ -5206,14 +5214,6 @@ Use the ROW_NUMBER() OVER () function to get row numbers after grouping or in sp
 SELECT ROWNUM(), * FROM TEST;
 SELECT ROWNUM(), * FROM (SELECT * FROM TEST ORDER BY NAME);
 SELECT ID FROM (SELECT T.*, ROWNUM AS R FROM TEST T) WHERE R BETWEEN 2 AND 3;
-"
-
-"Functions (System)","SCHEMA","
-SCHEMA()
-","
-Returns the name of the default schema for this session.
-","
-CALL SCHEMA()
 "
 
 "Functions (System)","SCOPE_IDENTITY","

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -15,6 +15,7 @@ import static org.h2.util.ParserUtil.CHECK;
 import static org.h2.util.ParserUtil.CONSTRAINT;
 import static org.h2.util.ParserUtil.CROSS;
 import static org.h2.util.ParserUtil.CURRENT_DATE;
+import static org.h2.util.ParserUtil.CURRENT_SCHEMA;
 import static org.h2.util.ParserUtil.CURRENT_TIME;
 import static org.h2.util.ParserUtil.CURRENT_TIMESTAMP;
 import static org.h2.util.ParserUtil.CURRENT_USER;
@@ -454,6 +455,8 @@ public class Parser {
             "CROSS",
             // CURRENT_DATE
             "CURRENT_DATE",
+            // CURRENT_SCHEMA
+            "CURRENT_SCHEMA",
             // CURRENT_TIME
             "CURRENT_TIME",
             // CURRENT_TIMESTAMP
@@ -4299,6 +4302,10 @@ public class Parser {
         case CURRENT_DATE:
             read();
             r = readKeywordFunction(Function.CURRENT_DATE);
+            break;
+        case CURRENT_SCHEMA:
+            read();
+            r = readKeywordFunction(Function.CURRENT_SCHEMA);
             break;
         case CURRENT_TIME:
             read();

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -143,7 +143,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             CAST = 203, COALESCE = 204, NULLIF = 205, CASE = 206,
             NEXTVAL = 207, CURRVAL = 208, ARRAY_GET = 209, CSVREAD = 210,
             CSVWRITE = 211, MEMORY_FREE = 212, MEMORY_USED = 213,
-            LOCK_MODE = 214, SCHEMA = 215, SESSION_ID = 216,
+            LOCK_MODE = 214, CURRENT_SCHEMA = 215, SESSION_ID = 216,
             ARRAY_LENGTH = 217, LINK_SCHEMA = 218, GREATEST = 219, LEAST = 220,
             CANCEL_SESSION = 221, SET = 222, TABLE = 223, TABLE_DISTINCT = 224,
             FILE_READ = 225, TRANSACTION_ID = 226, TRUNCATE_VALUE = 227,
@@ -462,8 +462,8 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                 0, Value.INT);
         addFunctionNotDeterministic("LOCK_MODE", LOCK_MODE,
                 0, Value.INT);
-        addFunctionNotDeterministic("SCHEMA", SCHEMA,
-                0, Value.STRING);
+        addFunctionNotDeterministic("CURRENT_SCHEMA", CURRENT_SCHEMA, 0, Value.STRING, false);
+        addFunctionNotDeterministic("SCHEMA", CURRENT_SCHEMA, 0, Value.STRING);
         addFunctionNotDeterministic("SESSION_ID", SESSION_ID,
                 0, Value.INT);
         addFunction("ARRAY_LENGTH", ARRAY_LENGTH,
@@ -1012,7 +1012,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         case LOCK_MODE:
             result = ValueInt.get(database.getLockMode());
             break;
-        case SCHEMA:
+        case CURRENT_SCHEMA:
             result = ValueString.get(session.getCurrentSchemaName(),
                     database.getMode().treatEmptyStringsAsNull);
             break;

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -1541,7 +1541,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * table/column/index name, in addition to the SQL:2003 keywords. The list
      * returned is:
      * <pre>
-     * GROUPS
+     * CURRENT_SCHEMA,
+     * GROUPS,
      * IF,ILIKE,INTERSECTS,
      * LIMIT,
      * MINUS,
@@ -1555,7 +1556,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * <pre>
      * ALL, AND, ARRAY, AS,
      * BETWEEN, BOTH
-     * CASE, CHECK, CONSTRAINT, CROSS, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_USER,
+     * CASE, CHECK, CONSTRAINT, CROSS, CURRENT_DATE, CURRENT_SCHEMA,
+     * CURRENT_TIME, CURRENT_TIMESTAMP, CURRENT_USER,
      * DISTINCT,
      * EXCEPT, EXISTS,
      * FALSE, FETCH, FILTER, FOR, FOREIGN, FROM, FULL,
@@ -1582,7 +1584,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     @Override
     public String getSQLKeywords() {
         debugCodeCall("getSQLKeywords");
-        return "GROUPS," //
+        return "CURRENT_SCHEMA," //
+                + "GROUPS," //
                 + "IF,ILIKE,INTERSECTS," //
                 + "LIMIT," //
                 + "MINUS," //

--- a/h2/src/main/org/h2/server/pg/PgServer.java
+++ b/h2/src/main/org/h2/server/pg/PgServer.java
@@ -333,19 +333,6 @@ public class PgServer implements Service {
     }
 
     /**
-     * Get the name of the current schema.
-     * This method is called by the database.
-     *
-     * @param conn the connection
-     * @return the schema name
-     */
-    public static String getCurrentSchema(Connection conn) throws SQLException {
-        ResultSet rs = conn.createStatement().executeQuery("call schema()");
-        rs.next();
-        return rs.getString(1);
-    }
-
-    /**
      * Get the OID of an object. This method is called by the database.
      *
      * @param conn the connection

--- a/h2/src/main/org/h2/server/pg/pg_catalog.sql
+++ b/h2/src/main/org/h2/server/pg/pg_catalog.sql
@@ -247,9 +247,6 @@ create alias pg_catalog.format_type for "org.h2.server.pg.PgServer.formatType";
 drop alias if exists version;
 create alias version for "org.h2.server.pg.PgServer.getVersion";
 
-drop alias if exists current_schema;
-create alias current_schema for "org.h2.server.pg.PgServer.getCurrentSchema";
-
 drop alias if exists pg_encoding_to_char;
 create alias pg_encoding_to_char for "org.h2.server.pg.PgServer.getEncodingName";
 

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -53,9 +53,14 @@ public class ParserUtil {
     public static final int CURRENT_DATE = CROSS + 1;
 
     /**
+     * The token "CURRENT_SCHEMA".
+     */
+    public static final int CURRENT_SCHEMA = CURRENT_DATE + 1;
+
+    /**
      * The token "CURRENT_TIME".
      */
-    public static final int CURRENT_TIME = CURRENT_DATE + 1;
+    public static final int CURRENT_TIME = CURRENT_SCHEMA + 1;
 
     /**
      * The token "CURRENT_TIMESTAMP".
@@ -438,6 +443,8 @@ public class ParserUtil {
                 return CROSS;
             } else if (eq("CURRENT_DATE", s, ignoreCase, start, end)) {
                 return CURRENT_DATE;
+            } else if (eq("CURRENT_SCHEMA", s, ignoreCase, start, end)) {
+                return CURRENT_SCHEMA;
             } else if (eq("CURRENT_TIME", s, ignoreCase, start, end)) {
                 return CURRENT_TIME;
             } else if (eq("CURRENT_TIMESTAMP", s, ignoreCase, start, end)) {

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -461,7 +461,8 @@ public class TestMetaData extends TestDb {
 
         assertEquals("schema", meta.getSchemaTerm());
         assertEquals("\\", meta.getSearchStringEscape());
-        assertEquals("GROUPS," //
+        assertEquals("CURRENT_SCHEMA," //
+                + "GROUPS," //
                 + "IF,ILIKE,INTERSECTS," //
                 + "LIMIT," //
                 + "MINUS," //

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -202,12 +202,12 @@ public class TestScript extends TestDb {
         }
         for (String s : new String[] { "array-cat", "array-contains", "array-get",
                 "array-length","array-slice", "autocommit", "cancel-session", "casewhen",
-                "cast", "coalesce", "convert", "csvread", "csvwrite", "currval",
+                "cast", "coalesce", "convert", "csvread", "csvwrite", "current_schema", "currval",
                 "database-path", "database", "decode", "disk-space-used",
                 "file-read", "file-write", "greatest", "h2version", "identity",
                 "ifnull", "last-insert-id", "least", "link-schema", "lock-mode", "lock-timeout",
                 "memory-free", "memory-used", "nextval", "nullif", "nvl2",
-                "readonly", "rownum", "schema", "scope-identity", "session-id",
+                "readonly", "rownum", "scope-identity", "session-id",
                 "set", "table", "transaction-id", "truncate-value", "unnest", "user" }) {
             testScript("functions/system/" + s + ".sql");
         }

--- a/h2/src/test/org/h2/test/scripts/functions/system/current_schema.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/current_schema.sql
@@ -1,0 +1,25 @@
+-- Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+SELECT CURRENT_SCHEMA, SCHEMA();
+> CURRENT_SCHEMA SCHEMA()
+> -------------- --------
+> PUBLIC         PUBLIC
+> rows: 1
+
+CREATE SCHEMA S1;
+> ok
+
+SET SCHEMA S1;
+> ok
+
+SELECT CURRENT_SCHEMA;
+>> S1
+
+SET SCHEMA PUBLIC;
+> ok
+
+DROP SCHEMA S1;
+> ok

--- a/h2/src/test/org/h2/test/scripts/functions/system/schema.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/schema.sql
@@ -1,4 +1,0 @@
--- Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
--- and the EPL 1.0 (https://h2database.com/html/license.html).
--- Initial Developer: H2 Group
---

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -813,3 +813,4 @@ waiters reliably httpsdocs privileged narrow spending swallow locally uncomment 
 setjava lift hyperlinks lazarevn nikita lazarev lvl ispras bias dbff fals tru dfff
 recognition spared hacky employing occupancy baos shifts littlejohn pushes scrub existent asterisked projections
 omits redefined ensured arrayagg objectagg bmp uabcd prefixed incoherence aggressively smb invalidating filesystems
+improper


### PR DESCRIPTION
Standard Feature F763: “CURRENT_SCHEMA”.

H2 had only own non-standard function `SCHEMA()`. The standard function is introduced here.