### PR TITLE
Don't include settings from unused engine into INFORMATION_SCHEMA.SETTINGS

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2040: INFORMATION_SCHEMA.SETTINGS contains unrelevant settings
+</li>
+<li>PR #2038: MVMap: lock reduction on updates
+</li>
+<li>PR #2037: Fix SYS_GUID, RAWTOHEX, and HEXTORAW in Oracle mode
+</li>
 <li>Issue #2016: ExpressionColumn.mapColumns() performance complexity is quadratic
 </li>
 <li>Issue #2028: Sporadic inconsistent state after concurrent UPDATE in 1.4.199

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -652,7 +652,7 @@ public class ConnectionInfo implements Cloneable {
 
     public DbSettings getDbSettings() {
         DbSettings defaultSettings = DbSettings.getDefaultSettings();
-        HashMap<String, String> s = new HashMap<>();
+        HashMap<String, String> s = new HashMap<>(DbSettings.TABLE_SIZE);
         for (Object k : prop.keySet()) {
             String key = k.toString();
             if (!isKnownSetting(key) && defaultSettings.containsKey(key)) {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -789,8 +790,24 @@ public class Database implements DataHandler {
                 getPageStore();
             }
         }
-        if(store != null) {
+        if (store != null) {
             store.getTransactionStore().init();
+        }
+        if (dbSettings.mvStore) {
+            // MVStore
+            for (Iterator<String> i = dbSettings.getSettings().keySet().iterator(); i.hasNext();) {
+                if (i.next().startsWith("PAGE_STORE_")) {
+                    i.remove();
+                }
+            }
+        } else if (store == null) {
+            // PageStore without additional MVStore for spatial features
+            for (Iterator<String> i = dbSettings.getSettings().keySet().iterator(); i.hasNext();) {
+                String name = i.next();
+                if ("COMPRESS".equals(name) || "REUSE_SPACE".equals(name)) {
+                    i.remove();
+                }
+            }
         }
         systemUser = new User(this, 0, SYSTEM_USER_NAME, true);
         mainSchema = new Schema(this, Constants.MAIN_SCHEMA_ID, sysIdentifier(Constants.SCHEMA_MAIN), systemUser,

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -27,6 +27,11 @@ public class DbSettings extends SettingsBase {
     private static DbSettings defaultSettings;
 
     /**
+     * The intitial size of the hash table.
+     */
+    static final int TABLE_SIZE = 64;
+
+    /**
      * Database setting <code>ALIAS_COLUMN_NAME</code> (default: false).<br />
      * When enabled, aliased columns (as in SELECT ID AS I FROM TEST) return the
      * alias (I in this case) in ResultSetMetaData.getColumnName() and 'null' in
@@ -381,7 +386,7 @@ public class DbSettings extends SettingsBase {
      */
     public static DbSettings getDefaultSettings() {
         if (defaultSettings == null) {
-            defaultSettings = new DbSettings(new HashMap<String, String>());
+            defaultSettings = new DbSettings(new HashMap<String, String>(TABLE_SIZE));
         }
         return defaultSettings;
     }

--- a/h2/src/main/org/h2/engine/SettingsBase.java
+++ b/h2/src/main/org/h2/engine/SettingsBase.java
@@ -5,7 +5,11 @@
  */
 package org.h2.engine;
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import org.h2.api.ErrorCode;
 import org.h2.message.DbException;
@@ -106,6 +110,23 @@ public class SettingsBase {
      */
     public HashMap<String, String> getSettings() {
         return settings;
+    }
+
+    /**
+     * Get all settings in alphabetical order.
+     *
+     * @return the settings
+     */
+    public Entry<String, String>[] getSortedSettings() {
+        @SuppressWarnings("unchecked")
+        Map.Entry<String, String>[] entries = settings.entrySet().toArray(new Map.Entry[0]);
+        Arrays.sort(entries, new Comparator<Map.Entry<String, String>>() {
+            @Override
+            public int compare(Entry<String, String> o1, Entry<String, String> o2) {
+                return o1.getKey().compareTo(o2.getKey());
+            }
+        });
+        return entries;
     }
 
 }

--- a/h2/src/main/org/h2/jmx/DatabaseInfo.java
+++ b/h2/src/main/org/h2/jmx/DatabaseInfo.java
@@ -11,7 +11,7 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.Map.Entry;
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -229,13 +229,11 @@ public class DatabaseInfo implements DatabaseInfoMBean {
 
     @Override
     public String listSettings() {
-        StringBuilder buff = new StringBuilder();
-        for (Map.Entry<String, String> e :
-                new TreeMap<>(
-                database.getSettings().getSettings()).entrySet()) {
-            buff.append(e.getKey()).append(" = ").append(e.getValue()).append('\n');
+        StringBuilder builder = new StringBuilder();
+        for (Entry<String, String> e : database.getSettings().getSortedSettings()) {
+            builder.append(e.getKey()).append(" = ").append(e.getValue()).append('\n');
         }
-        return buff.toString();
+        return builder.toString();
     }
 
     @Override

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -14,9 +14,8 @@ import java.sql.ResultSet;
 import java.sql.Types;
 import java.text.Collator;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import org.h2.command.Command;
 import org.h2.constraint.Constraint;
@@ -1129,12 +1128,8 @@ public class MetaTable extends Table {
             add(rows, "RETENTION_TIME", Integer.toString(database.getRetentionTime()));
             add(rows, "LOG", Integer.toString(database.getLogMode()));
             // database settings
-            HashMap<String, String> s = database.getSettings().getSettings();
-            ArrayList<String> settingNames = new ArrayList<>(s.size());
-            settingNames.addAll(s.keySet());
-            Collections.sort(settingNames);
-            for (String k : settingNames) {
-                add(rows, k, s.get(k));
+            for (Map.Entry<String, String> entry : database.getSettings().getSortedSettings()) {
+                add(rows, entry.getKey(), entry.getValue());
             }
             if (database.isPersistent()) {
                 PageStore pageStore = database.getPageStore();

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1200,11 +1200,18 @@ public class TestMetaData extends TestDb {
         stat.execute("DROP TABLE TEST");
 
         rs = stat.executeQuery("SELECT * FROM INFORMATION_SCHEMA.SETTINGS");
+        int mvStoreSettingsCount = 0, pageStoreSettingsCount = 0;
         while (rs.next()) {
             String name = rs.getString("NAME");
-            String value = rs.getString("VALUE");
-            trace(name + "=" + value);
+            trace(name + '=' + rs.getString("VALUE"));
+            if ("COMPRESS".equals(name) || "REUSE_SPACE".equals(name)) {
+                mvStoreSettingsCount++;
+            } else if (name.startsWith("PAGE_STORE_")) {
+                pageStoreSettingsCount++;
+            }
         }
+        assertEquals(config.mvStore ? 2 : 0, mvStoreSettingsCount);
+        assertEquals(config.mvStore ? 0 : 3, pageStoreSettingsCount);
 
         testMore();
 


### PR DESCRIPTION
Closes #2040.

A new method `SettingsBase.getSortedSettings()` is created for `INFORMATION_SCHEMA.SETTINGS` and JMX to replace their own different approaches to sort the settings.