### PR TITLE
Allow IN predicate with an empty list only in Regular and Ignite modes

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2116: Empty IN() operator should result in error (MSSQL)
+</li>
 <li>Issue #2036: CAST from TIME to TIMESTAMP returns incorrect result
 </li>
 <li>PR #2114: Assorted changes

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3258,7 +3258,7 @@ public class Parser {
 
     private Expression readInPredicate(Expression left) {
         read(OPEN_PAREN);
-        if (!database.getMode().prohibitEmptyInPredicate && readIf(CLOSE_PAREN)) {
+        if (database.getMode().allowEmptyInPredicate && readIf(CLOSE_PAREN)) {
             return ValueExpression.getBoolean(false);
         }
         ArrayList<Expression> v;

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -176,9 +176,9 @@ public class Mode {
     public boolean supportPoundSymbolForColumnNames;
 
     /**
-     * Whether an empty list as in "NAME IN()" results in a syntax error.
+     * Whether IN predicate may have an empty value list.
      */
-    public boolean prohibitEmptyInPredicate;
+    public boolean allowEmptyInPredicate;
 
     /**
      * Whether AFFINITY KEY keywords are supported.
@@ -276,6 +276,7 @@ public class Mode {
     static {
         Mode mode = new Mode(ModeEnum.REGULAR);
         mode.nullConcatIsNull = true;
+        mode.allowEmptyInPredicate = true;
         mode.dateTimeValueWithinTransaction = true;
         add(mode);
 
@@ -289,7 +290,6 @@ public class Mode {
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile("ApplicationName|ClientAccountingInformation|" +
                         "ClientUser|ClientCorrelationToken");
-        mode.prohibitEmptyInPredicate = true;
         mode.allowDB2TimestampFormat = true;
         add(mode);
 
@@ -353,7 +353,6 @@ public class Mode {
         //     JDBC4CommentClientInfoProvider.java
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile(".*");
-        mode.prohibitEmptyInPredicate = true;
         mode.charToBinaryInUtf8 = true;
         mode.zeroExLiteralsAreBinaryStrings = true;
         mode.allowUnrelatedOrderByExpressionsInDistinctQueries = true;
@@ -373,7 +372,6 @@ public class Mode {
         // https://docs.oracle.com/database/121/JJDBC/jdbcvers.htm#JJDBC29006
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile(".*\\..*");
-        mode.prohibitEmptyInPredicate = true;
         mode.alterTableModifyColumn = true;
         mode.decimalSequences = true;
         dt = DataType.createDate(/* 2001-01-01 23:59:59 */ 19, 19, "DATE", false, 0, 0);
@@ -396,7 +394,6 @@ public class Mode {
         //     org/postgresql/jdbc4/AbstractJdbc4Connection.java
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile("ApplicationName");
-        mode.prohibitEmptyInPredicate = true;
         mode.padFixedLengthStrings = true;
         // Enumerate all H2 types NOT supported by PostgreSQL:
         Set<String> disallowedTypes = new java.util.HashSet<>();
@@ -417,6 +414,7 @@ public class Mode {
         mode.nullConcatIsNull = true;
         mode.allowAffinityKey = true;
         mode.indexDefinitionInCreateTable = true;
+        mode.allowEmptyInPredicate = true;
         mode.dateTimeValueWithinTransaction = true;
         add(mode);
     }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -3973,7 +3973,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
         return getTraceObjectName() + ": " + result;
     }
 
-    private void patchCurrentRow(Value[] row) throws SQLException {
+    private void patchCurrentRow(Value[] row) {
         boolean changed = false;
         Value[] current = result.currentRow();
         CompareMode compareMode = conn.getCompareMode();

--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -917,7 +917,7 @@ public class WebServer implements Service {
     /**
      * Check the admin password.
      *
-     * @param the password to test
+     * @param password the password to test
      * @return true if admin password not configure, or admin password correct
      */
     boolean checkAdminPassword(String password) {

--- a/h2/src/main/org/h2/store/FileLock.java
+++ b/h2/src/main/org/h2/store/FileLock.java
@@ -201,7 +201,7 @@ public class FileLock implements Runnable {
     /**
      * Aggressively read last modified time, to work-around remote filesystems.
      *
-     * @param filename file name to check
+     * @param fileName file name to check
      * @return last modified date/time in milliseconds UTC
      */
     private static long aggressiveLastModified(String fileName) {

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -100,7 +100,7 @@ public class DateTimeUtils {
             30, 31, 31, 30, 31, 30, 31 };
 
     /**
-     * Multipliers for {@link #convertScale(long, int)}.
+     * Multipliers for {@link #convertScale(long, int, long)}.
      */
     private static final int[] CONVERT_SCALE_TABLE = { 1_000_000_000, 100_000_000,
             10_000_000, 1_000_000, 100_000, 10_000, 1_000, 100, 10 };

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -11,7 +11,6 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import org.h2.api.ErrorCode;
 import org.h2.engine.CastDataProvider;
-import org.h2.engine.Mode;
 import org.h2.message.DbException;
 import org.h2.util.DateTimeUtils;
 import org.h2.util.LocalDateTimeUtils;
@@ -131,7 +130,7 @@ public class ValueTimestamp extends Value {
     }
 
     /**
-     * Parse a string to a ValueTimestamp, using the given {@link Mode}.
+     * Parse a string to a ValueTimestamp, using the given {@link CastDataProvider}.
      * This method supports the format +/-year-month-day[ -]hour[:.]minute[:.]seconds.fractional
      * and an optional timezone part.
      *

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -229,11 +229,6 @@ public class TestCompatibility extends TestDb {
         prep.setInt(1, 2);
         prep.executeQuery();
         stat.execute("DROP TABLE TEST IF EXISTS");
-
-        stat.execute("DROP TABLE TEST IF EXISTS");
-        stat.execute("CREATE TABLE TEST(ID INT)");
-        stat.executeQuery("SELECT * FROM TEST WHERE ID IN ()");
-        stat.execute("DROP TABLE TEST IF EXISTS");
     }
 
     private void testLog(double expected, Statement stat) throws SQLException {

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -766,7 +766,7 @@ public class TestCompatibility extends TestDb {
         }
     }
 
-    private void testUnknownURL() throws SQLException {
+    private void testUnknownURL() {
         try {
             getConnection("compatibility;MODE=Unknown").close();
             deleteDb("compatibility");

--- a/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
@@ -43,7 +43,6 @@ public class TestCompatibilityOracle extends TestDb {
         testDecimalScale();
         testPoundSymbolInColumnName();
         testToDate();
-        testForbidEmptyInClause();
         testSpecialTypes();
         testDate();
         testSequenceNextval();
@@ -237,22 +236,6 @@ public class TestCompatibilityOracle extends TestDb {
                 "SELECT TEST_VAL FROM DATE_TABLE WHERE ID=2");
 
         conn.close();
-    }
-
-    private void testForbidEmptyInClause() throws SQLException {
-        deleteDb("oracle");
-        Connection conn = getConnection("oracle;MODE=Oracle");
-        Statement stat = conn.createStatement();
-
-        stat.execute("CREATE TABLE A (ID NUMBER, X VARCHAR2(1))");
-        try {
-            stat.executeQuery("SELECT * FROM A WHERE ID IN ()");
-            fail();
-        } catch (SQLException e) {
-            // expected
-        } finally {
-            conn.close();
-        }
     }
 
     private void testDate() throws SQLException {

--- a/h2/src/test/org/h2/test/db/TestIgnoreCatalogs.java
+++ b/h2/src/test/org/h2/test/db/TestIgnoreCatalogs.java
@@ -78,6 +78,7 @@ public class TestIgnoreCatalogs extends TestDb {
                 assertThrows(ErrorCode.SYNTAX_ERROR_2, stat, "comment on column catalog1...test.id is 'id comment1'");
                 assertThrows(ErrorCode.SYNTAX_ERROR_2, stat, "comment on column catalog1..test..id is 'id comment1'");
                 assertThrows(ErrorCode.SYNTAX_ERROR_2, stat, "comment on column ..test..id is 'id comment1'");
+                assertThrows(ErrorCode.SYNTAX_ERROR_2, stat, "comment on column test..id is 'id comment1'");
                 assertThrows(ErrorCode.SYNTAX_ERROR_2, stat, "comment on column .PUBLIC.TEST.ID 'id comment1'");
                 assertThrows(ErrorCode.SYNTAX_ERROR_2, stat, "comment on column .TEST.ID 'id comment1'");
             }
@@ -161,6 +162,7 @@ public class TestIgnoreCatalogs extends TestDb {
                 // schema test_x not found error
                 assertThrows(ErrorCode.SCHEMA_NOT_FOUND_1, stat,
                         "create table test_x.dbo.test(id int primary key, name varchar(255))");
+                assertThrows(ErrorCode.DATABASE_NOT_FOUND_1, stat, "comment on column db..test.id is 'id'");
             }
         } finally {
             deleteDb("ignoreCatalogs");

--- a/h2/src/test/org/h2/test/scripts/predicates/in.sql
+++ b/h2/src/test/org/h2/test/scripts/predicates/in.sql
@@ -289,3 +289,63 @@ SELECT * FROM SYSTEM_RANGE(1, 10) WHERE X IN ((SELECT 1), (SELECT 2));
 
 EXPLAIN SELECT * FROM SYSTEM_RANGE(1, 10) WHERE X IN ((SELECT 1), (SELECT 2));
 >> SELECT "SYSTEM_RANGE"."X" FROM SYSTEM_RANGE(1, 10) /* range index: X IN((SELECT 1 FROM SYSTEM_RANGE(1, 1) /++ range index ++/), (SELECT 2 FROM SYSTEM_RANGE(1, 1) /++ range index ++/)) */ WHERE "X" IN((SELECT 1 FROM SYSTEM_RANGE(1, 1) /* range index */), (SELECT 2 FROM SYSTEM_RANGE(1, 1) /* range index */))
+
+-- Tests for IN predicate with an empty list
+
+SELECT 1 WHERE 1 IN ();
+> 1
+> -
+> rows: 0
+
+SET MODE DB2;
+> ok
+
+SELECT 1 WHERE 1 IN ();
+> exception SYNTAX_ERROR_2
+
+SET MODE Derby;
+> ok
+
+SELECT 1 WHERE 1 IN ();
+> exception SYNTAX_ERROR_2
+
+SET MODE MSSQLServer;
+> ok
+
+SELECT 1 WHERE 1 IN ();
+> exception SYNTAX_ERROR_2
+
+SET MODE HSQLDB;
+> ok
+
+SELECT 1 WHERE 1 IN ();
+> exception SYNTAX_ERROR_2
+
+SET MODE MySQL;
+> ok
+
+SELECT 1 WHERE 1 IN ();
+> exception SYNTAX_ERROR_2
+
+SET MODE Oracle;
+> ok
+
+SELECT 1 WHERE 1 IN ();
+> exception SYNTAX_ERROR_2
+
+SET MODE PostgreSQL;
+> ok
+
+SELECT 1 WHERE 1 IN ();
+> exception SYNTAX_ERROR_2
+
+SET MODE Ignite;
+> ok
+
+SELECT 1 WHERE 1 IN ();
+> 1
+> -
+> rows: 0
+
+SET MODE Regular;
+> ok


### PR DESCRIPTION
1. Closes #2116.

2. `Parser.parseComment()` is simplified and error detection in it is improved.