### PR TITLE
Assorted changes

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2016: ExpressionColumn.mapColumns() performance complexity is quadratic
+</li>
+<li>Issue #2028: Sporadic inconsistent state after concurrent UPDATE in 1.4.199
+</li>
+<li>PR #2033: Assorted changes
+</li>
 <li>Issue #2025: Incorrect query result when (OFFSET + FETCH) &gt; Integer.MAX_VALUE
 </li>
 <li>PR #2023: traverseDown() code deduplication

--- a/h2/src/main/org/h2/command/dml/SelectListColumnResolver.java
+++ b/h2/src/main/org/h2/command/dml/SelectListColumnResolver.java
@@ -6,6 +6,8 @@
 package org.h2.command.dml;
 
 import java.util.ArrayList;
+
+import org.h2.engine.Database;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.table.Column;
@@ -50,6 +52,17 @@ public class SelectListColumnResolver implements ColumnResolver {
     @Override
     public Column[] getColumns() {
         return columns;
+    }
+
+    @Override
+    public Column findColumn(String name) {
+        Database db = select.getSession().getDatabase();
+        for (Column column : columns) {
+            if (db.equalsIdentifiers(column.getName(), name)) {
+                return column;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/TableValueConstructor.java
+++ b/h2/src/main/org/h2/command/dml/TableValueConstructor.java
@@ -50,6 +50,11 @@ public class TableValueConstructor extends Query {
         }
 
         @Override
+        public Column findColumn(String name) {
+            return table.findColumn(name);
+        }
+
+        @Override
         public String getColumnName(Column column) {
             return column.getName();
         }

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -69,7 +69,7 @@ public class ExpressionColumn extends Expression {
         }
         if (column != null) {
             if (columnResolver != null && columnResolver.hasDerivedColumnList()) {
-                Parser.quoteIdentifier(builder, columnName, alwaysQuote);
+                Parser.quoteIdentifier(builder, columnResolver.getColumnName(column), alwaysQuote);
             } else {
                 column.getSQL(builder, alwaysQuote);
             }
@@ -242,7 +242,13 @@ public class ExpressionColumn extends Expression {
 
     @Override
     public String getColumnName() {
-        return columnName != null ? columnName : column.getName();
+        if (column != null) {
+            if (columnResolver != null) {
+                return columnResolver.getColumnName(column);
+            }
+            return column.getName();
+        }
+        return columnName;
     }
 
     @Override
@@ -266,7 +272,7 @@ public class ExpressionColumn extends Expression {
             return column.getName();
         }
         if (tableAlias != null) {
-            return tableAlias + "." + columnName;
+            return tableAlias + '.' + columnName;
         }
         return columnName;
     }

--- a/h2/src/main/org/h2/expression/ExpressionColumn.java
+++ b/h2/src/main/org/h2/expression/ExpressionColumn.java
@@ -102,19 +102,14 @@ public class ExpressionColumn extends Expression {
             }
             return;
         }
-        for (Column col : resolver.getColumns()) {
-            String n = resolver.getColumnName(col);
-            if (database.equalsIdentifiers(columnName, n)) {
-                mapColumn(resolver, col, level);
-                if (resolver.hasDerivedColumnList()) {
-                    columnName = n;
-                }
-                return;
-            }
+        Column col = resolver.findColumn(columnName);
+        if (col != null) {
+            mapColumn(resolver, col, level);
+            return;
         }
         Column[] columns = resolver.getSystemColumns();
         for (int i = 0; columns != null && i < columns.length; i++) {
-            Column col = columns[i];
+            col = columns[i];
             if (database.equalsIdentifiers(columnName, col.getName())) {
                 mapColumn(resolver, col, level);
                 return;

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -646,7 +646,7 @@ public class Column {
             return;
         }
         if (resolver == null) {
-            resolver = new SingleColumnResolver(this);
+            resolver = new SingleColumnResolver(session.getDatabase(), this);
         }
         synchronized (this) {
             String oldName = name;

--- a/h2/src/main/org/h2/table/ColumnResolver.java
+++ b/h2/src/main/org/h2/table/ColumnResolver.java
@@ -31,6 +31,16 @@ public interface ColumnResolver {
     Column[] getColumns();
 
     /**
+     * Get the column with the specified name.
+     *
+     * @param name
+     *            the column name, must be a derived name if this column
+     *            resolver has a derived column list
+     * @return the column with the specified name, or {@code null}
+     */
+    Column findColumn(String name);
+
+    /**
      * Get the name of the specified column.
      *
      * @param column column

--- a/h2/src/main/org/h2/table/SingleColumnResolver.java
+++ b/h2/src/main/org/h2/table/SingleColumnResolver.java
@@ -6,6 +6,7 @@
 package org.h2.table;
 
 import org.h2.command.dml.Select;
+import org.h2.engine.Database;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.value.Value;
@@ -16,10 +17,12 @@ import org.h2.value.Value;
  */
 public class SingleColumnResolver implements ColumnResolver {
 
+    private final Database database;
     private final Column column;
     private Value value;
 
-    SingleColumnResolver(Column column) {
+    SingleColumnResolver(Database database, Column column) {
+        this.database = database;
         this.column = column;
     }
 
@@ -40,6 +43,14 @@ public class SingleColumnResolver implements ColumnResolver {
     @Override
     public Column[] getColumns() {
         return new Column[] { column };
+    }
+
+    @Override
+    public Column findColumn(String name) {
+        if (database.equalsIdentifiers(column.getName(), name)) {
+            return column;
+        }
+        return null;
     }
 
     @Override

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1064,6 +1064,21 @@ public class TableFilter implements ColumnResolver {
     }
 
     @Override
+    public Column findColumn(String name) {
+        HashMap<Column, String> map = derivedColumnMap;
+        if (map != null) {
+            Database db = session.getDatabase();
+            for (Entry<Column, String> entry : derivedColumnMap.entrySet()) {
+                if (db.equalsIdentifiers(entry.getValue(), name)) {
+                    return entry.getKey();
+                }
+            }
+            return null;
+        }
+        return table.findColumn(name);
+    }
+
+    @Override
     public String getColumnName(Column column) {
         HashMap<Column, String> map = derivedColumnMap;
         return map != null ? map.get(column) : column.getName();

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -579,32 +579,67 @@ public class DataType {
                 break;
             }
             case Value.DATE: {
+                if (LocalDateTimeUtils.isJava8DateApiPresent()) {
+                    try {
+                        Object value = rs.getObject(columnIndex, LocalDateTimeUtils.LOCAL_DATE);
+                        v = value == null ? ValueNull.INSTANCE : LocalDateTimeUtils.localDateToDateValue(value);
+                        break;
+                    } catch (SQLException ignore) {
+                        // Nothing to do
+                    }
+                }
                 Date value = rs.getDate(columnIndex);
                 v = value == null ? ValueNull.INSTANCE : ValueDate.get(value);
                 break;
             }
             case Value.TIME: {
+                if (LocalDateTimeUtils.isJava8DateApiPresent()) {
+                    try {
+                        Object value = rs.getObject(columnIndex, LocalDateTimeUtils.LOCAL_TIME);
+                        v = value == null ? ValueNull.INSTANCE : LocalDateTimeUtils.localTimeToTimeValue(value);
+                        break;
+                    } catch (SQLException ignore) {
+                        // Nothing to do
+                    }
+                }
                 Time value = rs.getTime(columnIndex);
                 v = value == null ? ValueNull.INSTANCE : ValueTime.get(value);
                 break;
             }
             case Value.TIMESTAMP: {
+                if (LocalDateTimeUtils.isJava8DateApiPresent()) {
+                    try {
+                        Object value = rs.getObject(columnIndex, LocalDateTimeUtils.LOCAL_DATE_TIME);
+                        v = value == null ? ValueNull.INSTANCE : LocalDateTimeUtils.localDateTimeToValue(value);
+                        break;
+                    } catch (SQLException ignore) {
+                        // Nothing to do
+                    }
+                }
                 Timestamp value = rs.getTimestamp(columnIndex);
                 v = value == null ? ValueNull.INSTANCE : ValueTimestamp.get(value);
                 break;
             }
             case Value.TIMESTAMP_TZ: {
+                if (LocalDateTimeUtils.isJava8DateApiPresent()) {
+                    try {
+                        Object value = rs.getObject(columnIndex, LocalDateTimeUtils.OFFSET_DATE_TIME);
+                        v = value == null ? ValueNull.INSTANCE : LocalDateTimeUtils.offsetDateTimeToValue(value);
+                        break;
+                    } catch (SQLException ignore) {
+                        // Nothing to do
+                    }
+                }
                 Object obj = rs.getObject(columnIndex);
                 if (obj == null) {
                     v = ValueNull.INSTANCE;
                 } else if (LocalDateTimeUtils.isJava8DateApiPresent()
-                        && LocalDateTimeUtils.OFFSET_DATE_TIME.isInstance(obj)) {
-                    v = LocalDateTimeUtils.offsetDateTimeToValue(obj);
-                } else if (LocalDateTimeUtils.isJava8DateApiPresent()
                         && LocalDateTimeUtils.ZONED_DATE_TIME.isInstance(obj)) {
                     v = LocalDateTimeUtils.zonedDateTimeToValue(obj);
-                } else {
+                } else if (obj instanceof TimestampWithTimeZone) {
                     v = ValueTimestampTimeZone.get((TimestampWithTimeZone) obj);
+                } else {
+                    v = ValueTimeTimeZone.parse(obj.toString());
                 }
                 break;
             }

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -639,7 +639,7 @@ public class DataType {
                 } else if (obj instanceof TimestampWithTimeZone) {
                     v = ValueTimestampTimeZone.get((TimestampWithTimeZone) obj);
                 } else {
-                    v = ValueTimeTimeZone.parse(obj.toString());
+                    v = ValueTimestampTimeZone.parse(obj.toString());
                 }
                 break;
             }

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -535,8 +535,7 @@ public class DataType {
      * @param type the data type
      * @return the value
      */
-    public static Value readValue(SessionInterface session, ResultSet rs,
-            int columnIndex, int type) {
+    public static Value readValue(SessionInterface session, ResultSet rs, int columnIndex, int type) {
         try {
             Value v;
             switch (type) {
@@ -571,32 +570,27 @@ public class DataType {
             }
             case Value.BOOLEAN: {
                 boolean value = rs.getBoolean(columnIndex);
-                v = rs.wasNull() ? (Value) ValueNull.INSTANCE :
-                    ValueBoolean.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueBoolean.get(value);
                 break;
             }
             case Value.BYTE: {
                 byte value = rs.getByte(columnIndex);
-                v = rs.wasNull() ? (Value) ValueNull.INSTANCE :
-                    ValueByte.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueByte.get(value);
                 break;
             }
             case Value.DATE: {
                 Date value = rs.getDate(columnIndex);
-                v = value == null ? (Value) ValueNull.INSTANCE :
-                    ValueDate.get(value);
+                v = value == null ? ValueNull.INSTANCE : ValueDate.get(value);
                 break;
             }
             case Value.TIME: {
                 Time value = rs.getTime(columnIndex);
-                v = value == null ? (Value) ValueNull.INSTANCE :
-                    ValueTime.get(value);
+                v = value == null ? ValueNull.INSTANCE : ValueTime.get(value);
                 break;
             }
             case Value.TIMESTAMP: {
                 Timestamp value = rs.getTimestamp(columnIndex);
-                v = value == null ? (Value) ValueNull.INSTANCE :
-                    ValueTimestamp.get(value);
+                v = value == null ? ValueNull.INSTANCE : ValueTimestamp.get(value);
                 break;
             }
             case Value.TIMESTAMP_TZ: {
@@ -616,56 +610,47 @@ public class DataType {
             }
             case Value.DECIMAL: {
                 BigDecimal value = rs.getBigDecimal(columnIndex);
-                v = value == null ? (Value) ValueNull.INSTANCE :
-                    ValueDecimal.get(value);
+                v = value == null ? ValueNull.INSTANCE : ValueDecimal.get(value);
                 break;
             }
             case Value.DOUBLE: {
                 double value = rs.getDouble(columnIndex);
-                v = rs.wasNull() ? (Value) ValueNull.INSTANCE :
-                    ValueDouble.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueDouble.get(value);
                 break;
             }
             case Value.FLOAT: {
                 float value = rs.getFloat(columnIndex);
-                v = rs.wasNull() ? (Value) ValueNull.INSTANCE :
-                    ValueFloat.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueFloat.get(value);
                 break;
             }
             case Value.INT: {
                 int value = rs.getInt(columnIndex);
-                v = rs.wasNull() ? (Value) ValueNull.INSTANCE :
-                    ValueInt.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueInt.get(value);
                 break;
             }
             case Value.LONG: {
                 long value = rs.getLong(columnIndex);
-                v = rs.wasNull() ? (Value) ValueNull.INSTANCE :
-                    ValueLong.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueLong.get(value);
                 break;
             }
             case Value.SHORT: {
                 short value = rs.getShort(columnIndex);
-                v = rs.wasNull() ? (Value) ValueNull.INSTANCE :
-                    ValueShort.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueShort.get(value);
                 break;
             }
             case Value.STRING_IGNORECASE: {
                 String s = rs.getString(columnIndex);
-                v = (s == null) ? (Value) ValueNull.INSTANCE :
-                    ValueStringIgnoreCase.get(s);
+                v = (s == null) ? ValueNull.INSTANCE : ValueStringIgnoreCase.get(s);
                 break;
             }
             case Value.STRING_FIXED: {
                 String s = rs.getString(columnIndex);
-                v = (s == null) ? (Value) ValueNull.INSTANCE :
-                    ValueStringFixed.get(s);
+                v = (s == null) ? ValueNull.INSTANCE : ValueStringFixed.get(s);
                 break;
             }
             case Value.STRING: {
                 String s = rs.getString(columnIndex);
-                v = (s == null) ? (Value) ValueNull.INSTANCE :
-                    ValueString.get(s);
+                v = (s == null) ? ValueNull.INSTANCE : ValueString.get(s);
                 break;
             }
             case Value.CLOB: {
@@ -678,8 +663,7 @@ public class DataType {
                     if (in == null) {
                         v = ValueNull.INSTANCE;
                     } else {
-                        v = session.getDataHandler().getLobStorage().
-                                createClob(new BufferedReader(in), -1);
+                        v = session.getDataHandler().getLobStorage().createClob(new BufferedReader(in), -1);
                     }
                 }
                 if (session != null) {
@@ -690,12 +674,10 @@ public class DataType {
             case Value.BLOB: {
                 if (session == null) {
                     byte[] buff = rs.getBytes(columnIndex);
-                    return buff == null ? ValueNull.INSTANCE :
-                        ValueLobDb.createSmallLob(Value.BLOB, buff);
+                    return buff == null ? ValueNull.INSTANCE : ValueLobDb.createSmallLob(Value.BLOB, buff);
                 }
                 InputStream in = rs.getBinaryStream(columnIndex);
-                v = (in == null) ? (Value) ValueNull.INSTANCE :
-                    session.getDataHandler().getLobStorage().createBlob(in, -1);
+                v = (in == null) ? ValueNull.INSTANCE : session.getDataHandler().getLobStorage().createBlob(in, -1);
                 session.addTemporaryLob(v);
                 break;
             }
@@ -706,8 +688,7 @@ public class DataType {
                         ValueJavaObject.getNoCopy(null, buff, session.getDataHandler());
                 } else {
                     Object o = rs.getObject(columnIndex);
-                    v = o == null ? ValueNull.INSTANCE :
-                        ValueJavaObject.getNoCopy(o, null, session.getDataHandler());
+                    v = o == null ? ValueNull.INSTANCE : ValueJavaObject.getNoCopy(o, null, session.getDataHandler());
                 }
                 break;
             }
@@ -730,8 +711,7 @@ public class DataType {
             }
             case Value.ENUM: {
                 int value = rs.getInt(columnIndex);
-                v = rs.wasNull() ? (Value) ValueNull.INSTANCE :
-                    ValueInt.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueInt.get(value);
                 break;
             }
             case Value.ROW: {

--- a/h2/src/main/org/h2/value/ValueTime.java
+++ b/h2/src/main/org/h2/value/ValueTime.java
@@ -195,6 +195,7 @@ public class ValueTime extends Value {
         if (LocalDateTimeUtils.isJava8DateApiPresent()) {
             try {
                 prep.setObject(parameterIndex, LocalDateTimeUtils.valueToLocalTime(this), Types.TIME);
+                return;
             } catch (SQLException ignore) {
                 // Nothing to do
             }

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -59,6 +59,7 @@ public class TestCompatibility extends TestDb {
 
         conn.close();
         testIdentifiers();
+        testIdentifiersCaseInResultSet();
         deleteDb("compatibility");
 
         testUnknownURL();
@@ -774,6 +775,22 @@ public class TestCompatibility extends TestDb {
             return;
         }
         fail();
+    }
+
+    private void testIdentifiersCaseInResultSet() throws SQLException {
+        try (Connection conn = getConnection(
+                "compatibility;DATABASE_TO_UPPER=FALSE;CASE_INSENSITIVE_IDENTIFIERS=TRUE")) {
+            Statement stat = conn.createStatement();
+            stat.execute("CREATE TABLE TEST(A INT)");
+            ResultSet rs = stat.executeQuery("SELECT a from test");
+            ResultSetMetaData md = rs.getMetaData();
+            assertEquals("A", md.getColumnName(1));
+            rs = stat.executeQuery("SELECT a FROM (SELECT 1) t(A)");
+            md = rs.getMetaData();
+            assertEquals("A", md.getColumnName(1));
+        } finally {
+            deleteDb("compatibility");
+        }
     }
 
 }

--- a/h2/src/test/org/h2/test/jdbc/TestUpdatableResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestUpdatableResultSet.java
@@ -528,6 +528,25 @@ public class TestUpdatableResultSet extends TestDb {
         // auml ouml uuml
         assertEquals("\u00ef\u00f6\u00fc", rs.getString(++c));
         assertEquals(new byte[] { (byte) 0xab, 0x12 }, rs.getBytes(++c));
+        c = 1;
+        rs.updateString(++c, "-");
+        rs.updateBigDecimal(++c, new BigDecimal("1.30"));
+        rs.updateBoolean(++c, false);
+        rs.updateByte(++c, (byte) 0x55);
+        rs.updateBytes(++c, new byte[] { 0x01, (byte) 0xfe });
+        rs.updateDate(++c, Date.valueOf("2005-09-22"));
+        rs.updateTime(++c, Time.valueOf("21:46:29"));
+        rs.updateTimestamp(++c, Timestamp.valueOf("2005-09-21 21:47:10.111222333"));
+        rs.updateObject(++c, new TimestampWithTimeZone(DateTimeUtils.dateValue(2005, 9, 22), 10_111_222_333L,
+                (short) 120));
+        rs.updateDouble(++c, 2.25);
+        rs.updateFloat(++c, 3.5f);
+        rs.updateLong(++c, Long.MAX_VALUE - 1);
+        rs.updateInt(++c, 11);
+        rs.updateShort(++c, (short) -1_000);
+        rs.updateString(++c, "ABCD");
+        rs.updateBytes(++c, new byte[] { 1, 2 });
+        rs.updateRow();
 
         for (int i = 3; i <= 14; i++) {
             rs.next();
@@ -535,6 +554,30 @@ public class TestUpdatableResultSet extends TestDb {
             assertEquals("\u00ef\u00f6\u00fc", rs.getString(clobIndex));
             assertEquals(new byte[] { (byte) 0xab, 0x12 }, rs.getBytes(blobIndex));
         }
+        assertFalse(rs.next());
+
+        rs = stat.executeQuery("SELECT * FROM TEST WHERE ID = 2");
+        rs.next();
+        c = 0;
+        assertTrue(rs.getInt(++c) == 2);
+        assertEquals("-", rs.getString(++c));
+        assertEquals("1.30", rs.getBigDecimal(++c).toString());
+        assertFalse(rs.getBoolean(++c));
+        assertTrue((rs.getByte(++c) & 0xff) == 0x55);
+        assertEquals(new byte[] { 0x01, (byte) 0xfe }, rs.getBytes(++c));
+        assertEquals("2005-09-22", rs.getDate(++c).toString());
+        assertEquals("21:46:29", rs.getTime(++c).toString());
+        assertEquals("2005-09-21 21:47:10.111222333", rs.getTimestamp(++c).toString());
+        assertEquals(SysProperties.RETURN_OFFSET_DATE_TIME && LocalDateTimeUtils.isJava8DateApiPresent() //
+                ? "2005-09-22T00:00:10.111222333+02:00" : "2005-09-22 00:00:10.111222333+02", //
+                rs.getObject(++c).toString());
+        assertTrue(rs.getDouble(++c) == 2.25);
+        assertTrue(rs.getFloat(++c) == 3.5f);
+        assertTrue(rs.getLong(++c) == Long.MAX_VALUE - 1);
+        assertEquals(11, ((Integer) rs.getObject(++c)).intValue());
+        assertTrue(rs.getShort(++c) == -1_000);
+        assertEquals("ABCD", rs.getString(++c));
+        assertEquals(new byte[] { 1, 2 }, rs.getBytes(++c));
         assertFalse(rs.next());
 
         stat.execute("DROP TABLE TEST");

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -817,4 +817,4 @@ improper subcondition boxes negates abrupt chooses hindi updater zoned tolerable
 prepend honored evacuated peeked queued transforms inbounded fragmented unprotected adjustment supposedly alloted
 housekeeping trail breadcrumb bets seasoned rewritable rpi eliminating projected reenterant varint races outcomes
 sparsely shifting vacated evacuation bullet allocations projected evacuatable pin capable rewritable deficiency
-successfull deduplication entrant mvmap
+successfull deduplication entrant mvmap sporadic


### PR DESCRIPTION
1. Missing return statement from #2033 is placed where it should be, the problem wasn't detected due to fallback code below.

2. Unnecessary casts in `DataType.readValue()` are removed and its code coverage is improved.

3. H2 now tries to read datetime values from result sets using JSR 310 classes when possible. The similar change in another place was made in #2033.

4. Issue #2016 is fixed. Execution time of a query with 50,000 columns was reduced from 30 to 0,2 seconds on my system with cold JVM. Existing maps are used when possible. When a map isn't available, the plain iteration is used as it was before. Additional maps can be created, but I don't think that they are necessary, overhead of their construction may be larger than improvement during their usage in typical cases.