### PR TITLE
Test improvements, OOME elimination

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -93,7 +93,7 @@
     <!-- START TEST DEPENDENCIES !-->
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <artifactId>slf4j-nop</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
@@ -194,6 +194,8 @@
   <testResource>
     <directory>src/test</directory>
       <includes>
+        <include>org/h2/test/bench/test.properties</include>
+        <include>org/h2/test/script/testScrip.sql</include>
         <include>org/h2/test/scripts/**/*.sql</include>
         <include>org/h2/samples/newsfeed.sql</include>
         <include>org/h2/samples/optimizations.sql</include>

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -1344,14 +1344,17 @@ public abstract class TestBase {
      */
     protected void eatMemory(int remainingKB) {
         int memoryFreeKB;
-        while ((memoryFreeKB = Utils.getMemoryFree()) > remainingKB) {
-                try {
-                    byte[] block = new byte[Math.max((memoryFreeKB - remainingKB) / 16, 1) * 1024];
-                    memory.add(block);
-                } catch (OutOfMemoryError e) {
-                    memory.clear();
-                    throw e;
-                }
+        try {
+            while ((memoryFreeKB = Utils.getMemoryFree()) > remainingKB) {
+                byte[] block = new byte[Math.max((memoryFreeKB - remainingKB) / 16, 16) * 1024];
+                memory.add(block);
+            }
+        } catch (OutOfMemoryError e) {
+            if (remainingKB >= 3000) { // OOM is not expected
+                memory.clear();
+                throw e;
+            }
+            // OOM can be ignored because it's tolerable (separate process?)
         }
     }
 

--- a/h2/src/test/org/h2/test/db/TestMemoryUsage.java
+++ b/h2/src/test/org/h2/test/db/TestMemoryUsage.java
@@ -66,7 +66,7 @@ public class TestMemoryUsage extends TestDb {
         // to eliminate background thread interference
         conn = getConnection("memoryUsage;WRITE_DELAY=0");
         try {
-            eatMemory(6000);
+            eatMemory(4000);
             for (int i = 0; i < 4000; i++) {
                 Connection c2 = getConnection("memoryUsage");
                 c2.createStatement();

--- a/h2/src/test/org/h2/test/db/TestMemoryUsage.java
+++ b/h2/src/test/org/h2/test/db/TestMemoryUsage.java
@@ -63,7 +63,8 @@ public class TestMemoryUsage extends TestDb {
             return;
         }
         deleteDb("memoryUsage");
-        conn = getConnection("memoryUsage");
+        // to eliminate background thread interference
+        conn = getConnection("memoryUsage;WRITE_DELAY=0");
         try {
             eatMemory(4000);
             for (int i = 0; i < 4000; i++) {
@@ -127,7 +128,7 @@ public class TestMemoryUsage extends TestDb {
             return;
         }
         deleteDb("memoryUsageClob");
-        conn = getConnection("memoryUsageClob");
+        conn = getConnection("memoryUsageClob;WRITE_DELAY=0");
         Statement stat = conn.createStatement();
         stat.execute("SET MAX_LENGTH_INPLACE_LOB 8192");
         stat.execute("SET CACHE_SIZE 8000");

--- a/h2/src/test/org/h2/test/db/TestMemoryUsage.java
+++ b/h2/src/test/org/h2/test/db/TestMemoryUsage.java
@@ -66,7 +66,7 @@ public class TestMemoryUsage extends TestDb {
         // to eliminate background thread interference
         conn = getConnection("memoryUsage;WRITE_DELAY=0");
         try {
-            eatMemory(4000);
+            eatMemory(6000);
             for (int i = 0; i < 4000; i++) {
                 Connection c2 = getConnection("memoryUsage");
                 c2.createStatement();
@@ -133,13 +133,11 @@ public class TestMemoryUsage extends TestDb {
         stat.execute("SET MAX_LENGTH_INPLACE_LOB 8192");
         stat.execute("SET CACHE_SIZE 8000");
         stat.execute("CREATE TABLE TEST(ID IDENTITY, DATA CLOB)");
-        freeSoftReferences();
         try {
             int base = Utils.getMemoryUsed();
             for (int i = 0; i < 4; i++) {
                 stat.execute("INSERT INTO TEST(DATA) " +
                         "SELECT SPACE(8000) FROM SYSTEM_RANGE(1, 800)");
-                freeSoftReferences();
                 int used = Utils.getMemoryUsed();
                 if ((used - base) > 3 * 8192) {
                     fail("Used: " + (used - base) + " i: " + i);
@@ -166,20 +164,6 @@ public class TestMemoryUsage extends TestDb {
                 throw e;
             }
         }
-    }
-
-    /**
-     * Eat memory so that all soft references are garbage collected.
-     */
-    void freeSoftReferences() {
-        try {
-            eatMemory(1);
-        } catch (OutOfMemoryError e) {
-            // ignore
-        }
-        System.gc();
-        System.gc();
-        freeMemory();
     }
 
     private void testCreateIndex() throws SQLException {

--- a/h2/src/test/org/h2/test/db/TestOutOfMemory.java
+++ b/h2/src/test/org/h2/test/db/TestOutOfMemory.java
@@ -131,7 +131,7 @@ public class TestOutOfMemory extends TestDb {
                         ErrorCode.DATABASE_IS_CLOSED == e.getErrorCode() ||
                         ErrorCode.GENERAL_ERROR_1 == e.getErrorCode());
             }
-            recoverAfterOOM(memoryFree/2);
+            recoverAfterOOM(memoryFree * 3 / 4);
             try {
                 conn.close();
                 fail();
@@ -142,7 +142,7 @@ public class TestOutOfMemory extends TestDb {
                         ErrorCode.DATABASE_IS_CLOSED == e.getErrorCode() ||
                         ErrorCode.GENERAL_ERROR_1 == e.getErrorCode());
             }
-            recoverAfterOOM(memoryFree/2);
+            recoverAfterOOM(memoryFree * 3 / 4);
             conn = DriverManager.getConnection(url);
             stat = conn.createStatement();
             stat.execute("SELECT 1");
@@ -154,7 +154,7 @@ public class TestOutOfMemory extends TestDb {
     }
 
     private static void recoverAfterOOM(int expectedFreeMemory) throws InterruptedException {
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 50; i++) {
             if (Utils.getMemoryFree() > expectedFreeMemory) {
                 break;
             }
@@ -247,7 +247,7 @@ public class TestOutOfMemory extends TestDb {
                 assertTrue(rs.next());
                 assertEquals(3010893, rs.getInt(1));
 
-                eatMemory(80);
+                eatMemory(6000);
                 prep.execute();
                 fail();
             } catch (SQLException ignore) {

--- a/h2/src/test/org/h2/test/db/TestOutOfMemory.java
+++ b/h2/src/test/org/h2/test/db/TestOutOfMemory.java
@@ -21,6 +21,7 @@ import org.h2.store.fs.FilePathMem;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
+import org.h2.util.Utils;
 
 /**
  * Tests out of memory situations. The database must not get corrupted, and
@@ -118,6 +119,7 @@ public class TestOutOfMemory extends TestDb {
         try {
             Connection conn = DriverManager.getConnection(url);
             Statement stat = conn.createStatement();
+            int memoryFree = Utils.getMemoryFree();
             try {
                 stat.execute("create table test(id int, name varchar) as " +
                         "select x, space(10000000+x) from system_range(1, 1000)");
@@ -129,7 +131,7 @@ public class TestOutOfMemory extends TestDb {
                         ErrorCode.DATABASE_IS_CLOSED == e.getErrorCode() ||
                         ErrorCode.GENERAL_ERROR_1 == e.getErrorCode());
             }
-            recoverAfterOOM();
+            recoverAfterOOM(memoryFree/2);
             try {
                 conn.close();
                 fail();
@@ -140,7 +142,7 @@ public class TestOutOfMemory extends TestDb {
                         ErrorCode.DATABASE_IS_CLOSED == e.getErrorCode() ||
                         ErrorCode.GENERAL_ERROR_1 == e.getErrorCode());
             }
-            recoverAfterOOM();
+            recoverAfterOOM(memoryFree/2);
             conn = DriverManager.getConnection(url);
             stat = conn.createStatement();
             stat.execute("SELECT 1");
@@ -151,9 +153,11 @@ public class TestOutOfMemory extends TestDb {
         }
     }
 
-    private static void recoverAfterOOM() throws InterruptedException {
+    private static void recoverAfterOOM(int expectedFreeMemory) throws InterruptedException {
         for (int i = 0; i < 5; i++) {
-            System.gc();
+            if (Utils.getMemoryFree() > expectedFreeMemory) {
+                break;
+            }
             Thread.sleep(20);
         }
     }

--- a/h2/src/test/org/h2/test/db/TestOutOfMemory.java
+++ b/h2/src/test/org/h2/test/db/TestOutOfMemory.java
@@ -247,7 +247,7 @@ public class TestOutOfMemory extends TestDb {
                 assertTrue(rs.next());
                 assertEquals(3010893, rs.getInt(1));
 
-                eatMemory(6000);
+                eatMemory(80);
                 prep.execute();
                 fail();
             } catch (SQLException ignore) {

--- a/h2/src/test/org/h2/test/store/TestDefrag.java
+++ b/h2/src/test/org/h2/test/store/TestDefrag.java
@@ -58,7 +58,7 @@ public class TestDefrag  extends TestDb
         long compactedSize = dbFile.length();
         String message = "after defrag: " + nf.format(compactedSize);
         trace(message);
-        assertTrue(message, compactedSize < 2_400_000_000L);
+        assertTrue(message, compactedSize < 400_000_000L);
 
         try (Connection c = getConnection(dbName + ";LAZY_QUERY_EXECUTION=1")) {
             try (Statement st = c.createStatement()) {

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -32,6 +32,7 @@ import org.h2.store.fs.FilePath;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
 import org.h2.test.utils.AssertThrows;
+import org.h2.util.Utils;
 
 /**
  * Tests the MVStore.
@@ -842,6 +843,7 @@ public class TestMVStore extends TestBase {
         };
         for (int cacheSize = 0; cacheSize <= 6; cacheSize += 1) {
             int cacheMB = 1 + 3 * cacheSize;
+            Utils.collectGarbage();
             s = new MVStore.Builder().
                     fileName(fileName).
                     autoCommitDisabled().

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -32,6 +32,7 @@ import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.tools.Recover;
 import org.h2.tools.Restore;
+import org.h2.util.IOUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.Task;
 
@@ -121,26 +122,26 @@ public class TestMVTableEngine extends TestDb {
 
     private void testLobReuse() throws Exception {
         deleteDb(getTestName());
-        Connection conn1 = getConnection(getTestName());
-        Statement stat = conn1.createStatement();
-        stat.execute("create table test(id identity primary key, lob clob)");
-        byte[] buffer = new byte[8192];
-        for (int i = 0; i < 20; i++) {
-            Connection conn2 = getConnection(getTestName());
-            stat = conn2.createStatement();
-            stat.execute("insert into test(lob) select space(1025) from system_range(1, 10)");
-            stat.execute("delete from test where random() > 0.5");
-            ResultSet rs = conn2.createStatement().executeQuery(
-                    "select lob from test");
-            while (rs.next()) {
-                InputStream is = rs.getBinaryStream(1);
-                while (is.read(buffer) != -1) {
-                    // ignore
+        try (Connection conn1 = getConnection(getTestName())) {
+            Statement stat = conn1.createStatement();
+            stat.execute("create table test(id identity primary key, lob clob)");
+            byte[] buffer = new byte[8192];
+            for (int i = 0; i < 20; i++) {
+                try (Connection conn2 = getConnection(getTestName())) {
+                    stat = conn2.createStatement();
+                    stat.execute("insert into test(lob) select space(1025) from system_range(1, 10)");
+                    stat.execute("delete from test where random() > 0.5");
+                    ResultSet rs = conn2.createStatement().executeQuery(
+                            "select lob from test");
+                    while (rs.next()) {
+                        InputStream is = rs.getBinaryStream(1);
+                        while (is.read(buffer) != -1) {
+                            // ignore
+                        }
+                    }
                 }
             }
-            conn2.close();
         }
-        conn1.close();
     }
 
     private void testShutdownDuringLobCreation() throws Exception {
@@ -148,69 +149,62 @@ public class TestMVTableEngine extends TestDb {
             return;
         }
         deleteDb(getTestName());
-        Connection conn = getConnection(getTestName());
-        Statement stat = conn.createStatement();
-        stat.execute("create table test(data clob) as select space(10000)");
-        final PreparedStatement prep = conn
-                .prepareStatement("set @lob = ?");
-        final AtomicBoolean end = new AtomicBoolean();
-        Task t = new Task() {
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            stat.execute("create table test(data clob) as select space(10000)");
+            final PreparedStatement prep = conn
+                    .prepareStatement("set @lob = ?");
+            final AtomicBoolean end = new AtomicBoolean();
+            Task t = new Task() {
 
-            @Override
-            public void call() throws Exception {
-                prep.setBinaryStream(1, new InputStream() {
+                @Override
+                public void call() throws Exception {
+                    prep.setBinaryStream(1, new InputStream() {
 
-                    int len;
+                        int len;
 
-                    @Override
-                    public int read() throws IOException {
-                        if (len++ < 1024 * 1024 * 4) {
-                            return 0;
-                        }
-                        end.set(true);
-                        while (!stop) {
-                            try {
-                                Thread.sleep(1);
-                            } catch (InterruptedException e) {
-                                // ignore
+                        @Override
+                        public int read() throws IOException {
+                            if (len++ < 1024 * 1024 * 4) {
+                                return 0;
                             }
+                            end.set(true);
+                            while (!stop) {
+                                try {
+                                    Thread.sleep(1);
+                                } catch (InterruptedException e) {
+                                    // ignore
+                                }
+                            }
+                            return -1;
                         }
-                        return -1;
-                    }
-                }    , -1);
+                    }, -1);
+                }
+            };
+            t.execute();
+            while (!end.get()) {
+                Thread.sleep(1);
             }
-        };
-        t.execute();
-        while (!end.get()) {
-            Thread.sleep(1);
+            stat.execute("checkpoint");
+            stat.execute("shutdown immediately");
+            Exception ex = t.getException();
+            assertNotNull(ex);
+            IOUtils.closeSilently(conn);
         }
-        stat.execute("checkpoint");
-        stat.execute("shutdown immediately");
-        Exception ex = t.getException();
-        assertNotNull(ex);
-        try {
-            conn.close();
-        } catch (Exception e) {
-            // ignore
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            stat.execute("shutdown defrag");
         }
-        conn = getConnection(getTestName());
-        stat = conn.createStatement();
-        stat.execute("shutdown defrag");
-        try {
-            conn.close();
-        } catch (Exception e) {
-            // ignore
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            ResultSet rs = stat.executeQuery("select * " +
+                    "from information_schema.settings " +
+                    "where name = 'info.PAGE_COUNT'");
+            rs.next();
+            int pages = rs.getInt(2);
+            // only one lob should remain (but it is small and compressed)
+            assertTrue("p:" + pages, pages < 4);
         }
-        conn = getConnection(getTestName());
-        stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("select * " +
-                "from information_schema.settings " +
-                "where name = 'info.PAGE_COUNT'");
-        rs.next();
-        int pages = rs.getInt(2);
-        // only one lob should remain (but it is small and compressed)
-        assertTrue("p:" + pages, pages < 4);
-        conn.close();
     }
 
     private void testLobCreationThenShutdown() throws Exception {
@@ -218,60 +212,53 @@ public class TestMVTableEngine extends TestDb {
             return;
         }
         deleteDb(getTestName());
-        Connection conn = getConnection(getTestName());
-        Statement stat = conn.createStatement();
-        stat.execute("create table test(id identity, data clob)");
-        PreparedStatement prep = conn
-                .prepareStatement("insert into test values(?, ?)");
-        for (int i = 0; i < 9; i++) {
-            prep.setInt(1, i);
-            int size = i * i * i * i * 1024;
-            prep.setCharacterStream(2, new StringReader(new String(
-                    new char[size])));
-            prep.execute();
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            stat.execute("create table test(id identity, data clob)");
+            PreparedStatement prep = conn
+                    .prepareStatement("insert into test values(?, ?)");
+            for (int i = 0; i < 9; i++) {
+                prep.setInt(1, i);
+                int size = i * i * i * i * 1024;
+                prep.setCharacterStream(2, new StringReader(new String(
+                        new char[size])));
+                prep.execute();
+            }
+            stat.execute("shutdown immediately");
+            IOUtils.closeSilently(conn);
         }
-        stat.execute("shutdown immediately");
-        try {
-            conn.close();
-        } catch (Exception e) {
-            // ignore
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            stat.execute("drop all objects");
+            stat.execute("shutdown defrag");
         }
-        conn = getConnection(getTestName());
-        stat = conn.createStatement();
-        stat.execute("drop all objects");
-        stat.execute("shutdown defrag");
-        try {
-            conn.close();
-        } catch (Exception e) {
-            // ignore
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            ResultSet rs = stat.executeQuery("select * " +
+                    "from information_schema.settings " +
+                    "where name = 'info.PAGE_COUNT'");
+            rs.next();
+            int pages = rs.getInt(2);
+            // no lobs should remain
+            assertTrue("p:" + pages, pages < 4);
         }
-        conn = getConnection(getTestName());
-        stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("select * " +
-                "from information_schema.settings " +
-                "where name = 'info.PAGE_COUNT'");
-        rs.next();
-        int pages = rs.getInt(2);
-        // no lobs should remain
-        assertTrue("p:" + pages, pages < 4);
-        conn.close();
     }
 
     private void testManyTransactions() throws Exception {
         deleteDb(getTestName());
-        Connection conn = getConnection(getTestName());
-        Statement stat = conn.createStatement();
-        stat.execute("create table test()");
-        conn.setAutoCommit(false);
-        stat.execute("insert into test values()");
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            stat.execute("create table test()");
+            conn.setAutoCommit(false);
+            stat.execute("insert into test values()");
 
-        Connection conn2 = getConnection(getTestName());
-        Statement stat2 = conn2.createStatement();
-        for (long i = 0; i < 100000; i++) {
-            stat2.execute("insert into test values()");
+            try (Connection conn2 = getConnection(getTestName())) {
+                Statement stat2 = conn2.createStatement();
+                for (long i = 0; i < 100000; i++) {
+                    stat2.execute("insert into test values()");
+                }
+            }
         }
-        conn2.close();
-        conn.close();
     }
 
     private void testAppendOnly() throws Exception {
@@ -279,225 +266,214 @@ public class TestMVTableEngine extends TestDb {
             return;
         }
         deleteDb(getTestName());
-        Connection conn = getConnection(getTestName());
-        Statement stat = conn.createStatement();
-        stat.execute("set retention_time 0");
-        for (int i = 0; i < 10; i++) {
-            stat.execute("create table dummy" + i +
-                    " as select x, space(100) from system_range(1, 1000)");
-            stat.execute("checkpoint");
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            stat.execute("set retention_time 0");
+            for (int i = 0; i < 10; i++) {
+                stat.execute("create table dummy" + i +
+                        " as select x, space(100) from system_range(1, 1000)");
+                stat.execute("checkpoint");
+            }
+            stat.execute("create table test as select x from system_range(1, 1000)");
         }
-        stat.execute("create table test as select x from system_range(1, 1000)");
-        conn.close();
+
         String fileName = getBaseDir() + "/" + getTestName() + Constants.SUFFIX_MV_FILE;
         long fileSize = FileUtils.size(fileName);
 
-        conn = getConnection(
-                getTestName() + ";reuse_space=false");
-        stat = conn.createStatement();
-        stat.execute("set retention_time 0");
-        for (int i = 0; i < 10; i++) {
-            stat.execute("drop table dummy" + i);
-            stat.execute("checkpoint");
+        try (Connection conn = getConnection(getTestName() + ";reuse_space=false")) {
+            Statement stat = conn.createStatement();
+            stat.execute("set retention_time 0");
+            for (int i = 0; i < 10; i++) {
+                stat.execute("drop table dummy" + i);
+                stat.execute("checkpoint");
+            }
+            stat.execute("alter table test alter column x rename to y");
+            stat.execute("select y from test where 1 = 0");
+            stat.execute("create table test2 as select x from system_range(1, 1000)");
         }
-        stat.execute("alter table test alter column x rename to y");
-        stat.execute("select y from test where 1 = 0");
-        stat.execute("create table test2 as select x from system_range(1, 1000)");
-        conn.close();
 
-        FileChannel fc = FileUtils.open(fileName, "rw");
-        // undo all changes
-        fc.truncate(fileSize);
-        fc.close();
+        try (FileChannel fc = FileUtils.open(fileName, "rw")) {
+            // undo all changes
+            fc.truncate(fileSize);
+        }
 
-        conn = getConnection(getTestName());
-        stat = conn.createStatement();
-        stat.execute("select * from dummy0 where 1 = 0");
-        stat.execute("select * from dummy9 where 1 = 0");
-        stat.execute("select x from test where 1 = 0");
-        conn.close();
+        try (Connection conn = getConnection(getTestName())) {
+            Statement stat = conn.createStatement();
+            stat.execute("select * from dummy0 where 1 = 0");
+            stat.execute("select * from dummy9 where 1 = 0");
+            stat.execute("select x from test where 1 = 0");
+        }
     }
 
     private void testLowRetentionTime() throws SQLException {
         deleteDb(getTestName());
-        Connection conn = getConnection(
-                getTestName() + ";RETENTION_TIME=10;WRITE_DELAY=10");
-        Statement stat = conn.createStatement();
-        Connection conn2 = getConnection(getTestName());
-        Statement stat2 = conn2.createStatement();
-        stat.execute("create alias sleep as " +
-                "$$void sleep(int ms) throws Exception { Thread.sleep(ms); }$$");
-        stat.execute("create table test(id identity, name varchar) " +
-                "as select x, 'Init' from system_range(0, 1999)");
-        for (int i = 0; i < 10; i++) {
-            stat.execute("insert into test values(null, 'Hello')");
-            // create and delete a large table: this will force compaction
-            stat.execute("create table temp(id identity, name varchar) as " +
-                    "select x, space(1000000) from system_range(0, 10)");
-            stat.execute("drop table temp");
+        try (Connection conn = getConnection(getTestName() + ";RETENTION_TIME=10;WRITE_DELAY=10")) {
+            Statement stat = conn.createStatement();
+            try (Connection conn2 = getConnection(getTestName())) {
+                Statement stat2 = conn2.createStatement();
+                stat.execute("create alias sleep as " +
+                        "$$void sleep(int ms) throws Exception { Thread.sleep(ms); }$$");
+                stat.execute("create table test(id identity, name varchar) " +
+                        "as select x, 'Init' from system_range(0, 1999)");
+                for (int i = 0; i < 10; i++) {
+                    stat.execute("insert into test values(null, 'Hello')");
+                    // create and delete a large table: this will force compaction
+                    stat.execute("create table temp(id identity, name varchar) as " +
+                            "select x, space(1000000) from system_range(0, 10)");
+                    stat.execute("drop table temp");
+                }
+                ResultSet rs = stat2
+                        .executeQuery("select *, sleep(1) from test order by id");
+                for (int i = 0; i < 2000 + 10; i++) {
+                    assertTrue(rs.next());
+                    assertEquals(i, rs.getInt(1));
+                }
+                assertFalse(rs.next());
+            }
         }
-        ResultSet rs = stat2
-                .executeQuery("select *, sleep(1) from test order by id");
-        for (int i = 0; i < 2000 + 10; i++) {
-            assertTrue(rs.next());
-            assertEquals(i, rs.getInt(1));
-        }
-        assertFalse(rs.next());
-        conn2.close();
-        conn.close();
     }
 
     private void testOldAndNew() throws SQLException {
         if (config.memory) {
             return;
         }
-        Connection conn;
         deleteDb(getTestName());
         String urlOld = getURL(getTestName() + ";MV_STORE=FALSE", true);
         String urlNew = getURL(getTestName() + ";MV_STORE=TRUE", true);
         String url = getURL(getTestName(), true);
 
-        conn = getConnection(urlOld);
-        conn.createStatement().execute("create table test_old(id int)");
-        conn.close();
-        conn = getConnection(url);
-        conn.createStatement().execute("select * from test_old");
-        conn.close();
-        conn = getConnection(urlNew);
-        conn.createStatement().execute("create table test_new(id int)");
-        conn.close();
-        conn = getConnection(url);
-        conn.createStatement().execute("select * from test_new");
-        conn.close();
-        conn = getConnection(urlOld);
-        conn.createStatement().execute("select * from test_old");
-        conn.close();
-        conn = getConnection(urlNew);
-        conn.createStatement().execute("select * from test_new");
-        conn.close();
+        try (Connection conn = getConnection(urlOld)) {
+            conn.createStatement().execute("create table test_old(id int)");
+        }
+        try (Connection conn = getConnection(url)) {
+            conn.createStatement().execute("select * from test_old");
+        }
+        try (Connection conn = getConnection(urlNew)) {
+            conn.createStatement().execute("create table test_new(id int)");
+        }
+        try (Connection conn = getConnection(url)) {
+            conn.createStatement().execute("select * from test_new");
+        }
+        try (Connection conn = getConnection(urlOld)) {
+            conn.createStatement().execute("select * from test_old");
+        }
+        try (Connection conn = getConnection(urlNew)) {
+            conn.createStatement().execute("select * from test_new");
+        }
     }
 
     private void testTemporaryTables() throws SQLException {
-        Connection conn;
-        Statement stat;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("set max_memory_rows 100");
-        stat.execute("create table t1 as select x from system_range(1, 200)");
-        stat.execute("create table t2 as select x from system_range(1, 200)");
-        for (int i = 0; i < 20; i++) {
-            // this will create temporary results that
-            // internally use temporary tables, which are not all closed
-            stat.execute("select count(*) from t1 where t1.x in (select t2.x from t2)");
+        try (Connection conn = getConnection(url)) {
+            Statement stat = conn.createStatement();
+            stat.execute("set max_memory_rows 100");
+            stat.execute("create table t1 as select x from system_range(1, 200)");
+            stat.execute("create table t2 as select x from system_range(1, 200)");
+            for (int i = 0; i < 20; i++) {
+                // this will create temporary results that
+                // internally use temporary tables, which are not all closed
+                stat.execute("select count(*) from t1 where t1.x in (select t2.x from t2)");
+            }
         }
-        conn.close();
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        for (int i = 0; i < 20; i++) {
-            stat.execute("create table a" + i + "(id int primary key)");
-            ResultSet rs = stat.executeQuery("select count(*) from a" + i);
-            rs.next();
-            assertEquals(0, rs.getInt(1));
+        try (Connection conn = getConnection(url)) {
+            Statement stat = conn.createStatement();
+            for (int i = 0; i < 20; i++) {
+                stat.execute("create table a" + i + "(id int primary key)");
+                ResultSet rs = stat.executeQuery("select count(*) from a" + i);
+                rs.next();
+                assertEquals(0, rs.getInt(1));
+            }
         }
-        conn.close();
     }
 
     private void testUniqueIndex() throws SQLException {
-        Connection conn;
-        Statement stat;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("create table test as select x, 0 from system_range(1, 5000)");
-        stat.execute("create unique index on test(x)");
-        ResultSet rs = stat.executeQuery("select * from test where x=1");
-        assertTrue(rs.next());
-        assertFalse(rs.next());
-        conn.close();
+        try (Connection conn = getConnection(url)) {
+            Statement stat = conn.createStatement();
+            stat.execute("create table test as select x, 0 from system_range(1, 5000)");
+            stat.execute("create unique index on test(x)");
+            ResultSet rs = stat.executeQuery("select * from test where x=1");
+            assertTrue(rs.next());
+            assertFalse(rs.next());
+        }
     }
 
     private void testSecondaryIndex() throws SQLException {
-        Connection conn;
-        Statement stat;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("create table test(id int)");
-        int size = 8 * 1024;
-        stat.execute("insert into test select mod(x * 111, " + size + ") " +
-                "from system_range(1, " + size + ")");
-        stat.execute("create index on test(id)");
-        ResultSet rs = stat.executeQuery(
-                "select count(*) from test inner join " +
-                "system_range(1, " + size + ") where " +
-                "id = mod(x * 111, " + size + ")");
-        rs.next();
-        assertEquals(size, rs.getInt(1));
-        conn.close();
+        try (Connection conn = getConnection(url)) {
+            Statement stat = conn.createStatement();
+            stat.execute("create table test(id int)");
+            int size = 8 * 1024;
+            stat.execute("insert into test select mod(x * 111, " + size + ") " +
+                    "from system_range(1, " + size + ")");
+            stat.execute("create index on test(id)");
+            ResultSet rs = stat.executeQuery(
+                    "select count(*) from test inner join " +
+                            "system_range(1, " + size + ") where " +
+                            "id = mod(x * 111, " + size + ")");
+            rs.next();
+            assertEquals(size, rs.getInt(1));
+        }
     }
 
     private void testGarbageCollectionForLOB() throws SQLException {
         if (config.memory) {
             return;
         }
-        Connection conn;
-        Statement stat;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("create table test(id int, data blob)");
-        stat.execute("insert into test select x, repeat('0', 10000) " +
-                "from system_range(1, 10)");
-        stat.execute("drop table test");
-        stat.execute("create table test2(id int, data blob)");
-        PreparedStatement prep = conn.prepareStatement(
-                "insert into test2 values(?, ?)");
-        prep.setInt(1, 1);
-        assertThrows(ErrorCode.IO_EXCEPTION_1, prep).
-            setBinaryStream(1, createFailingStream(new IOException()));
-        prep.setInt(1, 2);
-        assertThrows(ErrorCode.IO_EXCEPTION_1, prep).
-            setBinaryStream(1, createFailingStream(new IllegalStateException()));
-        conn.close();
-        MVStore s = MVStore.open(getBaseDir()+ "/" + getTestName() + ".mv.db");
-        assertTrue(s.hasMap("lobData"));
-        MVMap<Long, byte[]> lobData = s.openMap("lobData");
-        assertEquals(0, lobData.sizeAsLong());
-        assertTrue(s.hasMap("lobMap"));
-        MVMap<Long, byte[]> lobMap = s.openMap("lobMap");
-        assertEquals(0, lobMap.sizeAsLong());
-        assertTrue(s.hasMap("lobRef"));
-        MVMap<Long, byte[]> lobRef = s.openMap("lobRef");
-        assertEquals(0, lobRef.sizeAsLong());
-        s.close();
+        try (Connection conn = getConnection(url)) {
+            Statement stat = conn.createStatement();
+            stat.execute("create table test(id int, data blob)");
+            stat.execute("insert into test select x, repeat('0', 10000) " +
+                    "from system_range(1, 10)");
+            stat.execute("drop table test");
+            stat.execute("create table test2(id int, data blob)");
+            PreparedStatement prep = conn.prepareStatement(
+                    "insert into test2 values(?, ?)");
+            prep.setInt(1, 1);
+            assertThrows(ErrorCode.IO_EXCEPTION_1, prep).
+                    setBinaryStream(1, createFailingStream(new IOException()));
+            prep.setInt(1, 2);
+            assertThrows(ErrorCode.IO_EXCEPTION_1, prep).
+                    setBinaryStream(1, createFailingStream(new IllegalStateException()));
+        }
+        try (MVStore s = MVStore.open(getBaseDir()+ "/" + getTestName() + ".mv.db")) {
+            assertTrue(s.hasMap("lobData"));
+            MVMap<Long, byte[]> lobData = s.openMap("lobData");
+            assertEquals(0, lobData.sizeAsLong());
+            assertTrue(s.hasMap("lobMap"));
+            MVMap<Long, byte[]> lobMap = s.openMap("lobMap");
+            assertEquals(0, lobMap.sizeAsLong());
+            assertTrue(s.hasMap("lobRef"));
+            MVMap<Long, byte[]> lobRef = s.openMap("lobRef");
+            assertEquals(0, lobRef.sizeAsLong());
+        }
     }
 
     private void testSpatial() throws SQLException {
-        Connection conn;
         Statement stat;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("call rand(1)");
-        stat.execute("create table coordinates as select rand()*50 x, " +
-                "rand()*50 y from system_range(1, 5000)");
-        stat.execute("create table test(id identity, data geometry)");
-        stat.execute("create spatial index on test(data)");
-        stat.execute("insert into test(data) select 'polygon(('||" +
-                "(1+x)||' '||(1+y)||', '||(2+x)||' '||(2+y)||', "+
-                "'||(3+x)||' '||(1+y)||', '||(1+x)||' '||(1+y)||'))' from coordinates;");
-        conn.close();
+        try (Connection conn = getConnection(url)) {
+            stat = conn.createStatement();
+            stat.execute("call rand(1)");
+            stat.execute("create table coordinates as select rand()*50 x, " +
+                    "rand()*50 y from system_range(1, 5000)");
+            stat.execute("create table test(id identity, data geometry)");
+            stat.execute("create spatial index on test(data)");
+            stat.execute("insert into test(data) select 'polygon(('||" +
+                    "(1+x)||' '||(1+y)||', '||(2+x)||' '||(2+y)||', " +
+                    "'||(3+x)||' '||(1+y)||', '||(1+x)||' '||(1+y)||'))' from coordinates;");
+        }
     }
 
     private void testCount() throws Exception {
@@ -505,175 +481,162 @@ public class TestMVTableEngine extends TestDb {
             return;
         }
 
-        Connection conn;
-        Connection conn2;
         Statement stat;
         Statement stat2;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("create table test(id int)");
-        stat.execute("create table test2(id int)");
-        stat.execute("insert into test select x from system_range(1, 10000)");
-        conn.close();
+        try (Connection conn = getConnection(url)) {
+            stat = conn.createStatement();
+            stat.execute("create table test(id int)");
+            stat.execute("create table test2(id int)");
+            stat.execute("insert into test select x from system_range(1, 10000)");
+        }
 
-        ResultSet rs;
         String plan;
 
-        conn2 = getConnection(url);
-        stat2 = conn2.createStatement();
-        rs = stat2.executeQuery("explain analyze select count(*) from test");
-        rs.next();
-        plan = rs.getString(1);
-        assertTrue(plan, plan.indexOf("reads:") < 0);
+        ResultSet rs;
+        try (Connection conn2 = getConnection(url)) {
+            stat2 = conn2.createStatement();
+            rs = stat2.executeQuery("explain analyze select count(*) from test");
+            rs.next();
+            plan = rs.getString(1);
+            assertTrue(plan, !plan.contains("reads:"));
+            try (Connection conn = getConnection(url)) {
+                stat = conn.createStatement();
+                conn.setAutoCommit(false);
+                stat.execute("insert into test select x from system_range(1, 1000)");
+                rs = stat.executeQuery("select count(*) from test");
+                rs.next();
+                assertEquals(11000, rs.getInt(1));
 
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        conn.setAutoCommit(false);
-        stat.execute("insert into test select x from system_range(1, 1000)");
-        rs = stat.executeQuery("select count(*) from test");
-        rs.next();
-        assertEquals(11000, rs.getInt(1));
+                // not yet committed
+                rs = stat2.executeQuery("explain analyze select count(*) from test");
+                rs.next();
+                plan = rs.getString(1);
+                // transaction log is small, so no need to read the table
+                assertTrue(plan, !plan.contains("reads:"));
+                rs = stat2.executeQuery("select count(*) from test");
+                rs.next();
+                assertEquals(10000, rs.getInt(1));
 
-        // not yet committed
-        rs = stat2.executeQuery("explain analyze select count(*) from test");
-        rs.next();
-        plan = rs.getString(1);
-        // transaction log is small, so no need to read the table
-        assertTrue(plan, plan.indexOf("reads:") < 0);
-        rs = stat2.executeQuery("select count(*) from test");
-        rs.next();
-        assertEquals(10000, rs.getInt(1));
+                stat.execute("insert into test2 select x from system_range(1, 11000)");
+                rs = stat2.executeQuery("explain analyze select count(*) from test");
+                rs.next();
+                plan = rs.getString(1);
+                // transaction log is larger than the table, so read the table
+                assertContains(plan, "reads:");
+                rs = stat2.executeQuery("select count(*) from test");
+                rs.next();
+                assertEquals(10000, rs.getInt(1));
+            }
+        }
 
-        stat.execute("insert into test2 select x from system_range(1, 11000)");
-        rs = stat2.executeQuery("explain analyze select count(*) from test");
-        rs.next();
-        plan = rs.getString(1);
-        // transaction log is larger than the table, so read the table
-        assertContains(plan, "reads:");
-        rs = stat2.executeQuery("select count(*) from test");
-        rs.next();
-        assertEquals(10000, rs.getInt(1));
-
-        conn2.close();
-        conn.close();
     }
 
     private void testMinMaxWithNull() throws Exception {
-        Connection conn;
-        Connection conn2;
         Statement stat;
         Statement stat2;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("create table test(data int)");
-        stat.execute("create index on test(data)");
-        stat.execute("insert into test values(null), (2)");
-        conn2 = getConnection(url);
-        stat2 = conn2.createStatement();
-        conn.setAutoCommit(false);
-        conn2.setAutoCommit(false);
-        stat.execute("insert into test values(1)");
-        ResultSet rs;
-        rs = stat.executeQuery("select min(data) from test");
-        rs.next();
-        assertEquals(1, rs.getInt(1));
-        rs = stat2.executeQuery("select min(data) from test");
-        rs.next();
-        // not yet committed
-        assertEquals(2, rs.getInt(1));
-        conn2.close();
-        conn.close();
+        try (Connection conn = getConnection(url)) {
+            stat = conn.createStatement();
+            stat.execute("create table test(data int)");
+            stat.execute("create index on test(data)");
+            stat.execute("insert into test values(null), (2)");
+            try (Connection conn2 = getConnection(url)) {
+                stat2 = conn2.createStatement();
+                conn.setAutoCommit(false);
+                conn2.setAutoCommit(false);
+                stat.execute("insert into test values(1)");
+                ResultSet rs;
+                rs = stat.executeQuery("select min(data) from test");
+                rs.next();
+                assertEquals(1, rs.getInt(1));
+                rs = stat2.executeQuery("select min(data) from test");
+                rs.next();
+                // not yet committed
+                assertEquals(2, rs.getInt(1));
+            }
+        }
     }
 
     private void testTimeout() throws Exception {
-        Connection conn;
-        Connection conn2;
         Statement stat;
         Statement stat2;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("create table test(id identity, name varchar)");
-        conn2 = getConnection(url);
-        stat2 = conn2.createStatement();
-        conn.setAutoCommit(false);
-        conn2.setAutoCommit(false);
-        stat.execute("insert into test values(1, 'Hello')");
-        assertThrows(ErrorCode.LOCK_TIMEOUT_1, stat2).
-                execute("insert into test values(1, 'Hello')");
-        conn2.close();
-        conn.close();
+        try (Connection conn = getConnection(url)) {
+            stat = conn.createStatement();
+            stat.execute("create table test(id identity, name varchar)");
+            try (Connection conn2 = getConnection(url)) {
+                stat2 = conn2.createStatement();
+                conn.setAutoCommit(false);
+                conn2.setAutoCommit(false);
+                stat.execute("insert into test values(1, 'Hello')");
+                assertThrows(ErrorCode.LOCK_TIMEOUT_1, stat2).
+                        execute("insert into test values(1, 'Hello')");
+            }
+        }
     }
 
     private void testExplainAnalyze() throws Exception {
         if (config.memory) {
             return;
         }
-        Connection conn;
         Statement stat;
         deleteDb(getTestName());
-        String url = getTestName() + ";MV_STORE=TRUE";
+        String url = getTestName() + ";MV_STORE=TRUE;WRITE_DELAY=0";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("create table test(id identity, name varchar) as " +
-                "select x, space(1000) from system_range(1, 1000)");
-        ResultSet rs;
-        conn.close();
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        rs = stat.executeQuery("explain analyze select * from test");
-        rs.next();
-        String plan = rs.getString(1);
-        // expect about 1000 reads
-        String readCount = plan.substring(plan.indexOf("reads: "));
-        readCount = readCount.substring("reads: ".length(), readCount.indexOf('\n'));
-        int rc = Integer.parseInt(readCount);
-        assertTrue(plan, rc >= 60 && rc <= 80);
-//        assertTrue(plan, rc >= 1000 && rc <= 1200);
-        conn.close();
+        try (Connection conn = getConnection(url)) {
+            stat = conn.createStatement();
+            stat.execute("create table test(id identity, name varchar) as " +
+                    "select x, space(1000) from system_range(1, 1000)");
+        }
+        try (Connection conn = getConnection(url)) {
+            stat = conn.createStatement();
+            ResultSet rs = stat.executeQuery("explain analyze select * from test");
+            rs.next();
+            String plan = rs.getString(1);
+            // expect about 1000 reads
+            String readCount = plan.substring(plan.indexOf("reads: "));
+            readCount = readCount.substring("reads: ".length(), readCount.indexOf('\n'));
+            int rc = Integer.parseInt(readCount);
+            assertTrue(plan, rc >= 60 && rc <= 80);
+        }
     }
 
     private void testTransactionLogEmptyAfterCommit() throws Exception {
-        Connection conn;
         Statement stat;
         deleteDb(getTestName());
         String url = getTestName() + ";MV_STORE=TRUE";
         url = getURL(url, true);
-        conn = getConnection(url);
-        stat = conn.createStatement();
-        stat.execute("create table test(id identity, name varchar)");
-        stat.execute("set write_delay 0");
-        conn.setAutoCommit(false);
-        PreparedStatement prep = conn.prepareStatement(
-                "insert into test(name) values(space(10000))");
-        for (int j = 0; j < 100; j++) {
-            for (int i = 0; i < 100; i++) {
-                prep.execute();
+        try (Connection conn = getConnection(url)) {
+            stat = conn.createStatement();
+            stat.execute("create table test(id identity, name varchar)");
+            stat.execute("set write_delay 0");
+            conn.setAutoCommit(false);
+            PreparedStatement prep = conn.prepareStatement(
+                    "insert into test(name) values(space(10000))");
+            for (int j = 0; j < 100; j++) {
+                for (int i = 0; i < 100; i++) {
+                    prep.execute();
+                }
+                conn.commit();
             }
-            conn.commit();
-        }
-        stat.execute("shutdown immediately");
-        JdbcUtils.closeSilently(conn);
+            stat.execute("shutdown immediately");
+        } catch (Exception ignore) {/**/}
 
-        String file = getBaseDir() + "/" + getTestName() +
-                Constants.SUFFIX_MV_FILE;
-
-        MVStore store = MVStore.open(file);
-        TransactionStore t = new TransactionStore(store);
-        t.init();
-        int openTransactions = t.getOpenTransactions().size();
-        store.close();
-        if (openTransactions != 0) {
-            fail("transaction log was not empty");
+        String file = getTestName() + Constants.SUFFIX_MV_FILE;
+        try (MVStore store = MVStore.open(file)) {
+            TransactionStore t = new TransactionStore(store);
+            t.init();
+            int openTransactions = t.getOpenTransactions().size();
+            if (openTransactions != 0) {
+                fail("transaction log was not empty");
+            }
         }
     }
 
@@ -1137,15 +1100,12 @@ public class TestMVTableEngine extends TestDb {
     private void testReuseDiskSpace() throws Exception {
         deleteDb(getTestName());
         // set WRITE_DELAY=0 so the free-unused-space runs on commit
-        String dbName = getTestName() + ";MV_STORE=TRUE;WRITE_DELAY=0";
+        String dbName = getTestName() + ";MV_STORE=TRUE;WRITE_DELAY=0;RETENTION_TIME=0";
         Connection conn;
         Statement stat;
         long maxSize = 0;
         for (int i = 0; i < 20; i++) {
             conn = getConnection(dbName);
-            Database db = (Database) ((JdbcConnection) conn).
-                    getSession().getDataHandler();
-            db.getStore().getMvStore().setRetentionTime(0);
             stat = conn.createStatement();
             stat.execute("create table test(id int primary key, data varchar)");
             stat.execute("insert into test select x, space(1000) " +
@@ -1154,8 +1114,9 @@ public class TestMVTableEngine extends TestDb {
             conn.close();
             long size = FileUtils.size(getBaseDir() + "/" + getTestName()
                     + Constants.SUFFIX_MV_FILE);
+//            trace("Pass #" + i + ": size=" + size);
             if (i < 10) {
-                maxSize = (int) (Math.max(size, maxSize) * 1.1);
+                maxSize = (int) (Math.max(size * 1.1, maxSize));
             } else if (size > maxSize) {
                 fail(i + " size: " + size + " max: " + maxSize);
             }

--- a/h2/src/test/org/h2/test/unit/TestCache.java
+++ b/h2/src/test/org/h2/test/unit/TestCache.java
@@ -39,7 +39,7 @@ public class TestCache extends TestDb implements CacheWriter {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-//        test.config.traceTest = true;
+        test.config.traceTest = true;
         test.test();
     }
 
@@ -189,9 +189,6 @@ public class TestCache extends TestDb implements CacheWriter {
     private int getRealMemory() {
         StringUtils.clearCache();
         Value.clearCache();
-        eatMemory(100);
-        freeMemory();
-        System.gc();
         return Utils.getMemoryUsed();
     }
 


### PR DESCRIPTION
Apart from tidying up some tests by using try-with resorce, the main focus here is to eliminate OOMEs during test run, especially for cases when just weak reference clearance is expected. Endangering further tests by allowing OOME is the cure that worse than the decease.