### PR TITLE
bugfix - mvstore data lost issue when partial write occurs

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -893,7 +893,7 @@ public class MVStore implements AutoCloseable {
         long end = fileStore.size();
         // The end position of chunk should be block align
         final long part = end % BLOCK_SIZE;
-        if(part > 0){
+        if(part > 0L){
             end -= part;
         }
         
@@ -916,12 +916,11 @@ public class MVStore implements AutoCloseable {
                     final int chunk = DataUtils.readHexInt(m, "chunk", 0);
                     final Chunk c = new Chunk(chunk);
                     c.version = DataUtils.readHexLong(m, "version", 0);
-                    c.block = DataUtils.readHexLong(m, "block", 0);
-                    // read the chunk header
-                    final Chunk header = readChunkHeader(c.block);
-                    if(header != null && header.id == c.id){
-                        if(newest == null || header.version > newest.version){
-                            return header;
+                    c.block   = DataUtils.readHexLong(m, "block", 0);
+                    final Chunk test = readChunkHeaderAndFooter(c.block);
+                    if(test != null && test.id == c.id){
+                        if(newest == null || test.version > newest.version){
+                            return test;
                         }
                         return newest;
                     }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -752,15 +752,10 @@ public class MVStore implements AutoCloseable {
             creationTime = now;
             storeHeader.put("created", creationTime);
         }
-        Chunk test = readChunkFooter(fileStore.size());
-        if (test != null) {
-            test = readChunkHeaderAndFooter(test.block);
-            if (test != null) {
-                if (newest == null || test.version > newest.version) {
-                    newest = test;
-                }
-            }
-        }
+        
+        // bugfix - data lost issue when partial write occurs at end of file store.
+        // @since 2019-07-31 little-pan
+        newest = readChunkHeaderAndFooterFromStoreTail(newest);
 
         long blocksInStore = fileStore.size() / BLOCK_SIZE;
         // this queue will hold potential candidates for lastChunk to fall back to
@@ -779,6 +774,7 @@ public class MVStore implements AutoCloseable {
         });
         Map<Long, Chunk> validChunkCacheByLocation = new HashMap<>();
 
+        Chunk test;
         if (newest != null) {
             // read the chunk header and footer,
             // and follow the chain of next chunks
@@ -876,6 +872,64 @@ public class MVStore implements AutoCloseable {
         setWriteVersion(currentVersion);
         if (lastStoredVersion == INITIAL_VERSION) {
             lastStoredVersion = currentVersion - 1;
+        }
+    }
+    
+    /**
+     * <p>Try to read a chunk with valid header and footer from the end of the file store, and 
+     * compare it with the given newest, return the newest one.
+     * </p>
+     * 
+     * <p>We skip these chunks with invalid header or footer block by block, because of these 
+     * chunks are corrupted by partial write in the case of power off, or OOM etc.
+     * </p>
+     * 
+     * @param newest
+     * @return the newest chunk
+     * 
+     * @since 2019-07-31 little-pan
+     */
+    private Chunk readChunkHeaderAndFooterFromStoreTail(final Chunk newest){
+        long end = fileStore.size();
+        // The end position of chunk should be block align
+        final long part = end % BLOCK_SIZE;
+        if(part > 0){
+            end -= part;
+        }
+        
+        final byte[] buff = new byte[Chunk.FOOTER_LENGTH];
+        // We should read and check the chunk header and footer straight ahead block by block 
+        //for chunk partial write issue.
+        for(;;){
+            // read the chunk footer of the last block of the file
+            final long pos = end - Chunk.FOOTER_LENGTH;
+            if(pos < 0L) {
+                return newest;
+            }
+            
+            final ByteBuffer lastBlock = fileStore.readFully(pos, Chunk.FOOTER_LENGTH);
+            lastBlock.get(buff);
+            // check the chunk
+            try {
+                final HashMap<String, String> m = DataUtils.parseChecksummedMap(buff);
+                if (m != null) {
+                    final int chunk = DataUtils.readHexInt(m, "chunk", 0);
+                    final Chunk c = new Chunk(chunk);
+                    c.version = DataUtils.readHexLong(m, "version", 0);
+                    c.block = DataUtils.readHexLong(m, "block", 0);
+                    // read the chunk header
+                    final Chunk header = readChunkHeader(c.block);
+                    if(header != null && header.id == c.id){
+                        if(newest == null || header.version > newest.version){
+                            return header;
+                        }
+                        return newest;
+                    }
+                } 
+            } catch(final Exception e){
+                // ignore: corrupted chunk or normal pages
+            } 
+            end -= BLOCK_SIZE;
         }
     }
 
@@ -2520,7 +2574,7 @@ public class MVStore implements AutoCloseable {
     public void removeMap(String name) {
         int id = getMapId(name);
         if(id > 0) {
-            MVMap map = getMap(id);
+            MVMap<?, ?> map = getMap(id);
             if (map == null) {
                 map = openMap(name);
             }

--- a/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
+++ b/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
@@ -39,13 +39,14 @@ public class TestReorderWrites extends TestBase {
     public void test() throws Exception {
         testMVStore(false);
         testMVStore(true);
-        testFileSystem();
+        testFileSystem(false);
+        testFileSystem(true);
     }
 
     private void testMVStore(final boolean partialWrite) {
         // Add partial write test
         // @since 2019-07-31 little-pan
-        println("partial write: " + partialWrite);
+        println(String.format("testMVStore(): %s partial write", partialWrite? "Enable": "Disable"));
         FilePathReorderWrites.setPartialWrites(partialWrite);
         
         FilePathReorderWrites fs = FilePathReorderWrites.register();
@@ -142,10 +143,14 @@ public class TestReorderWrites extends TestBase {
         }
     }
 
-    private void testFileSystem() throws IOException {
+    private void testFileSystem(final boolean partialWrite) throws IOException {
         FilePathReorderWrites fs = FilePathReorderWrites.register();
-        // disable this for now, still bug(s) in our code
-        FilePathReorderWrites.setPartialWrites(false);
+        // *disable this for now, still bug(s) in our code*
+        // Add partial write enable test
+        // @since 2019-07-31 little-pan
+        FilePathReorderWrites.setPartialWrites(partialWrite);
+        println(String.format("testFileSystem(): %s partial write", partialWrite? "Enable": "Disable"));
+        
         String fileName = "reorder:memFS:test";
         final ByteBuffer empty = ByteBuffer.allocate(1024);
         Random r = new Random(1);

--- a/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
+++ b/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
@@ -45,7 +45,7 @@ public class TestReorderWrites extends TestBase {
     private void testMVStore(final boolean partialWrite) {
         // Add partial write test
         // @since 2019-07-31 little-pan
-        System.out.println("partial write: " + partialWrite);
+        println("partial write: " + partialWrite);
         FilePathReorderWrites.setPartialWrites(partialWrite);
         
         FilePathReorderWrites fs = FilePathReorderWrites.register();

--- a/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
+++ b/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
@@ -37,11 +37,17 @@ public class TestReorderWrites extends TestBase {
 
     @Override
     public void test() throws Exception {
-        testMVStore();
+        testMVStore(false);
+        testMVStore(true);
         testFileSystem();
     }
 
-    private void testMVStore() {
+    private void testMVStore(final boolean partialWrite) {
+        // Add partial write test
+        // @since 2019-07-31 little-pan
+        System.out.println("partial write: " + partialWrite);
+        FilePathReorderWrites.setPartialWrites(partialWrite);
+        
         FilePathReorderWrites fs = FilePathReorderWrites.register();
         String fileName = "reorder:memFS:test.mv";
         try {


### PR DESCRIPTION
In org.h2.test.poweroff.TestReorderWrites, the test case of testMVStore() can't pass when enable partial write, because of h2 mvstore can't restore correctly from corrupted file store. 

If we skip the corruption part at the end of the file store, and read a chunk with valid header and footer straight ahead block by block, it works and the test cass pass.