### PR TITLE
Evaluate local conditions before global conditions

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2088: Division by zero caused by evaluation of global conditions before local conditions
+</li>
 <li>Issue #2086: TCP_QUICKACK on server socket
 </li>
 <li>Issue #2073: TableLink should not pass queries to DatabaseMetaData.getColumns()

--- a/h2/src/main/org/h2/expression/condition/ConditionAndOr.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionAndOr.java
@@ -140,74 +140,51 @@ public class ConditionAndOr extends Condition {
             left = right;
             right = t;
         }
-        // this optimization does not work in the following case,
-        // but NOT is optimized before:
-        // CREATE TABLE TEST(A INT, B INT);
-        // INSERT INTO TEST VALUES(1, NULL);
-        // SELECT * FROM TEST WHERE NOT (B=A AND B=0); // no rows
-        // SELECT * FROM TEST WHERE NOT (B=A AND B=0 AND A=0); // 1, NULL
-        if (session.getDatabase().getSettings().optimizeTwoEquals &&
-                andOrType == AND) {
+        switch (andOrType) {
+        case AND:
+            if (!session.getDatabase().getSettings().optimizeTwoEquals) {
+                break;
+            }
+            // this optimization does not work in the following case,
+            // but NOT is optimized before:
+            // CREATE TABLE TEST(A INT, B INT);
+            // INSERT INTO TEST VALUES(1, NULL);
+            // SELECT * FROM TEST WHERE NOT (B=A AND B=0); // no rows
+            // SELECT * FROM TEST WHERE NOT (B=A AND B=0 AND A=0); // 1, NULL
             // try to add conditions (A=B AND B=1: add A=1)
             if (left instanceof Comparison && right instanceof Comparison) {
-                Comparison compLeft = (Comparison) left;
-                Comparison compRight = (Comparison) right;
-                Expression added = compLeft.getAdditionalAnd(session, compRight);
+                // try to add conditions (A=B AND B=1: add A=1)
+                Expression added = ((Comparison) left).getAdditionalAnd(session, (Comparison) right);
                 if (added != null) {
                     this.added = added.optimize(session);
                 }
             }
-        }
-
-        if (andOrType == OR &&
-                session.getDatabase().getSettings().optimizeOr) {
-            // try to add conditions (A=B AND B=1: add A=1)
+            break;
+        case OR:
+            if (!session.getDatabase().getSettings().optimizeOr) {
+                break;
+            }
+            Expression reduced;
             if (left instanceof Comparison && right instanceof Comparison) {
-                Comparison compLeft = (Comparison) left;
-                Comparison compRight = (Comparison) right;
-                Expression added = compLeft.optimizeOr(session, compRight);
-                if (added != null) {
-                    return added.optimize(session);
-                }
-            } else if (left instanceof ConditionIn &&
-                    right instanceof Comparison) {
-                Expression added = ((ConditionIn) left).
-                        getAdditional((Comparison) right);
-                if (added != null) {
-                    return added.optimize(session);
-                }
-            } else if (right instanceof ConditionIn &&
-                    left instanceof Comparison) {
-                Expression added = ((ConditionIn) right).
-                        getAdditional((Comparison) left);
-                if (added != null) {
-                    return added.optimize(session);
-                }
-            } else if (left instanceof ConditionInConstantSet &&
-                    right instanceof Comparison) {
-                Expression added = ((ConditionInConstantSet) left).
-                        getAdditional(session, (Comparison) right);
-                if (added != null) {
-                    return added.optimize(session);
-                }
-            } else if (right instanceof ConditionInConstantSet &&
-                    left instanceof Comparison) {
-                Expression added = ((ConditionInConstantSet) right).
-                        getAdditional(session, (Comparison) left);
-                if (added != null) {
-                    return added.optimize(session);
-                }
-            } else if (left instanceof ConditionAndOr &&
-                    right instanceof ConditionAndOr ){
-                ConditionAndOr condAORight = (ConditionAndOr)right;
-                ConditionAndOr condAORLeft = (ConditionAndOr)left;
-                Expression reduced = optimizeConditionAndOr(condAORLeft,condAORight);
-                if(reduced != null){
-                    return reduced.optimize(session);
-                }
+                reduced = ((Comparison) left).optimizeOr(session, (Comparison) right);
+            } else if (left instanceof ConditionIn && right instanceof Comparison) {
+                reduced = ((ConditionIn) left).getAdditional((Comparison) right);
+            } else if (right instanceof ConditionIn && left instanceof Comparison) {
+                reduced = ((ConditionIn) right).getAdditional((Comparison) left);
+            } else if (left instanceof ConditionInConstantSet && right instanceof Comparison) {
+                reduced = ((ConditionInConstantSet) left).getAdditional(session, (Comparison) right);
+            } else if (right instanceof ConditionInConstantSet && left instanceof Comparison) {
+                reduced = ((ConditionInConstantSet) right).getAdditional(session, (Comparison) left);
+            } else if (left instanceof ConditionAndOr && right instanceof ConditionAndOr) {
+                reduced = optimizeConditionAndOr((ConditionAndOr)left, (ConditionAndOr)right);
+            } else {
+                // TODO optimization: convert .. OR .. to UNION if the cost is lower
+                break;
+            }
+            if (reduced != null) {
+                return reduced.optimize(session);
             }
         }
-        // TODO optimization: convert .. OR .. to UNION if the cost is lower
         Value l = left.isConstant() ? left.getValue(session) : null;
         Value r = right.isConstant() ? right.getValue(session) : null;
         if (l == null && r == null) {

--- a/h2/src/main/org/h2/expression/condition/ConditionAndOr.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionAndOr.java
@@ -134,8 +134,7 @@ public class ConditionAndOr extends Condition {
         // http://www-cs-students.stanford.edu/~wlam/compsci/sqlnulls
         left = left.optimize(session);
         right = right.optimize(session);
-        int lc = left.getCost();
-        int rc = right.getCost();
+        int lc = left.getCost(), rc = right.getCost();
         if (rc < lc) {
             Expression t = left;
             left = right;

--- a/h2/src/main/org/h2/expression/condition/ConditionLocalAndGlobal.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionLocalAndGlobal.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.condition;
+
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionVisitor;
+import org.h2.message.DbException;
+import org.h2.table.ColumnResolver;
+import org.h2.table.TableFilter;
+import org.h2.value.Value;
+import org.h2.value.ValueBoolean;
+import org.h2.value.ValueNull;
+
+/**
+ * A global condition or combination of local and global conditions. May be used
+ * only as a top-level expression in a WHERE, HAVING, or QUALIFY clause of a
+ * SELECT.
+ */
+public class ConditionLocalAndGlobal extends Condition {
+
+    private Expression local, global;
+
+    public ConditionLocalAndGlobal(Expression local, Expression global) {
+        if (global == null) {
+            DbException.throwInternalError();
+        }
+        this.local = local;
+        this.global = global;
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, boolean alwaysQuote) {
+        if (local == null) {
+            return global.getSQL(builder, alwaysQuote);
+        }
+        builder.append('(');
+        local.getSQL(builder, alwaysQuote);
+        builder.append("\n    _LOCAL_AND_GLOBAL_ ");
+        return global.getSQL(builder, alwaysQuote).append(')');
+    }
+
+    @Override
+    public void createIndexConditions(Session session, TableFilter filter) {
+        if (local != null) {
+            local.createIndexConditions(session, filter);
+        }
+        global.createIndexConditions(session, filter);
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        if (local == null) {
+            return global.getValue(session);
+        }
+        Value l = local.getValue(session);
+        if (l != ValueNull.INSTANCE && !l.getBoolean()) {
+            return ValueBoolean.FALSE;
+        }
+        Value r = global.getValue(session);
+        if (r != ValueNull.INSTANCE && !r.getBoolean()) {
+            return ValueBoolean.FALSE;
+        }
+        if (l == ValueNull.INSTANCE || r == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        return ValueBoolean.TRUE;
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        global = global.optimize(session);
+        if (local != null) {
+            local = local.optimize(session);
+            return ConditionAndOr.optimizeConstant(session, this, ConditionAndOr.AND, local, global);
+        }
+        return this;
+    }
+
+    @Override
+    public void addFilterConditions(TableFilter filter) {
+        if (local != null) {
+            local.addFilterConditions(filter);
+        }
+        global.addFilterConditions(filter);
+    }
+
+    @Override
+    public void mapColumns(ColumnResolver resolver, int level, int state) {
+        if (local != null) {
+            local.mapColumns(resolver, level, state);
+        }
+        global.mapColumns(resolver, level, state);
+    }
+
+    @Override
+    public void setEvaluatable(TableFilter tableFilter, boolean b) {
+        if (local != null) {
+            local.setEvaluatable(tableFilter, b);
+        }
+        global.setEvaluatable(tableFilter, b);
+    }
+
+    @Override
+    public void updateAggregate(Session session, int stage) {
+        if (local != null) {
+            local.updateAggregate(session, stage);
+        }
+        global.updateAggregate(session, stage);
+    }
+
+    @Override
+    public boolean isEverything(ExpressionVisitor visitor) {
+        return (local == null || local.isEverything(visitor)) && global.isEverything(visitor);
+    }
+
+    @Override
+    public int getCost() {
+        int cost = global.getCost();
+        if (local != null) {
+            cost += local.getCost();
+        }
+        return cost;
+    }
+
+    @Override
+    public int getSubexpressionCount() {
+        return local == null ? 1 : 2;
+    }
+
+    @Override
+    public Expression getSubexpression(int index) {
+        switch (index) {
+        case 0:
+            return local != null ? local : global;
+        case 1:
+            if (local != null) {
+                return global;
+            }
+            //$FALL-THROUGH$
+        default:
+            throw new IndexOutOfBoundsException();
+        }
+    }
+
+}

--- a/h2/src/test/org/h2/test/db/TestPersistentCommonTableExpressions.java
+++ b/h2/src/test/org/h2/test/db/TestPersistentCommonTableExpressions.java
@@ -56,8 +56,8 @@ public class TestPersistentCommonTableExpressions extends AbstractBaseForCommonT
                 "    INNER JOIN PUBLIC.C\n" +
                 "        /++ PUBLIC.C.tableScan ++/\n" +
                 "        ON 1=1\n" +
-                "    WHERE (A IS NOT DISTINCT FROM ?1)\n" +
-                "        AND (B.VAL = C.B)\n" +
+                "    WHERE (B.VAL = C.B)\n" +
+                "        _LOCAL_AND_GLOBAL_ (A IS NOT DISTINCT FROM ?1)\n" +
                 "    GROUP BY A: A IS NOT DISTINCT FROM A.VAL\n" +
                 "     */\n" +
                 "    /* scanCount: 1 */\n" +

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -608,7 +608,7 @@ public class TestTableEngines extends TestDb {
                 + "/++ batched:fake PUBLIC.U_IDX_A: A IS NOT DISTINCT FROM ?1 ++/ "
                 + "/++ WHERE U.A IS NOT DISTINCT FROM ?1 ++/ INNER JOIN PUBLIC.T "
                 + "/++ batched:test PUBLIC.T_IDX_B: B = U.B ++/ "
-                + "ON 1=1 WHERE (U.A IS NOT DISTINCT FROM ?1) AND (U.B = T.B): A = T.A */ "
+                + "ON 1=1 WHERE (U.B = T.B) _LOCAL_AND_GLOBAL_ (U.A IS NOT DISTINCT FROM ?1): A = T.A */ "
                 + "ON 1=1 WHERE \"Z\".\"A\" = \"T\".\"A\"");
         checkPlan(stat, "SELECT 1 FROM \"PUBLIC\".\"T\" /* PUBLIC.T_IDX_A */ "
                 + "INNER JOIN ( SELECT \"A\" FROM \"PUBLIC\".\"U\" ) \"Z\" /* SELECT A FROM PUBLIC.U "

--- a/h2/src/test/org/h2/test/scripts/dml/with.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/with.sql
@@ -160,3 +160,33 @@ WITH CTE_TEST AS (TABLE TEST) ((SELECT A, B, C FROM CTE_TEST));
 
 DROP TABLE TEST;
 > ok
+
+WITH RECURSIVE V(V1, V2) AS (
+    SELECT 0 V1, 1 V2
+    UNION ALL
+    SELECT V1 + 1, V2 + 1 FROM V WHERE V2 < 4
+)
+SELECT V1, V2, COUNT(*) FROM V
+LEFT JOIN (SELECT T1 / T2 R FROM (VALUES (10, 0)) T(T1, T2) WHERE T2*T2*T2*T2*T2*T2 <> 0) X ON X.R > V.V1 AND X.R < V.V2
+GROUP BY V1, V2;
+> V1 V2 COUNT(*)
+> -- -- --------
+> 0  1  1
+> 1  2  1
+> 2  3  1
+> 3  4  1
+> rows: 4
+
+EXPLAIN WITH RECURSIVE V(V1, V2) AS (
+    SELECT 0 V1, 1 V2
+    UNION ALL
+    SELECT V1 + 1, V2 + 1 FROM V WHERE V2 < 10
+)
+SELECT V1, V2, COUNT(*) FROM V
+LEFT JOIN (SELECT T1 / T2 R FROM (VALUES (10, 0)) T(T1, T2) WHERE T2*T2*T2*T2*T2*T2 <> 0) X ON X.R > V.V1 AND X.R < V.V2
+GROUP BY V1, V2;
+>> WITH RECURSIVE "PUBLIC"."V"("V1", "V2") AS ( (SELECT 0 AS "V1", 1 AS "V2" FROM SYSTEM_RANGE(1, 1) /* range index */) UNION ALL (SELECT ("V1" + 1), ("V2" + 1) FROM "PUBLIC"."V" /* PUBLIC.V.tableScan */ WHERE "V2" < 10) ) SELECT "V1", "V2", COUNT(*) FROM "PUBLIC"."V" "V" /* null */ LEFT OUTER JOIN ( SELECT ("T1" / "T2") AS "R" FROM (VALUES (10, 0)) "T"("T1", "T2") WHERE ((((("T2" * "T2") * "T2") * "T2") * "T2") * "T2") <> 0 ) "X" /* SELECT (T1 / T2) AS R FROM (VALUES (10, 0)) T(T1, T2) /++ table scan ++/ WHERE ((((((T2 * T2) * T2) * T2) * T2) * T2) <> 0) _LOCAL_AND_GLOBAL_ (((T1 / T2) >= ?1) AND ((T1 / T2) <= ?2)): R > V.V1 AND R < V.V2 */ ON ("X"."R" > "V"."V1") AND ("X"."R" < "V"."V2") GROUP BY "V1", "V2"
+
+-- Workraround for a leftover view after EXPLAIN WITH
+DROP VIEW V;
+> ok


### PR DESCRIPTION
Closes #2088.

New operator `_LOCAL_AND_GLOBAL_` shouldn't conflict with anything, because identifiers aren't expected in its context, because I intentionally restricted its parsing to `WHERE`, `HAVING`, and `QUALIFY` conditions. They may not have aliases.