### PR TITLE
Assorted changes

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3111,6 +3111,7 @@ INT | INTEGER | MEDIUMINT | INT4 | SIGNED
 ","
 Possible values: -2147483648 to 2147483647.
 
+See also [integer](https://h2database.com/html/grammar.html#int) literal grammar.
 Mapped to ""java.lang.Integer"".
 ","
 INT
@@ -3119,8 +3120,9 @@ INT
 "Data Types","BOOLEAN Type","
 BOOLEAN | BIT | BOOL
 ","
-Possible values: TRUE and FALSE.
+Possible values: TRUE, FALSE, and UNKNOWN (NULL).
 
+See also [boolean](https://h2database.com/html/grammar.html#boolean) literal grammar.
 Mapped to ""java.lang.Boolean"".
 ","
 BOOLEAN
@@ -3131,6 +3133,7 @@ TINYINT
 ","
 Possible values are: -128 to 127.
 
+See also [integer](https://h2database.com/html/grammar.html#int) literal grammar.
 Mapped to ""java.lang.Byte"".
 ","
 TINYINT
@@ -3141,6 +3144,7 @@ SMALLINT | INT2 | YEAR
 ","
 Possible values: -32768 to 32767.
 
+See also [integer](https://h2database.com/html/grammar.html#int) literal grammar.
 Mapped to ""java.lang.Short"".
 ","
 SMALLINT
@@ -3151,6 +3155,7 @@ BIGINT | INT8
 ","
 Possible values: -9223372036854775808 to 9223372036854775807.
 
+See also [long](https://h2database.com/html/grammar.html#long) literal grammar.
 Mapped to ""java.lang.Long"".
 ","
 BIGINT
@@ -3163,6 +3168,7 @@ Auto-Increment value. Possible values: -9223372036854775808 to
 9223372036854775807. Used values are never re-used, even when the transaction is
 rolled back.
 
+See also [long](https://h2database.com/html/grammar.html#long) literal grammar.
 Mapped to ""java.lang.Long"".
 ","
 IDENTITY
@@ -3174,6 +3180,7 @@ IDENTITY
 Data type with fixed precision and scale. This data type is recommended for
 storing currency values.
 
+See also [numeric](https://h2database.com/html/grammar.html#numeric) literal grammar.
 Mapped to ""java.math.BigDecimal"".
 ","
 DECIMAL(20, 2)
@@ -3186,6 +3193,7 @@ A floating point number. Should not be used to represent currency values, becaus
 of rounding problems.
 If precision value is specified for FLOAT type name, it should be from 25 to 53.
 
+See also [numeric](https://h2database.com/html/grammar.html#numeric) literal grammar.
 Mapped to ""java.lang.Double"".
 ","
 DOUBLE
@@ -3198,6 +3206,7 @@ A single precision floating point number. Should not be used to represent curren
 values, because of rounding problems.
 Precision value for FLOAT type name should be from 0 to 24.
 
+See also [numeric](https://h2database.com/html/grammar.html#numeric) literal grammar.
 Mapped to ""java.lang.Float"".
 ","
 REAL
@@ -3209,6 +3218,7 @@ TIME [ ( precisionInt ) ] [ WITHOUT TIME ZONE ]
 The time data type. The format is hh:mm:ss[.nnnnnnnnn].
 If fractional seconds precision is specified it should be from 0 to 9, 0 is default.
 
+See also [time](https://h2database.com/html/grammar.html#time) literal grammar.
 Mapped to ""java.sql.Time"". When converted to a ""java.sql.Date"", the date is set to ""1970-01-01"".
 ""java.time.LocalTime"" is also supported and recommended on Java 8 and later versions.
 Use ""java.time.LocalTime"" or ""String"" instead of ""java.sql.Time"" when non-zero precision is needed.
@@ -3224,6 +3234,7 @@ DATE
 ","
 The date data type. The proleptic Gregorian calendar is used.
 
+See also [date](https://h2database.com/html/grammar.html#date) literal grammar.
 Mapped to ""java.sql.Date"", with the time set to ""00:00:00""
 (or to the next possible time if midnight doesn't exist for the given date and timezone due to a daylight saving change).
 If you deal with old dates note that ""java.sql.Date"" uses a mixed Julian/Gregorian calendar,
@@ -3244,6 +3255,7 @@ Stored internally as a BCD-encoded date, and nanoseconds since midnight.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 Fractional seconds precision of SMALLDATETIME is always 0 and cannot be specified.
 
+See also [timestamp](https://h2database.com/html/grammar.html#timestamp) literal grammar.
 Mapped to ""java.sql.Timestamp"" (""java.util.Date"" may be used too).
 If you deal with old dates note that ""java.sql.Timestamp"" uses a mixed Julian/Gregorian calendar,
 ""java.util.GregorianCalendar"" can be configured to proleptic Gregorian with
@@ -3264,6 +3276,7 @@ The timestamp with time zone data type. The proleptic Gregorian calendar is used
 Stored internally as a BCD-encoded date, nanoseconds since midnight, and time zone offset in minutes.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 
+See also [timestamp with time zone](https://h2database.com/html/grammar.html#timestamp_with_time_zone) literal grammar.
 Mapped to ""org.h2.api.TimestampWithTimeZone"" by default and can be optionally mapped to ""java.time.OffsetDateTime"".
 ""java.time.ZonedDateTime"" and ""java.time.Instant"" are also supported on Java 8 and later versions.
 
@@ -3288,6 +3301,7 @@ memory when using this data type. The precision is a size constraint;
 only the actual data is persisted. For large text data BLOB or CLOB
 should be used.
 
+See also [bytes](https://h2database.com/html/grammar.html#bytes) literal grammar.
 Mapped to byte[].
 ","
 BINARY(1000)
@@ -3320,6 +3334,7 @@ The precision is a size constraint; only the actual data is persisted.
 The whole text is loaded into memory when using this data type.
 For large text data CLOB should be used; see there for details.
 
+See also [string](https://h2database.com/html/grammar.html#string) literal grammar.
 Mapped to ""java.lang.String"".
 ","
 VARCHAR(255)
@@ -3337,6 +3352,7 @@ The precision is a size constraint; only the actual data is persisted.
 The whole text is loaded into memory when using this data type.
 For large text data CLOB should be used; see there for details.
 
+See also [string](https://h2database.com/html/grammar.html#string) literal grammar.
 Mapped to ""java.lang.String"".
 ","
 VARCHAR_IGNORECASE
@@ -3355,6 +3371,7 @@ The precision is a size constraint; only the actual data is persisted.
 The whole text is kept in memory when using this data type.
 For large text data CLOB should be used; see there for details.
 
+See also [string](https://h2database.com/html/grammar.html#string) literal grammar.
 Mapped to ""java.lang.String"".
 ","
 CHAR(10)
@@ -3422,6 +3439,8 @@ ARRAY [ '[' maximumCardinalityInt ']' ]
 ","
 An array of values.
 Maximum cardinality, if any, specifies maximum allowed number of elements in the array.
+
+See also [array](https://h2database.com/html/grammar.html#array) literal grammar.
 Mapped to ""java.lang.Object[]"" (arrays of any non-primitive type are also supported).
 
 Use ""PreparedStatement.setArray(..)"" or ""PreparedStatement.setObject(.., new Object[] {..})"" to store values,
@@ -3488,6 +3507,8 @@ GEOMETRY(GEOMETRY, 4326)
 JSON
 ","
 A RFC 8259-compliant JSON text.
+
+See also [json](https://h2database.com/html/grammar.html#json) literal grammar.
 Mapped to ""byte[]"".
 To set a JSON value with ""java.lang.String"" in a PreparedStatement use a ""FORMAT JSON"" data format
 (""INSERT INTO TEST(ID, DATA) VALUES (?, ? FORMAT JSON)"").
@@ -3524,6 +3545,7 @@ INTERVAL YEAR [ ( precisionInt ) ]
 Interval data type.
 If precision is specified it should be from 1 to 18, 2 is default.
 
+See also [year interval](https://h2database.com/html/grammar.html#interval_year) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Period"" is also supported on Java 8 and later versions.
 ","
@@ -3536,6 +3558,7 @@ INTERVAL MONTH [ ( precisionInt ) ]
 Interval data type.
 If precision is specified it should be from 1 to 18, 2 is default.
 
+See also [month interval](https://h2database.com/html/grammar.html#interval_month) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Period"" is also supported on Java 8 and later versions.
 ","
@@ -3548,6 +3571,7 @@ INTERVAL DAY [ ( precisionInt ) ]
 Interval data type.
 If precision is specified it should be from 1 to 18, 2 is default.
 
+See also [day interval](https://h2database.com/html/grammar.html#interval_day) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3560,6 +3584,7 @@ INTERVAL HOUR [ ( precisionInt ) ]
 Interval data type.
 If precision is specified it should be from 1 to 18, 2 is default.
 
+See also [hour interval](https://h2database.com/html/grammar.html#interval_hour) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3572,6 +3597,7 @@ INTERVAL MINUTE [ ( precisionInt ) ]
 Interval data type.
 If precision is specified it should be from 1 to 18, 2 is default.
 
+See also [minute interval](https://h2database.com/html/grammar.html#interval_minute) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3585,6 +3611,7 @@ Interval data type.
 If precision is specified it should be from 1 to 18, 2 is default.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 
+See also [second interval](https://h2database.com/html/grammar.html#interval_second) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3597,6 +3624,7 @@ INTERVAL YEAR [ ( precisionInt ) ] TO MONTH
 Interval data type.
 If leading field precision is specified it should be from 1 to 18, 2 is default.
 
+See also [year to month interval](https://h2database.com/html/grammar.html#interval_year_to_month) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Period"" is also supported on Java 8 and later versions.
 ","
@@ -3609,6 +3637,7 @@ INTERVAL DAY [ ( precisionInt ) ] TO HOUR
 Interval data type.
 If leading field precision is specified it should be from 1 to 18, 2 is default.
 
+See also [day to hour interval](https://h2database.com/html/grammar.html#interval_day_to_hour) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3621,6 +3650,7 @@ INTERVAL DAY [ ( precisionInt ) ] TO MINUTE
 Interval data type.
 If leading field precision is specified it should be from 1 to 18, 2 is default.
 
+See also [day to minute interval](https://h2database.com/html/grammar.html#interval_day_to_minute) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3634,6 +3664,7 @@ Interval data type.
 If leading field precision is specified it should be from 1 to 18, 2 is default.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 
+See also [day to second interval](https://h2database.com/html/grammar.html#interval_day_to_second) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3646,6 +3677,7 @@ INTERVAL HOUR [ ( precisionInt ) ] TO MINUTE
 Interval data type.
 If leading field precision is specified it should be from 1 to 18, 2 is default.
 
+See also [hour to minute interval](https://h2database.com/html/grammar.html#interval_hour_to_minute) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3659,6 +3691,7 @@ Interval data type.
 If leading field precision is specified it should be from 1 to 18, 2 is default.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 
+See also [hour to second interval](https://h2database.com/html/grammar.html#interval_hour_to_second) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","
@@ -3672,6 +3705,7 @@ Interval data type.
 If leading field precision is specified it should be from 1 to 18, 2 is default.
 If fractional seconds precision is specified it should be from 0 to 9, 6 is default.
 
+See also [minute to second interval](https://h2database.com/html/grammar.html#interval_minute_to_second) literal grammar.
 Mapped to ""org.h2.api.Interval"".
 ""java.time.Duration"" is also supported on Java 8 and later versions.
 ","

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -43,7 +43,7 @@ Change Log
 </li>
 <li>PR #1998: Reduce TxCounter memory footprint
 </li>
-<li>PR #1999: Make RootReference lock re-enterant
+<li>PR #1999: Make RootReference lock re-entrant
 </li>
 <li>PR #2001: Test improvements, OOME elimination
 </li>

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -330,7 +330,7 @@ public class Chunk {
 
                 int length = DataUtils.getPageMaxLength(pos);
                 if (length == DataUtils.PAGE_LARGE) {
-                    // read the first bytes to figure out actual lenght
+                    // read the first bytes to figure out actual length
                     length = fileStore.readFully(filePos, 128).getInt();
                 }
                 length = (int) Math.min(maxPos - filePos, length);

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -379,11 +379,16 @@ public class Chunk {
     }
 
     /**
-     * Modifies internal state to reflect the fact that one more page is stored within this chunk.
-     * @param pageLengthOnDisk size of the page
-     * @param singleWriter indicates whether page belongs to append mode capable map (single writer map).
-     *                     Such pages are "pinned" to the chunk, they can't be evacuated (moved to a different chunk)
-     *                     while on-line, but they assumed to be short-lived anyway.
+     * Modifies internal state to reflect the fact that one more page is stored
+     * within this chunk.
+     *
+     * @param pageLengthOnDisk
+     *            size of the page
+     * @param singleWriter
+     *            indicates whether page belongs to append mode capable map
+     *            (single writer map). Such pages are "pinned" to the chunk,
+     *            they can't be evacuated (moved to a different chunk) while
+     *            on-line, but they assumed to be short-lived anyway.
      */
     void accountForWrittenPage(int pageLengthOnDisk, boolean singleWriter) {
         maxLen += pageLengthOnDisk;
@@ -396,13 +401,20 @@ public class Chunk {
     }
 
     /**
-     * Modifies internal state to reflect the fact that one the pages within this chunk was removed from the map.
-     * @param pageLength on disk of the removed page
-     * @param pinned whether removed page was pinned
-     * @param now is a moment in time (since creation of the store), when removal is recorded,
-     *            and retention period starts
-     * @param version at which page was removed
-     * @return true if all of the pages, this chunk contains, were already removed, and false otherwise
+     * Modifies internal state to reflect the fact that one the pages within
+     * this chunk was removed from the map.
+     *
+     * @param pageLength
+     *            on disk of the removed page
+     * @param pinned
+     *            whether removed page was pinned
+     * @param now
+     *            is a moment in time (since creation of the store), when
+     *            removal is recorded, and retention period starts
+     * @param version
+     *            at which page was removed
+     * @return true if all of the pages, this chunk contains, were already
+     *         removed, and false otherwise
      */
     boolean accountForRemovedPage(int pageLength, boolean pinned, long now, long version) {
         assert isSaved() : this;

--- a/h2/src/main/org/h2/mvstore/CursorPos.java
+++ b/h2/src/main/org/h2/mvstore/CursorPos.java
@@ -8,7 +8,7 @@ package org.h2.mvstore;
 /**
  * A position in a cursor.
  * Instance represents a node in the linked list, which traces path
- * fom a specific (target) key within a leaf node all the way up to te root
+ * from a specific (target) key within a leaf node all the way up to te root
  * (bottom up path).
  */
 public class CursorPos

--- a/h2/src/main/org/h2/mvstore/CursorPos.java
+++ b/h2/src/main/org/h2/mvstore/CursorPos.java
@@ -39,8 +39,9 @@ public class CursorPos
     }
 
     /**
-     * Searches for a given key and creates a breadcrumb trail through a B-tree rooted at a given Page.
-     * Resulting path starts at "insertion point" for a given key and goes back to the root.
+     * Searches for a given key and creates a breadcrumb trail through a B-tree
+     * rooted at a given Page. Resulting path starts at "insertion point" for a
+     * given key and goes back to the root.
      *
      * @param page      root of the tree
      * @param key       the key to search for

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -515,7 +515,7 @@ public final class DataUtils {
      * Get the maximum length for the given code.
      * For the code 31, PAGE_LARGE is returned.
      *
-     * @param code encoded page lenth
+     * @param code encoded page length
      * @return the maximum length
      */
     public static int decodePageLength(int code) {

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -568,7 +568,8 @@ public final class DataUtils {
      * Find out if page was removed.
      *
      * @param pos the position
-     * @return true if page has been removed (no longer accessible from the current root of the tree)
+     * @return true if page has been removed (no longer accessible from the
+     *         current root of the tree)
      */
     static boolean isPageRemoved(long pos) {
         return pos == 1L;

--- a/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
+++ b/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
@@ -32,10 +32,11 @@ public class FreeSpaceBitSet {
     private final BitSet set = new BitSet();
 
     /**
-     * Left-shifting register, which holds outcomes of recent allocations.
-     * Only allocations done in "reuseSpace" mode are recorded here.
-     * For example, rightmost bit set to 1 means that last allocation failed to find a hole big enough,
-     * and next bit set to 0 means that previous allocation request have found one.
+     * Left-shifting register, which holds outcomes of recent allocations. Only
+     * allocations done in "reuseSpace" mode are recorded here. For example,
+     * rightmost bit set to 1 means that last allocation failed to find a hole
+     * big enough, and next bit set to 0 means that previous allocation request
+     * have found one.
      */
     private int failureFlags;
 
@@ -193,10 +194,15 @@ public class FreeSpaceBitSet {
     }
 
     /**
-     * Calculates a prospective fill rate, which store would have after rewrite of sparsely populated chunk(s)
-     * and evacuation of still live data into a new chunk.
-     * @param live amount of memory (bytes) from vacated block, which would be written into a new chunk
-     * @param vacatedBlocks number of blocks vacated
+     * Calculates a prospective fill rate, which store would have after rewrite
+     * of sparsely populated chunk(s) and evacuation of still live data into a
+     * new chunk.
+     *
+     * @param live
+     *            amount of memory (bytes) from vacated block, which would be
+     *            written into a new chunk
+     * @param vacatedBlocks
+     *            number of blocks vacated
      * @return prospective fill rate (0 - 100)
      */
     int getProjectedFillRate(long live, int vacatedBlocks) {

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -877,8 +877,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @return new RootReference or null if update failed
      */
     protected final boolean updateRoot(RootReference expectedRootReference, Page newRootPage,
-                                       int attemptUpdateCounter)
-    {
+            int attemptUpdateCounter) {
         return expectedRootReference.updateRootPage(newRootPage, attemptUpdateCounter) != null;
     }
 
@@ -1293,7 +1292,8 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                     }
                 }
                 p = replacePage(pos, p, unsavedMemoryHolder);
-                rootReference = rootReference.updatePageAndLockedStatus(p, preLocked || isPersistent(), remainingBuffer);
+                rootReference = rootReference.updatePageAndLockedStatus(p, preLocked || isPersistent(),
+                        remainingBuffer);
                 if (rootReference != null) {    // should always be the case, except for spurious failure?
                     locked = preLocked || isPersistent();
                     if (isPersistent() && tip != null) {

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -852,7 +852,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * Roll the root back to the specified version.
      *
      * @param version to rollback to
-     * @return true if rollback was a cuccess, false if there was not enough in-memory history
+     * @return true if rollback was a success, false if there was not enough in-memory history
      */
     boolean rollbackRoot(long version)
     {

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1186,7 +1186,8 @@ public class MVStore implements AutoCloseable {
                         } catch (IllegalStateException e) {
                             panic(e);
                         } catch (Throwable e) {
-                            panic(DataUtils.newIllegalStateException(DataUtils.ERROR_INTERNAL, "{0}", e.toString(), e));
+                            panic(DataUtils.newIllegalStateException(DataUtils.ERROR_INTERNAL, "{0}", e.toString(),
+                                    e));
                         }
                     }
                 } finally {
@@ -2190,13 +2191,14 @@ public class MVStore implements AutoCloseable {
     }
 
     /**
-     * Adjust amount of "unsaved memory" meaning amount of RAM occupied by pages not saved yet to the file.
-     * This is the amount which triggers auto-commit.
+     * Adjust amount of "unsaved memory" meaning amount of RAM occupied by pages
+     * not saved yet to the file. This is the amount which triggers auto-commit.
      *
      * @param memory adjustment
      */
     public void registerUnsavedMemory(int memory) {
-        // this counter was intentionaly left unprotected against race condition for performance reasons
+        // this counter was intentionaly left unprotected against race condition
+        // for performance reasons
         // TODO: evaluate performance impact of atomic implementation,
         //       since updates to unsavedMemory are largely aggregated now
         unsavedMemory += memory;

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1911,13 +1911,13 @@ public class MVStore implements AutoCloseable {
         writeStoreHeader();
         sync();
 
-        int rewritedPageCount = 0;
+        int rewrittenPageCount = 0;
         storeLock.unlock();
         try {
             for (MVMap<?, ?> map : maps.values()) {
                 if (!map.isClosed() && !map.isSingleWriter()) {
                     try {
-                        rewritedPageCount += map.rewrite(set);
+                        rewrittenPageCount += map.rewrite(set);
                     } catch(IllegalStateException ex) {
                         if (!map.isClosed()) {
                             throw ex;
@@ -1928,14 +1928,14 @@ public class MVStore implements AutoCloseable {
             int rewriteMetaCount = meta.rewrite(set);
             if (rewriteMetaCount > 0) {
                 markMetaChanged();
-                rewritedPageCount += rewriteMetaCount;
+                rewrittenPageCount += rewriteMetaCount;
             }
         } finally {
             storeLock.lock();
         }
         commit();
         assert validateRewrite(set);
-        return rewritedPageCount;
+        return rewrittenPageCount;
     }
 
     private boolean validateRewrite(Set<Integer> set) {
@@ -2197,8 +2197,8 @@ public class MVStore implements AutoCloseable {
      * @param memory adjustment
      */
     public void registerUnsavedMemory(int memory) {
-        // this counter was intentionaly left unprotected against race condition
-        // for performance reasons
+        // this counter was intentionally left unprotected against race
+        // condition for performance reasons
         // TODO: evaluate performance impact of atomic implementation,
         //       since updates to unsavedMemory are largely aggregated now
         unsavedMemory += memory;

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -551,10 +551,10 @@ public class MVStoreTool {
                                 keyType(new GenericDataType()).
                                 valueType(new GenericDataType());
                 // This is a hack to preserve chunks occupancy rate accounting.
-                // It exposes desin deficiency flaw in MVStore related to lack of
+                // It exposes design deficiency flaw in MVStore related to lack of
                 // map's type metadata.
                 // TODO: Introduce type metadata which will allow to open any store
-                // TODO: without prior knoledge of keys / values types and map implementation
+                // TODO: without prior knowledge of keys / values types and map implementation
                 // TODO: (MVMap vs MVRTreeMap, regular vs. singleWriter etc.)
                 if (mapName.startsWith(TransactionStore.UNDO_LOG_NAME_PREFIX)) {
                     mp.singleWriter();

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -47,10 +47,10 @@ public abstract class Page implements Cloneable
      * This "removed" flag is to keep track of pages that concurrently
      * changed while they are being stored, in which case the live bookkeeping
      * needs to be aware of such cases.
-     * Field need to be volatile to avoid races bettwen saving thread setting it
+     * Field need to be volatile to avoid races between saving thread setting it
      * and other thread reading it to access the page.
      * On top of this update atomicity is required so removal mark and saved position
-     * cas be set concurrently
+     * can be set concurrently
      */
     private volatile long pos;
 
@@ -885,7 +885,7 @@ public abstract class Page implements Cloneable
 
     /**
      * Remove all page data recursively.
-     * @param version at wich page got removed
+     * @param version at which page got removed
      * @return adjustment for "unsaved memory" amount
      */
     public abstract int removeAllRecursive(long version);

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -569,7 +569,9 @@ public abstract class Page implements Cloneable
      * @param chunkId the chunk id
      */
     private void read(ByteBuffer buff, int chunkId) {
-        int pageLength = buff.remaining() + 10;  // size of int + short + varint, since we've read page length, check and mapId already
+        // size of int + short + varint, since we've read page length, check and
+        // mapId already
+        int pageLength = buff.remaining() + 10;
         int len = DataUtils.readVarInt(buff);
         keys = createKeyStorage(len);
         int type = buff.get();
@@ -624,10 +626,13 @@ public abstract class Page implements Cloneable
     }
 
     /**
-     * Mark this page as removed "in memory". That means that only adjustment of "unsaved memory" amount is required.
-     * On the other hand, if page was persisted, it's removal should be reflected in occupancy of the containing chunk.
+     * Mark this page as removed "in memory". That means that only adjustment of
+     * "unsaved memory" amount is required. On the other hand, if page was
+     * persisted, it's removal should be reflected in occupancy of the
+     * containing chunk.
+     *
      * @return true if it was marked by this call or has been marked already,
-     *          false if page has been saved already.
+     *         false if page has been saved already.
      */
     private boolean markAsRemoved() {
         assert getTotalCount() > 0 : this;
@@ -840,10 +845,13 @@ public abstract class Page implements Cloneable
     public void setComplete() {}
 
     /**
-     * Make accounting changes (chunk occupancy or "unsaved" RAM), related to this page removal.
+     * Make accounting changes (chunk occupancy or "unsaved" RAM), related to
+     * this page removal.
+     *
      * @param version at which page was removed
-     * @return amount (negative), by which "unsaved memory" should be adjusted, if page is unsaved one,
-     *          and 0 for page that was already saved, or in case of non-persistent map
+     * @return amount (negative), by which "unsaved memory" should be adjusted,
+     *         if page is unsaved one, and 0 for page that was already saved, or
+     *         in case of non-persistent map
      */
     public final int removePage(long version) {
         if(isPersistent() && getTotalCount() > 0) {

--- a/h2/src/main/org/h2/mvstore/RootReference.java
+++ b/h2/src/main/org/h2/mvstore/RootReference.java
@@ -81,7 +81,8 @@ public final class RootReference
         this.previous = r.previous;
         this.updateCounter = r.updateCounter + 1;
         this.updateAttemptCounter = r.updateAttemptCounter + attempt;
-        assert r.holdCount == 0 || r.ownerId == Thread.currentThread().getId() : Thread.currentThread().getId() + " " + r;
+        assert r.holdCount == 0 || r.ownerId == Thread.currentThread().getId() //
+                : Thread.currentThread().getId() + " " + r;
         this.holdCount = (byte)(r.holdCount + 1);
         this.ownerId = Thread.currentThread().getId();
         this.appendCounter = r.appendCounter;
@@ -94,7 +95,8 @@ public final class RootReference
         this.previous = r.previous;
         this.updateCounter = r.updateCounter;
         this.updateAttemptCounter = r.updateAttemptCounter;
-        assert r.holdCount > 0 && r.ownerId == Thread.currentThread().getId() : Thread.currentThread().getId() + " " + r;
+        assert r.holdCount > 0 && r.ownerId == Thread.currentThread().getId() //
+                : Thread.currentThread().getId() + " " + r;
         this.holdCount = (byte)(r.holdCount - (keepLocked ? 0 : 1));
         this.ownerId = this.holdCount == 0 ? 0 : Thread.currentThread().getId();
         this.appendCounter = (byte) appendCounter;
@@ -166,7 +168,8 @@ public final class RootReference
         for(RootReference rootRef = this; rootRef != null; rootRef = rootRef.previous) {
             if (rootRef.version < oldestVersionToKeep) {
                 RootReference previous;
-                assert (previous = rootRef.previous) == null || previous.getAppendCounter() == 0 : oldestVersionToKeep + " " + rootRef.previous;
+                assert (previous = rootRef.previous) == null || previous.getAppendCounter() == 0 //
+                        : oldestVersionToKeep + " " + rootRef.previous;
                 rootRef.previous = null;
             }
         }

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.api.TableEngine;

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -41,10 +40,6 @@ public class Utils {
      * An 0-size long array.
      */
     private static final long[] EMPTY_LONG_ARRAY = {};
-
-    private static final int GC_DELAY = 50;
-    private static final int MAX_GC = 8;
-    private static long lastGC;
 
     private static final HashMap<String, byte[]> RESOURCES = new HashMap<>();
 

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -268,8 +268,8 @@ public class DataType {
         // Types.TIMESTAMP_WITH_TIMEZONE once Java 1.8 is required.
         add(Value.TIMESTAMP_TZ, 2014,
                 createDate(ValueTimestampTimeZone.MAXIMUM_PRECISION, ValueTimestampTimeZone.DEFAULT_PRECISION,
-                        "TIMESTAMP WITH TIME ZONE", true, ValueTimestampTimeZone.DEFAULT_SCALE,
-                        ValueTimestampTimeZone.MAXIMUM_SCALE),
+                        "TIMESTAMP WITH TIME ZONE", true, ValueTimestamp.DEFAULT_SCALE,
+                        ValueTimestamp.MAXIMUM_SCALE),
                 new String[]{"TIMESTAMP WITH TIME ZONE"}
         );
         add(Value.BYTES, Types.VARBINARY,

--- a/h2/src/main/org/h2/value/TypeInfo.java
+++ b/h2/src/main/org/h2/value/TypeInfo.java
@@ -211,7 +211,7 @@ public class TypeInfo {
         infos[Value.GEOMETRY] = TYPE_GEOMETRY = new TypeInfo(Value.GEOMETRY, Integer.MAX_VALUE, 0, Integer.MAX_VALUE,
                 null);
         infos[Value.TIMESTAMP_TZ] = TYPE_TIMESTAMP_TZ = new TypeInfo(Value.TIMESTAMP_TZ,
-                ValueTimestampTimeZone.MAXIMUM_PRECISION, ValueTimestampTimeZone.MAXIMUM_SCALE,
+                ValueTimestampTimeZone.MAXIMUM_PRECISION, ValueTimestamp.MAXIMUM_SCALE,
                 ValueTimestampTimeZone.MAXIMUM_PRECISION, null);
         infos[Value.ENUM] = TYPE_ENUM_UNDEFINED = new TypeInfo(Value.ENUM, Integer.MAX_VALUE, 0, Integer.MAX_VALUE,
                 null);
@@ -320,7 +320,7 @@ public class TypeInfo {
             return new TypeInfo(Value.TIMESTAMP, d, scale, d, null);
         }
         case Value.TIMESTAMP_TZ: {
-            if (scale < 0 || scale >= ValueTimestampTimeZone.MAXIMUM_SCALE) {
+            if (scale < 0 || scale >= ValueTimestamp.MAXIMUM_SCALE) {
                 return TYPE_TIMESTAMP_TZ;
             }
             int d = scale == 0 ? 25 : 26 + scale;

--- a/h2/src/main/org/h2/value/ValueDate.java
+++ b/h2/src/main/org/h2/value/ValueDate.java
@@ -8,10 +8,12 @@ package org.h2.value;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
 
 import org.h2.api.ErrorCode;
 import org.h2.message.DbException;
 import org.h2.util.DateTimeUtils;
+import org.h2.util.LocalDateTimeUtils;
 
 /**
  * Implementation of the DATE data type.
@@ -135,8 +137,15 @@ public class ValueDate extends Value {
     }
 
     @Override
-    public void set(PreparedStatement prep, int parameterIndex)
-            throws SQLException {
+    public void set(PreparedStatement prep, int parameterIndex) throws SQLException {
+        if (LocalDateTimeUtils.isJava8DateApiPresent()) {
+            try {
+                prep.setObject(parameterIndex, LocalDateTimeUtils.valueToLocalDate(this), Types.DATE);
+                return;
+            } catch (SQLException ignore) {
+                // Nothing to do
+            }
+        }
         prep.setDate(parameterIndex, getDate());
     }
 

--- a/h2/src/main/org/h2/value/ValueTime.java
+++ b/h2/src/main/org/h2/value/ValueTime.java
@@ -8,9 +8,11 @@ package org.h2.value;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Time;
+import java.sql.Types;
 import org.h2.api.ErrorCode;
 import org.h2.message.DbException;
 import org.h2.util.DateTimeUtils;
+import org.h2.util.LocalDateTimeUtils;
 
 /**
  * Implementation of the TIME data type.
@@ -189,8 +191,14 @@ public class ValueTime extends Value {
     }
 
     @Override
-    public void set(PreparedStatement prep, int parameterIndex)
-            throws SQLException {
+    public void set(PreparedStatement prep, int parameterIndex) throws SQLException {
+        if (LocalDateTimeUtils.isJava8DateApiPresent()) {
+            try {
+                prep.setObject(parameterIndex, LocalDateTimeUtils.valueToLocalTime(this), Types.TIME);
+            } catch (SQLException ignore) {
+                // Nothing to do
+            }
+        }
         prep.setTime(parameterIndex, getTime());
     }
 

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -8,10 +8,12 @@ package org.h2.value;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.sql.Types;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Mode;
 import org.h2.message.DbException;
 import org.h2.util.DateTimeUtils;
+import org.h2.util.LocalDateTimeUtils;
 
 /**
  * Implementation of the TIMESTAMP data type.
@@ -258,8 +260,15 @@ public class ValueTimestamp extends Value {
     }
 
     @Override
-    public void set(PreparedStatement prep, int parameterIndex)
-            throws SQLException {
+    public void set(PreparedStatement prep, int parameterIndex) throws SQLException {
+        if (LocalDateTimeUtils.isJava8DateApiPresent()) {
+            try {
+                prep.setObject(parameterIndex, LocalDateTimeUtils.valueToLocalDateTime(this), Types.TIMESTAMP);
+                return;
+            } catch (SQLException ignore) {
+                // Nothing to do
+            }
+        }
         prep.setTimestamp(parameterIndex, getTimestamp());
     }
 

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -262,8 +262,17 @@ public class ValueTimestampTimeZone extends Value {
     }
 
     @Override
-    public void set(PreparedStatement prep, int parameterIndex)
-            throws SQLException {
+    public void set(PreparedStatement prep, int parameterIndex) throws SQLException {
+        if (LocalDateTimeUtils.isJava8DateApiPresent()) {
+            try {
+                prep.setObject(parameterIndex, LocalDateTimeUtils.valueToOffsetDateTime(this),
+                        // TODO use Types.TIMESTAMP_WITH_TIMEZONE on Java 8
+                        2014);
+                return;
+            } catch (SQLException ignore) {
+                // Nothing to do
+            }
+        }
         prep.setString(parameterIndex, getString());
     }
 

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -267,16 +267,4 @@ public class ValueTimestampTimeZone extends Value {
         prep.setString(parameterIndex, getString());
     }
 
-    @Override
-    public Value add(Value v) {
-        throw DbException.getUnsupportedException(
-                "manipulating TIMESTAMP WITH TIME ZONE values is unsupported");
-    }
-
-    @Override
-    public Value subtract(Value v) {
-        throw DbException.getUnsupportedException(
-                "manipulating TIMESTAMP WITH TIME ZONE values is unsupported");
-    }
-
 }

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -36,16 +36,6 @@ public class ValueTimestampTimeZone extends Value {
     public static final int MAXIMUM_PRECISION = 35;
 
     /**
-     * The default scale for timestamps.
-     */
-    static final int DEFAULT_SCALE = ValueTimestamp.DEFAULT_SCALE;
-
-    /**
-     * The default scale for timestamps.
-     */
-    static final int MAXIMUM_SCALE = ValueTimestamp.MAXIMUM_SCALE;
-
-    /**
      * A bit field with bits for the year, month, and day (see DateTimeUtils for
      * encoding)
      */
@@ -196,7 +186,7 @@ public class ValueTimestampTimeZone extends Value {
 
     @Override
     public Value convertScale(boolean onlyToSmallerScale, int targetScale) {
-        if (targetScale >= MAXIMUM_SCALE) {
+        if (targetScale >= ValueTimestamp.MAXIMUM_SCALE) {
             return this;
         }
         if (targetScale < 0) {
@@ -221,7 +211,7 @@ public class ValueTimestampTimeZone extends Value {
         // Maximum time zone offset is +/-18 hours so difference in days between local
         // and UTC cannot be more than one day
         long dateValueA = dateValue;
-        long timeA = timeNanos - timeZoneOffsetMins * 60_000_000_000L;
+        long timeA = timeNanos - timeZoneOffsetMins * DateTimeUtils.NANOS_PER_MINUTE;
         if (timeA < 0) {
             timeA += DateTimeUtils.NANOS_PER_DAY;
             dateValueA = DateTimeUtils.decrementDateValue(dateValueA);
@@ -230,7 +220,7 @@ public class ValueTimestampTimeZone extends Value {
             dateValueA = DateTimeUtils.incrementDateValue(dateValueA);
         }
         long dateValueB = t.dateValue;
-        long timeB = t.timeNanos - t.timeZoneOffsetMins * 60_000_000_000L;
+        long timeB = t.timeNanos - t.timeZoneOffsetMins * DateTimeUtils.NANOS_PER_MINUTE;
         if (timeB < 0) {
             timeB += DateTimeUtils.NANOS_PER_DAY;
             dateValueB = DateTimeUtils.decrementDateValue(dateValueB);

--- a/h2/src/test/org/h2/test/store/TestMVStoreStopCompact.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreStopCompact.java
@@ -72,7 +72,8 @@ public class TestMVStoreStopCompact extends TestBase {
             Thread.sleep(5000);
             long newWriteCount = s.getFileStore().getWriteCount();
             // expect that compaction didn't cause many writes
-            assertTrue("writeCount diff: " + retentionTime + "/" + timeout + " " + (newWriteCount - oldWriteCount), newWriteCount - oldWriteCount < 130);
+            assertTrue("writeCount diff: " + retentionTime + "/" + timeout + " " + (newWriteCount - oldWriteCount),
+                    newWriteCount - oldWriteCount < 130);
         }
     }
 }

--- a/h2/src/test/org/h2/test/unit/TestCache.java
+++ b/h2/src/test/org/h2/test/unit/TestCache.java
@@ -186,7 +186,7 @@ public class TestCache extends TestDb implements CacheWriter {
                 " after closing: " + afterClose);
     }
 
-    private int getRealMemory() {
+    private static int getRealMemory() {
         StringUtils.clearCache();
         Value.clearCache();
         return Utils.getMemoryUsed();

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -814,3 +814,7 @@ setjava lift hyperlinks lazarevn nikita lazarev lvl ispras bias dbff fals tru df
 recognition spared hacky employing occupancy baos shifts littlejohn pushes scrub existent asterisked projections
 omits redefined ensured arrayagg objectagg bmp uabcd prefixed incoherence aggressively smb invalidating filesystems
 improper subcondition boxes negates abrupt chooses hindi updater zoned tolerable interference elimination
+prepend honored evacuated peeked queued transforms inbounded fragmented unprotected adjustment supposedly alloted
+housekeeping trail breadcrumb bets seasoned rewritable rpi eliminating projected reenterant varint races outcomes
+sparsely shifting vacated evacuation bullet allocations projected evacuatable pin capable rewritable deficiency
+successfull deduplication entrant mvmap


### PR DESCRIPTION
1. Data types in documentation now have hyperlinks to their literals (with few exclusions). Some people find the definition of data type and try to guess how its literal looks like and use, for example, string representations of datetime data types instead of normal literals.

2. When a datetime value is passed to an updatable result set or to a linked table the JSR 310 data types are probed first on Java 8+, and only when they aren't accepted the legacy data types are used. Legacy datetime data types are buggy and not fully compatible with internal representations of datetime values in H2.

3. Long lines are wrapped, spelling is fixed.

4. Unused imports, some unused fields, and some duplicate constants are removed.