### PR TITLE
Switch from log map rename to "commited" marker log record

### DIFF
--- a/h2/src/test/org/h2/test/store/TestTransactionStore.java
+++ b/h2/src/test/org/h2/test/store/TestTransactionStore.java
@@ -425,7 +425,7 @@ public class TestTransactionStore extends TestBase {
 
     private static boolean hasDataUndoLog(MVStore s) {
         for (int i = 0; i < 255; i++) {
-            if (s.hasData(TransactionStore.getUndoLogName(true, 1))) {
+            if (s.hasData(TransactionStore.getUndoLogName(i))) {
                 return true;
             }
         }


### PR DESCRIPTION
Switch committed transaction designation (before transaction is fully committed) from a log map rename to a special marker log record.
Map rename is shown by a profiler as very expensive, therefore this PR replaces it with a single log map manipulation instead of six manipulations of a meta map involved into a map double re-naming.