### PR TITLE
Do not process outer joins in addFilterConditions()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1963: Expression.addFilterConditions() with outer joins
+</li>
+<li>PR #1966: Add standard CURRENT_SCHEMA function
+</li>
 <li>PR #1964: Add Feature T571: Truth value tests
 </li>
 <li>PR #1962: Fix data types of optimized conditions

--- a/h2/src/main/org/h2/command/dml/MergeUsing.java
+++ b/h2/src/main/org/h2/command/dml/MergeUsing.java
@@ -398,8 +398,8 @@ public class MergeUsing extends Prepared {
 
     @Override
     public void prepare() {
-        onCondition.addFilterConditions(sourceTableFilter, true);
-        onCondition.addFilterConditions(targetTableFilter, true);
+        onCondition.addFilterConditions(sourceTableFilter);
+        onCondition.addFilterConditions(targetTableFilter);
 
         onCondition.mapColumns(sourceTableFilter, 2, Expression.MAP_INITIAL);
         onCondition.mapColumns(targetTableFilter, 1, Expression.MAP_INITIAL);

--- a/h2/src/main/org/h2/expression/Expression.java
+++ b/h2/src/main/org/h2/expression/Expression.java
@@ -348,11 +348,9 @@ public abstract class Expression {
      * Add conditions to a table filter if they can be evaluated.
      *
      * @param filter the table filter
-     * @param outerJoin if the expression is part of an outer join
      */
-    public void addFilterConditions(TableFilter filter, boolean outerJoin) {
-        if (!addedToFilter && !outerJoin &&
-                isEverything(ExpressionVisitor.EVALUATABLE_VISITOR)) {
+    public void addFilterConditions(TableFilter filter) {
+        if (!addedToFilter && isEverything(ExpressionVisitor.EVALUATABLE_VISITOR)) {
             filter.addFilterCondition(this, false);
             addedToFilter = true;
         }

--- a/h2/src/main/org/h2/expression/condition/ConditionAndOr.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionAndOr.java
@@ -254,12 +254,12 @@ public class ConditionAndOr extends Condition {
     }
 
     @Override
-    public void addFilterConditions(TableFilter filter, boolean outerJoin) {
+    public void addFilterConditions(TableFilter filter) {
         if (andOrType == AND) {
-            left.addFilterConditions(filter, outerJoin);
-            right.addFilterConditions(filter, outerJoin);
+            left.addFilterConditions(filter);
+            right.addFilterConditions(filter);
         } else {
-            super.addFilterConditions(filter, outerJoin);
+            super.addFilterConditions(filter);
         }
     }
 

--- a/h2/src/main/org/h2/expression/condition/ConditionNot.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionNot.java
@@ -80,20 +80,6 @@ public class ConditionNot extends Condition {
     }
 
     @Override
-    public void addFilterConditions(TableFilter filter, boolean outerJoin) {
-        if (outerJoin) {
-            // can not optimize:
-            // select * from test t1 left join test t2 on t1.id = t2.id where
-            // not t2.id is not null
-            // to
-            // select * from test t1 left join test t2 on t1.id = t2.id and
-            // t2.id is not null
-            return;
-        }
-        super.addFilterConditions(filter, outerJoin);
-    }
-
-    @Override
     public boolean isEverything(ExpressionVisitor visitor) {
         return condition.isEverything(visitor);
     }

--- a/h2/src/main/org/h2/expression/condition/NullPredicate.java
+++ b/h2/src/main/org/h2/expression/condition/NullPredicate.java
@@ -131,18 +131,4 @@ public class NullPredicate extends Predicate {
         }
     }
 
-    @Override
-    public void addFilterConditions(TableFilter filter, boolean outerJoin) {
-        if (!not && outerJoin) {
-            // can not optimize:
-            // select * from test t1 left join test t2 on t1.id = t2.id
-            // where t2.id is null
-            // to
-            // select * from test t1 left join test t2
-            // on t1.id = t2.id and t2.id is null
-            return;
-        }
-        super.addFilterConditions(filter, outerJoin);
-    }
-
 }

--- a/h2/src/main/org/h2/table/Plan.java
+++ b/h2/src/main/org/h2/table/Plan.java
@@ -89,7 +89,7 @@ public class Plan {
                 // the last table doesn't need the optimization,
                 // otherwise the expression is calculated twice unnecessarily
                 // (not that bad but not optimal)
-                f.optimizeFullCondition(false);
+                f.optimizeFullCondition();
             }
             f.removeUnusableIndexConditions();
         }

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1005,17 +1005,15 @@ public class TableFilter implements ColumnResolver {
     /**
      * Optimize the full condition. This will add the full condition to the
      * filter condition.
-     *
-     * @param fromOuterJoin if this method was called from an outer joined table
      */
-    void optimizeFullCondition(boolean fromOuterJoin) {
-        if (fullCondition != null) {
-            fullCondition.addFilterConditions(this, fromOuterJoin || joinOuter);
+    void optimizeFullCondition() {
+        if (!joinOuter && fullCondition != null) {
+            fullCondition.addFilterConditions(this);
             if (nestedJoin != null) {
-                nestedJoin.optimizeFullCondition(fromOuterJoin || joinOuter);
+                nestedJoin.optimizeFullCondition();
             }
             if (join != null) {
-                join.optimizeFullCondition(fromOuterJoin || joinOuter);
+                join.optimizeFullCondition();
             }
         }
     }


### PR DESCRIPTION
Closes #1963.

Outer joins are now rejected immediately during creation of filter conditions. Before this change they were recursively processed, but conditions weren't created anyway.

The only one place where behavior can be changed is a `MergeUsing`. Now it really can create some filter conditions. Its search condition (`ON`) doesn't look like an outer join. `TestMergeUsing` has some tests where filter conditions are created from now and they aren't broken.