### PR TITLE
Use proleptic Gregorian calendar for datetime values

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -1967,11 +1967,9 @@ X'01' '02'
 "
 
 "Literals","Date","
-DATE 'yyyy-MM-dd'
+DATE '[-]yyyy-MM-dd'
 ","
-A date literal. The limitations are the same as for the Java data type
-""java.sql.Date"", but for compatibility with other databases the suggested minimum
-and maximum years are 0001 and 9999.
+A date literal.
 ","
 DATE '2004-12-31'
 "
@@ -2093,17 +2091,15 @@ TIME '23:59:59'
 "
 
 "Literals","Timestamp","
-TIMESTAMP [ WITHOUT TIME ZONE ] 'yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]'
+TIMESTAMP [ WITHOUT TIME ZONE ] '[-]yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]'
 ","
-A timestamp literal. The limitations are the same as for the Java data type
-""java.sql.Timestamp"", but for compatibility with other databases the suggested
-minimum and maximum years are 0001 and 9999.
+A timestamp literal.
 ","
 TIMESTAMP '2005-12-31 23:59:59'
 "
 
 "Literals","Timestamp with time zone","
-TIMESTAMP WITH TIME ZONE 'yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]
+TIMESTAMP WITH TIME ZONE '[-]yyyy-MM-dd hh:mm:ss[.nnnnnnnnn]
 [Z | { - | + } timeZoneOffsetString | timeZoneNameString ]'
 ","
 A timestamp with time zone literal.
@@ -3213,7 +3209,7 @@ The time data type. The format is hh:mm:ss[.nnnnnnnnn].
 If fractional seconds precision is specified it should be from 0 to 9, 0 is default.
 
 Mapped to ""java.sql.Time"". When converted to a ""java.sql.Date"", the date is set to ""1970-01-01"".
-""java.time.LocalTime"" is also supported on Java 8 and later versions.
+""java.time.LocalTime"" is also supported and recommended on Java 8 and later versions.
 Use ""java.time.LocalTime"" or ""String"" instead of ""java.sql.Time"" when non-zero precision is needed.
 Cast from higher fractional seconds precision to lower fractional seconds precision performs round half up;
 if result of rounding is higher than maximum supported value 23:59:59.999999999 it is saturated to 23:59:59.999999999.
@@ -3225,11 +3221,15 @@ TIME(9)
 "Data Types","DATE Type","
 DATE
 ","
-The date data type. The format is yyyy-MM-dd.
+The date data type. The proleptic Gregorian calendar is used.
 
 Mapped to ""java.sql.Date"", with the time set to ""00:00:00""
 (or to the next possible time if midnight doesn't exist for the given date and timezone due to a daylight saving change).
-""java.time.LocalDate"" is also supported on Java 8 and later versions.
+If you deal with old dates note that ""java.sql.Date"" uses a mixed Julian/Gregorian calendar,
+""java.util.GregorianCalendar"" can be configured to proleptic Gregorian with
+""setGregorianChange(new java.util.Date(Long.MIN_VALUE))"" and used to read or write fields of dates.
+
+""java.time.LocalDate"" is also supported and recommended on Java 8 and later versions.
 ","
 DATE
 "
@@ -3238,13 +3238,18 @@ DATE
 { TIMESTAMP [ ( precisionInt ) ] [ WITHOUT TIME ZONE ]
     | DATETIME [ ( precisionInt ) ] | SMALLDATETIME }
 ","
-The timestamp data type. The format is yyyy-MM-dd hh:mm:ss[.nnnnnnnnn].
+The timestamp data type. The proleptic Gregorian calendar is used.
 Stored internally as a BCD-encoded date, and nanoseconds since midnight.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 Fractional seconds precision of SMALLDATETIME is always 0 and cannot be specified.
 
 Mapped to ""java.sql.Timestamp"" (""java.util.Date"" may be used too).
-""java.time.LocalDateTime"" is also supported on Java 8 and later versions.
+If you deal with old dates note that ""java.sql.Timestamp"" uses a mixed Julian/Gregorian calendar,
+""java.util.GregorianCalendar"" can be configured to proleptic Gregorian with
+""setGregorianChange(new java.util.Date(Long.MIN_VALUE))"" and used to read or write fields of timestamps.
+
+""java.time.LocalDateTime"" is also supported and recommended on Java 8 and later versions.
+
 Cast from higher fractional seconds precision to lower fractional seconds precision performs round half up.
 ","
 TIMESTAMP
@@ -3254,7 +3259,7 @@ TIMESTAMP(9)
 "Data Types","TIMESTAMP WITH TIME ZONE Type","
 TIMESTAMP [ ( precisionInt ) ] WITH TIME ZONE
 ","
-The timestamp with time zone data type.
+The timestamp with time zone data type. The proleptic Gregorian calendar is used.
 Stored internally as a BCD-encoded date, nanoseconds since midnight, and time zone offset in minutes.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -530,7 +530,7 @@ public class PgServerThread implements Runnable {
     }
 
     private static long toPostgreDays(long dateValue) {
-        return DateTimeUtils.prolepticGregorianAbsoluteDayFromDateValue(dateValue) - 10_957;
+        return DateTimeUtils.absoluteDayFromDateValue(dateValue) - 10_957;
     }
 
     private void writeDataColumn(ResultSet rs, int column, int pgType, boolean text)

--- a/h2/src/main/org/h2/tools/Csv.java
+++ b/h2/src/main/org/h2/tools/Csv.java
@@ -81,21 +81,7 @@ public class Csv implements SimpleRowSource {
             }
             while (rs.next()) {
                 for (int i = 0; i < columnCount; i++) {
-                    Object o;
-                    switch (sqlTypes[i]) {
-                    case Types.DATE:
-                        o = rs.getDate(i + 1);
-                        break;
-                    case Types.TIME:
-                        o = rs.getTime(i + 1);
-                        break;
-                    case Types.TIMESTAMP:
-                        o = rs.getTimestamp(i + 1);
-                        break;
-                    default:
-                        o = rs.getString(i + 1);
-                    }
-                    row[i] = o == null ? null : o.toString();
+                    row[i] = rs.getString(i + 1);
                 }
                 writeRow(row);
                 rows++;

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -68,18 +68,18 @@ public class DateTimeUtils {
     private static final int SHIFT_MONTH = 5;
 
     /**
+     * Gregorian change date for a {@link GregorianCalendar} that represents a
+     * proleptic Gregorian calendar.
+     */
+    private static final Date PROLEPTIC_GREGORIAN_CHANGE = new Date(Long.MIN_VALUE);
+
+    /**
      * Date value for 1970-01-01.
      */
     public static final int EPOCH_DATE_VALUE = (1970 << SHIFT_YEAR) + (1 << SHIFT_MONTH) + 1;
 
     private static final int[] NORMAL_DAYS_PER_MONTH = { 0, 31, 28, 31, 30, 31,
             30, 31, 31, 30, 31, 30, 31 };
-
-    /**
-     * Offsets of month within a year, starting with March, April,...
-     */
-    private static final int[] DAYS_OFFSET = { 0, 31, 61, 92, 122, 153, 184,
-            214, 245, 275, 306, 337, 366 };
 
     /**
      * Multipliers for {@link #convertScale(long, int)}.
@@ -187,7 +187,9 @@ public class DateTimeUtils {
      * @return a new calendar instance.
      */
     public static GregorianCalendar createGregorianCalendar() {
-        return new GregorianCalendar();
+        GregorianCalendar c = new GregorianCalendar();
+        c.setGregorianChange(PROLEPTIC_GREGORIAN_CHANGE);
+        return c;
     }
 
     /**
@@ -201,7 +203,9 @@ public class DateTimeUtils {
      * @return a new calendar instance.
      */
     public static GregorianCalendar createGregorianCalendar(TimeZone tz) {
-        return new GregorianCalendar(tz);
+        GregorianCalendar c = new GregorianCalendar(tz);
+        c.setGregorianChange(PROLEPTIC_GREGORIAN_CHANGE);
+        return c;
     }
 
     /**
@@ -944,13 +948,7 @@ public class DateTimeUtils {
         if (month != 2) {
             return NORMAL_DAYS_PER_MONTH[month];
         }
-        // All leap years divisible by 4
-        return (year & 3) == 0
-                // All such years before 1582 are Julian and leap
-                && (year < 1582
-                        // Otherwise check Gregorian conditions
-                        || year % 100 != 0 || year % 400 == 0)
-                ? 29 : 28;
+        return (year & 3) == 0 && (year % 100 != 0 || year % 400 == 0) ? 29 : 28;
     }
 
     /**
@@ -962,14 +960,7 @@ public class DateTimeUtils {
      * @return true if it is valid
      */
     public static boolean isValidDate(int year, int month, int day) {
-        if (month < 1 || month > 12 || day < 1) {
-            return false;
-        }
-        if (year == 1582 && month == 10) {
-            // special case: days 1582-10-05 .. 1582-10-14 don't exist
-            return day < 5 || (day > 14 && day <= 31);
-        }
-        return day <= getDaysInMonth(year, month);
+        return month >= 1 && month <= 12 && day >= 1 && day <= getDaysInMonth(year, month);
     }
 
     /**
@@ -1266,14 +1257,11 @@ public class DateTimeUtils {
      * @return the absolute day
      */
     public static long absoluteDayFromYear(long year) {
-        year--;
-        long a = ((year * 1461L) >> 2) - 719_177;
-        if (year < 1582) {
-            // Julian calendar
-            a += 13;
-        } else if (year < 1900 || year > 2099) {
-            // Gregorian calendar (slow mode)
-            a += (year / 400) - (year / 100) + 15;
+        long a = 365 * year - 719_528;
+        if (year >= 0) {
+            a += (year + 3) / 4 - (year + 99) / 100 + (year + 399) / 400;
+        } else {
+            a -= year / -4 - year / -100 + year / -400;
         }
         return a;
     }
@@ -1288,40 +1276,13 @@ public class DateTimeUtils {
         long y = yearFromDateValue(dateValue);
         int m = monthFromDateValue(dateValue);
         int d = dayFromDateValue(dateValue);
-        if (m <= 2) {
-            y--;
-            m += 12;
-        }
-        long a = ((y * 1461L) >> 2) + DAYS_OFFSET[m - 3] + d - 719_484;
-        if (y <= 1582 && ((y < 1582) || (m * 100 + d < 10_15))) {
-            // Julian calendar (cutover at 1582-10-04 / 1582-10-15)
-            a += 13;
-        } else if (y < 1900 || y > 2099) {
-            // Gregorian calendar (slow mode)
-            a += (y / 400) - (y / 100) + 15;
-        }
-        return a;
-    }
-
-    /**
-     * Calculate the absolute day from an encoded date value in proleptic Gregorian
-     * calendar.
-     *
-     * @param dateValue the date value
-     * @return the absolute day in proleptic Gregorian calendar
-     */
-    public static long prolepticGregorianAbsoluteDayFromDateValue(long dateValue) {
-        long y = yearFromDateValue(dateValue);
-        int m = monthFromDateValue(dateValue);
-        int d = dayFromDateValue(dateValue);
-        if (m <= 2) {
-            y--;
-            m += 12;
-        }
-        long a = ((y * 1461L) >> 2) + DAYS_OFFSET[m - 3] + d - 719_484;
-        if (y < 1900 || y > 2099) {
-            // Slow mode
-            a += (y / 400) - (y / 100) + 15;
+        long a = absoluteDayFromYear(y);
+        a += ((367 * m - 362) / 12) + d - 1;
+        if (m > 2) {
+            a--;
+            if ((y & 3) != 0 || (y % 100 == 0 && y % 400 != 0)) {
+                a--;
+            }
         }
         return a;
     }
@@ -1334,37 +1295,26 @@ public class DateTimeUtils {
      */
     public static long dateValueFromAbsoluteDay(long absoluteDay) {
         long d = absoluteDay + 719_468;
-        long y100, offset;
-        if (d > 578_040) {
-            // Gregorian calendar
-            long y400 = d / 146_097;
-            d -= y400 * 146_097;
-            y100 = d / 36_524;
-            d -= y100 * 36_524;
-            offset = y400 * 400 + y100 * 100;
-        } else {
-            // Julian calendar
-            y100 = 0;
-            d += 292_200_000_002L;
-            offset = -800_000_000;
+        long a = 0;
+        if (d < 0) {
+            a = (d + 1) / 146_097 - 1;
+            d -= a * 146_097;
+            a *= 400;
         }
-        long y4 = d / 1461;
-        d -= y4 * 1461;
-        long y = d / 365;
-        d -= y * 365;
-        if (d == 0 && (y == 4 || y100 == 4)) {
+        long y = (400 * d + 591) / 146_097;
+        int day = (int) (d - (365 * y + y / 4 - y / 100 + y / 400));
+        if (day < 0) {
             y--;
-            d += 365;
+            day = (int) (d - (365 * y + y / 4 - y / 100 + y / 400));
         }
-        y += offset + y4 * 4;
-        // month of a day
-        int m = ((int) d * 2 + 1) * 5 / 306;
-        d -= DAYS_OFFSET[m] - 1;
+        y += a;
+        int m = (day * 5 + 2) / 153;
+        day -= (m * 306 + 5) / 10 - 1;
         if (m >= 10) {
             y++;
             m -= 12;
         }
-        return dateValue(y, m + 3, (int) d);
+        return dateValue(y, m + 3, day);
     }
 
     /**
@@ -1375,15 +1325,11 @@ public class DateTimeUtils {
      * @return the next date value
      */
     public static long incrementDateValue(long dateValue) {
-        int year = yearFromDateValue(dateValue);
-        if (year == 1582) {
-            // Use slow way instead of rarely needed large custom code.
-            return dateValueFromAbsoluteDay(absoluteDayFromDateValue(dateValue) + 1);
-        }
         int day = dayFromDateValue(dateValue);
         if (day < 28) {
             return dateValue + 1;
         }
+        int year = yearFromDateValue(dateValue);
         int month = monthFromDateValue(dateValue);
         if (day < getDaysInMonth(year, month)) {
             return dateValue + 1;
@@ -1405,14 +1351,10 @@ public class DateTimeUtils {
      * @return the previous date value
      */
     public static long decrementDateValue(long dateValue) {
-        int year = yearFromDateValue(dateValue);
-        if (year == 1582) {
-            // Use slow way instead of rarely needed large custom code.
-            return dateValueFromAbsoluteDay(absoluteDayFromDateValue(dateValue) - 1);
-        }
         if (dayFromDateValue(dateValue) > 1) {
             return dateValue - 1;
         }
+        int year = yearFromDateValue(dateValue);
         int month = monthFromDateValue(dateValue);
         if (month > 1) {
             month--;

--- a/h2/src/main/org/h2/util/LocalDateTimeUtils.java
+++ b/h2/src/main/org/h2/util/LocalDateTimeUtils.java
@@ -596,19 +596,10 @@ public class LocalDateTimeUtils {
 
     private static Object localDateFromDateValue(long dateValue)
                     throws IllegalAccessException, InvocationTargetException {
-
         int year = DateTimeUtils.yearFromDateValue(dateValue);
         int month = DateTimeUtils.monthFromDateValue(dateValue);
         int day = DateTimeUtils.dayFromDateValue(dateValue);
-        try {
-            return LOCAL_DATE_OF_YEAR_MONTH_DAY.invoke(null, year, month, day);
-        } catch (InvocationTargetException e) {
-            if (year <= 1500 && (year & 3) == 0 && month == 2 && day == 29) {
-                // If proleptic Gregorian doesn't have such date use the next day
-                return LOCAL_DATE_OF_YEAR_MONTH_DAY.invoke(null, year, 3, 1);
-            }
-            throw e;
-        }
+        return LOCAL_DATE_OF_YEAR_MONTH_DAY.invoke(null, year, month, day);
     }
 
     private static Object localDateTimeFromDateNanos(long dateValue, long timeNanos)

--- a/h2/src/test/org/h2/test/db/TestCsv.java
+++ b/h2/src/test/org/h2/test/db/TestCsv.java
@@ -107,9 +107,7 @@ public class TestCsv extends TestDb {
         csv.setLineSeparator(";");
         csv.write(writer, rs);
         conn.close();
-        // getTimestamp().getString() needs to be used (not for H2, but for
-        // Oracle)
-        assertEquals("TS,N;0101-01-01 12:00:00.0,;", writer.toString());
+        assertEquals("TS,N;-100-01-01 12:00:00,;", writer.toString());
     }
 
     private void testCaseSensitiveColumnNames() throws Exception {

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -1511,8 +1511,9 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         assertResult("014", stat, "SELECT TO_CHAR(DATE '2013-12-30', 'IYY') FROM DUAL");
         assertResult("14", stat, "SELECT TO_CHAR(DATE '2013-12-30', 'IY') FROM DUAL");
         assertResult("4", stat, "SELECT TO_CHAR(DATE '2013-12-30', 'I') FROM DUAL");
-        assertResult("0001", stat, "SELECT TO_CHAR(DATE '-0001-01-01', 'IYYY') FROM DUAL");
-        assertResult("0005", stat, "SELECT TO_CHAR(DATE '-0004-01-01', 'IYYY') FROM DUAL");
+        assertResult("0002", stat, "SELECT TO_CHAR(DATE '-0001-01-01', 'IYYY') FROM DUAL");
+        assertResult("0001", stat, "SELECT TO_CHAR(DATE '-0001-01-04', 'IYYY') FROM DUAL");
+        assertResult("0004", stat, "SELECT TO_CHAR(DATE '-0004-01-01', 'IYYY') FROM DUAL");
         assertResult("08:12 AM", stat, "SELECT TO_CHAR(X, 'HH:MI AM') FROM T");
         assertResult("08:12 A.M.", stat, "SELECT TO_CHAR(X, 'HH:MI A.M.') FROM T");
         assertResult("02:04 P.M.", stat, "SELECT TO_CHAR(X, 'HH:MI A.M.') FROM U");

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -760,37 +760,20 @@ public class TestPreparedStatement extends TestDb {
         localDate2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE);
         assertEquals(localDate, localDate2);
         rs.close();
-        /*
-         * Check that date that doesn't exist in proleptic Gregorian calendar can be
-         * read as a next date.
-         */
-        prep.setString(1, "1500-02-29");
+        prep.setString(1, "1500-02-28");
         rs = prep.executeQuery();
         rs.next();
         localDate2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE);
-        assertEquals(parseLocalDate("1500-03-01"), localDate2);
+        assertEquals(parseLocalDate("1500-02-28"), localDate2);
         rs.close();
-        prep.setString(1, "1400-02-29");
+        prep.setString(1, "-0100-02-28");
         rs = prep.executeQuery();
         rs.next();
         localDate2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE);
-        assertEquals(parseLocalDate("1400-03-01"), localDate2);
-        rs.close();
-        prep.setString(1, "1300-02-29");
-        rs = prep.executeQuery();
-        rs.next();
-        localDate2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE);
-        assertEquals(parseLocalDate("1300-03-01"), localDate2);
-        rs.close();
-        prep.setString(1, "-0100-02-29");
-        rs = prep.executeQuery();
-        rs.next();
-        localDate2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE);
-        assertEquals(parseLocalDate("-0100-03-01"), localDate2);
+        assertEquals(parseLocalDate("-0100-02-28"), localDate2);
         rs.close();
         /*
-         * Check that date that doesn't exist in traditional calendar can be set and
-         * read with LocalDate and can be read with getDate() as a next date.
+         * Test dates during Julian to Gregorian transition.
          */
         localDate = parseLocalDate("1582-10-05");
         prep.setObject(1, localDate);
@@ -799,11 +782,7 @@ public class TestPreparedStatement extends TestDb {
         localDate2 = rs.getObject(1, LocalDateTimeUtils.LOCAL_DATE);
         assertEquals(localDate, localDate2);
         assertEquals("1582-10-05", rs.getString(1));
-        assertEquals(Date.valueOf("1582-10-15"), rs.getDate(1));
-        /*
-         * Also check that date that doesn't exist in traditional calendar can be read
-         * with getDate() with custom Calendar properly.
-         */
+        assertEquals(Date.valueOf("1582-09-25"), rs.getDate(1));
         GregorianCalendar gc = new GregorianCalendar();
         gc.setGregorianChange(new java.util.Date(Long.MIN_VALUE));
         gc.clear();

--- a/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
@@ -121,7 +121,7 @@ public class TestDateTimeUtils extends TestBase {
         assertEquals(dateValue(2001, 2, 28), DateTimeUtils.dateValueFromDenormalizedDate(2000, 14, 29));
         assertEquals(dateValue(1999, 8, 1), DateTimeUtils.dateValueFromDenormalizedDate(2000, -4, -100));
         assertEquals(dateValue(2100, 12, 31), DateTimeUtils.dateValueFromDenormalizedDate(2100, 12, 2000));
-        assertEquals(dateValue(-100, 2, 29), DateTimeUtils.dateValueFromDenormalizedDate(-100, 2, 30));
+        assertEquals(dateValue(-100, 2, 28), DateTimeUtils.dateValueFromDenormalizedDate(-100, 2, 30));
     }
 
     private void testUTC2Value(boolean allTimeZones) {


### PR DESCRIPTION
The handling of datetime values is aligned with the SQL Standard and many other databases.
https://github.com/h2database/h2database/issues/831#issuecomment-472316821

H2 in MVStore mode stores datetime values in a custom BCD encoding. `java.sql.*` and `java.time.*` source values were stored in different way with possible incompatible dates. Values that were passed to H2 via `java.time.*` classes were stored using the proleptic Gregorian calendar, others were stored using the mixed Julian/Gregorian calendar. Unfortunately, there is no way to check how exactly values were stored.

In this PR `java.sql.*` source values are converted to proleptic Gregorian calendar properly (`1582-09-25` -> `DATE '1582-10-05'`) and stored in the BCD encoding in the same way as `java.time.*`-sourced values. Such date is returned back as `DATE '1582-10-05'` if JSR-310 data type is requested, but it is still returned as `java.sql.Date.valueOf("1582-09-25")` if old plain `getDate(…)` was called.

String representation of datetime values was switched to proleptic Gregorian too.

*Old PageStore databases (due to different storage format) and dates since `1582-10-15` in old MVStore databases are not affected.*

Please note that old `java.sql.*` and `java.util.*` classes have other issues with old dates, for example, they have problems with string representation of negative years (BC). They also usually aren't used in modern projects and libraries. So from my point of view internal encoding of JSR-310 values for such old dates is used more often.

I didn't add any compatibility code because such dates are rarely used and new behavior is consistent and standard compliant.

@grandinj