### PR TITLE
fix for #2028, TxDecisionMaker re-factoring

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -285,7 +285,7 @@ public class TransactionMap<K, V> extends AbstractMap<K, V> {
     }
 
     private V set(Object key, V value) {
-        TxDecisionMaker decisionMaker = new TxDecisionMaker.PutDecisionMaker(map.getId(), key, value, transaction);
+        TxDecisionMaker decisionMaker = new TxDecisionMaker(map.getId(), key, value, transaction);
         return set(key, decisionMaker);
     }
 


### PR DESCRIPTION
This PR fixes #2028, and makes some refactoring in TxDecisionMaker class. 
Basically,  when transaction AAA is in logically committed but before all participated map entries converted from uncommitted (pair of current and last committed values) to committed ones, concurrent transaction BBB may try to lock entry, without waiting for AAA's full commit, but it records wrong value as "last committed". It takes "last committed" as it was before AAA, where it should be "current value" of AAA, as it's known to be committed now. If BBB would be rolled back later, it will effectively erase the change made by AAA. Similar problem existed not only in LockDecisionMaker, but in PutDecisionMaker and PutIfAbsentDecisionMaker, as well.