### PR TITLE
Happy path: speed up database opening

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -774,11 +774,6 @@ public class Database implements DataHandler {
                 getPageStore();
             }
             starting = false;
-            if (store == null) {
-                writer = WriterThread.create(this, writeDelay);
-            } else {
-                setWriteDelay(writeDelay);
-            }
         } else {
             if (autoServerMode) {
                 throw DbException.getUnsupportedException(
@@ -896,6 +891,13 @@ public class Database implements DataHandler {
         systemSession.commit(true);
 
         trace.info("opened {0}", databaseName);
+        if (persistent) {
+            if (store == null) {
+                writer = WriterThread.create(this, writeDelay);
+            } else {
+                setWriteDelay(writeDelay);
+            }
+        }
         if (checkpointAllowed > 0) {
             afterWriting();
         }

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -16,7 +16,8 @@ import java.util.HashMap;
  * There are at most 67 million (2^26) chunks,
  * each chunk is at most 2 GB large.
  */
-public class Chunk {
+public class Chunk
+{
 
     /**
      * The maximum chunk id.
@@ -34,6 +35,23 @@ public class Chunk {
      * version:ffffffffffffffff,fletcher:ffffffff
      */
     static final int FOOTER_LENGTH = 128;
+
+    private static final String ATTR_CHUNK = "chunk";
+    private static final String ATTR_BLOCK = "block";
+    private static final String ATTR_LEN = "len";
+    private static final String ATTR_MAP = "map";
+    private static final String ATTR_MAX = "max";
+    private static final String ATTR_NEXT = "next";
+    private static final String ATTR_PAGES = "pages";
+    private static final String ATTR_ROOT = "root";
+    private static final String ATTR_TIME = "time";
+    private static final String ATTR_VERSION = "version";
+    private static final String ATTR_LIVE_MAX = "liveMax";
+    private static final String ATTR_LIVE_PAGES = "livePages";
+    private static final String ATTR_UNUSED = "unused";
+    private static final String ATTR_UNUSED_AT_VERSION = "unusedAtVersion";
+    private static final String ATTR_PIN_COUNT = "pinCount";
+    private static final String ATTR_FLETCHER = "fletcher";
 
     /**
      * The chunk id.
@@ -182,7 +200,7 @@ public class Chunk {
      * @return the metadata key
      */
     static String getMetaKey(int chunkId) {
-        return "chunk." + Integer.toHexString(chunkId);
+        return ATTR_CHUNK + "." + Integer.toHexString(chunkId);
     }
 
     /**
@@ -193,22 +211,22 @@ public class Chunk {
      */
     public static Chunk fromString(String s) {
         HashMap<String, String> map = DataUtils.parseMap(s);
-        int id = DataUtils.readHexInt(map, "chunk", 0);
+        int id = DataUtils.readHexInt(map, ATTR_CHUNK, 0);
         Chunk c = new Chunk(id);
-        c.block = DataUtils.readHexLong(map, "block", 0);
-        c.len = DataUtils.readHexInt(map, "len", 0);
-        c.pageCount = DataUtils.readHexInt(map, "pages", 0);
-        c.pageCountLive = DataUtils.readHexInt(map, "livePages", c.pageCount);
-        c.mapId = DataUtils.readHexInt(map, "map", 0);
-        c.maxLen = DataUtils.readHexLong(map, "max", 0);
-        c.maxLenLive = DataUtils.readHexLong(map, "liveMax", c.maxLen);
-        c.metaRootPos = DataUtils.readHexLong(map, "root", 0);
-        c.time = DataUtils.readHexLong(map, "time", 0);
-        c.unused = DataUtils.readHexLong(map, "unused", 0);
-        c.unusedAtVersion = DataUtils.readHexLong(map, "unusedAtVersion", 0);
-        c.version = DataUtils.readHexLong(map, "version", id);
-        c.next = DataUtils.readHexLong(map, "next", 0);
-        c.pinCount = DataUtils.readHexInt(map, "pinCount", 0);
+        c.block = DataUtils.readHexLong(map, ATTR_BLOCK, 0);
+        c.len = DataUtils.readHexInt(map, ATTR_LEN, 0);
+        c.pageCount = DataUtils.readHexInt(map, ATTR_PAGES, 0);
+        c.pageCountLive = DataUtils.readHexInt(map, ATTR_LIVE_PAGES, c.pageCount);
+        c.mapId = DataUtils.readHexInt(map, ATTR_MAP, 0);
+        c.maxLen = DataUtils.readHexLong(map, ATTR_MAX, 0);
+        c.maxLenLive = DataUtils.readHexLong(map, ATTR_LIVE_MAX, c.maxLen);
+        c.metaRootPos = DataUtils.readHexLong(map, ATTR_ROOT, 0);
+        c.time = DataUtils.readHexLong(map, ATTR_TIME, 0);
+        c.unused = DataUtils.readHexLong(map, ATTR_UNUSED, 0);
+        c.unusedAtVersion = DataUtils.readHexLong(map, ATTR_UNUSED_AT_VERSION, 0);
+        c.version = DataUtils.readHexLong(map, ATTR_VERSION, id);
+        c.next = DataUtils.readHexLong(map, ATTR_NEXT, 0);
+        c.pinCount = DataUtils.readHexInt(map, ATTR_PIN_COUNT, 0);
         return c;
     }
 
@@ -244,42 +262,42 @@ public class Chunk {
      */
     public String asString() {
         StringBuilder buff = new StringBuilder(240);
-        DataUtils.appendMap(buff, "chunk", id);
-        DataUtils.appendMap(buff, "block", block);
-        DataUtils.appendMap(buff, "len", len);
+        DataUtils.appendMap(buff, ATTR_CHUNK, id);
+        DataUtils.appendMap(buff, ATTR_BLOCK, block);
+        DataUtils.appendMap(buff, ATTR_LEN, len);
         if (maxLen != maxLenLive) {
-            DataUtils.appendMap(buff, "liveMax", maxLenLive);
+            DataUtils.appendMap(buff, ATTR_LIVE_MAX, maxLenLive);
         }
         if (pageCount != pageCountLive) {
-            DataUtils.appendMap(buff, "livePages", pageCountLive);
+            DataUtils.appendMap(buff, ATTR_LIVE_PAGES, pageCountLive);
         }
-        DataUtils.appendMap(buff, "map", mapId);
-        DataUtils.appendMap(buff, "max", maxLen);
+        DataUtils.appendMap(buff, ATTR_MAP, mapId);
+        DataUtils.appendMap(buff, ATTR_MAX, maxLen);
         if (next != 0) {
-            DataUtils.appendMap(buff, "next", next);
+            DataUtils.appendMap(buff, ATTR_NEXT, next);
         }
-        DataUtils.appendMap(buff, "pages", pageCount);
-        DataUtils.appendMap(buff, "root", metaRootPos);
-        DataUtils.appendMap(buff, "time", time);
+        DataUtils.appendMap(buff, ATTR_PAGES, pageCount);
+        DataUtils.appendMap(buff, ATTR_ROOT, metaRootPos);
+        DataUtils.appendMap(buff, ATTR_TIME, time);
         if (unused != 0) {
-            DataUtils.appendMap(buff, "unused", unused);
+            DataUtils.appendMap(buff, ATTR_UNUSED, unused);
         }
         if (unusedAtVersion != 0) {
-            DataUtils.appendMap(buff, "unusedAtVersion", unusedAtVersion);
+            DataUtils.appendMap(buff, ATTR_UNUSED_AT_VERSION, unusedAtVersion);
         }
-        DataUtils.appendMap(buff, "version", version);
-        DataUtils.appendMap(buff, "pinCount", pinCount);
+        DataUtils.appendMap(buff, ATTR_VERSION, version);
+        DataUtils.appendMap(buff, ATTR_PIN_COUNT, pinCount);
         return buff.toString();
     }
 
     byte[] getFooterBytes() {
         StringBuilder buff = new StringBuilder(FOOTER_LENGTH);
-        DataUtils.appendMap(buff, "chunk", id);
-        DataUtils.appendMap(buff, "block", block);
-        DataUtils.appendMap(buff, "version", version);
+        DataUtils.appendMap(buff, ATTR_CHUNK, id);
+        DataUtils.appendMap(buff, ATTR_BLOCK, block);
+        DataUtils.appendMap(buff, ATTR_VERSION, version);
         byte[] bytes = buff.toString().getBytes(StandardCharsets.ISO_8859_1);
         int checksum = DataUtils.getFletcher32(bytes, 0, bytes.length);
-        DataUtils.appendMap(buff, "fletcher", checksum);
+        DataUtils.appendMap(buff, ATTR_FLETCHER, checksum);
         while (buff.length() < FOOTER_LENGTH - 1) {
             buff.append(' ');
         }

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -751,7 +751,7 @@ public final class DataUtils {
      * @return the map without mapping for {@code "fletcher"}, or {@code null} if checksum is wrong
      * @throws IllegalStateException if parsing failed
      */
-    public static HashMap<String, String> parseChecksummedMap(byte[] bytes) {
+    static HashMap<String, String> parseChecksummedMap(byte[] bytes) {
         int start = 0, end = bytes.length;
         while (start < end && bytes[start] <= ' ') {
             start++;
@@ -766,7 +766,8 @@ public final class DataUtils {
             int startKey = i;
             i = s.indexOf(':', i);
             if (i < 0) {
-                throw newIllegalStateException(ERROR_FILE_CORRUPT, "Not a map: {0}", s);
+                // Corrupted map
+                return null;
             }
             if (i - startKey == 8 && s.regionMatches(startKey, "fletcher", 0, 8)) {
                 parseMapValue(buff, s, i + 1, size);

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -749,7 +749,7 @@ public final class DataUtils {
      *
      * @param bytes encoded map
      * @return the map without mapping for {@code "fletcher"}, or {@code null} if checksum is wrong
-     * @throws IllegalStateException if parsing failed
+     *              or parameter do not represent a properly formatted map serialization
      */
     static HashMap<String, String> parseChecksummedMap(byte[] bytes) {
         int start = 0, end = bytes.length;

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -154,6 +154,12 @@ public final class DataUtils {
      */
     public static final int PAGE_LARGE = 2 * 1024 * 1024;
 
+    // The following are key prefixes used in meta map
+    public static final String META_CHUNK = "chunk."; // + hex chunk id -> serialized chunk metadata
+    public static final String META_NAME = "name.";   // + map's name -> hex map id
+    public static final String META_MAP = "map.";     // + hex map id -> serialized map metadata
+    public static final String META_ROOT = "root.";   // + hex map id -> hex root page "position"
+
     /**
      * Get the length of the variable size int.
      *

--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -351,11 +351,11 @@ public class FileStore {
     /**
      * Calculate starting position of the prospective allocation.
      *
-     * @param length the number of bytes to allocate
-     * @return the start position in bytes
+     * @param blocks the number of blocks to allocate
+     * @return the starting block index
      */
-    long predictAllocation(int length) {
-        return freeSpace.predictAllocation(length);
+    long predictAllocation(int blocks) {
+        return freeSpace.predictAllocation(blocks);
     }
 
     boolean isFragmented() {

--- a/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
+++ b/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
@@ -104,25 +104,24 @@ public class FreeSpaceBitSet {
      * @return the start position in bytes
      */
     public long allocate(int length) {
-        return allocate(length, true);
+        return getPos(allocate(getBlockCount(length), true));
     }
 
     /**
      * Calculate starting position of the prospective allocation.
      *
-     * @param length the number of bytes to allocate
-     * @return the start position in bytes
+     * @param blocks the number of blocks to allocate
+     * @return the starting block index
      */
-    long predictAllocation(int length) {
-        return allocate(length, false);
+    long predictAllocation(int blocks) {
+        return allocate(blocks, false);
     }
 
     boolean isFragmented() {
         return Integer.bitCount(failureFlags & 0x0F) > 1;
     }
 
-    private long allocate(int length, boolean allocate) {
-        int blocks = getBlockCount(length);
+    private int allocate(int blocks, boolean allocate) {
         int freeBlocksTotal = 0;
         for (int i = 0;;) {
             int start = set.nextClearBit(i);
@@ -139,7 +138,7 @@ public class FreeSpaceBitSet {
                         failureFlags |= 1;
                     }
                 }
-                return getPos(start);
+                return start;
             }
             freeBlocksTotal += freeBlocks;
             i = end;

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -125,7 +125,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @return the metadata key
      */
     static String getMapRootKey(int mapId) {
-        return MVStore.META_ROOT + Integer.toHexString(mapId);
+        return DataUtils.META_ROOT + Integer.toHexString(mapId);
     }
 
     /**
@@ -135,7 +135,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @return the metadata key
      */
     static String getMapKey(int mapId) {
-        return MVStore.META_MAP + Integer.toHexString(mapId);
+        return DataUtils.META_MAP + Integer.toHexString(mapId);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -886,7 +886,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      *                             were made to update root
      * @return new RootReference or null if update failed
      */
-    protected final boolean updateRoot(RootReference expectedRootReference, Page newRootPage,
+    protected static boolean updateRoot(RootReference expectedRootReference, Page newRootPage,
             int attemptUpdateCounter) {
         return expectedRootReference.updateRootPage(newRootPage, attemptUpdateCounter) != null;
     }

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -125,7 +125,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @return the metadata key
      */
     static String getMapRootKey(int mapId) {
-        return "root." + Integer.toHexString(mapId);
+        return MVStore.META_ROOT + Integer.toHexString(mapId);
     }
 
     /**
@@ -135,7 +135,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @return the metadata key
      */
     static String getMapKey(int mapId) {
-        return "map." + Integer.toHexString(mapId);
+        return MVStore.META_MAP + Integer.toHexString(mapId);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -129,6 +129,7 @@ MVStore:
  */
 public class MVStore implements AutoCloseable
 {
+    // The following are attribute names (keys) in store header map
     private static final String HDR_H = "H";
     private static final String HDR_BLOCK_SIZE = "blockSize";
     private static final String HDR_FORMAT = "format";
@@ -140,10 +141,11 @@ public class MVStore implements AutoCloseable
     private static final String HDR_CLEAN = "clean";
     private static final String HDR_FLETCHER = "fletcher";
 
-    public static final String META_CHUNK = "chunk.";
-    public static final String META_NAME = "name.";
-    public static final String META_MAP = "map.";
-    public static final String META_ROOT = "root.";
+    // The following are key prefixes used in meta map
+    public static final String META_CHUNK = "chunk."; // + hex chunk id -> serialized chunk metadata
+    public static final String META_NAME = "name.";   // + map's name -> hex map id
+    public static final String META_MAP = "map.";     // + hex map id -> serialized map metadata
+    public static final String META_ROOT = "root.";   // + hex map id -> hex root page "position"
 
 
     /**

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -701,14 +701,8 @@ public class MVStore implements AutoCloseable
             try {
                 HashMap<String, String> m = DataUtils.parseChecksummedMap(buff);
                 if (m == null) {
+                    assumeCleanShutdown = false;
                     continue;
-                }
-                int blockSize = DataUtils.readHexInt(m, HDR_BLOCK_SIZE, BLOCK_SIZE);
-                if (blockSize != BLOCK_SIZE) {
-                    throw DataUtils.newIllegalStateException(
-                            DataUtils.ERROR_UNSUPPORTED_FORMAT,
-                            "Block size {0} is currently not supported",
-                            blockSize);
                 }
                 long version = DataUtils.readHexLong(m, HDR_VERSION, 0);
                 // if both header blocks do agree on version
@@ -734,6 +728,13 @@ public class MVStore implements AutoCloseable
             throw DataUtils.newIllegalStateException(
                     DataUtils.ERROR_FILE_CORRUPT,
                     "Store header is corrupt: {0}", fileStore);
+        }
+        int blockSize = DataUtils.readHexInt(storeHeader, HDR_BLOCK_SIZE, BLOCK_SIZE);
+        if (blockSize != BLOCK_SIZE) {
+            throw DataUtils.newIllegalStateException(
+                    DataUtils.ERROR_UNSUPPORTED_FORMAT,
+                    "Block size {0} is currently not supported",
+                    blockSize);
         }
         long format = DataUtils.readHexLong(storeHeader, HDR_FORMAT, 1);
         if (format > FORMAT_WRITE && !fileStore.isReadOnly()) {

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -450,7 +450,7 @@ public class MVStore implements AutoCloseable
                 break;
             }
             String mapIdStr = key.substring(key.lastIndexOf('.') + 1);
-            if(!meta.containsKey(MVStore.META_MAP + mapIdStr)) {
+            if(!meta.containsKey(META_MAP + mapIdStr)) {
                 meta.remove(key);
                 markMetaChanged();
                 keysToRemove.add(key);
@@ -462,13 +462,13 @@ public class MVStore implements AutoCloseable
             markMetaChanged();
         }
 
-        for (Iterator<String> it = meta.keyIterator(MVStore.META_MAP); it.hasNext();) {
+        for (Iterator<String> it = meta.keyIterator(META_MAP); it.hasNext();) {
             String key = it.next();
-            if (!key.startsWith(MVStore.META_MAP)) {
+            if (!key.startsWith(META_MAP)) {
                 break;
             }
             String mapName = DataUtils.getMapName(meta.get(key));
-            String mapIdStr = key.substring(MVStore.META_MAP.length());
+            String mapIdStr = key.substring(META_MAP.length());
             // ensure that last map id is not smaller than max of any existing map ids
             int mapId = DataUtils.parseHexInt(mapIdStr);
             if (mapId > lastMapId.get()) {
@@ -717,6 +717,8 @@ public class MVStore implements AutoCloseable
                             blockSize);
                 }
                 long version = DataUtils.readHexLong(m, HDR_VERSION, 0);
+                // if both header blocks do agree on version
+                // we'll continue on happy path - assume that previous shutdown was clean
                 assumeCleanShutdown = newest == null || version == newest.version;
                 if (newest == null || version > newest.version) {
                     validStoreHeader = true;
@@ -1503,7 +1505,7 @@ public class MVStore implements AutoCloseable
         }
     }
 
-    private boolean canOverwriteChunk(Chunk c, long oldestVersionToKeep) {
+    private static boolean canOverwriteChunk(Chunk c, long oldestVersionToKeep) {
         return !c.isLive() && c.unusedAtVersion < oldestVersionToKeep;
     }
 
@@ -2079,7 +2081,7 @@ public class MVStore implements AutoCloseable
         return true;
     }
 
-    private HashSet<Integer> createIdSet(Iterable<Chunk> toCompact) {
+    private static HashSet<Integer> createIdSet(Iterable<Chunk> toCompact) {
         HashSet<Integer> set = new HashSet<>();
         for (Chunk c : toCompact) {
             set.add(c.id);

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -368,7 +368,7 @@ public class MVStoreTool {
             long maxLengthNotEmpty = 0;
             for (Entry<String, String> e : meta.entrySet()) {
                 String k = e.getKey();
-                if (k.startsWith(MVStore.META_CHUNK)) {
+                if (k.startsWith(DataUtils.META_CHUNK)) {
                     Chunk c = Chunk.fromString(e.getValue());
                     chunks.put(c.id, c);
                     chunkLength += c.len * MVStore.BLOCK_SIZE;
@@ -524,13 +524,13 @@ public class MVStoreTool {
             MVMap<String, String> targetMeta = target.getMetaMap();
             for (Entry<String, String> m : sourceMeta.entrySet()) {
                 String key = m.getKey();
-                if (key.startsWith(MVStore.META_CHUNK)) {
+                if (key.startsWith(DataUtils.META_CHUNK)) {
                     // ignore
-                } else if (key.startsWith(MVStore.META_MAP)) {
+                } else if (key.startsWith(DataUtils.META_MAP)) {
                     // ignore
-                } else if (key.startsWith(MVStore.META_NAME)) {
+                } else if (key.startsWith(DataUtils.META_NAME)) {
                     // ignore
-                } else if (key.startsWith(MVStore.META_ROOT)) {
+                } else if (key.startsWith(DataUtils.META_ROOT)) {
                     // ignore
                 } else {
                     targetMeta.put(key, m.getValue());

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -368,7 +368,7 @@ public class MVStoreTool {
             long maxLengthNotEmpty = 0;
             for (Entry<String, String> e : meta.entrySet()) {
                 String k = e.getKey();
-                if (k.startsWith("chunk.")) {
+                if (k.startsWith(MVStore.META_CHUNK)) {
                     Chunk c = Chunk.fromString(e.getValue());
                     chunks.put(c.id, c);
                     chunkLength += c.len * MVStore.BLOCK_SIZE;
@@ -524,13 +524,13 @@ public class MVStoreTool {
             MVMap<String, String> targetMeta = target.getMetaMap();
             for (Entry<String, String> m : sourceMeta.entrySet()) {
                 String key = m.getKey();
-                if (key.startsWith("chunk.")) {
+                if (key.startsWith(MVStore.META_CHUNK)) {
                     // ignore
-                } else if (key.startsWith("map.")) {
+                } else if (key.startsWith(MVStore.META_MAP)) {
                     // ignore
-                } else if (key.startsWith("name.")) {
+                } else if (key.startsWith(MVStore.META_NAME)) {
                     // ignore
-                } else if (key.startsWith("root.")) {
+                } else if (key.startsWith(MVStore.META_ROOT)) {
                     // ignore
                 } else {
                     targetMeta.put(key, m.getValue());

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -19,6 +19,7 @@ import org.h2.index.BaseIndex;
 import org.h2.index.Cursor;
 import org.h2.index.IndexType;
 import org.h2.message.DbException;
+import org.h2.mvstore.MVStore;
 import org.h2.mvstore.tx.Transaction;
 import org.h2.mvstore.tx.TransactionMap;
 import org.h2.result.Row;
@@ -54,7 +55,7 @@ public class MVPrimaryIndex extends BaseIndex {
         ValueDataType keyType = new ValueDataType();
         ValueDataType valueType = new ValueDataType(db, sortTypes);
         mapName = "table." + getId();
-        assert db.isStarting() || !db.getStore().getMvStore().getMetaMap().containsKey("name." + mapName);
+        assert db.isStarting() || !db.getStore().getMvStore().getMetaMap().containsKey(MVStore.META_NAME + mapName);
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(mapName, keyType, valueType);
         dataMap.map.setVolatile(!table.isPersistData() || !indexType.isPersistent());

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -19,7 +19,7 @@ import org.h2.index.BaseIndex;
 import org.h2.index.Cursor;
 import org.h2.index.IndexType;
 import org.h2.message.DbException;
-import org.h2.mvstore.MVStore;
+import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.tx.Transaction;
 import org.h2.mvstore.tx.TransactionMap;
 import org.h2.result.Row;
@@ -55,7 +55,7 @@ public class MVPrimaryIndex extends BaseIndex {
         ValueDataType keyType = new ValueDataType();
         ValueDataType valueType = new ValueDataType(db, sortTypes);
         mapName = "table." + getId();
-        assert db.isStarting() || !db.getStore().getMvStore().getMetaMap().containsKey(MVStore.META_NAME + mapName);
+        assert db.isStarting() || !db.getStore().getMvStore().getMetaMap().containsKey(DataUtils.META_NAME + mapName);
         Transaction t = mvTable.getTransactionBegin();
         dataMap = t.openMap(mapName, keyType, valueType);
         dataMap.map.setVolatile(!table.isPersistData() || !indexType.isPersistent());

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -58,7 +58,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         // even for unique indexes, as some of the index columns could be null
         keyColumns = columns.length + 1;
         String mapName = "index." + getId();
-        assert db.isStarting() || !db.getStore().getMvStore().getMetaMap().containsKey("name." + mapName);
+        assert db.isStarting() || !db.getStore().getMvStore().getMetaMap().containsKey(MVStore.META_NAME + mapName);
         int[] sortTypes = new int[keyColumns];
         for (int i = 0; i < columns.length; i++) {
             sortTypes[i] = columns[i].sortType;

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -19,6 +19,7 @@ import org.h2.index.BaseIndex;
 import org.h2.index.Cursor;
 import org.h2.index.IndexType;
 import org.h2.message.DbException;
+import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.tx.Transaction;
@@ -58,7 +59,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         // even for unique indexes, as some of the index columns could be null
         keyColumns = columns.length + 1;
         String mapName = "index." + getId();
-        assert db.isStarting() || !db.getStore().getMvStore().getMetaMap().containsKey(MVStore.META_NAME + mapName);
+        assert db.isStarting() || !db.getStore().getMvStore().getMetaMap().containsKey(DataUtils.META_NAME + mapName);
         int[] sortTypes = new int[keyColumns];
         for (int i = 0; i < columns.length; i++) {
             sortTypes[i] = columns[i].sortType;

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -94,6 +94,11 @@ public class MVTableEngine implements TableEngine {
                 }
 
             });
+            // always start without background thread first, and if neccessary,
+            // it will be set up later, after db has been fully started,
+            // otherwise background thread would compete for store lock
+            // with maps opening procedure
+            builder.autoCommitDisabled();
         }
         store.open(db, builder, encrypted);
         db.setStore(store);

--- a/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
+++ b/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
@@ -52,7 +52,7 @@ public class TestReorderWrites extends TestBase {
         FilePathReorderWrites fs = FilePathReorderWrites.register();
         String fileName = "reorder:memFS:test.mv";
         try {
-            for (int i = 0; i < 1000; i++) {
+            for (int i = 0; i < (config.big ? 1000 : 100); i++) {
                 log(i + " --------------------------------");
                 // this test is not interested in power off failures during
                 // initial creation
@@ -69,7 +69,7 @@ public class TestReorderWrites extends TestBase {
                 store.commit();
                 store.getFileStore().sync();
                 Random r = new Random(i);
-                int stop = 4 + r.nextInt(150);
+                int stop = 4 + r.nextInt(config.big ? 150 : 20);
                 log("countdown start");
                 fs.setPowerOffCountdown(stop, i);
                 try {

--- a/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
+++ b/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
@@ -69,7 +69,7 @@ public class TestReorderWrites extends TestBase {
                 store.commit();
                 store.getFileStore().sync();
                 Random r = new Random(i);
-                int stop = 4 + r.nextInt(20);
+                int stop = 4 + r.nextInt(150);
                 log("countdown start");
                 fs.setPowerOffCountdown(stop, i);
                 try {

--- a/h2/src/test/org/h2/test/store/TestConcurrent.java
+++ b/h2/src/test/org/h2/test/store/TestConcurrent.java
@@ -447,7 +447,7 @@ public class TestConcurrent extends TestMVStore {
                 MVMap<String, String> meta = s.getMetaMap();
                 int chunkCount = 0;
                 for (String k : meta.keyList()) {
-                    if (k.startsWith(MVStore.META_CHUNK)) {
+                    if (k.startsWith(DataUtils.META_CHUNK)) {
                         chunkCount++;
                     }
                 }

--- a/h2/src/test/org/h2/test/store/TestConcurrent.java
+++ b/h2/src/test/org/h2/test/store/TestConcurrent.java
@@ -447,7 +447,7 @@ public class TestConcurrent extends TestMVStore {
                 MVMap<String, String> meta = s.getMetaMap();
                 int chunkCount = 0;
                 for (String k : meta.keyList()) {
-                    if (k.startsWith("chunk.")) {
+                    if (k.startsWith(MVStore.META_CHUNK)) {
                         chunkCount++;
                     }
                 }

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -284,7 +284,7 @@ public class TestMVStore extends TestBase {
         map.put(1, new byte[10 * 1024]);
         s.commit();
         MVMap<String, String> meta = s.getMetaMap();
-        Chunk c = Chunk.fromString(meta.get(MVStore.META_CHUNK+"1"));
+        Chunk c = Chunk.fromString(meta.get(DataUtils.META_CHUNK+"1"));
         assertTrue(c.maxLen < Integer.MAX_VALUE);
         assertTrue(c.maxLenLive < Integer.MAX_VALUE);
         s.close();
@@ -1528,7 +1528,7 @@ public class TestMVStore extends TestBase {
         assertTrue(s.hasUnsavedChanges());
         s.rollbackTo(v2);
         assertFalse(s.hasUnsavedChanges());
-        assertNull(meta.get(MVStore.META_NAME+"data1"));
+        assertNull(meta.get(DataUtils.META_NAME+"data1"));
         assertNull(m0.get("1"));
         assertEquals("Hello", m.get("1"));
         // no changes - no real commit here
@@ -1539,9 +1539,9 @@ public class TestMVStore extends TestBase {
         s.setRetentionTime(45000);
         assertEquals(2, s.getCurrentVersion());
         meta = s.getMetaMap();
-        assertNotNull(meta.get(MVStore.META_NAME + "data"));
-        assertNotNull(meta.get(MVStore.META_NAME + "data0"));
-        assertNull(meta.get(MVStore.META_NAME + "data1"));
+        assertNotNull(meta.get(DataUtils.META_NAME + "data"));
+        assertNotNull(meta.get(DataUtils.META_NAME + "data0"));
+        assertNull(meta.get(DataUtils.META_NAME + "data1"));
         m = s.openMap("data");
         m0 = s.openMap("data0");
         assertNull(m0.get("1"));
@@ -1634,13 +1634,13 @@ public class TestMVStore extends TestBase {
         assertNull(s.getMapName(s.getMetaMap().getId()));
         assertNull(s.getMapName(data.getId() + 1));
 
-        String id = s.getMetaMap().get(MVStore.META_NAME + "data");
-        assertEquals("name:data", m.get(MVStore.META_MAP + id));
+        String id = s.getMetaMap().get(DataUtils.META_NAME + "data");
+        assertEquals("name:data", m.get(DataUtils.META_MAP + id));
         assertEquals("Hello", data.put("1", "Hallo"));
         s.commit();
-        assertEquals("name:data", m.get(MVStore.META_MAP + id));
+        assertEquals("name:data", m.get(DataUtils.META_MAP + id));
         assertTrue(m.get("root.1").length() > 0);
-        assertTrue(m.containsKey(MVStore.META_CHUNK + "1"));
+        assertTrue(m.containsKey(DataUtils.META_CHUNK + "1"));
 
         assertEquals(2, s.getCurrentVersion());
 
@@ -1800,7 +1800,7 @@ public class TestMVStore extends TestBase {
     private int getChunkCount(Map<String, String> meta) {
         int chunkCount = 0;
         for (String k : meta.keySet()) {
-            if (k.startsWith(MVStore.META_CHUNK)) {
+            if (k.startsWith(DataUtils.META_CHUNK)) {
                 chunkCount++;
             }
         }

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1462,7 +1462,7 @@ public class TestMVStore extends TestBase {
         assertEquals(0, m.size());
         s.commit();
         // ensure only nodes are read, but not leaves
-        assertEquals(8, s.getFileStore().getReadCount());
+        assertEquals(5, s.getFileStore().getReadCount());
         assertTrue(s.getFileStore().getWriteCount() < 5);
         s.close();
     }

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -284,7 +284,7 @@ public class TestMVStore extends TestBase {
         map.put(1, new byte[10 * 1024]);
         s.commit();
         MVMap<String, String> meta = s.getMetaMap();
-        Chunk c = Chunk.fromString(meta.get("chunk.1"));
+        Chunk c = Chunk.fromString(meta.get(MVStore.META_CHUNK+"1"));
         assertTrue(c.maxLen < Integer.MAX_VALUE);
         assertTrue(c.maxLenLive < Integer.MAX_VALUE);
         s.close();
@@ -1528,7 +1528,7 @@ public class TestMVStore extends TestBase {
         assertTrue(s.hasUnsavedChanges());
         s.rollbackTo(v2);
         assertFalse(s.hasUnsavedChanges());
-        assertNull(meta.get("name.data1"));
+        assertNull(meta.get(MVStore.META_NAME+"data1"));
         assertNull(m0.get("1"));
         assertEquals("Hello", m.get("1"));
         // no changes - no real commit here
@@ -1539,9 +1539,9 @@ public class TestMVStore extends TestBase {
         s.setRetentionTime(45000);
         assertEquals(2, s.getCurrentVersion());
         meta = s.getMetaMap();
-        assertNotNull(meta.get("name.data"));
-        assertNotNull(meta.get("name.data0"));
-        assertNull(meta.get("name.data1"));
+        assertNotNull(meta.get(MVStore.META_NAME + "data"));
+        assertNotNull(meta.get(MVStore.META_NAME + "data0"));
+        assertNull(meta.get(MVStore.META_NAME + "data1"));
         m = s.openMap("data");
         m0 = s.openMap("data0");
         assertNull(m0.get("1"));
@@ -1634,13 +1634,13 @@ public class TestMVStore extends TestBase {
         assertNull(s.getMapName(s.getMetaMap().getId()));
         assertNull(s.getMapName(data.getId() + 1));
 
-        String id = s.getMetaMap().get("name.data");
-        assertEquals("name:data", m.get("map." + id));
+        String id = s.getMetaMap().get(MVStore.META_NAME + "data");
+        assertEquals("name:data", m.get(MVStore.META_MAP + id));
         assertEquals("Hello", data.put("1", "Hallo"));
         s.commit();
-        assertEquals("name:data", m.get("map." + id));
+        assertEquals("name:data", m.get(MVStore.META_MAP + id));
         assertTrue(m.get("root.1").length() > 0);
-        assertTrue(m.containsKey("chunk.1"));
+        assertTrue(m.containsKey(MVStore.META_CHUNK + "1"));
 
         assertEquals(2, s.getCurrentVersion());
 
@@ -1800,7 +1800,7 @@ public class TestMVStore extends TestBase {
     private int getChunkCount(Map<String, String> meta) {
         int chunkCount = 0;
         for (String k : meta.keySet()) {
-            if (k.startsWith("chunk.")) {
+            if (k.startsWith(MVStore.META_CHUNK)) {
                 chunkCount++;
             }
         }


### PR DESCRIPTION
This PR is an attempt to speed up database opening, if case of previous clean shutdown has been detected. It will address #2048. Minimal verification will include store header and chunk header/footer validation for up to 20 latest chunks.
On the other hand, on a long path, it will do a full data file scan for an automatic recovery.
Power-off countdown in TestReorderWrites was increased to give it a time to create more messy chunk mixes and reveal failures of the current recovery procedure. 
Detection of overlapping chunks and stray (non-matching) header/footer in the middle of otherwise valid chunk was added.

PR also includes additional logic to decrease number of writes, when chunks are moved during compaction, Instead of copying all of the candidates to the end of file first, and only then to target location, chunks can be moved directly to target location until that new chunk location overlaps with the source location(s) of the chunk group. From that point on, an old two-phased move is engaged.
