### PR TITLE
Use RESTART IDENTITY in TRUNCATE TABLE in MySQL and MSSQLServer compatibility modes

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2074: MySQL and MSSQLServer Mode: TRUNCATE TABLE should always RESTART IDENTITY
+</li>
 <li>Issue #2063: MySQL mode: "drop foreign key if exists" support
 </li>
 <li>PR #2061: Use VirtualTable as a base class for RangeTable

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -946,6 +946,7 @@ or the SQL statement <code>SET MODE MSSQLServer</code>.
 </li><li>Table hints are discarded. Example: <code>SELECT * FROM table WITH (NOLOCK)</code>.
 </li><li>Datetime value functions return the same value within a command.
 </li><li>0x literals are parsed as binary string literals.
+</li><li>TRUNCATE TABLE restarts next values of generated columns.
 </li></ul>
 
 <h3>MySQL Compatibility Mode</h3>
@@ -972,6 +973,7 @@ Do not change value of DATABASE_TO_LOWER after creation of database.
 </li><li>0x literals are parsed as binary string literals.
 </li><li>Unrelated expressions in ORDER BY clause of DISTINCT queries are allowed.
 </li><li>Some MySQL-specific ALTER TABLE commands are partially supported.
+</li><li>TRUNCATE TABLE restarts next values of generated columns.
 </li></ul>
 <p>
 Text comparison in MySQL is case insensitive by default, while in H2 it is case sensitive (as in most other databases).

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2135,15 +2135,13 @@ public class Parser {
     private Prepared parseTruncate() {
         read(TABLE);
         Table table = readTableOrView();
-        boolean restart;
+        boolean restart = database.getMode().truncateTableRestartIdentity;
         if (readIf("CONTINUE")) {
             read("IDENTITY");
             restart = false;
         } else if (readIf("RESTART")) {
             read("IDENTITY");
             restart = true;
-        } else {
-            restart = false;
         }
         TruncateTable command = new TruncateTable(session);
         command.setTable(table);

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -239,6 +239,11 @@ public class Mode {
     public boolean alterTableModifyColumn;
 
     /**
+     * if {@code true} TRUNCATE TABLE uses RESTART IDENTITY by default.
+     */
+    public boolean truncateTableRestartIdentity;
+
+    /**
      * An optional Set of hidden/disallowed column types.
      * Certain DBMSs don't support all column types provided by H2, such as
      * "NUMBER" when using PostgreSQL mode.
@@ -307,6 +312,7 @@ public class Mode {
         // https://msdn.microsoft.com/en-Us/library/dd571296%28v=sql.110%29.aspx
         mode.supportedClientInfoPropertiesRegEx = null;
         mode.zeroExLiteralsAreBinaryStrings = true;
+        mode.truncateTableRestartIdentity = true;
         DataType dt = DataType.createNumeric(19, 4, false);
         dt.type = Value.DECIMAL;
         dt.sqlType = Types.NUMERIC;
@@ -338,6 +344,7 @@ public class Mode {
         mode.allowUnrelatedOrderByExpressionsInDistinctQueries = true;
         mode.alterTableExtensionsMySQL = true;
         mode.alterTableModifyColumn = true;
+        mode.truncateTableRestartIdentity = true;
         add(mode);
 
         mode = new Mode(ModeEnum.Oracle);

--- a/h2/src/test/org/h2/test/scripts/ddl/truncateTable.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/truncateTable.sql
@@ -118,6 +118,41 @@ SELECT * FROM TEST ORDER BY VALUE;
 > 2   2   8   2
 > rows (ordered): 2
 
+SET MODE MSSQLServer;
+> ok
+
+TRUNCATE TABLE TEST;
+> ok
+
+INSERT INTO TEST(VALUE) VALUES (1), (2);
+> update count: 2
+
+SELECT * FROM TEST ORDER BY VALUE;
+> ID1 ID2 ID3 VALUE
+> --- --- --- -----
+> 1   1   9   1
+> 2   2   10  2
+> rows (ordered): 2
+
+SET MODE MySQL;
+> ok
+
+TRUNCATE TABLE TEST;
+> ok
+
+INSERT INTO TEST(VALUE) VALUES (1), (2);
+> update count: 2
+
+SELECT * FROM TEST ORDER BY VALUE;
+> ID1 ID2 ID3 VALUE
+> --- --- --- -----
+> 1   1   11  1
+> 2   2   12  2
+> rows (ordered): 2
+
+SET MODE Regular;
+> ok
+
 DROP TABLE TEST;
 > ok
 


### PR DESCRIPTION
Closes #2074.