### PR TITLE
Fix ordinary grouping set with parentheses and empty grouping set in GROUP BY

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -10,7 +10,7 @@ SELECT [ TOP term [ PERCENT ] [ WITH TIES ] ]
 selectExpression [,...]
 [ FROM tableExpression [,...] ]
 [ WHERE expression ]
-[ GROUP BY expression [,...] ] [ HAVING expression ]
+[ GROUP BY groupingElement [,...] ] [ HAVING expression ]
 [ WINDOW { { windowName AS windowSpecification } [,...] } ]
 [ QUALIFY expression ]
 [ { UNION [ ALL ] | EXCEPT | MINUS | INTERSECT } query ]
@@ -2730,6 +2730,16 @@ term [ { { * | / | % } term } [...] ]
 A value or a numeric factor.
 ","
 ID * 10
+"
+
+"Other Grammar","Grouping element","
+expression | (expression [, ...]) | ()
+","
+A grouping element of GROUP BY clause.
+","
+A
+(B, C)
+()
 "
 
 "Other Grammar","Hex","

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2980,10 +2980,19 @@ public class Parser {
             command.setGroupQuery();
             ArrayList<Expression> list = Utils.newSmallArrayList();
             do {
-                Expression expr = readExpression();
-                list.add(expr);
+                if (readIf(OPEN_PAREN)) {
+                    if (!readIf(CLOSE_PAREN)) {
+                        do {
+                            list.add(readExpression());
+                        } while (readIfMore());
+                    }
+                } else {
+                    list.add(readExpression());
+                }
             } while (readIf(COMMA));
-            command.setGroupBy(list);
+            if (!list.isEmpty()) {
+                command.setGroupBy(list);
+            }
         }
         currentSelect = command;
         if (readIf(HAVING)) {


### PR DESCRIPTION
H2 accepted empty grouping sets `()`, but returned incorrect results when there were no rows.

H2 accepted ordinary grouping sets with parentheses, but as unexpected row value expressions (or arrays in older versions).

With these changes H2 handles all simple (in terms of the SQL Standard) `GROUP BY` clauses properly and translates them into primitive or empty with exception of unsupported optional set quantifier and collate clauses, they are rejected.