### PR TITLE
Recovery mode

### DIFF
--- a/h2/src/main/org/h2/mvstore/Cursor.java
+++ b/h2/src/main/org/h2/mvstore/Cursor.java
@@ -63,13 +63,15 @@ public class Cursor<K, V> implements Iterator<K> {
                         }
                         index = 0;
                     }
-                    K key = (K) page.getKey(index);
-                    if (to != null && page.map.getKeyType().compare(key, to) > 0) {
-                        return false;
+                    if (index < page.getKeyCount()) {
+                        K key = (K) page.getKey(index);
+                        if (to != null && page.map.getKeyType().compare(key, to) > 0) {
+                            return false;
+                        }
+                        current = last = key;
+                        lastValue = (V) page.getValue(index);
+                        lastPage = page;
                     }
-                    current = last = key;
-                    lastValue = (V) page.getValue(index);
-                    lastPage = page;
                 }
                 ++cursorPos.index;
             }

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -355,10 +355,9 @@ public class MVStoreTool {
             return "File not found: " + fileName;
         }
         long fileLength = FileUtils.size(fileName);
-        MVStore store = new MVStore.Builder().
-                fileName(fileName).
-                readOnly().open();
-        try {
+        try (MVStore store = new MVStore.Builder().
+                fileName(fileName).recoveryMode().
+                readOnly().open()) {
             MVMap<String, String> meta = store.getMetaMap();
             Map<String, Object> header = store.getStoreHeader();
             long fileCreated = DataUtils.readHexLong(header, "created", 0L);
@@ -412,8 +411,6 @@ public class MVStoreTool {
             pw.println("ERROR: " + e);
             e.printStackTrace(pw);
             return e.getMessage();
-        } finally {
-            store.close();
         }
         pw.flush();
         return null;


### PR DESCRIPTION
Since v.1.4.197 additional data integrity checks were made in MVStore opening procedure.
Now version which has some dangling page references due to missing chunk(s), will not be opened.
This severely degraded ability of recovery tool (and was topic of multiple complains in support group), since recovery uses the same store opening procedure.
This PR introduces MVStore special mode of operation, intended to be used by recovery tool.
It tries to ignore missing pages by assuming that they are empty.
It should have zero impact on normal mode.