### PR TITLE
Optimize the mvstore opening and fix error code 90020 issue for closing database incorrectly

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -594,7 +594,7 @@ public class Database implements DataHandler {
                 DbException.traceThrowable(e);
             }
         }
-        Engine.getInstance().close(databaseName);
+        Engine.getInstance().close(this);
         throw DbException.get(ErrorCode.DATABASE_IS_CLOSED);
     }
 
@@ -1552,7 +1552,7 @@ public class Database implements DataHandler {
                 }
             }
         } finally {
-            Engine.getInstance().close(databaseName);
+            Engine.getInstance().close(this);
         }
     }
 

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -239,6 +239,7 @@ public class Database implements DataHandler {
     private LocalResultFactory resultFactory = LocalResultFactory.DEFAULT;
 
     private Authenticator authenticator;
+    private boolean recoveryMode;
 
     public Database(ConnectionInfo ci, String cipher) {
         if (ASSERT) {
@@ -315,6 +316,7 @@ public class Database implements DataHandler {
                 TraceSystem.DEFAULT_TRACE_LEVEL_SYSTEM_OUT);
         this.cacheType = StringUtils.toUpperEnglish(
                 ci.removeProperty("CACHE_TYPE", Constants.CACHE_TYPE_DEFAULT));
+        this.recoveryMode = ci.removeProperty("RECOVER", false);
         openDatabase(traceLevelFile, traceLevelSystemOut, closeAtVmShutdown, ci);
     }
 
@@ -3230,4 +3232,15 @@ public class Database implements DataHandler {
         }
         this.authenticator=authenticator;
     }
+    
+    /**
+     * Whether enable recoveryMode in MVStore.
+     * 
+     * @return true if enable recoveryMode
+     * @since 2019-08-10 little-pan
+     */
+    public boolean isRecoveryMode() {
+        return recoveryMode;
+    }
+    
 }

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -3237,7 +3237,6 @@ public class Database implements DataHandler {
      * Whether enable recoveryMode in MVStore.
      * 
      * @return true if enable recoveryMode
-     * @since 2019-08-10 little-pan
      */
     public boolean isRecoveryMode() {
         return recoveryMode;

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -294,6 +294,15 @@ public class DbSettings extends SettingsBase {
      * milliseconds before updating the database.
      */
     public final int reconnectCheckDelay = get("RECONNECT_CHECK_DELAY", 200);
+    
+    /**
+     * Database setting <code>RECOVER</code> (default: false).<br />
+     * If setting it true, then enable recoveryMode(skipping invalid disc chunk) 
+     * in MVStore.
+     * 
+     * @since 2019-08-10 little-pan
+     */
+    public final boolean recover = get("RECOVER", false);
 
     /**
      * Database setting <code>REUSE_SPACE</code> (default: true).<br />

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -299,8 +299,6 @@ public class DbSettings extends SettingsBase {
      * Database setting <code>RECOVER</code> (default: false).<br />
      * If setting it true, then enable recoveryMode(skipping invalid disc chunk) 
      * in MVStore.
-     * 
-     * @since 2019-08-10 little-pan
      */
     public final boolean recover = get("RECOVER", false);
 

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -293,7 +293,6 @@ public class Engine implements SessionFactory {
      * 
      * <p>Support the method close() that should be resilient against being called more
      * than once, and fix the error code 90020 issue caused by closing the database incorrectly.
-     * @since 2019-08-08 little-pan
      * </p>
      *
      * @param maybeOlder the database will be closed from the engine

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -298,14 +298,14 @@ public class Engine implements SessionFactory {
      *
      * @param maybeOlder the database will be closed from the engine
      */
-    void close(final Database maybeOlder) {
+    void close(Database maybeOlder) {
         if(maybeOlder == null){
             return;
         }
         
-        final String name = maybeOlder.getName();
+        String name = maybeOlder.getName();
         synchronized (DATABASES) {
-            final Database intent = DATABASES.get(name);
+            Database intent = DATABASES.get(name);
             if(intent != maybeOlder){
                 return;
             }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1896,6 +1896,7 @@ public class MVStore implements AutoCloseable
             
             // last do shrink
             shrinkFileIfPossible(0);
+            sync();
         }
     }
     

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1883,12 +1883,13 @@ public class MVStore implements AutoCloseable
                 sync();
                 // b) free() must be before shrink for calculation of free space
                 freeMovedChunkSpaces();
-                freePending = null;
                 
                 // last do shrink
                 shrinkFileIfPossible(0);
                 sync();
             }
+            // cleanup & reset
+            freePending = null;
         }
     }
     

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -719,11 +719,11 @@ public class MVStore implements AutoCloseable
             fileHeaderBlocks.get(buff);
             // the following can fail for various reasons
             try {
-                final HashMap<String, String> m = DataUtils.parseChecksummedMap(buff);
+                HashMap<String, String> m = DataUtils.parseChecksummedMap(buff);
                 if (m == null) {
                     continue;
                 }
-                final long version = DataUtils.readHexLong(m, HDR_VERSION, 0);
+                long version = DataUtils.readHexLong(m, HDR_VERSION, 0);
                 // if both header blocks do agree on version
                 // we'll continue on happy path - assume that previous shutdown was clean
                 if (newest == null || version > newest.version) {
@@ -731,9 +731,9 @@ public class MVStore implements AutoCloseable
                     headerVersion = version;
                     storeHeader.putAll(m);
                     creationTime = DataUtils.readHexLong(m, HDR_CREATED, 0);
-                    final int chunkId = DataUtils.readHexInt(m, HDR_CHUNK, 0);
-                    final long block = DataUtils.readHexLong(m, HDR_BLOCK, 0);
-                    final Chunk test = readChunkHeaderAndFooter(block, chunkId);
+                    int chunkId = DataUtils.readHexInt(m, HDR_CHUNK, 0);
+                    long block = DataUtils.readHexLong(m, HDR_BLOCK, 0);
+                    Chunk test = readChunkHeaderAndFooter(block, chunkId);
                     if (test != null) {
                         newest = test;
                     }
@@ -775,7 +775,7 @@ public class MVStore implements AutoCloseable
         
         lastStoredVersion = INITIAL_VERSION;
         chunks.clear();
-        final long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
         // calculate the year (doesn't have to be exact;
         // we assume 365.25 days per year, * 4 = 1461)
         int year =  1970 + (int) (now / (1000L * 60 * 60 * 6 * 1461));
@@ -913,10 +913,10 @@ public class MVStore implements AutoCloseable
         
         // build the free space list
         fileStore.clear();
-        for (final Chunk c : chunks.values()) {
+        for (Chunk c : chunks.values()) {
             if (c.isSaved()) {
-                final long start = c.block * BLOCK_SIZE;
-                final int length = c.len * BLOCK_SIZE;
+                long start = c.block * BLOCK_SIZE;
+                int length = c.len * BLOCK_SIZE;
                 fileStore.markUsed(start, length);
             }
             if (!c.isLive()) {
@@ -974,7 +974,7 @@ public class MVStore implements AutoCloseable
                         return test;
                     }
                 }
-            } catch(final Exception e) {
+            } catch(Exception e) {
                 // ignore: corrupted chunk or normal pages
             }
             end -= BLOCK_SIZE;
@@ -1029,9 +1029,9 @@ public class MVStore implements AutoCloseable
      * @since 2019-08-08 little-pan
      */
     private Chunk readChunkHeaderAndFooter(long block) {
-        final Chunk header = readChunkHeaderOptionally(block);
+        Chunk header = readChunkHeaderOptionally(block);
         if (header != null) {
-            final Chunk footer = readChunkFooter(block + header.len);
+            Chunk footer = readChunkFooter(block + header.len);
             if (footer == null || footer.id != header.id || footer.block != header.block) {
                 return null;
             }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -816,12 +816,12 @@ public class MVStore implements AutoCloseable
         }
         if(newest == null){
             // + Check integrity of the newest chunk and it's version in file header
-            if(headerVersion > 0L){
+            if(headerVersion > 0L && !recoveryMode){
                 throw DataUtils.newIllegalStateException(
                         DataUtils.ERROR_FILE_CORRUPT, 
                         "No valid chunk for last version {0}", headerVersion);
             }
-            // Only file headers for new database
+            // Only file headers for new database or in recoveryMode
             return;
         }
         
@@ -904,7 +904,7 @@ public class MVStore implements AutoCloseable
         if(newest == null){
             throw DataUtils.newIllegalStateException(
                     DataUtils.ERROR_FILE_CORRUPT, 
-                    "Restore failed, no valid chunk for last version {0}", currentVersion);
+                    "Restore failed, not valid chunk for last version {0}", currentVersion);
         }
         
         // build the free space list

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -788,6 +788,10 @@ public class MVStore implements AutoCloseable
         // bugfix - data lost issue when partial write occurs at end of file store.
         // @since 2019-07-31 little-pan
         newest = readChunkHeaderAndFooterFromStoreTail(newest);
+        if(newest == null){
+            // Only file headers
+            return;
+        }
         
         // Step-3: read the newest chunk by following the chain of next chunks in the current newest
         // recursively, until the partial write chunk or invalid chunk

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1886,8 +1886,8 @@ public class MVStore implements AutoCloseable
                 
                 Chunk copy = Chunk.fromString(chunk.asString());
                 if (moveChunk(chunk, false)) {
-                    commit();
                     freePending.add(copy);
+                    commit();
                 }
                 shrinkFileIfPossible(0);
                 sync();

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -822,6 +822,9 @@ public class MVStore implements AutoCloseable
                         "No valid chunk for last version {0}", headerVersion);
             }
             // Only file headers for new database or in recoveryMode
+            storeHeader.remove(HDR_BLOCK);
+            storeHeader.remove(HDR_CHUNK);
+            storeHeader.remove(HDR_VERSION);
             return;
         }
         

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -161,16 +161,22 @@ public class MVStoreTool {
                     continue;
                 }
                 int length = c.len * MVStore.BLOCK_SIZE;
-                pw.printf("%n%0" + len + "x chunkHeader %s%n",
-                        pos, c.toString());
+                pw.printf("%n%0" + len + "x chunkHeader %s%n", pos, c.toString());
                 ByteBuffer chunk = ByteBuffer.allocate(length);
-                DataUtils.readFully(file, pos, chunk);
+                // bugfix - not catch EOF
+                // @since 2019-08-09 little-pan
+                try {
+                    DataUtils.readFully(file, pos, chunk);
+                } catch (IllegalStateException e){
+                    pos += length;
+                    pw.printf("ERROR illegal eof %d%n", pos);
+                    continue;
+                }
                 int p = block.position();
                 pos += length;
                 int remaining = c.pageCount;
                 pageCount += c.pageCount;
-                TreeMap<Integer, Integer> mapSizes =
-                        new TreeMap<>();
+                TreeMap<Integer, Integer> mapSizes = new TreeMap<>();
                 int pageSizeSum = 0;
                 while (remaining > 0) {
                     int start = p;

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -163,8 +163,6 @@ public class MVStoreTool {
                 int length = c.len * MVStore.BLOCK_SIZE;
                 pw.printf("%n%0" + len + "x chunkHeader %s%n", pos, c.toString());
                 ByteBuffer chunk = ByteBuffer.allocate(length);
-                // bugfix - not catch EOF
-                // @since 2019-08-09 little-pan
                 try {
                     DataUtils.readFully(file, pos, chunk);
                 } catch (IllegalStateException e){

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -99,6 +99,10 @@ public class MVTableEngine implements TableEngine {
             // otherwise background thread would compete for store lock
             // with maps opening procedure
             builder.autoCommitDisabled();
+            
+            if(db.isRecoveryMode()) {
+                builder.recoveryMode();
+            }
         }
         store.open(db, builder, encrypted);
         db.setStore(store);

--- a/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
+++ b/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
@@ -116,7 +116,9 @@ public class TestReorderWrites extends TestBase {
                 }
                 store = new MVStore.Builder().
                         fileName(fileName).
-                        autoCommitDisabled().open();
+                        autoCommitDisabled().
+                        recoveryMode().
+                        open();
                 map = store.openMap("data");
                 if (!map.containsKey(-1)) {
                     fail("key not found, size=" + map.size() + " i=" + i);

--- a/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
+++ b/h2/src/test/org/h2/test/poweroff/TestReorderWrites.java
@@ -48,7 +48,6 @@ public class TestReorderWrites extends TestBase {
 
     private void testMVStore(boolean partialWrite, boolean consistent) {
         // Add partial write test
-        // @since 2019-07-31 little-pan
         println("testMVStore(): partial write " + partialWrite + ", check consistency " + consistent);
         FilePathReorderWrites.setPartialWrites(partialWrite);
 
@@ -93,12 +92,22 @@ public class TestReorderWrites extends TestBase {
                             log("PUT: key=" +key + ", value.len="+len);
                         }
                         log("op " + j + ": ");
-                        store.commit();
+                        boolean failed = true;
+                        try {
+                            store.commit();
+                            failed = false;
+                        } finally {
+                            if (failed && key == lastKey) {
+                                // unknown state
+                                lastKey = lastLen = -1;
+                            }
+                        }
                         lastLen = -2;
                         
                         // enhance test: whether data lost for consistency
                         if (consistent) {
                             store.sync();
+                            // consistent state
                             log("SYN: key=" +key + ", j=" +j);
                             lastj = j;
                             lastKey = key;
@@ -197,7 +206,6 @@ public class TestReorderWrites extends TestBase {
         FilePathReorderWrites fs = FilePathReorderWrites.register();
         // *disable this for now, still bug(s) in our code*
         // Add partial write enable test
-        // @since 2019-07-31 little-pan
         FilePathReorderWrites.setPartialWrites(partialWrite);
         println("testFileSystem(): partial write " + partialWrite);
 

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -982,7 +982,6 @@ public class TestMVStore extends TestBase {
             FileChannel fc = f.open("rw");
             // Since h2-1.3.176, file header doesn't be written at the end of the
             // store file again in MVStore, so we need comment the following code.
-            // @since 2019-08-09 little-pan
             //if (i == 0) {
                 // corrupt the last block (the end header)
             //    fc.write(ByteBuffer.allocate(256), fc.size() - 256);
@@ -1467,7 +1466,6 @@ public class TestMVStore extends TestBase {
         // ensure only nodes are read, but not leaves
         // *We must read a chunk from the end of store file, otherwise maybe data lost,
         // so read count should be 8 here as before.
-        // @since 2019-08-09 little-pan
         assertEquals(8, s.getFileStore().getReadCount());
         assertTrue(s.getFileStore().getWriteCount() < 5);
         s.close();

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -297,7 +297,7 @@ public class TestMVTableEngine extends TestDb {
             fc.truncate(fileSize);
         }
 
-        try (Connection conn = getConnection(getTestName())) {
+        try (Connection conn = getConnection(getTestName()+";recover=true")) {
             Statement stat = conn.createStatement();
             stat.execute("select * from dummy0 where 1 = 0");
             stat.execute("select * from dummy9 where 1 = 0");

--- a/h2/src/test/org/h2/test/store/TestTransactionStore.java
+++ b/h2/src/test/org/h2/test/store/TestTransactionStore.java
@@ -408,7 +408,11 @@ public class TestTransactionStore extends TestBase {
             // re-open TransactionStore, because we rolled back
             // underlying MVStore without rolling back TransactionStore
             s.close();
-            s = MVStore.open(fileName);
+            // enable recoveryMode
+            s = new MVStore.Builder().
+                fileName(fileName).
+                recoveryMode().
+                open();
             ts = new TransactionStore(s);
             List<Transaction> list = ts.getOpenTransactions();
             if (list.size() != 0) {

--- a/h2/src/test/org/h2/test/utils/FilePathReorderWrites.java
+++ b/h2/src/test/org/h2/test/utils/FilePathReorderWrites.java
@@ -222,13 +222,13 @@ class FileReorderWrites extends FileBase {
         return this;
     }
 
-    private int addOperation(final FileWriteOperation op) throws IOException {
+    private int addOperation(FileWriteOperation op) throws IOException {
         trace("op " + op);
         checkError();
         notAppliedList.add(op);
         long now = op.getTime();
         for (int i = 0; i < notAppliedList.size() - 1; i++) {
-            final FileWriteOperation old = notAppliedList.get(i);
+            FileWriteOperation old = notAppliedList.get(i);
             boolean applyOld = false;
             // String reason = "";
             if (old.getTime() + 45000 < now) {

--- a/h2/src/test/org/h2/test/utils/FilePathReorderWrites.java
+++ b/h2/src/test/org/h2/test/utils/FilePathReorderWrites.java
@@ -243,7 +243,6 @@ class FileReorderWrites extends FileBase {
             }
             if (applyOld) {
                 // bugfix - here should trace old instead of op
-                // @since 2019-08-09 little-pan
                 trace("op apply " + old);
                 old.apply(base);
                 notAppliedList.remove(i);

--- a/h2/src/test/org/h2/test/utils/FilePathReorderWrites.java
+++ b/h2/src/test/org/h2/test/utils/FilePathReorderWrites.java
@@ -222,13 +222,13 @@ class FileReorderWrites extends FileBase {
         return this;
     }
 
-    private int addOperation(FileWriteOperation op) throws IOException {
+    private int addOperation(final FileWriteOperation op) throws IOException {
         trace("op " + op);
         checkError();
         notAppliedList.add(op);
         long now = op.getTime();
         for (int i = 0; i < notAppliedList.size() - 1; i++) {
-            FileWriteOperation old = notAppliedList.get(i);
+            final FileWriteOperation old = notAppliedList.get(i);
             boolean applyOld = false;
             // String reason = "";
             if (old.getTime() + 45000 < now) {
@@ -242,7 +242,9 @@ class FileReorderWrites extends FileBase {
                 applyOld = true;
             }
             if (applyOld) {
-                trace("op apply " + op);
+                // bugfix - here should trace old instead of op
+                // @since 2019-08-09 little-pan
+                trace("op apply " + old);
                 old.apply(base);
                 notAppliedList.remove(i);
                 i--;


### PR DESCRIPTION
In the method readStoreHeader() of MVStore, the opening procedure of the mvstore is very redundant and poor performance(see #2048). Actually the newest is the last chunk, otherwise the store is corrupted by H2 bug, a rogue thread or process.

It's unnecessary that verifying the all chunk validity in the meta of last chunk candidates:
1) If the store corrupted by a rogue thread or process and we fall back to the older chunk,
 then the data lost, it's very bad. We should suggest recovering the store by tool to user or enabling recoveryMode.
2) And if the newest chunk valid(both header and footer valid), the all chunks referenced 
 in the meta of the newest also valid, otherwise why is the newest valid?, or the store corrupted.
3) The bug of database corruption by partial write and the store not closed when fatal error
occurs in H2 has been fixed.

And  fix error code 90020 issue for closing database incorrectly in Engine close().
