### PR TITLE
Change dead chunks determination algorithm

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1607,18 +1607,7 @@ public class Database implements DataHandler {
                             compactMode == CommandInterface.SHUTDOWN_COMPACT ||
                             compactMode == CommandInterface.SHUTDOWN_DEFRAG ||
                             getSettings().defragAlways;
-                    if (!compactFully && !mvStore.isReadOnly()) {
-                        if (dbSettings.maxCompactTime > 0) {
-                            try {
-                                store.compactFile(dbSettings.maxCompactTime);
-                            } catch (Throwable t) {
-                                trace.error(t, "compactFile");
-                            }
-                        } else {
-                            mvStore.commit();
-                        }
-                    }
-                    store.close(compactFully);
+                    store.close(compactFully ? -1 : dbSettings.maxCompactTime);
                 }
             }
             if (systemSession != null) {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2302,11 +2302,13 @@ public class Database implements DataHandler {
         session.setAllCommitted();
     }
 
-    private void throwLastBackgroundException() {
-        DbException b = backgroundException.getAndSet(null);
-        if (b != null) {
-            // wrap the exception, so we see it was thrown here
-            throw DbException.get(b.getErrorCode(), b, b.getMessage());
+    void throwLastBackgroundException() {
+        if (store == null || !store.getMvStore().isBackgroundThread()) {
+            DbException b = backgroundException.getAndSet(null);
+            if (b != null) {
+                // wrap the exception, so we see it was thrown here
+                throw DbException.get(b.getErrorCode(), b, b.getMessage());
+            }
         }
     }
 

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -891,6 +891,8 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         // so, we should prevent double-closure
         if (state.getAndSet(State.CLOSED) != State.CLOSED) {
             try {
+                database.throwLastBackgroundException();
+
                 database.checkPowerOff();
 
                 // release any open table locks

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -345,6 +345,8 @@ public class DbException extends RuntimeException {
                 throw (Error) e;
             }
             return get(GENERAL_ERROR_1, e, e.toString());
+        } catch (OutOfMemoryError ignore) {
+            return OOME;
         } catch (Throwable ex) {
             try {
                 DbException dbException = new DbException(

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -102,7 +102,7 @@ public class Chunk {
      * Version of the store at which chunk become unused and therefore can be
      * considered "dead" and collected after this version is no longer in use.
      */
-    public long unusedAtVersion;
+    long unusedAtVersion;
 
     /**
      * The last used map id.

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -162,12 +162,16 @@ public class Chunk {
      * @param minLength the minimum length
      */
     void writeChunkHeader(WriteBuffer buff, int minLength) {
-        long pos = buff.position();
-        buff.put(asString().getBytes(StandardCharsets.ISO_8859_1));
-        while (buff.position() - pos < minLength - 1) {
+        writeChunkHeader(buff, minLength, asString());
+    }
+
+    static void writeChunkHeader(WriteBuffer buff, int minLength, String header) {
+        long delimiterPosition = buff.position() + minLength - 1;
+        buff.put(header.getBytes(StandardCharsets.ISO_8859_1));
+        while (buff.position() < delimiterPosition) {
             buff.put((byte) ' ');
         }
-        if (minLength != 0 && buff.position() > minLength) {
+        if (minLength != 0 && buff.position() > delimiterPosition) {
             throw DataUtils.newIllegalStateException(
                     DataUtils.ERROR_INTERNAL,
                     "Chunk metadata too long");
@@ -243,6 +247,10 @@ public class Chunk {
      * @return the string
      */
     public String asString() {
+        return asString(block, next);
+    }
+
+    public String asString(long block, long next) {
         StringBuilder buff = new StringBuilder(240);
         DataUtils.appendMap(buff, "chunk", id);
         DataUtils.appendMap(buff, "block", block);
@@ -273,6 +281,10 @@ public class Chunk {
     }
 
     byte[] getFooterBytes() {
+        return getFooterBytes(block);
+    }
+
+    byte[] getFooterBytes(long block) {
         StringBuilder buff = new StringBuilder(FOOTER_LENGTH);
         DataUtils.appendMap(buff, "chunk", id);
         DataUtils.appendMap(buff, "block", block);

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -291,7 +291,18 @@ public class Chunk {
         return block != Long.MAX_VALUE;
     }
 
-    boolean isEvacuatable() {
+    boolean isLive() {
+        return pageCountLive > 0;
+    }
+
+    boolean isRewritable() {
+        return isSaved()
+                && isLive()
+                && pageCountLive < pageCount    // not fully occupied
+                && isEvacuatable();
+    }
+
+    private boolean isEvacuatable() {
         return pinCount == 0;
     }
 
@@ -397,7 +408,7 @@ public class Chunk {
         assert maxLenLive >= 0 : this;
         assert (pageCountLive == 0) == (maxLenLive == 0) : this;
 
-        if (pageCountLive == 0) {
+        if (!isLive()) {
             assert isEvacuatable() : this;
             unused = now;
             return true;

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -43,7 +43,7 @@ public class Chunk {
     /**
      * The start block number within the file.
      */
-    public long block;
+    public volatile long block;
 
     /**
      * The length in number of blocks.
@@ -53,12 +53,12 @@ public class Chunk {
     /**
      * The total number of pages in this chunk.
      */
-    public int pageCount;
+    int pageCount;
 
     /**
      * The number of pages still alive.
      */
-    public int pageCountLive;
+    int pageCountLive;
 
     /**
      * The sum of the max length of all pages.
@@ -74,12 +74,12 @@ public class Chunk {
      * The garbage collection priority. Priority 0 means it needs to be
      * collected, a high value means low priority.
      */
-    public int collectPriority;
+    int collectPriority;
 
     /**
      * The position of the meta root.
      */
-    public long metaRootPos;
+    long metaRootPos;
 
     /**
      * The version stored in this chunk.
@@ -210,7 +210,8 @@ public class Chunk {
      *
      * @return the fill rate
      */
-    public int getFillRate() {
+    int getFillRate() {
+        assert maxLenLive <= maxLen : maxLenLive + " > " + maxLen;
         if (maxLenLive <= 0) {
             return 0;
         } else if (maxLenLive == maxLen) {
@@ -276,6 +277,82 @@ public class Chunk {
         }
         buff.append('\n');
         return buff.toString().getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    boolean isSaved() {
+        return block != Long.MAX_VALUE;
+    }
+
+    /**
+     * Read a page of data into a ByteBuffer.
+     *
+     * @param fileStore to use
+     * @param pos page pos
+     * @param expectedMapId expected map id for the page
+     * @return ByteBuffer containing page data.
+     */
+    ByteBuffer readBufferForPage(FileStore fileStore, long pos, int expectedMapId) {
+        assert isSaved() : this;
+        while (true) {
+            long originalBlock = block;
+            try {
+                long filePos = originalBlock * MVStore.BLOCK_SIZE;
+                long maxPos = filePos + len * MVStore.BLOCK_SIZE;
+                filePos += DataUtils.getPageOffset(pos);
+                if (filePos < 0) {
+                    throw DataUtils.newIllegalStateException(
+                            DataUtils.ERROR_FILE_CORRUPT,
+                            "Negative position {0}; p={1}, c={2}", filePos, pos, toString());
+                }
+
+                int length = DataUtils.getPageMaxLength(pos);
+                if (length == DataUtils.PAGE_LARGE) {
+                    // read the first bytes to figure out actual lenght
+                    length = fileStore.readFully(filePos, 128).getInt();
+                }
+                length = (int) Math.min(maxPos - filePos, length);
+                if (length < 0) {
+                    throw DataUtils.newIllegalStateException(DataUtils.ERROR_FILE_CORRUPT,
+                            "Illegal page length {0} reading at {1}; max pos {2} ", length, filePos, maxPos);
+                }
+
+                ByteBuffer buff = fileStore.readFully(filePos, length);
+
+                int offset = DataUtils.getPageOffset(pos);
+                int start = buff.position();
+                int remaining = buff.remaining();
+                int pageLength = buff.getInt();
+                if (pageLength > remaining || pageLength < 4) {
+                    throw DataUtils.newIllegalStateException(DataUtils.ERROR_FILE_CORRUPT,
+                            "File corrupted in chunk {0}, expected page length 4..{1}, got {2}", id, remaining,
+                            pageLength);
+                }
+                buff.limit(start + pageLength);
+
+                short check = buff.getShort();
+                int checkTest = DataUtils.getCheckValue(id)
+                        ^ DataUtils.getCheckValue(offset)
+                        ^ DataUtils.getCheckValue(pageLength);
+                if (check != (short) checkTest) {
+                    throw DataUtils.newIllegalStateException(DataUtils.ERROR_FILE_CORRUPT,
+                            "File corrupted in chunk {0}, expected check value {1}, got {2}", id, checkTest, check);
+                }
+
+                int mapId = DataUtils.readVarInt(buff);
+                if (mapId != expectedMapId) {
+                    throw DataUtils.newIllegalStateException(DataUtils.ERROR_FILE_CORRUPT,
+                            "File corrupted in chunk {0}, expected map id {1}, got {2}", id, expectedMapId, mapId);
+                }
+
+                if (originalBlock == block) {
+                    return buff;
+                }
+            } catch (IllegalStateException ex) {
+                if (originalBlock == block) {
+                    throw ex;
+                }
+            }
+        }
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -162,12 +162,8 @@ public class Chunk {
      * @param minLength the minimum length
      */
     void writeChunkHeader(WriteBuffer buff, int minLength) {
-        writeChunkHeader(buff, minLength, asString());
-    }
-
-    static void writeChunkHeader(WriteBuffer buff, int minLength, String header) {
         long delimiterPosition = buff.position() + minLength - 1;
-        buff.put(header.getBytes(StandardCharsets.ISO_8859_1));
+        buff.put(asString().getBytes(StandardCharsets.ISO_8859_1));
         while (buff.position() < delimiterPosition) {
             buff.put((byte) ' ');
         }
@@ -247,10 +243,6 @@ public class Chunk {
      * @return the string
      */
     public String asString() {
-        return asString(block, next);
-    }
-
-    public String asString(long block, long next) {
         StringBuilder buff = new StringBuilder(240);
         DataUtils.appendMap(buff, "chunk", id);
         DataUtils.appendMap(buff, "block", block);
@@ -281,10 +273,6 @@ public class Chunk {
     }
 
     byte[] getFooterBytes() {
-        return getFooterBytes(block);
-    }
-
-    byte[] getFooterBytes(long block) {
         StringBuilder buff = new StringBuilder(FOOTER_LENGTH);
         DataUtils.appendMap(buff, "chunk", id);
         DataUtils.appendMap(buff, "block", block);

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -397,18 +397,18 @@ public class Chunk {
 
     /**
      * Modifies internal state to reflect the fact that one the pages within this chunk was removed from the map.
-     * @param pagePos
+     * @param pageLength on disk of the removed page
+     * @param pinned whether removed page was pinned
      * @param now is a moment in time (since creation of the store), when removal is recorded,
      *            and retention period starts
-     * @param version
+     * @param version at which page was removed
      * @return true if all of the pages, this chunk contains, were already removed, and false otherwise
      */
-    boolean accountForRemovedPage(long pagePos, long now, long version) {
+    boolean accountForRemovedPage(int pageLength, boolean pinned, long now, long version) {
         assert isSaved() : this;
-        int pageLength = DataUtils.getPageMaxLength(pagePos);
         maxLenLive -= pageLength;
         pageCountLive--;
-        if (DataUtils.isPagePinned(pagePos)) {
+        if (pinned) {
             pinCount--;
         }
 

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -561,12 +561,8 @@ public final class DataUtils {
      * @param isPinned whether page belong to a "single writer" map
      * @return removed page info that contains at least chunk id, page length and pinned flag
      */
-    public static long createRemovedPageInfo(long pagePos, boolean isPinned) {
-        pagePos &= ~1L;
-        if (isPinned) {
-            pagePos |= 1L;
-        }
-        return pagePos;
+    static int createRemovedPageInfo(long pagePos, boolean isPinned) {
+        return ((int)(pagePos >>> 32)) & ~0x3F | ((int)pagePos) & 0x3E | (isPinned ? 1 : 0);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -501,14 +501,24 @@ public final class DataUtils {
     }
 
     /**
-     * Get the maximum length for the given code.
-     * For the code 31, PAGE_LARGE is returned.
+     * Get the maximum length for the given page position.
      *
      * @param pos the position
      * @return the maximum length
      */
     public static int getPageMaxLength(long pos) {
         int code = (int) ((pos >> 1) & 31);
+        return decodePageLength(code);
+    }
+
+    /**
+     * Get the maximum length for the given code.
+     * For the code 31, PAGE_LARGE is returned.
+     *
+     * @param code encoded page lenth
+     * @return the maximum length
+     */
+    public static int decodePageLength(int code) {
         if (code == 31) {
             return PAGE_LARGE;
         }
@@ -555,17 +565,6 @@ public final class DataUtils {
     }
 
     /**
-     * Transforms saved page position into removed page info, by re-purposing
-     * "removed" / "page type" / bit as "pinned page" flag
-     * @param pagePos of the saved page
-     * @param isPinned whether page belong to a "single writer" map
-     * @return removed page info that contains at least chunk id, page length and pinned flag
-     */
-    static int createRemovedPageInfo(long pagePos, boolean isPinned) {
-        return ((int)(pagePos >>> 32)) & ~0x3F | ((int)pagePos) & 0x3E | (isPinned ? 1 : 0);
-    }
-
-    /**
      * Find out if page was removed.
      *
      * @param pos the position
@@ -573,17 +572,6 @@ public final class DataUtils {
      */
     static boolean isPageRemoved(long pos) {
         return pos == 1L;
-    }
-
-    /**
-     * Find out if page was pinned (can not be evacuated to a new chunk).
-     *
-     * @param pos the position
-     * @return true if page has been pinned
-     */
-    static boolean isPagePinned(long pos) {
-        assert isPageSaved(pos);
-        return (pos & 1L) == 1L;
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -429,9 +429,9 @@ public final class DataUtils {
             }
             throw newIllegalStateException(
                     ERROR_READING_FAILED,
-                    "Reading from {0} failed; file length {1} " +
-                    "read length {2} at {3}",
-                    file, size, dst.remaining(), pos, e);
+                    "Reading from file {0} failed at {1} (length {2}), " +
+                    "read {3}, remaining {4}",
+                    file, pos, size, dst.position(), dst.remaining(), e);
         }
     }
 
@@ -542,7 +542,17 @@ public final class DataUtils {
      * @return true if page has been saved
      */
     public static boolean isPageSaved(long pos) {
-        return pos != 0;
+        return (pos & ~1L) != 0;
+    }
+
+    /**
+     * Find out if page was removed.
+     *
+     * @param pos the position
+     * @return true if page has been removed (no longer accessible from the current root of the tree)
+     */
+    static boolean isPageRemoved(long pos) {
+        return pos == 1L;
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -536,6 +536,15 @@ public final class DataUtils {
     }
 
     /**
+     * Determines whether specified file position corresponds to a leaf page
+     * @param pos the position
+     * @return true if it is a leaf, false otherwise
+     */
+    public static boolean isLeafPosition(long pos) {
+        return getPageType(pos) == PAGE_TYPE_LEAF;
+    }
+
+    /**
      * Find out if page was saved.
      *
      * @param pos the position
@@ -546,6 +555,21 @@ public final class DataUtils {
     }
 
     /**
+     * Transforms saved page position into removed page info, by re-purposing
+     * "removed" / "page type" / bit as "pinned page" flag
+     * @param pagePos of the saved page
+     * @param isPinned whether page belong to a "single writer" map
+     * @return removed page info that contains at least chunk id, page length and pinned flag
+     */
+    public static long createRemovedPagePos(long pagePos, boolean isPinned) {
+        pagePos &= ~1L;
+        if (isPinned) {
+            pagePos |= 1L;
+        }
+        return pagePos;
+    }
+
+    /**
      * Find out if page was removed.
      *
      * @param pos the position
@@ -553,6 +577,17 @@ public final class DataUtils {
      */
     static boolean isPageRemoved(long pos) {
         return pos == 1L;
+    }
+
+    /**
+     * Find out if page was pinned (can not be evacuated to a new chunk).
+     *
+     * @param pos the position
+     * @return true if page has been pinned
+     */
+    static boolean isPagePinned(long pos) {
+        assert isPageSaved(pos);
+        return (pos & 1L) == 1L;
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -561,7 +561,7 @@ public final class DataUtils {
      * @param isPinned whether page belong to a "single writer" map
      * @return removed page info that contains at least chunk id, page length and pinned flag
      */
-    public static long createRemovedPagePos(long pagePos, boolean isPinned) {
+    public static long createRemovedPageInfo(long pagePos, boolean isPinned) {
         pagePos &= ~1L;
         if (isPinned) {
             pagePos |= 1L;

--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -354,8 +354,12 @@ public class FileStore {
      * @param length the number of bytes to allocate
      * @return the start position in bytes
      */
-    public long predictAllocation(int length) {
+    long predictAllocation(int length) {
         return freeSpace.predictAllocation(length);
+    }
+
+    boolean isFragmented() {
+        return freeSpace.isFragmented();
     }
 
     /**
@@ -370,6 +374,10 @@ public class FileStore {
 
     public int getFillRate() {
         return freeSpace.getFillRate();
+    }
+
+    public int getProjectedFillRate(long live, int total) {
+        return freeSpace.getProjectedFillRate(live, total);
     }
 
     long getFirstFree() {

--- a/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
+++ b/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
@@ -32,7 +32,7 @@ public class FreeSpaceBitSet {
     private final BitSet set = new BitSet();
 
     /**
-     * Left-shifting, which holds outcomes of recent allocations.
+     * Left-shifting register, which holds outcomes of recent allocations.
      * Only allocations done in "reuseSpace" mode are recorded here.
      * For example, rightmost bit set to 1 means that last allocation failed to find a hole big enough,
      * and next bit set to 0 means that previous allocation request have found one.

--- a/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
+++ b/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
@@ -32,7 +32,10 @@ public class FreeSpaceBitSet {
     private final BitSet set = new BitSet();
 
     /**
-     * Last allocations failures
+     * Left-shifting, which holds outcomes of recent allocations.
+     * Only allocations done in "reuseSpace" mode are recorded here.
+     * For example, rightmost bit set to 1 means that last allocation failed to find a hole big enough,
+     * and next bit set to 0 means that previous allocation request have found one.
      */
     private int failureFlags;
 

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -968,14 +968,12 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                 version, createVersion);
         RootReference rootReference = getRoot();
         removeUnusedOldVersions(rootReference);
-        while (rootReference != null && rootReference.version > version) {
-            rootReference = rootReference.previous;
+        RootReference previous;
+        while ((previous = rootReference.previous) != null && previous.version >= version) {
+            rootReference = previous;
         }
-
-        if (rootReference == null) {
-            // smaller than all in-memory versions
-            MVMap<K, V> map = openReadOnly(store.getRootPos(getId(), version), version);
-            return map;
+        if (previous == null && version < store.getOldestVersionToKeep()) {
+            throw DataUtils.newIllegalArgumentException("Unknown version {0}", version);
         }
         MVMap<K, V> m = openReadOnly(rootReference.root, version);
         assert m.getVersion() <= version : m.getVersion() + " <= " + version;

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1173,7 +1173,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
             }
             target.setComplete();
         }
-        store.registerUnsavedPage(target.getMemory());
+        store.registerUnsavedMemory(target.getMemory());
         if (store.isSaveNeeded()) {
             store.commit();
         }
@@ -1295,7 +1295,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                         tip = tip.parent;
                     }
                     if (isPersistent()) {
-                        store.registerUnsavedPage(unsavedMemoryHolder.value);
+                        store.registerUnsavedMemory(unsavedMemoryHolder.value);
                     }
                     assert updatedRootReference.getAppendCounter() <= availabilityThreshold;
                     return updatedRootReference;
@@ -1815,7 +1815,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                 tip = tip.parent;
             }
             if (isPersistent()) {
-                store.registerUnsavedPage(unsavedMemoryHolder.value);
+                store.registerUnsavedMemory(unsavedMemoryHolder.value);
             }
             return result;
         }

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -433,14 +433,11 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                 Page page = lockedRootReference.root;
                 try {
                     store.registerUnsavedMemory(page.removeAllRecursive(lockedRootReference.version));
-                    rootReference = unlockRoot(emptyRootPage);
-                    lockedRootReference = null;
-                    return rootReference;
+                    page = emptyRootPage;
                 } finally {
-                    if(lockedRootReference != null) {
-                        unlockRoot(page);
-                    }
+                    unlockRoot(page);
                 }
+                return rootReference;
             }
         }
     }

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -619,7 +619,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                 return 0;
             }
             assert p.getKeyCount() > 0;
-            return rewritePage(p) ? 0 : 1;
+            return rewritePage(p) ? 1 : 0;
         }
         int writtenPageCount = 0;
         for (int i = 0; i < getChildPageCount(p); i++) {
@@ -645,14 +645,12 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                 // (this is not needed if anyway one of the children
                 // was changed, as this would have updated this
                 // page as well)
-                Page p2 = p;
-                while (!p2.isLeaf()) {
-                    p2 = p2.getChildPage(0);
+                while (!p.isLeaf()) {
+                    p = p.getChildPage(0);
                 }
-                if (rewritePage(p2)) {
-                    return 0;
+                if (rewritePage(p)) {
+                    writtenPageCount = 1;
                 }
-                writtenPageCount++;
             }
         }
         return writtenPageCount;
@@ -662,7 +660,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         @SuppressWarnings("unchecked")
         K key = (K) p.getKey(0);
         if (!isClosed()) {
-            return !rewrite(key);
+            return rewrite(key);
         }
         return true;
     }

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1094,7 +1094,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
             } else if (isClosed()) {
                 // map was closed a while back and can not possibly be in use by now
                 // it's time to remove it completely from the store (it was anonymous already)
-                if (rootReference.version < store.getOldestVersionToKeep()) {
+                if (rootReference.getVersion() + 1 < store.getOldestVersionToKeep()) {
                     store.deregisterMapRoot(id);
                     return null;
                 }

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -953,6 +953,9 @@ public class MVMap<K, V> extends AbstractMap<K, V>
 
     /**
      * Open an old version for the given map.
+     * It will restore map at last known state of the version specified.
+     * (at the point right before the commit() call, which advanced map to the next version)
+     * Map is opened in read-only mode.
      *
      * @param version the version
      * @return the map

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1687,13 +1687,15 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      */
     @SuppressWarnings("unchecked")
     public V operate(K key, V value, DecisionMaker<? super V> decisionMaker) {
-        beforeWrite();
         IntValueHolder unsavedMemoryHolder = new IntValueHolder();
         int attempt = 0;
         while(true) {
             RootReference rootReference = flushAndGetRoot();
+            if (attempt++ == 0 && !rootReference.isLockedByCurrentThread()) {
+                beforeWrite();
+            }
             RootReference lockedRootReference = null;
-            if ((++attempt > 3 || rootReference.isLocked())) {
+            if (attempt > 3 || rootReference.isLocked()) {
                 lockedRootReference = lockRoot(rootReference, attempt);
                 rootReference = lockedRootReference;
             }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2572,7 +2572,7 @@ public class MVStore implements AutoCloseable {
         if (autoCompactFillRate > 0 && lastChunk != null && reuseSpace) {
             try {
                 int lastProjectedFillRate = -1;
-                for (int cnt = 0; ; cnt++) {
+                for (int cnt = 0; cnt < 5; cnt++) {
                     int fillRate = getFillRate();
                     int projectedFillRate = fillRate;
                     if (fillRate > targetFillRate) {

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2383,11 +2383,15 @@ public class MVStore implements AutoCloseable {
     }
 
     /**
-     * Increment the number of unsaved pages.
+     * Adjust amount of "unsaved memory" meaning amount of RAM occupied by pages not saved yet to the file.
+     * This is the amount which triggers auto-commit.
      *
-     * @param memory the memory usage of the page
+     * @param memory adjustment
      */
-    public void registerUnsavedPage(int memory) {
+    public void registerUnsavedMemory(int memory) {
+        // this counter was intentionaly left unprotected against race condition for performance reasons
+        // TODO: evaluate performance impact of atomic implementation,
+        //       since updates to unsavedMemory are largely aggregated now
         unsavedMemory += memory;
         int newValue = unsavedMemory;
         if (newValue > autoCommitMemory && autoCommitMemory > 0) {

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2556,7 +2556,7 @@ public class MVStore implements AutoCloseable {
                     compact(-targetFillRate, autoCommitMemory);
                 }
             }
-            if (fileStore.isFragmented() || targetFillRate == autoCompactFillRate) {
+            if (fileStore.isFragmented() || isIdle()) {
                 doMaintenance(targetFillRate);
             }
             autoCompactLastFileOpCount = fileStore.getWriteCount() + fileStore.getReadCount();
@@ -2612,11 +2612,14 @@ public class MVStore implements AutoCloseable {
     private int getTargetFillRate() {
         int targetRate = autoCompactFillRate;
         // use a lower fill rate if there were any file operations since the last time
-        long fileOpCount = fileStore.getWriteCount() + fileStore.getReadCount();
-        if (autoCompactLastFileOpCount != fileOpCount) {
+        if (!isIdle()) {
             targetRate /= 3;
         }
         return targetRate;
+    }
+
+    private boolean isIdle() {
+        return autoCompactLastFileOpCount == fileStore.getWriteCount() + fileStore.getReadCount();
     }
 
     private void handleException(Throwable ex) {

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1862,7 +1862,7 @@ public class MVStore implements AutoCloseable {
                 try {
                     retentionTime = -1;
                     dropUnusedChunks();
-                    if (fileStore.getFillRate() <= targetFillRate) {
+                    if (getFillRate() <= targetFillRate) {
                         long start = fileStore.getFirstFree() / BLOCK_SIZE;
                         Iterable<Chunk> move = findChunksToMove(start, moveSize);
                         if (move != null) {
@@ -2111,8 +2111,12 @@ public class MVStore implements AutoCloseable {
                 maxLengthLiveSum += c.maxLenLive;
             }
         }
-        int fillRate = getFileStore().getProjectedFillRate(maxLengthLiveSum, maxLengthSum);
+        int fillRate = fileStore.getProjectedFillRate(maxLengthLiveSum, maxLengthSum);
         return fillRate;
+    }
+
+    public int getFillRate() {
+        return fileStore.getFillRate();
     }
 
     private Iterable<Chunk> findOldChunks(int writeLimit) {
@@ -2848,7 +2852,7 @@ public class MVStore implements AutoCloseable {
             }
             int lastProjectedFillRate = -1;
             for (int cnt = 0; ; cnt++) {
-                int fillRate = fileStore.getFillRate();
+                int fillRate = getFillRate();
                 int projectedFillRate = fillRate;
                 if (fillRate > thresholdRate) {
                     projectedFillRate = getProjectedFillRate();

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2556,7 +2556,7 @@ public class MVStore implements AutoCloseable {
                     compact(-targetFillRate, autoCommitMemory);
                 }
             }
-            if (fileStore.isFragmented()) {
+            if (fileStore.isFragmented() || targetFillRate == autoCompactFillRate) {
                 doMaintance(targetFillRate);
             }
             autoCompactLastFileOpCount = fileStore.getWriteCount() + fileStore.getReadCount();

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -786,7 +786,7 @@ public class MVStore implements AutoCloseable {
                     break;
                 }
                 test = readChunkHeaderAndFooter(newest.next);
-                if (test == null || test.id <= newest.id) {
+                if (test == null || test.version <= newest.version) {
                     break;
                 }
                 newest = test;
@@ -1699,9 +1699,9 @@ public class MVStore implements AutoCloseable {
         long pos = allocateFileSpace(length, toTheEnd);
         long block = pos / BLOCK_SIZE;
         buff.position(0);
-        // can not set chunck's new block/len until it's fully written
-        // concurrent reader can pick it up prematurely, hence workaround
-        // also occupancy accounting fields should not leak into header,
+        // can not set chunk's new block/len until it's fully written at new location,
+        // because concurrent reader can pick it up prematurely,
+        // also occupancy accounting fields should not leak into header
         chunk.block = block;
         chunk.next = 0;
         chunk.writeChunkHeader(buff, chunkHeaderLen);

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1302,7 +1302,7 @@ public class MVStore implements AutoCloseable {
         c.metaRootPos = metaRoot.getPos();
         // calculate and set the likely next position
         if (reuseSpace) {
-            c.next = fileStore.predictAllocation(c.len * BLOCK_SIZE) / BLOCK_SIZE;
+            c.next = fileStore.predictAllocation(length) / BLOCK_SIZE;
         } else {
             // just after this chunk
             c.next = 0;

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1915,7 +1915,13 @@ public class MVStore implements AutoCloseable {
         try {
             for (MVMap<?, ?> map : maps.values()) {
                 if (!map.isClosed() && !map.isSingleWriter()) {
-                    rewritedPageCount += map.rewrite(set);
+                    try {
+                        rewritedPageCount += map.rewrite(set);
+                    } catch(IllegalStateException ex) {
+                        if (!map.isClosed()) {
+                            throw ex;
+                        }
+                    }
                 }
             }
             int rewriteMetaCount = meta.rewrite(set);

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -286,7 +286,7 @@ public class MVStore implements AutoCloseable {
     /**
      * The version of the current store operation (if any).
      */
-    volatile long currentStoreVersion = -1;
+    private volatile long currentStoreVersion = -1;
 
     private volatile boolean metaChanged;
 
@@ -1989,7 +1989,7 @@ public class MVStore implements AutoCloseable {
      */
     void accountForRemovedPage(long pos, long version, boolean pinned) {
         assert DataUtils.isPageSaved(pos);
-        pos = DataUtils.createRemovedPagePos(pos, pinned);
+        pos = DataUtils.createRemovedPageInfo(pos, pinned);
         RemovedPageInfo rpi = new RemovedPageInfo(pos, version);
         removedPages.add(rpi);
     }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1163,7 +1163,7 @@ public class MVStore implements AutoCloseable {
 
     private void store() {
         try {
-            if (isOpenOrStopping() && hasUnsavedChangesInternal()) {
+            if (isOpenOrStopping() && hasUnsavedChanges()) {
                 currentStoreVersion = currentVersion;
                 if (fileStore == null) {
                     lastStoredVersion = currentVersion;
@@ -1800,13 +1800,6 @@ public class MVStore implements AutoCloseable {
             }
         }
         return false;
-    }
-
-    private boolean hasUnsavedChangesInternal() {
-        if (meta.hasChangesSince(lastStoredVersion)) {
-            return true;
-        }
-        return hasUnsavedChanges();
     }
 
     private Chunk readChunkHeader(long block) {

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1029,7 +1029,7 @@ public class MVStore implements AutoCloseable {
                                 if (allowedCompactionTime > 0) {
                                     compactFile(allowedCompactionTime);
                                 } else if (allowedCompactionTime < 0) {
-                                    doMaintance(autoCompactFillRate);
+                                    doMaintenance(autoCompactFillRate);
                                 }
                                 shrinkFileIfPossible(0);
                                 assert validateFileLength("on close");
@@ -2557,7 +2557,7 @@ public class MVStore implements AutoCloseable {
                 }
             }
             if (fileStore.isFragmented() || targetFillRate == autoCompactFillRate) {
-                doMaintance(targetFillRate);
+                doMaintenance(targetFillRate);
             }
             autoCompactLastFileOpCount = fileStore.getWriteCount() + fileStore.getReadCount();
         } catch (Throwable e) {
@@ -2568,7 +2568,7 @@ public class MVStore implements AutoCloseable {
         }
     }
 
-    private void doMaintance(int targetFillRate) {
+    private void doMaintenance(int targetFillRate) {
         if (autoCompactFillRate > 0 && lastChunk != null && reuseSpace) {
             try {
                 int lastProjectedFillRate = -1;

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2276,7 +2276,7 @@ public class MVStore implements AutoCloseable {
      * @param version at which page was removed
      * @param pinned whether page is considered pinned
      */
-    public void accountForRemovedPage(long pos, long version, boolean pinned) {
+    void accountForRemovedPage(long pos, long version, boolean pinned) {
         assert DataUtils.isPageSaved(pos);
         pos = DataUtils.createRemovedPagePos(pos, pinned);
         RemovedPageInfo rpi = new RemovedPageInfo(pos, version);

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -515,18 +515,6 @@ public class MVStore implements AutoCloseable {
     }
 
     /**
-     * Find position of the root page for historical version of the map.
-     *
-     * @param mapId to find the old version for
-     * @param version the version
-     * @return position of the root Page
-     */
-    long getRootPos(int mapId, long version) {
-        MVMap<String, String> oldMeta = getMetaMap(version);
-        return getRootPos(oldMeta, mapId);
-    }
-
-    /**
      * Open a map with the default settings. The map is automatically create if
      * it does not yet exist. If a map with this name is already open, this map
      * is returned.
@@ -799,7 +787,7 @@ public class MVStore implements AutoCloseable {
 
         long blocksInStore = fileStore.size() / BLOCK_SIZE;
         // this queue will hold potential candidates for lastChunk to fall back to
-        Queue<Chunk> lastChunkCandidates = new PriorityQueue<>(Math.max(32, (int)(blocksInStore / 4)),
+        Queue<Chunk> lastChunkCandidates = new PriorityQueue<>(Math.max(32, (int)(blocksInStore / 4) + 1),
                 new Comparator<Chunk>() {
             @Override
             public int compare(Chunk one, Chunk two) {
@@ -2979,7 +2967,7 @@ public class MVStore implements AutoCloseable {
         }
     }
 
-    boolean isBackgroundThread() {
+    public boolean isBackgroundThread() {
         return Thread.currentThread() == backgroundWriterThread.get();
     }
 

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -22,6 +22,7 @@ import org.h2.compress.CompressLZF;
 import org.h2.compress.Compressor;
 import org.h2.engine.Constants;
 import org.h2.message.DbException;
+import org.h2.mvstore.tx.TransactionStore;
 import org.h2.mvstore.type.DataType;
 import org.h2.mvstore.type.StringDataType;
 import org.h2.store.fs.FilePath;
@@ -549,6 +550,15 @@ public class MVStoreTool {
                         new MVMap.Builder<>().
                                 keyType(new GenericDataType()).
                                 valueType(new GenericDataType());
+                // This is a hack to preserve chunks occupancy rate accounting.
+                // It exposes desin deficiency flaw in MVStore related to lack of
+                // map's type metadata.
+                // TODO: Introduce type metadata which will allow to open any store
+                // TODO: without prior knoledge of keys / values types and map implementation
+                // TODO: (MVMap vs MVRTreeMap, regular vs. singleWriter etc.)
+                if (mapName.startsWith(TransactionStore.UNDO_LOG_NAME_PREFIX)) {
+                    mp.singleWriter();
+                }
                 MVMap<Object, Object> sourceMap = source.openMap(mapName, mp);
                 MVMap<Object, Object> targetMap = target.openMap(mapName, mp);
                 targetMap.copyFrom(sourceMap);

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -192,7 +192,7 @@ public abstract class Page implements Cloneable
     }
 
     private void initMemoryAccount(int memoryCount) {
-        if(map.store.getFileStore() == null) {
+        if(!map.isPersistent()) {
             memory = IN_MEMORY;
         } else if (memoryCount == 0) {
             recalculateMemory();

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -422,26 +422,8 @@ public abstract class Page implements Cloneable
      * @return a mutable copy of this page
      */
     public final Page copy() {
-        return copy(false);
-    }
-
-    /**
-     * Create a copy of this page.
-     *
-     * @param countRemoval When {@code true} the current page is removed,
-     *                     when {@code false} just copy the page.
-     * @return a mutable copy of this page
-     */
-    public final Page copy(boolean countRemoval) {
         Page newPage = clone();
         newPage.pos = 0;
-        // mark the old as deleted
-        if(countRemoval) {
-            removePage();
-            if(isPersistent()) {
-                map.store.registerUnsavedMemory(newPage.getMemory());
-            }
-        }
         return newPage;
     }
 

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -709,10 +709,10 @@ public abstract class Page implements Cloneable
      * @return true if it was marked by this call or has been marked already,
      *          false if page has been saved already.
      */
-    public final boolean markAsRemoved() {
+    private boolean markAsRemoved() {
         long pagePos;
         do {
-            pagePos = this.pos;
+            pagePos = pos;
             if (DataUtils.isPageSaved(pagePos)) {
                 return false;
             }

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -439,7 +439,7 @@ public abstract class Page implements Cloneable
         if(countRemoval) {
             removePage();
             if(isPersistent()) {
-                map.store.registerUnsavedPage(newPage.getMemory());
+                map.store.registerUnsavedMemory(newPage.getMemory());
             }
         }
         return newPage;

--- a/h2/src/main/org/h2/mvstore/RootReference.java
+++ b/h2/src/main/org/h2/mvstore/RootReference.java
@@ -175,7 +175,7 @@ public final class RootReference
         return holdCount != 0;
     }
 
-    boolean isLockedByCurrentThread() {
+    public boolean isLockedByCurrentThread() {
         return holdCount != 0 && ownerId == Thread.currentThread().getId();
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -167,6 +167,7 @@ public class MVTableEngine implements TableEngine {
                 if (!db.getSettings().reuseSpace) {
                     mvStore.setReuseSpace(false);
                 }
+                mvStore.setVersionsToKeep(0);
                 this.transactionStore = new TransactionStore(mvStore,
                         new ValueDataType(db, null), db.getLockTimeout());
             } catch (IllegalStateException e) {

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -364,11 +364,16 @@ public class MVTableEngine implements TableEngine {
         }
 
         /**
-         * Close the store. Pending changes are persisted. Chunks with a low
-         * fill rate are compacted, but old chunks are kept for some time, so
-         * most likely the database file will not shrink.
+         * Close the store. Pending changes are persisted.
+         * If time is allocated for housekeeping, chunks with a low
+         * fill rate are compacted, and some chunks are put next to each other.
+         * If time is unlimited then full compaction is performed, which uses
+         * different algorithm - opens alternative temp store and writes all live
+         * data there, then replaces this store with a new one.
          *
-         * @param compactFully true if storage need to be compacted after closer
+         * @param allowedCompactionTime time (in milliseconds) alloted for file
+         *                              compaction activity, 0 means no compaction,
+         *                              -1 means unlimited time (full compaction)
          */
         public void close(long allowedCompactionTime) {
             try {

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -411,7 +411,7 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
 
     private Page newPage(boolean leaf) {
         Page page = leaf ? createEmptyLeaf() : createEmptyNode();
-        if(store.getFileStore() != null)
+        if(isPersistent())
         {
             store.registerUnsavedPage(page.getMemory());
         }

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -28,7 +28,7 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
     /**
      * The spatial key type.
      */
-    private final SpatialDataType keyType;
+    final SpatialDataType keyType;
 
     private boolean quadraticSplit;
 

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -181,7 +181,9 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
                         long version = lockedRootReference.version;
                         int unsavedMemory = 0;
                         for (Page page : removedPages) {
-                            unsavedMemory += page.removePage(version);
+                            if (!page.isRemoved()) {
+                                unsavedMemory += page.removePage(version);
+                            }
                         }
                         store.registerUnsavedMemory(unsavedMemory);
                     } finally {

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -184,14 +184,10 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
                             unsavedMemory += page.removePage(version);
                         }
                         store.registerUnsavedMemory(unsavedMemory);
-                        unlockRoot(p);
-                        lockedRootReference = null;
-                        return result;
                     } finally {
-                        if(lockedRootReference != null) {
-                            unlockRoot(p);
-                        }
+                        unlockRoot(p);
                     }
+                    return result;
                 }
                 removedPages.clear();
             }

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -157,7 +157,7 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
                 };
                 p = Page.createNode(this, keys, children, totalCount, 0);
                 if(store.getFileStore() != null) {
-                    store.registerUnsavedPage(p.getMemory());
+                    store.registerUnsavedMemory(p.getMemory());
                 }
             }
             if(updateRoot(rootReference, p, attempt)) {
@@ -413,7 +413,7 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
         Page page = leaf ? createEmptyLeaf() : createEmptyNode();
         if(isPersistent())
         {
-            store.registerUnsavedPage(page.getMemory());
+            store.registerUnsavedMemory(page.getMemory());
         }
         return page;
     }

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -437,11 +437,9 @@ public class TransactionStore {
     /**
      * Remove the given map.
      *
-     * @param <K> the key type
-     * @param <V> the value type
      * @param map the map
      */
-    <K, V> void removeMap(TransactionMap<K, V> map) {
+    void removeMap(TransactionMap map) {
         store.removeMap(map.map);
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -442,7 +442,7 @@ public class TransactionStore {
      * @param map the map
      */
     <K, V> void removeMap(TransactionMap<K, V> map) {
-        store.removeMap(map.map, false);
+        store.removeMap(map.map);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -91,7 +91,7 @@ public class TransactionStore {
     private final AtomicReferenceArray<Transaction> transactions =
                                                         new AtomicReferenceArray<>(MAX_OPEN_TRANSACTIONS + 1);
 
-    private static final String UNDO_LOG_NAME_PREFIX = "undoLog";
+    public static final String UNDO_LOG_NAME_PREFIX = "undoLog";
     private static final char UNDO_LOG_COMMITTED = '-'; // must come before open in lexicographical order
     private static final char UNDO_LOG_OPEN = '.';
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -439,7 +439,7 @@ public class TransactionStore {
      *
      * @param map the map
      */
-    void removeMap(TransactionMap map) {
+    void removeMap(TransactionMap<?,?> map) {
         store.removeMap(map.map);
     }
 

--- a/h2/src/test/org/h2/test/store/TestConcurrent.java
+++ b/h2/src/test/org/h2/test/store/TestConcurrent.java
@@ -396,6 +396,8 @@ public class TestConcurrent extends TestMVStore {
                     fileName(fileName).autoCommitDisabled().open();
             try {
                 s.setRetentionTime(0);
+                s.setVersionsToKeep(0);
+                s.setFreeUnusedOnBackgroundThread(false);
                 final ArrayList<MVMap<Integer, Integer>> list = new ArrayList<>(count);
                 for (int i = 0; i < count; i++) {
                     MVMap<Integer, Integer> m = s.openMap("d" + i);
@@ -438,6 +440,11 @@ public class TestConcurrent extends TestMVStore {
                 // this will remove them, so we end up with
                 // one unused one, and one active one
                 MVMap<Integer, Integer> m = s.openMap("dummy");
+                s.commit();
+                s.removeMap(m);
+                s.commit();
+                m = s.openMap("dummy");
+                s.commit();
                 m.put(1, 1);
                 s.commit();
                 m.put(2, 2);
@@ -450,7 +457,7 @@ public class TestConcurrent extends TestMVStore {
                         chunkCount++;
                     }
                 }
-                assertTrue("" + chunkCount, chunkCount < 3);
+                assertTrue("" + chunkCount, chunkCount <= 3);
             } finally {
                 s.close();
             }

--- a/h2/src/test/org/h2/test/store/TestConcurrent.java
+++ b/h2/src/test/org/h2/test/store/TestConcurrent.java
@@ -55,7 +55,7 @@ public class TestConcurrent extends TestMVStore {
         testConcurrentReplaceAndRead();
         testConcurrentChangeAndCompact();
         testConcurrentChangeAndGetVersion();
-        testConcurrentFree();
+//        testConcurrentFree();
         testConcurrentStoreAndRemoveMap();
         testConcurrentStoreAndClose();
         testConcurrentOnlineBackup();

--- a/h2/src/test/org/h2/test/store/TestConcurrent.java
+++ b/h2/src/test/org/h2/test/store/TestConcurrent.java
@@ -55,7 +55,7 @@ public class TestConcurrent extends TestMVStore {
         testConcurrentReplaceAndRead();
         testConcurrentChangeAndCompact();
         testConcurrentChangeAndGetVersion();
-//        testConcurrentFree();
+        testConcurrentFree();
         testConcurrentStoreAndRemoveMap();
         testConcurrentStoreAndClose();
         testConcurrentOnlineBackup();
@@ -397,7 +397,6 @@ public class TestConcurrent extends TestMVStore {
             try {
                 s.setRetentionTime(0);
                 s.setVersionsToKeep(0);
-                s.setFreeUnusedOnBackgroundThread(false);
                 final ArrayList<MVMap<Integer, Integer>> list = new ArrayList<>(count);
                 for (int i = 0; i < count; i++) {
                     MVMap<Integer, Integer> m = s.openMap("d" + i);
@@ -440,11 +439,6 @@ public class TestConcurrent extends TestMVStore {
                 // this will remove them, so we end up with
                 // one unused one, and one active one
                 MVMap<Integer, Integer> m = s.openMap("dummy");
-                s.commit();
-                s.removeMap(m);
-                s.commit();
-                m = s.openMap("dummy");
-                s.commit();
                 m.put(1, 1);
                 s.commit();
                 m.put(2, 2);
@@ -457,7 +451,7 @@ public class TestConcurrent extends TestMVStore {
                         chunkCount++;
                     }
                 }
-                assertTrue("" + chunkCount, chunkCount <= 3);
+                assertTrue("" + chunkCount, chunkCount < 3);
             } finally {
                 s.close();
             }

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -433,7 +433,6 @@ public class TestMVStore extends TestBase {
                 fileName(fileName).
                 open();
         s.setRetentionTime(Integer.MAX_VALUE);
-        s.setFreeUnusedOnBackgroundThread(false);
         Map<String, Object> header = s.getStoreHeader();
         assertEquals("1", header.get("format").toString());
         header.put("formatRead", "1");
@@ -755,7 +754,6 @@ public class TestMVStore extends TestBase {
         MVMap<Integer, Integer> m;
         s = openStore(fileName);
         s.setRetentionTime(Integer.MAX_VALUE);
-        s.setFreeUnusedOnBackgroundThread(false);
         m = s.openMap("test");
         m.put(1, 1);
         Map<String, Object> header = s.getStoreHeader();
@@ -901,7 +899,6 @@ public class TestMVStore extends TestBase {
         FileUtils.delete(fileName);
         MVStore s = openStore(fileName);
         s.setRetentionTime(Integer.MAX_VALUE);
-        s.setFreeUnusedOnBackgroundThread(false);
         long time = System.currentTimeMillis();
         Map<String, Object> m = s.getStoreHeader();
         assertEquals("1", m.get("format").toString());
@@ -995,8 +992,13 @@ public class TestMVStore extends TestBase {
             int bad = (old + 1) & 15;
             buff.put(idx + "fletcher:".length(),
                     (byte) Character.forDigit(bad, 16));
-            buff.rewind();
-            fc.write(buff, i);
+
+            // now intentionally corrupt first or both headers
+            // note that headers may be overwritten upon successfull opening
+            for (int b = 0; b <= i; b += blockSize) {
+                buff.rewind();
+                fc.write(buff, b);
+            }
             fc.close();
 
             if (i == 0) {
@@ -1449,7 +1451,7 @@ public class TestMVStore extends TestBase {
         }
         assertEquals(1000, m.size());
         // memory calculations were adjusted, so as this out-of-the-thin-air number
-        assertEquals(93522, s.getUnsavedMemory());
+        assertEquals(93635, s.getUnsavedMemory());
         s.commit();
         assertEquals(2, s.getFileStore().getWriteCount());
         s.close();
@@ -1751,6 +1753,7 @@ public class TestMVStore extends TestBase {
         String fileName = getBaseDir() + "/" + getTestName();
         FileUtils.delete(fileName);
         MVStore s = openStore(fileName, 1000);
+        s.setAutoCommitDelay(0);
         MVMap<Integer, String> m = s.openMap("data");
         int factor = 100;
         for (int j = 0; j < 10; j++) {
@@ -1762,25 +1765,15 @@ public class TestMVStore extends TestBase {
         s.close();
 
         s = openStore(fileName);
+        s.setAutoCommitDelay(0);
         s.setRetentionTime(0);
-        s.setFreeUnusedOnBackgroundThread(false);
 
         Map<String, String> meta = s.getMetaMap();
-        int chunkCount1 = 0;
-        for (String k : meta.keySet()) {
-            if (k.startsWith("chunk.")) {
-                chunkCount1++;
-            }
-        }
+        int chunkCount1 = getChunkCount(meta);
         s.compact(80, 1);
         s.compact(80, 1);
 
-        int chunkCount2 = 0;
-        for (String k : meta.keySet()) {
-            if (k.startsWith("chunk.")) {
-                chunkCount2++;
-            }
-        }
+        int chunkCount2 = getChunkCount(meta);
         assertTrue(chunkCount2 >= chunkCount1);
 
         m = s.openMap("data");
@@ -1793,12 +1786,7 @@ public class TestMVStore extends TestBase {
         }
         assertFalse(s.compact(50, 1024));
 
-        int chunkCount3 = 0;
-        for (String k : meta.keySet()) {
-            if (k.startsWith("chunk.")) {
-                chunkCount3++;
-            }
-        }
+        int chunkCount3 = getChunkCount(meta);
 
         assertTrue(chunkCount1 + ">" + chunkCount2 + ">" + chunkCount3,
                 chunkCount3 < chunkCount1);
@@ -1807,6 +1795,16 @@ public class TestMVStore extends TestBase {
             assertEquals("x" + i, "Hello" + (i / factor), m.get(i));
         }
         s.close();
+    }
+
+    private int getChunkCount(Map<String, String> meta) {
+        int chunkCount = 0;
+        for (String k : meta.keySet()) {
+            if (k.startsWith("chunk.")) {
+                chunkCount++;
+            }
+        }
+        return chunkCount;
     }
 
     private void testCompact() {
@@ -1824,7 +1822,7 @@ public class TestMVStore extends TestBase {
             }
             trace("Before - fill rate: " + s.getFileStore().getFillRate() + "%, chunks fill rate: "
                     + s.getChunksFillRate() + ", len: " + FileUtils.size(fileName));
-            s.compact(80, 1024);
+            s.compact(80, 2048);
             s.compactMoveChunks();
             trace("After  - fill rate: " + s.getFileStore().getFillRate() + "%, chunks fill rate: "
                     + s.getChunksFillRate() + ", len: " + FileUtils.size(fileName));
@@ -1865,7 +1863,7 @@ public class TestMVStore extends TestBase {
             sleep(2);
             MVStore s = openStore(fileName);
             s.setRetentionTime(0);
-            s.setFreeUnusedOnBackgroundThread(false);
+            s.setVersionsToKeep(0);
             MVMap<Integer, String> m = s.openMap("data");
             for (int i = 0; i < 10; i++) {
                 m.put(i, "Hello");
@@ -1881,7 +1879,7 @@ public class TestMVStore extends TestBase {
                 initialLength = len;
             } else {
                 assertTrue("len: " + len + " initial: " + initialLength + " j: " + j,
-                        len <= initialLength * 5);
+                        len <= initialLength * 3);
             }
         }
     }

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1820,11 +1820,11 @@ public class TestMVStore extends TestBase {
             for (int i = 0; i < 100; i++) {
                 m.put(j + i, "Hello " + j);
             }
-            trace("Before - fill rate: " + s.getFileStore().getFillRate() + "%, chunks fill rate: "
+            trace("Before - fill rate: " + s.getFillRate() + "%, chunks fill rate: "
                     + s.getChunksFillRate() + ", len: " + FileUtils.size(fileName));
             s.compact(80, 2048);
             s.compactMoveChunks();
-            trace("After  - fill rate: " + s.getFileStore().getFillRate() + "%, chunks fill rate: "
+            trace("After  - fill rate: " + s.getFillRate() + "%, chunks fill rate: "
                     + s.getChunksFillRate() + ", len: " + FileUtils.size(fileName));
             s.close();
             long len = FileUtils.size(fileName);

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1338,6 +1338,7 @@ public class TestMVStore extends TestBase {
         MVMap<String, String> m = s.openMap("data");
         s.commit();
         long first = s.getCurrentVersion();
+        assertEquals(1, first);
         m.put("0", "test");
         s.commit();
         m.put("1", "Hello");
@@ -1351,7 +1352,9 @@ public class TestMVStore extends TestBase {
         m.put("2", "Welt");
         MVMap<String, String> mFirst;
         mFirst = m.openVersion(first);
-        assertEquals(0, mFirst.size());
+        // openVersion() should restore map at last known state of the version specified
+        // not at the first known state, as it was before
+        assertEquals(1, mFirst.size());
         MVMap<String, String> mOld;
         assertEquals("Hallo", m.get("1"));
         assertEquals("Welt", m.get("2"));
@@ -1814,6 +1817,7 @@ public class TestMVStore extends TestBase {
             sleep(2);
             MVStore s = openStore(fileName);
             s.setRetentionTime(0);
+            s.setVersionsToKeep(0);
             MVMap<Integer, String> m = s.openMap("data");
             for (int i = 0; i < 100; i++) {
                 m.put(j + i, "Hello " + j);

--- a/h2/src/test/org/h2/test/store/TestMVStoreStopCompact.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreStopCompact.java
@@ -51,28 +51,28 @@ public class TestMVStoreStopCompact extends TestBase {
         FileUtils.delete(fileName);
         // store with a very small page size, to make sure
         // there are many leaf pages
-        MVStore s = new MVStore.Builder().
-                fileName(fileName).open();
-        s.setRetentionTime(retentionTime);
-        MVMap<Integer, String> map = s.openMap("data");
-        long start = System.currentTimeMillis();
-        Random r = new Random(1);
-        for (int i = 0; i < 4000000; i++) {
-            long time = System.currentTimeMillis() - start;
-            if (time > timeout) {
-                break;
+        MVStore.Builder builder = new MVStore.Builder().fileName(fileName);
+        try (MVStore s = builder.open()) {
+            s.setRetentionTime(retentionTime);
+            s.setVersionsToKeep(0);
+            MVMap<Integer, String> map = s.openMap("data");
+            long start = System.currentTimeMillis();
+            Random r = new Random(1);
+            for (int i = 0; i < 4_000_000; i++) {
+                long time = System.currentTimeMillis() - start;
+                if (time > timeout) {
+                    break;
+                }
+                int x = r.nextInt(10_000_000);
+                map.put(x, "Hello World " + i * 10);
             }
-            int x = r.nextInt(10000000);
-            map.put(x, "Hello World " + i * 10);
+            s.setAutoCommitDelay(100);
+            long oldWriteCount = s.getFileStore().getWriteCount();
+            // expect background write to stop after 5 seconds
+            Thread.sleep(5000);
+            long newWriteCount = s.getFileStore().getWriteCount();
+            // expect that compaction didn't cause many writes
+            assertTrue("writeCount diff: " + retentionTime + "/" + timeout + " " + (newWriteCount - oldWriteCount), newWriteCount - oldWriteCount < 130);
         }
-        s.setAutoCommitDelay(100);
-        long oldWriteCount = s.getFileStore().getWriteCount();
-        // expect background write to stop after 5 seconds
-        Thread.sleep(5000);
-        long newWriteCount = s.getFileStore().getWriteCount();
-        // expect that compaction didn't cause many writes
-        assertTrue(newWriteCount - oldWriteCount < 30);
-        s.close();
     }
-
 }

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -66,7 +66,7 @@ public class TestMVTableEngine extends TestDb {
         testLobCreationThenShutdown();
         testManyTransactions();
         testAppendOnly();
-        testLowRetentionTime();
+        testNoRetentionTime();
         testOldAndNew();
         testTemporaryTables();
         testUniqueIndex();
@@ -78,7 +78,7 @@ public class TestMVTableEngine extends TestDb {
         testTimeout();
         testExplainAnalyze();
         testTransactionLogEmptyAfterCommit();
-//        testShrinkDatabaseFile();
+        testShrinkDatabaseFile();
         testTwoPhaseCommit();
         testRecover();
         testSeparateKey();
@@ -91,7 +91,7 @@ public class TestMVTableEngine extends TestDb {
         testBlob();
         testEncryption();
         testReadOnly();
-//        testReuseDiskSpace();
+        testReuseDiskSpace();
         testDataTypes();
         testSimple();
         if (!config.travis) {
@@ -305,9 +305,9 @@ public class TestMVTableEngine extends TestDb {
         }
     }
 
-    private void testLowRetentionTime() throws SQLException {
+    private void testNoRetentionTime() throws SQLException {
         deleteDb(getTestName());
-        try (Connection conn = getConnection(getTestName() + ";RETENTION_TIME=10;WRITE_DELAY=10")) {
+        try (Connection conn = getConnection(getTestName() + ";RETENTION_TIME=0;WRITE_DELAY=10")) {
             Statement stat = conn.createStatement();
             try (Connection conn2 = getConnection(getTestName())) {
                 Statement stat2 = conn2.createStatement();

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -78,7 +78,7 @@ public class TestMVTableEngine extends TestDb {
         testTimeout();
         testExplainAnalyze();
         testTransactionLogEmptyAfterCommit();
-        testShrinkDatabaseFile();
+//        testShrinkDatabaseFile();
         testTwoPhaseCommit();
         testRecover();
         testSeparateKey();
@@ -91,7 +91,7 @@ public class TestMVTableEngine extends TestDb {
         testBlob();
         testEncryption();
         testReadOnly();
-        testReuseDiskSpace();
+//        testReuseDiskSpace();
         testDataTypes();
         testSimple();
         if (!config.travis) {
@@ -691,7 +691,7 @@ public class TestMVTableEngine extends TestDb {
                     + Constants.SUFFIX_MV_FILE;
             long size = FileUtils.size(fileName);
             if (i < 10) {
-                maxSize = (int) (Math.max(size, maxSize) * 1.2);
+                maxSize = (int) Math.max(size * 1.2, maxSize);
             } else if (size > maxSize) {
                 fail(i + " size: " + size + " max: " + maxSize);
             }

--- a/h2/src/test/org/h2/test/synth/TestKillRestartMulti.java
+++ b/h2/src/test/org/h2/test/synth/TestKillRestartMulti.java
@@ -81,7 +81,7 @@ public class TestKillRestartMulti extends TestDb {
     @Override
     public void test() throws Exception {
         deleteDb("killRestartMulti");
-        url = getURL("killRestartMulti", true);
+        url = getURL("killRestartMulti;RETENTION_TIME=0", true);
         user = getUser();
         password = getPassword();
         String selfDestruct = SelfDestructor.getPropertyString(60);

--- a/h2/src/test/org/h2/test/unit/TestCache.java
+++ b/h2/src/test/org/h2/test/unit/TestCache.java
@@ -39,7 +39,7 @@ public class TestCache extends TestDb implements CacheWriter {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-        test.config.traceTest = true;
+//        test.config.traceTest = true;
         test.test();
     }
 


### PR DESCRIPTION
Current dead chunks determination is based on chunk reachability from all in-use versions of all map roots. While it is very reliable, it does not scale well, because it's complexity is proportional to amount of data held. This may lead to long pauses during commit (see #1820) and can't keep up with intensive data updates, allowing database file to grow out of cotrol.

There is an alternative mechanism in place, based on tracking liveliness of individual data pages (and therefore chunk occupancy). This is currently used only to find candidate chunks for data evacuation (re-write compaction) and used to be approximate due to bugs and some design issues. 

This PR is an attempt to fix those issues, and used it for dead chunk determination. Cost of dead chunk detection is amortized now, and it's more or less independent of database size.

