### PR TITLE
MVMap: lock reduction on updates

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1211,17 +1211,6 @@ public class MVMap<K, V> extends AbstractMap<K, V>
             int keyCount;
             int availabilityThreshold = fullFlush ? 0 : keysPerPage - 1;
             while ((keyCount = rootReference.getAppendCounter()) > availabilityThreshold) {
-                Page rootPage = rootReference.root;
-                long version = rootReference.version;
-                CursorPos pos = rootPage.getAppendCursorPos(null);
-                assert pos != null;
-                assert pos.index < 0 : pos.index;
-                int index = -pos.index - 1;
-                assert index == pos.page.getKeyCount() : index + " != " + pos.page.getKeyCount();
-                Page p = pos.page;
-                CursorPos tip = pos;
-                pos = pos.parent;
-
                 if (!locked) {
                     // instead of just calling lockRoot() we loop here and check if someone else
                     // already flushed the buffer, then we don't need a lock
@@ -1232,6 +1221,17 @@ public class MVMap<K, V> extends AbstractMap<K, V>
                     }
                     locked = true;
                 }
+
+                Page rootPage = rootReference.root;
+                long version = rootReference.version;
+                CursorPos pos = rootPage.getAppendCursorPos(null);
+                assert pos != null;
+                assert pos.index < 0 : pos.index;
+                int index = -pos.index - 1;
+                assert index == pos.page.getKeyCount() : index + " != " + pos.page.getKeyCount();
+                Page p = pos.page;
+                CursorPos tip = pos;
+                pos = pos.parent;
 
                 int remainingBuffer = 0;
                 Page page = null;

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2473,8 +2473,8 @@ public class MVStore implements AutoCloseable {
             checkOpen();
             DataUtils.checkArgument(map != meta,
                     "Removing the meta map is not allowed");
-            map.close();
             RootReference rootReference = map.clearIt();
+            map.close();
 
             updateCounter += rootReference.updateCounter;
             updateAttemptCounter += rootReference.updateAttemptCounter;

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -855,7 +855,6 @@ public abstract class Page implements Cloneable
      */
     public final int removePage(long version) {
         if(isPersistent() && getTotalCount() > 0) {
-            assert map.getRoot().isLockedByCurrentThread();
             MVStore store = map.store;
             if (!markAsRemoved()) { // only if it has been saved already
                 long pagePos = pos;


### PR DESCRIPTION
Queuing of removed pages information does not have to be done anymore under map's root lock, as it used to be in the process of that feature development. This PR allows for a lock free changes to the map if contention is not high. Some measured improvement in scalability (about 5-10% increase of peak throughput) can be observed in TestScalability runs. Code is simplified in the process as well.