### PR TITLE
Do not pass queries to DatabaseMetaData.getColumns()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2073: TableLink should not pass queries to DatabaseMetaData.getColumns()
+</li>
 <li>Issue #2074: MySQL and MSSQLServer Mode: TRUNCATE TABLE should always RESTART IDENTITY
 </li>
 <li>Issue #2063: MySQL mode: "drop foreign key if exists" support

--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -29,7 +29,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 <ul><li>Replace file password hash with file encryption key; validate encryption key when connecting.
 </li><li>Remove "set binary collation" feature.
 </li><li>Remove the encryption algorithm XTEA.
-</li><li>Disallow referencing other tables in a table (via constraints for example).
 </li><li>Remove PageStore features like compress_lob.
 </li></ul>
 
@@ -82,7 +81,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Web server classloader: override findResource / getResourceFrom.
 </li><li>Cost for embedded temporary view is calculated wrong, if result is constant.
 </li><li>Count index range query (count(*) where id between 10 and 20).
-</li><li>Performance: update in-place.
 </li><li>Clustering: when a database is back alive, automatically synchronize with the master (requires readable transaction log).
 </li><li>Database file name suffix: a way to use no or a different suffix (for example using a slash).
 </li><li>Eclipse plugin.
@@ -185,7 +183,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>HSQLDB compatibility: automatically convert to the next 'higher' data type.
     Example: cast(2000000000 as int) + cast(2000000000 as int);
     (HSQLDB: long; PostgreSQL: integer out of range)
-</li><li>Provide an Java SQL builder with standard and H2 syntax
 </li><li>Trace: write OS, file system, JVM,... when opening the database
 </li><li>Support indexes for views (probably requires materialized views)
 </li><li>Document SET SEARCH_PATH, BEGIN, EXECUTE, parameters
@@ -307,7 +304,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Sybase/DB2/Oracle compatibility: support out parameters in stored procedures - See http://code.google.com/p/h2database/issues/detail?id=83
 </li><li>Combine Server and Console tool (only keep Server).
 </li><li>Store the Lucene index in the database itself.
-</li><li>MVCC: compare concurrent update behavior with PostgreSQL and Oracle.
 </li><li>HSQLDB compatibility: CREATE FUNCTION (maybe using a Function interface).
 </li><li>HSQLDB compatibility: support CALL "java.lang.Math.sqrt"(2.0)
 </li><li>Support comma as the decimal separator in the CSV tool.
@@ -470,7 +466,6 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Support SQL/XML data type.
 </li><li>Support concurrent opening of databases.
 </li><li>Improved error message and diagnostics in case of network configuration problems.
-</li><li>TRUNCATE should reset the identity columns by default in MySQL and MS SQL Server compatibility modes (and possibly other).
 </li><li>Adding a primary key should make the columns 'not null' unless if there is a row with null
     (compatibility with MySQL, PostgreSQL, HSQLDB; not Derby).
 </li><li>ARRAY data type: support Integer[] and so on in Java functions (currently only Object[] is supported).

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -7447,7 +7447,7 @@ public class Parser {
      * @return {@code true} if the table is DUAL special table. Otherwise returns {@code false}.
      * @see <a href="https://en.wikipedia.org/wiki/DUAL_table">Wikipedia: DUAL table</a>
      */
-    boolean isDualTable(String tableName) {
+    private boolean isDualTable(String tableName) {
         return ((schemaName == null || equalsToken(schemaName, "SYS")) && equalsToken("DUAL", tableName))
                 || (database.getMode().sysDummy1 && (schemaName == null || equalsToken(schemaName, "SYSIBM"))
                         && equalsToken("SYSDUMMY1", tableName));

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -3288,7 +3288,10 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     }
 
     /**
-     * [Not supported]
+     * Returns whether database always returns generated keys if valid names or
+     * indexes of columns were specified and command was completed successfully.
+     *
+     * @return true
      */
     @Override
     public boolean generatedKeyAlwaysReturned() {

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -120,48 +120,52 @@ public class TableLink extends Table {
         storesMixedCase = meta.storesMixedCaseIdentifiers();
         storesMixedCaseQuoted = meta.storesMixedCaseQuotedIdentifiers();
         supportsMixedCaseIdentifiers = meta.supportsMixedCaseIdentifiers();
-        ResultSet rs = meta.getTables(null, originalSchema, originalTable, null);
-        if (rs.next() && rs.next()) {
-            throw DbException.get(ErrorCode.SCHEMA_NAME_MUST_MATCH, originalTable);
-        }
-        rs.close();
-        rs = meta.getColumns(null, originalSchema, originalTable, null);
-        int i = 0;
         ArrayList<Column> columnList = Utils.newSmallArrayList();
         HashMap<String, Column> columnMap = new HashMap<>();
-        String catalog = null, schema = null;
-        while (rs.next()) {
-            String thisCatalog = rs.getString("TABLE_CAT");
-            if (catalog == null) {
-                catalog = thisCatalog;
+        String schema = null;
+        boolean isQuery = originalTable.startsWith("(");
+        if (!isQuery) {
+            ResultSet rs = meta.getTables(null, originalSchema, originalTable, null);
+            if (rs.next() && rs.next()) {
+                throw DbException.get(ErrorCode.SCHEMA_NAME_MUST_MATCH, originalTable);
             }
-            String thisSchema = rs.getString("TABLE_SCHEM");
-            if (schema == null) {
-                schema = thisSchema;
+            rs.close();
+            rs = meta.getColumns(null, originalSchema, originalTable, null);
+            int i = 0;
+            String catalog = null;
+            while (rs.next()) {
+                String thisCatalog = rs.getString("TABLE_CAT");
+                if (catalog == null) {
+                    catalog = thisCatalog;
+                }
+                String thisSchema = rs.getString("TABLE_SCHEM");
+                if (schema == null) {
+                    schema = thisSchema;
+                }
+                if (!Objects.equals(catalog, thisCatalog) ||
+                        !Objects.equals(schema, thisSchema)) {
+                    // if the table exists in multiple schemas or tables,
+                    // use the alternative solution
+                    columnMap.clear();
+                    columnList.clear();
+                    break;
+                }
+                String n = rs.getString("COLUMN_NAME");
+                n = convertColumnName(n);
+                int sqlType = rs.getInt("DATA_TYPE");
+                String sqlTypeName = rs.getString("TYPE_NAME");
+                long precision = rs.getInt("COLUMN_SIZE");
+                precision = convertPrecision(sqlType, precision);
+                int scale = rs.getInt("DECIMAL_DIGITS");
+                scale = convertScale(sqlType, scale);
+                int type = DataType.convertSQLTypeToValueType(sqlType, sqlTypeName);
+                Column col = new Column(n, TypeInfo.getTypeInfo(type, precision, scale, null));
+                col.setTable(this, i++);
+                columnList.add(col);
+                columnMap.put(n, col);
             }
-            if (!Objects.equals(catalog, thisCatalog) ||
-                    !Objects.equals(schema, thisSchema)) {
-                // if the table exists in multiple schemas or tables,
-                // use the alternative solution
-                columnMap.clear();
-                columnList.clear();
-                break;
-            }
-            String n = rs.getString("COLUMN_NAME");
-            n = convertColumnName(n);
-            int sqlType = rs.getInt("DATA_TYPE");
-            String sqlTypeName = rs.getString("TYPE_NAME");
-            long precision = rs.getInt("COLUMN_SIZE");
-            precision = convertPrecision(sqlType, precision);
-            int scale = rs.getInt("DECIMAL_DIGITS");
-            scale = convertScale(sqlType, scale);
-            int type = DataType.convertSQLTypeToValueType(sqlType, sqlTypeName);
-            Column col = new Column(n, TypeInfo.getTypeInfo(type, precision, scale, null));
-            col.setTable(this, i++);
-            columnList.add(col);
-            columnMap.put(n, col);
+            rs.close();
         }
-        rs.close();
         if (originalTable.indexOf('.') < 0 && !StringUtils.isNullOrEmpty(schema)) {
             qualifiedTableName = schema + "." + originalTable;
         } else {
@@ -170,12 +174,12 @@ public class TableLink extends Table {
         // check if the table is accessible
 
         try (Statement stat = conn.getConnection().createStatement()) {
-            rs = stat.executeQuery("SELECT * FROM " +
+            ResultSet rs = stat.executeQuery("SELECT * FROM " +
                     qualifiedTableName + " T WHERE 1=0");
             if (columnList.isEmpty()) {
                 // alternative solution
                 ResultSetMetaData rsMeta = rs.getMetaData();
-                for (i = 0; i < rsMeta.getColumnCount();) {
+                for (int i = 0; i < rsMeta.getColumnCount();) {
                     String n = rsMeta.getColumnName(i + 1);
                     n = convertColumnName(n);
                     int sqlType = rsMeta.getColumnType(i + 1);
@@ -201,6 +205,13 @@ public class TableLink extends Table {
         linkedIndex = new LinkedIndex(this, id, IndexColumn.wrap(cols),
                 IndexType.createNonUnique(false));
         indexes.add(linkedIndex);
+        if (!isQuery) {
+            readIndexes(meta, columnMap);
+        }
+    }
+
+    private void readIndexes(DatabaseMetaData meta, HashMap<String, Column> columnMap) throws SQLException {
+        ResultSet rs;
         try {
             rs = meta.getPrimaryKeys(null, originalSchema, originalTable);
         } catch (Exception e) {

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -220,14 +220,14 @@ public class TableLink extends Table {
             // http://www.datadirect.com/index.ssp
             rs = null;
         }
-        String pkName = "";
+        String pkName = null;
         ArrayList<Column> list;
         if (rs != null && rs.next()) {
             // the problem is, the rows are not sorted by KEY_SEQ
             list = Utils.newSmallArrayList();
             do {
                 int idx = rs.getInt("KEY_SEQ");
-                if (pkName == null) {
+                if (StringUtils.isNullOrEmpty(pkName)) {
                     pkName = rs.getString("PK_NAME");
                 }
                 while (list.size() < idx) {
@@ -263,7 +263,7 @@ public class TableLink extends Table {
                     continue;
                 }
                 String newIndex = rs.getString("INDEX_NAME");
-                if (pkName.equals(newIndex)) {
+                if (pkName != null && pkName.equals(newIndex)) {
                     continue;
                 }
                 if (indexName != null && !indexName.equals(newIndex)) {

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -125,57 +125,56 @@ public class TableLink extends Table {
         String schema = null;
         boolean isQuery = originalTable.startsWith("(");
         if (!isQuery) {
-            ResultSet rs = meta.getTables(null, originalSchema, originalTable, null);
-            if (rs.next() && rs.next()) {
-                throw DbException.get(ErrorCode.SCHEMA_NAME_MUST_MATCH, originalTable);
+            try (ResultSet rs = meta.getTables(null, originalSchema, originalTable, null)) {
+                if (rs.next() && rs.next()) {
+                    throw DbException.get(ErrorCode.SCHEMA_NAME_MUST_MATCH, originalTable);
+                }
             }
-            rs.close();
-            rs = meta.getColumns(null, originalSchema, originalTable, null);
-            int i = 0;
-            String catalog = null;
-            while (rs.next()) {
-                String thisCatalog = rs.getString("TABLE_CAT");
-                if (catalog == null) {
-                    catalog = thisCatalog;
+            try (ResultSet rs = meta.getColumns(null, originalSchema, originalTable, null)) {
+                int i = 0;
+                String catalog = null;
+                while (rs.next()) {
+                    String thisCatalog = rs.getString("TABLE_CAT");
+                    if (catalog == null) {
+                        catalog = thisCatalog;
+                    }
+                    String thisSchema = rs.getString("TABLE_SCHEM");
+                    if (schema == null) {
+                        schema = thisSchema;
+                    }
+                    if (!Objects.equals(catalog, thisCatalog) ||
+                            !Objects.equals(schema, thisSchema)) {
+                        // if the table exists in multiple schemas or tables,
+                        // use the alternative solution
+                        columnMap.clear();
+                        columnList.clear();
+                        break;
+                    }
+                    String n = rs.getString("COLUMN_NAME");
+                    n = convertColumnName(n);
+                    int sqlType = rs.getInt("DATA_TYPE");
+                    String sqlTypeName = rs.getString("TYPE_NAME");
+                    long precision = rs.getInt("COLUMN_SIZE");
+                    precision = convertPrecision(sqlType, precision);
+                    int scale = rs.getInt("DECIMAL_DIGITS");
+                    scale = convertScale(sqlType, scale);
+                    int type = DataType.convertSQLTypeToValueType(sqlType, sqlTypeName);
+                    Column col = new Column(n, TypeInfo.getTypeInfo(type, precision, scale, null));
+                    col.setTable(this, i++);
+                    columnList.add(col);
+                    columnMap.put(n, col);
                 }
-                String thisSchema = rs.getString("TABLE_SCHEM");
-                if (schema == null) {
-                    schema = thisSchema;
-                }
-                if (!Objects.equals(catalog, thisCatalog) ||
-                        !Objects.equals(schema, thisSchema)) {
-                    // if the table exists in multiple schemas or tables,
-                    // use the alternative solution
-                    columnMap.clear();
-                    columnList.clear();
-                    break;
-                }
-                String n = rs.getString("COLUMN_NAME");
-                n = convertColumnName(n);
-                int sqlType = rs.getInt("DATA_TYPE");
-                String sqlTypeName = rs.getString("TYPE_NAME");
-                long precision = rs.getInt("COLUMN_SIZE");
-                precision = convertPrecision(sqlType, precision);
-                int scale = rs.getInt("DECIMAL_DIGITS");
-                scale = convertScale(sqlType, scale);
-                int type = DataType.convertSQLTypeToValueType(sqlType, sqlTypeName);
-                Column col = new Column(n, TypeInfo.getTypeInfo(type, precision, scale, null));
-                col.setTable(this, i++);
-                columnList.add(col);
-                columnMap.put(n, col);
             }
-            rs.close();
         }
         if (originalTable.indexOf('.') < 0 && !StringUtils.isNullOrEmpty(schema)) {
-            qualifiedTableName = schema + "." + originalTable;
+            qualifiedTableName = schema + '.' + originalTable;
         } else {
             qualifiedTableName = originalTable;
         }
         // check if the table is accessible
 
-        try (Statement stat = conn.getConnection().createStatement()) {
-            ResultSet rs = stat.executeQuery("SELECT * FROM " +
-                    qualifiedTableName + " T WHERE 1=0");
+        try (Statement stat = conn.getConnection().createStatement();
+                ResultSet rs = stat.executeQuery("SELECT * FROM " + qualifiedTableName + " T WHERE 1=0")) {
             if (columnList.isEmpty()) {
                 // alternative solution
                 ResultSetMetaData rsMeta = rs.getMetaData();
@@ -194,10 +193,9 @@ public class TableLink extends Table {
                     columnMap.put(n, col);
                 }
             }
-            rs.close();
         } catch (Exception e) {
             throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, e,
-                    originalTable + "(" + e.toString() + ")");
+                    originalTable + '(' + e.toString() + ')');
         }
         Column[] cols = columnList.toArray(new Column[0]);
         setColumns(cols);
@@ -210,79 +208,79 @@ public class TableLink extends Table {
         }
     }
 
-    private void readIndexes(DatabaseMetaData meta, HashMap<String, Column> columnMap) throws SQLException {
-        ResultSet rs;
-        try {
-            rs = meta.getPrimaryKeys(null, originalSchema, originalTable);
+    private void readIndexes(DatabaseMetaData meta, HashMap<String, Column> columnMap) {
+        String pkName = null;
+        try (ResultSet rs = meta.getPrimaryKeys(null, originalSchema, originalTable)) {
+            if (rs.next()) {
+                pkName = readPrimaryKey(rs, columnMap);
+            }
         } catch (Exception e) {
             // Some ODBC bridge drivers don't support it:
             // some combinations of "DataDirect SequeLink(R) for JDBC"
             // http://www.datadirect.com/index.ssp
-            rs = null;
         }
-        String pkName = null;
-        ArrayList<Column> list;
-        if (rs != null && rs.next()) {
-            // the problem is, the rows are not sorted by KEY_SEQ
-            list = Utils.newSmallArrayList();
-            do {
-                int idx = rs.getInt("KEY_SEQ");
-                if (StringUtils.isNullOrEmpty(pkName)) {
-                    pkName = rs.getString("PK_NAME");
-                }
-                while (list.size() < idx) {
-                    list.add(null);
-                }
-                String col = rs.getString("COLUMN_NAME");
-                col = convertColumnName(col);
-                Column column = columnMap.get(col);
-                if (idx == 0) {
-                    // workaround for a bug in the SQLite JDBC driver
-                    list.add(column);
-                } else {
-                    list.set(idx - 1, column);
-                }
-            } while (rs.next());
-            addIndex(list, IndexType.createPrimaryKey(false, false));
-            rs.close();
-        }
-        try {
-            rs = meta.getIndexInfo(null, originalSchema, originalTable, false, true);
+        try (ResultSet rs = meta.getIndexInfo(null, originalSchema, originalTable, false, true)) {
+            readIndexes(rs, columnMap, pkName);
         } catch (Exception e) {
             // Oracle throws an exception if the table is not found or is a
             // SYNONYM
-            rs = null;
         }
-        String indexName = null;
-        list = Utils.newSmallArrayList();
-        IndexType indexType = null;
-        if (rs != null) {
-            while (rs.next()) {
-                if (rs.getShort("TYPE") == DatabaseMetaData.tableIndexStatistic) {
-                    // ignore index statistics
-                    continue;
-                }
-                String newIndex = rs.getString("INDEX_NAME");
-                if (pkName != null && pkName.equals(newIndex)) {
-                    continue;
-                }
-                if (indexName != null && !indexName.equals(newIndex)) {
-                    addIndex(list, indexType);
-                    indexName = null;
-                }
-                if (indexName == null) {
-                    indexName = newIndex;
-                    list.clear();
-                }
-                boolean unique = !rs.getBoolean("NON_UNIQUE");
-                indexType = unique ? IndexType.createUnique(false, false) :
-                        IndexType.createNonUnique(false);
-                String col = rs.getString("COLUMN_NAME");
-                col = convertColumnName(col);
-                Column column = columnMap.get(col);
-                list.add(column);
+    }
+
+    private String readPrimaryKey(ResultSet rs, HashMap<String, Column> columnMap) throws SQLException {
+        String pkName = null;
+        // the problem is, the rows are not sorted by KEY_SEQ
+        ArrayList<Column> list = Utils.newSmallArrayList();
+        do {
+            int idx = rs.getInt("KEY_SEQ");
+            if (StringUtils.isNullOrEmpty(pkName)) {
+                pkName = rs.getString("PK_NAME");
             }
-            rs.close();
+            while (list.size() < idx) {
+                list.add(null);
+            }
+            String col = rs.getString("COLUMN_NAME");
+            col = convertColumnName(col);
+            Column column = columnMap.get(col);
+            if (idx == 0) {
+                // workaround for a bug in the SQLite JDBC driver
+                list.add(column);
+            } else {
+                list.set(idx - 1, column);
+            }
+        } while (rs.next());
+        addIndex(list, IndexType.createPrimaryKey(false, false));
+        return pkName;
+    }
+
+    private void readIndexes(ResultSet rs, HashMap<String, Column> columnMap, String pkName) throws SQLException {
+        String indexName = null;
+        ArrayList<Column> list = Utils.newSmallArrayList();
+        IndexType indexType = null;
+        while (rs.next()) {
+            if (rs.getShort("TYPE") == DatabaseMetaData.tableIndexStatistic) {
+                // ignore index statistics
+                continue;
+            }
+            String newIndex = rs.getString("INDEX_NAME");
+            if (pkName != null && pkName.equals(newIndex)) {
+                continue;
+            }
+            if (indexName != null && !indexName.equals(newIndex)) {
+                addIndex(list, indexType);
+                indexName = null;
+            }
+            if (indexName == null) {
+                indexName = newIndex;
+                list.clear();
+            }
+            boolean unique = !rs.getBoolean("NON_UNIQUE");
+            indexType = unique ? IndexType.createUnique(false, false) :
+                    IndexType.createNonUnique(false);
+            String col = rs.getString("COLUMN_NAME");
+            col = convertColumnName(col);
+            Column column = columnMap.get(col);
+            list.add(column);
         }
         if (indexName != null) {
             addIndex(list, indexType);


### PR DESCRIPTION
Closes #2073.

The logic in `TableLink.readMetaData()` is very obscure in many places. Because it may be needed for some databases, I tried to preserve it as is when possible. After my changes the table metadata will not be accessed any more for queries.