### PR TITLE
NPE in Parser.parseUpdateSetClause() and changes in documentation

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,16 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2051: The website shows outdated information about the storage engine
+</li>
+<li>PR #2049: bugfix - mvstore data lost issue when partial write occurs
+</li>
+<li>PR #2047: File maintenance
+</li>
+<li>PR #2046: Recovery mode
+</li>
+<li>Issue #2044: setTransactionIsolation always call commit() even if transaction is auto-commit
+</li>
 <li>Issue #2042: Add possibility to specify generated columns for query in web console
 </li>
 <li>Issue #2040: INFORMATION_SCHEMA.SETTINGS contains irrelevant settings

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -735,7 +735,41 @@ but does not issue them with default MVStore engine.
 
 <h2 id="database_file_layout">Database File Layout</h2>
 <p>
-The following files are created for persistent databases:
+The following files are created for persistent databases when the default MVStore engine is used:
+</p>
+<table class="main">
+<tr><th>File Name</th><th>Description</th><th>Number of Files</th></tr>
+<tr><td class="notranslate">
+    test.mv.db
+</td><td>
+    Database file.<br />
+    Contains the transaction log, indexes, and data for all tables.<br />
+    Format: <code>&lt;database&gt;.mv.db</code>
+</td><td>
+    1 per database
+</td></tr>
+<tr><td class="notranslate">
+    test.newFile
+</td><td>
+    Temporary file for database compaction.<br />
+    Contains the new MVStore file.<br />
+    Format: <code>&lt;database&gt;.newFile</code>
+</td><td>
+    0 or 1 per database
+</td></tr>
+<tr><td class="notranslate">
+    test.tempFile
+</td><td>
+    Temporary file for database compaction.<br />
+    Contains the temporary MVStore file.<br />
+    Format: <code>&lt;database&gt;.tempFile</code>
+</td><td>
+    0 or 1 per database
+</td></tr>
+</table>
+
+<p>
+The following file is created for persistent databases when PageStore engine is used:
 </p>
 <table class="main">
 <tr><th>File Name</th><th>Description</th><th>Number of Files</th></tr>
@@ -748,6 +782,13 @@ The following files are created for persistent databases:
 </td><td>
     1 per database
 </td></tr>
+</table>
+
+<p>
+The following files are created for persistent databases by both MVStore and PageStore engines:
+</p>
+<table class="main">
+<tr><th>File Name</th><th>Description</th><th>Number of Files</th></tr>
 <tr><td class="notranslate">
     test.lock.db
 </td><td>
@@ -763,18 +804,9 @@ The following files are created for persistent databases:
     Trace file (if the trace option is enabled).<br />
     Contains trace information.<br />
     Format: <code>&lt;database&gt;.trace.db</code><br />
-    Renamed to <code>&lt;database&gt;.trace.db.old</code> is too big.
+    Renamed to <code>&lt;database&gt;.trace.db.old</code> if too big.
 </td><td>
     0 or 1 per database
-</td></tr>
-<tr><td class="notranslate">
-    test.lobs.db/*
-</td><td>
-    Directory containing one file for each<br />
-    BLOB or CLOB value larger than a certain size.<br />
-    Format: <code>&lt;id&gt;.t&lt;tableId&gt;.lob.db</code>
-</td><td>
-    1 per large object
 </td></tr>
 <tr><td class="notranslate">
     test.123.temp.db
@@ -784,6 +816,23 @@ The following files are created for persistent databases:
     Format: <code>&lt;database&gt;.&lt;id&gt;.temp.db</code>
 </td><td>
     1 per object
+</td></tr>
+</table>
+
+<p>
+Legacy PageStore databases from old versions of H2 can have the following additional files:
+</p>
+<table class="main">
+<tr><th>File Name</th><th>Description</th><th>Number of Files</th></tr>
+<tr><td class="notranslate">
+    test.lobs.db/*
+</td><td>
+    Directory containing one file for each<br />
+    BLOB or CLOB value larger than a certain size.
+    <br />
+    Format: <code>&lt;id&gt;.t&lt;tableId&gt;.lob.db</code>
+</td><td>
+    1 per large object
 </td></tr>
 </table>
 

--- a/h2/src/docsrc/html/mvstore.html
+++ b/h2/src/docsrc/html/mvstore.html
@@ -59,7 +59,7 @@ MVStore
 <h2 id="overview">Overview</h2>
 <p>
 The MVStore is a persistent, log structured key-value store.
-It is planned to be the next storage subsystem of H2,
+It is used as default storage subsystem of H2,
 but it can also be used directly within an application, without using JDBC or SQL.
 </p>
 <ul><li>MVStore stands for "multi-version store".

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1288,10 +1288,7 @@ public class Parser {
                 read(EQUAL);
                 Expression expression = readExpression();
                 int columnCount = columns.size();
-                if (columnCount == 1 && expression.getType().getValueType() != Value.ROW) {
-                    // Row value special case
-                    command.setAssignment(columns.get(0), expression);
-                } else if (expression instanceof ExpressionList) {
+                if (expression instanceof ExpressionList) {
                     ExpressionList list = (ExpressionList) expression;
                     if (list.getType().getValueType() != Value.ROW || columnCount != list.getSubexpressionCount()) {
                         throw DbException.get(ErrorCode.COLUMN_COUNT_DOES_NOT_MATCH);
@@ -1299,6 +1296,9 @@ public class Parser {
                     for (int i = 0; i < columnCount; i++) {
                         command.setAssignment(columns.get(i), list.getSubexpression(i));
                     }
+                } else if (columnCount == 1) {
+                    // Row value special case
+                    command.setAssignment(columns.get(0), expression);
                 } else {
                     for (int i = 0; i < columnCount; i++) {
                         command.setAssignment(columns.get(i),

--- a/h2/src/main/org/h2/expression/analysis/WindowFunction.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFunction.java
@@ -496,8 +496,7 @@ public class WindowFunction extends DataAnalysisOperation {
 
     @Override
     public StringBuilder getSQL(StringBuilder builder, boolean alwaysQuote) {
-        String name = type.getSQL();
-        builder.append(name).append('(');
+        builder.append(type.getSQL()).append('(');
         if (args != null) {
             writeExpressions(builder, args, alwaysQuote);
         }

--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -389,7 +389,7 @@ public class FileStore {
     }
 
     int getMovePriority(int block) {
-        return freeSpace.getMovePiority(block);
+        return freeSpace.getMovePriority(block);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
+++ b/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
@@ -247,7 +247,7 @@ public class FreeSpaceBitSet {
      * @param block where chunk starts
      * @return priority, bigger number indicate that chunk need to be moved sooner
      */
-    int getMovePiority(int block) {
+    int getMovePriority(int block) {
         // The most desirable chunks to move are the ones sitting within
         // a relatively short span of occupied blocks which is surrounded
         // from both sides by relatively long free spans

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -752,7 +752,7 @@ public class MVStore implements AutoCloseable {
             creationTime = now;
             storeHeader.put("created", creationTime);
         }
-        
+
         // bugfix - data lost issue when partial write occurs at end of file store.
         // @since 2019-07-31 little-pan
         newest = readChunkHeaderAndFooterFromStoreTail(newest);
@@ -874,19 +874,19 @@ public class MVStore implements AutoCloseable {
             lastStoredVersion = currentVersion - 1;
         }
     }
-    
+
     /**
-     * <p>Try to read a chunk with valid header and footer from the end of the file store, and 
+     * <p>Try to read a chunk with valid header and footer from the end of the file store, and
      * compare it with the given newest, return the newest one.
      * </p>
-     * 
-     * <p>We skip these chunks with invalid header or footer block by block, because of these 
+     *
+     * <p>We skip these chunks with invalid header or footer block by block, because of these
      * chunks are corrupted by partial write in the case of power off, or OOM etc.
      * </p>
-     * 
+     *
      * @param newest
      * @return the newest chunk
-     * 
+     *
      * @since 2019-07-31 little-pan
      */
     private Chunk readChunkHeaderAndFooterFromStoreTail(final Chunk newest){
@@ -896,9 +896,9 @@ public class MVStore implements AutoCloseable {
         if(part > 0L){
             end -= part;
         }
-        
+
         final byte[] buff = new byte[Chunk.FOOTER_LENGTH];
-        // We should read and check the chunk header and footer straight ahead block by block 
+        // We should read and check the chunk header and footer straight ahead block by block
         //for chunk partial write issue.
         for(;;){
             // read the chunk footer of the last block of the file
@@ -906,7 +906,7 @@ public class MVStore implements AutoCloseable {
             if(pos < 0L) {
                 return newest;
             }
-            
+
             final ByteBuffer lastBlock = fileStore.readFully(pos, Chunk.FOOTER_LENGTH);
             lastBlock.get(buff);
             // check the chunk
@@ -924,10 +924,10 @@ public class MVStore implements AutoCloseable {
                         }
                         return newest;
                     }
-                } 
+                }
             } catch(final Exception e){
                 // ignore: corrupted chunk or normal pages
-            } 
+            }
             end -= BLOCK_SIZE;
         }
     }
@@ -1663,7 +1663,7 @@ public class MVStore implements AutoCloseable {
                     new Comparator<Chunk>() {
                         @Override
                         public int compare(Chunk o1, Chunk o2) {
-                            // instead of selectiong just closest to beginning of the file,
+                            // instead of selection just closest to beginning of the file,
                             // pick smaller chunk(s) which sit in between bigger holes
                             int res = Integer.compare(o2.collectPriority, o1.collectPriority);
                             if (res != 0) {
@@ -3291,7 +3291,7 @@ public class MVStore implements AutoCloseable {
         }
 
         /**
-         * Open the file in recoverty mode, where some errors may be ignored.
+         * Open the file in recovery mode, where some errors may be ignored.
          *
          * @return this
          */

--- a/h2/src/test/org/h2/test/jdbc/TestConnection.java
+++ b/h2/src/test/org/h2/test/jdbc/TestConnection.java
@@ -174,8 +174,8 @@ public class TestConnection extends TestDb {
         conn.close();
         prep.close();
     }
-    
-     private void testChangeTransactionLevelCommitRunner() throws Exception {
+
+    private void testChangeTransactionLevelCommitRunner() throws Exception {
         assertFalse("Default value must be false", SysProperties.FORCE_AUTOCOMMIT_OFF_ON_COMMIT);
         testChangeTransactionLevelCommit(false);
         testChangeTransactionLevelCommit(true);
@@ -186,10 +186,9 @@ public class TestConnection extends TestDb {
         } finally {
             SysProperties.FORCE_AUTOCOMMIT_OFF_ON_COMMIT = false;
         }
-
     }
-     
-     private void testChangeTransactionLevelCommit(boolean setAutoCommit) throws Exception {
+
+    private void testChangeTransactionLevelCommit(boolean setAutoCommit) throws Exception {
         Connection conn = getConnection("clientInfo");
         conn.setAutoCommit(setAutoCommit);
         Statement stat = conn.createStatement();
@@ -202,8 +201,7 @@ public class TestConnection extends TestDb {
         prep.setString(index++, "test1");
         prep.execute();
         conn.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
-        
-        
+
         conn.createStatement().executeQuery("SELECT COUNT(*) FROM TEST");
         // throws exception if TransactionIsolation did not commit
 

--- a/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
+++ b/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
@@ -48,7 +48,7 @@ public class TestReorderWrites extends TestBase {
         // @since 2019-07-31 little-pan
         println(String.format("testMVStore(): %s partial write", partialWrite? "Enable": "Disable"));
         FilePathReorderWrites.setPartialWrites(partialWrite);
-        
+
         FilePathReorderWrites fs = FilePathReorderWrites.register();
         String fileName = "reorder:memFS:test.mv";
         try {
@@ -150,7 +150,7 @@ public class TestReorderWrites extends TestBase {
         // @since 2019-07-31 little-pan
         FilePathReorderWrites.setPartialWrites(partialWrite);
         println(String.format("testFileSystem(): %s partial write", partialWrite? "Enable": "Disable"));
-        
+
         String fileName = "reorder:memFS:test";
         final ByteBuffer empty = ByteBuffer.allocate(1024);
         Random r = new Random(1);

--- a/h2/src/test/org/h2/test/scripts/dml/update.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/update.sql
@@ -51,6 +51,9 @@ EXPLAIN UPDATE TEST SET A = 3, (B) = 4;
 UPDATE TEST SET (A, B) = (1, 2), (B, A) = (2, 1);
 > exception DUPLICATE_COLUMN_NAME_1
 
+UPDATE TEST SET (A) = A * 3;
+> update count: 1
+
 DROP TABLE TEST;
 > ok
 

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -818,3 +818,4 @@ prepend honored evacuated peeked queued transforms inbounded fragmented unprotec
 housekeeping trail breadcrumb bets seasoned rewritable rpi eliminating projected reenterant varint races outcomes
 sparsely shifting vacated evacuation bullet allocations projected evacuatable pin capable rewritable deficiency
 successfull deduplication entrant mvmap sporadic irrelevant interrupts
+sit sitting sooner


### PR DESCRIPTION
1. Possible NPE in `Parser.parseUpdateSetClause()` is fixed. It was not detected earlier because an unusual and unreasonable, but still correct syntax constuction is requred to reproduce it.

2. Some places in documentation are updated to current behavior of H2. Closes #2051.

3. Some typos and indentation are fixed, `dictionary.txt` is updated.