### PR TITLE
SQL: statement read consistency

### DIFF
--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -7,11 +7,13 @@ package org.h2.command;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.Database;
+import org.h2.engine.DbObject;
 import org.h2.engine.Session;
 import org.h2.expression.ParameterInterface;
 import org.h2.message.DbException;
@@ -195,7 +197,7 @@ public abstract class Command implements CommandInterface {
         }
         //noinspection SynchronizationOnLocalVariableOrMethodParameter
         synchronized (sync) {
-            session.startStatementWithinTransaction();
+            session.startStatementWithinTransaction(this);
             session.setCurrentCommand(this);
             try {
                 while (true) {
@@ -259,7 +261,7 @@ public abstract class Command implements CommandInterface {
         //noinspection SynchronizationOnLocalVariableOrMethodParameter
         synchronized (sync) {
             Session.Savepoint rollback = session.setSavepoint();
-            session.startStatementWithinTransaction();
+            session.startStatementWithinTransaction(this);
             session.setCurrentCommand(this);
             DbException ex = null;
             try {
@@ -397,4 +399,6 @@ public abstract class Command implements CommandInterface {
     public void setCanReuse(boolean canReuse) {
         this.canReuse = canReuse;
     }
+
+    public abstract Set<DbObject> getDependencies();
 }

--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -6,13 +6,16 @@
 package org.h2.command;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.command.dml.DataChangeStatement;
 import org.h2.command.dml.Explain;
 import org.h2.command.dml.Query;
 import org.h2.engine.Database;
+import org.h2.engine.DbObject;
 import org.h2.engine.DbSettings;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
@@ -329,4 +332,10 @@ public class CommandContainer extends Command {
         clearCTE(session, prepared);
     }
 
+    @Override
+    public Set<DbObject> getDependencies() {
+        HashSet<DbObject> dependencies = new HashSet<>();
+        prepared.collectDependecies(dependencies);
+        return dependencies;
+    }
 }

--- a/h2/src/main/org/h2/command/CommandList.java
+++ b/h2/src/main/org/h2/command/CommandList.java
@@ -6,7 +6,10 @@
 package org.h2.command;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
+import org.h2.engine.DbObject;
 import org.h2.engine.Session;
 import org.h2.expression.Parameter;
 import org.h2.expression.ParameterInterface;
@@ -113,4 +116,12 @@ class CommandList extends Command {
         return command.getCommandType();
     }
 
+    @Override
+    public Set<DbObject> getDependencies() {
+        HashSet<DbObject> dependencies = new HashSet<>();
+        for (Prepared prepared : commands) {
+            prepared.collectDependecies(dependencies);
+        }
+        return dependencies;
+    }
 }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1605,7 +1605,7 @@ public class Parser {
         }
         Merge command = new Merge(session, false);
         currentPrepared = command;
-        command.setTableFilter(targetTableFilter);
+        command.setTable(targetTableFilter.getTable());
         Table table = command.getTable();
         if (readIf(OPEN_PAREN)) {
             if (isQuery()) {

--- a/h2/src/main/org/h2/command/Prepared.java
+++ b/h2/src/main/org/h2/command/Prepared.java
@@ -476,5 +476,10 @@ public abstract class Prepared {
         return session;
     }
 
+    /**
+     * Find and collect all DbObjects, this Prepared depends on.
+     *
+     * @param dependencies collection of dependecies to populate
+     */
     public void collectDependecies(HashSet<DbObject> dependencies) {}
 }

--- a/h2/src/main/org/h2/command/Prepared.java
+++ b/h2/src/main/org/h2/command/Prepared.java
@@ -6,10 +6,12 @@
 package org.h2.command;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Database;
+import org.h2.engine.DbObject;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.expression.Parameter;
@@ -473,4 +475,6 @@ public abstract class Prepared {
     public Session getSession() {
         return session;
     }
+
+    public void collectDependecies(HashSet<DbObject> dependencies) {}
 }

--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -135,7 +135,7 @@ public class CreateTable extends CommandWithColumns {
                 boolean old = session.isUndoLogEnabled();
                 try {
                     session.setUndoLogEnabled(false);
-                    session.startStatementWithinTransaction();
+                    session.startStatementWithinTransaction(null);
                     Insert insert = new Insert(session);
                     insert.setSortedInsertMode(sortedInsertMode);
                     insert.setQuery(asQuery);

--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -144,6 +144,7 @@ public class CreateTable extends CommandWithColumns {
                     insert.prepare();
                     insert.update();
                 } finally {
+                    session.endStatement();
                     session.setUndoLogEnabled(old);
                 }
             }

--- a/h2/src/main/org/h2/command/dml/Delete.java
+++ b/h2/src/main/org/h2/command/dml/Delete.java
@@ -10,10 +10,12 @@ import java.util.HashSet;
 import org.h2.api.Trigger;
 import org.h2.command.CommandInterface;
 import org.h2.command.Prepared;
+import org.h2.engine.DbObject;
 import org.h2.engine.Right;
 import org.h2.engine.Session;
 import org.h2.engine.UndoLogRecord;
 import org.h2.expression.Expression;
+import org.h2.expression.ExpressionVisitor;
 import org.h2.result.ResultInterface;
 import org.h2.result.ResultTarget;
 import org.h2.result.Row;
@@ -233,4 +235,17 @@ public class Delete extends Prepared implements DataChangeStatement {
         return sourceTableFilter;
     }
 
+    @Override
+    public void collectDependecies(HashSet<DbObject> dependencies) {
+        ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
+        if (condition != null) {
+            condition.isEverything(visitor);
+        }
+        if (sourceTableFilter != null) {
+            Select select = sourceTableFilter.getSelect();
+            if (select != null) {
+                select.isEverything(visitor);
+            }
+        }
+    }
 }

--- a/h2/src/main/org/h2/command/dml/Delete.java
+++ b/h2/src/main/org/h2/command/dml/Delete.java
@@ -107,7 +107,9 @@ public class Delete extends Prepared implements DataChangeStatement {
             int count = 0;
             while (limitRows != 0 && targetTableFilter.next()) {
                 setCurrentRowNumber(rows.size() + 1);
-                if (condition == null || condition.getBooleanValue(session)) {
+                if (condition == null || condition.getBooleanValue(session)
+                        // the following is to support Oracle-style MERGE
+                        || (keysFilter != null && table.isMVStore())) {
                     Row row = targetTableFilter.get();
                     if (keysFilter == null || keysFilter.contains(row.getKey())) {
                         if (table.isMVStore()) {

--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -7,17 +7,20 @@ package org.h2.command.dml;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map.Entry;
 
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.command.Command;
 import org.h2.command.CommandInterface;
+import org.h2.engine.DbObject;
 import org.h2.engine.Right;
 import org.h2.engine.Session;
 import org.h2.engine.UndoLogRecord;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
+import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.Parameter;
 import org.h2.expression.ValueExpression;
 import org.h2.expression.condition.Comparison;
@@ -483,4 +486,17 @@ public class Insert extends CommandWithValues implements ResultTarget, DataChang
         this.sourceTableFilter = sourceTableFilter;
     }
 
+    @Override
+    public void collectDependecies(HashSet<DbObject> dependencies) {
+        ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
+        if (query != null) {
+            query.isEverything(visitor);
+        }
+        if (sourceTableFilter != null) {
+            Select select = sourceTableFilter.getSelect();
+            if (select != null) {
+                select.isEverything(visitor);
+            }
+        }
+    }
 }

--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -40,7 +40,6 @@ public class Merge extends CommandWithValues implements DataChangeStatement {
     private boolean isReplace;
 
     private Table table;
-    private TableFilter tableFilter;
     private Column[] columns;
     private Column[] keys;
     private Query query;
@@ -338,15 +337,6 @@ public class Merge extends CommandWithValues implements DataChangeStatement {
     @Override
     public boolean isCacheable() {
         return true;
-    }
-
-    public TableFilter getTableFilter() {
-        return tableFilter;
-    }
-
-    public void setTableFilter(TableFilter tableFilter) {
-        this.tableFilter = tableFilter;
-        setTable(tableFilter.getTable());
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -6,10 +6,12 @@
 package org.h2.command.dml;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.command.Command;
 import org.h2.command.CommandInterface;
+import org.h2.engine.DbObject;
 import org.h2.engine.Right;
 import org.h2.engine.Session;
 import org.h2.engine.UndoLogRecord;
@@ -347,4 +349,10 @@ public class Merge extends CommandWithValues implements DataChangeStatement {
         setTable(tableFilter.getTable());
     }
 
+    @Override
+    public void collectDependecies(HashSet<DbObject> dependencies) {
+        if (query != null) {
+            query.collectDependecies(dependencies);
+        }
+    }
 }

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -13,6 +13,7 @@ import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.command.Prepared;
 import org.h2.engine.Database;
+import org.h2.engine.DbObject;
 import org.h2.engine.Session;
 import org.h2.expression.Alias;
 import org.h2.expression.Expression;
@@ -928,4 +929,9 @@ public abstract class Query extends Prepared {
                 session.getUser(), alias, this, topQuery);
     }
 
+    @Override
+    public void collectDependecies(HashSet<DbObject> dependencies) {
+        ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
+        isEverything(visitor);
+    }
 }

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -14,9 +14,11 @@ import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.command.CommandInterface;
 import org.h2.command.Prepared;
+import org.h2.engine.DbObject;
 import org.h2.engine.Right;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
+import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.Parameter;
 import org.h2.expression.ValueExpression;
 import org.h2.message.DbException;
@@ -330,5 +332,19 @@ public class Update extends Prepared implements DataChangeStatement {
      */
     public void setUpdateToCurrentValuesReturnsZero(boolean updateToCurrentValuesReturnsZero) {
         this.updateToCurrentValuesReturnsZero = updateToCurrentValuesReturnsZero;
+    }
+
+    @Override
+    public void collectDependecies(HashSet<DbObject> dependencies) {
+        ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
+        if (condition != null) {
+            condition.isEverything(visitor);
+        }
+        if (sourceTableFilter != null) {
+            Select select = sourceTableFilter.getSelect();
+            if (select != null) {
+                select.isEverything(visitor);
+            }
+        }
     }
 }

--- a/h2/src/main/org/h2/constraint/ConstraintReferential.java
+++ b/h2/src/main/org/h2/constraint/ConstraintReferential.java
@@ -606,7 +606,7 @@ public class ConstraintReferential extends Constraint {
             // don't check at startup
             return;
         }
-        session.startStatementWithinTransaction();
+        session.startStatementWithinTransaction(null);
         StringBuilder builder = new StringBuilder("SELECT 1 FROM (SELECT ");
         IndexColumn.writeColumns(builder, columns, true);
         builder.append(" FROM ");

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1431,7 +1431,7 @@ public class Database implements DataHandler, CastDataProvider {
                 try {
                     // this will rollback outstanding transaction
                     s.close();
-                } catch (DbException e) {
+                } catch (Throwable e) {
                     trace.error(e, "disconnecting session #{0}", s.getId());
                 }
             }

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1003,7 +1003,9 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         if (!locks.isEmpty()) {
             Table[] array = locks.toArray(new Table[0]);
             for (Table t : array) {
-                t.unlock(this);
+                if (t != null) {
+                    t.unlock(this);
+                }
             }
             locks.clear();
         }

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -69,7 +69,7 @@ import org.h2.value.VersionedValue;
  */
 public class Session extends SessionWithState implements TransactionStore.RollbackListener, CastDataProvider {
 
-    public enum State { INIT, RUNNING, BLOCKED, SLEEP, CLOSED }
+    public enum State { INIT, RUNNING, BLOCKED, SLEEP, THROTTLED, SUSPENDED, CLOSED }
 
     /**
      * This special log position means that the log entry has been written.
@@ -885,6 +885,13 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         cancelAtNs = System.nanoTime();
     }
 
+    void suspend() {
+        cancel();
+        if (transitionToState(State.SUSPENDED, false) == State.SLEEP) {
+            close();
+        }
+    }
+
     @Override
     public void close() {
         // this is the only operation that can be invoked concurrently
@@ -1210,6 +1217,12 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         return state.get() == State.CLOSED;
     }
 
+    public boolean isOpen() {
+        State current = state.get();
+        checkSuspended(current);
+        return current != State.CLOSED;
+    }
+
     public void setThrottle(int throttle) {
         this.throttleNs = TimeUnit.MILLISECONDS.toNanos(throttle);
     }
@@ -1228,17 +1241,13 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         if (lastThrottle + TimeUnit.MILLISECONDS.toNanos(Constants.THROTTLE_DELAY) > time) {
             return;
         }
-        State prevState = this.state.get();
-        if (prevState != State.CLOSED) {
-            lastThrottle = time + throttleNs;
-            try {
-                state.compareAndSet(prevState, State.SLEEP);
-                Thread.sleep(TimeUnit.NANOSECONDS.toMillis(throttleNs));
-            } catch (Exception e) {
-                // ignore InterruptedException
-            } finally {
-                state.compareAndSet(State.SLEEP, prevState);
-            }
+        lastThrottle = time + throttleNs;
+        State prevState = transitionToState(State.THROTTLED, false);
+        try {
+            Thread.sleep(TimeUnit.NANOSECONDS.toMillis(throttleNs));
+        } catch (InterruptedException ignore) {
+        } finally {
+            transitionToState(prevState, false);
         }
     }
 
@@ -1248,21 +1257,37 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
      *
      * @param command the command
      */
-    public void setCurrentCommand(Command command) {
-        currentCommand = command;
-        if (command != null) {
-            if (queryTimeout > 0) {
-                currentCommandStart = CurrentTimestamp.get();
-                long now = System.nanoTime();
-                cancelAtNs = now + TimeUnit.MILLISECONDS.toNanos(queryTimeout);
-            } else {
-                currentCommandStart = null;
+    private void setCurrentCommand(Command command) {
+        State targetState = command == null ? State.SLEEP : State.RUNNING;
+        transitionToState(targetState, true);
+        if (isOpen()) {
+            currentCommand = command;
+            if (command != null) {
+                if (queryTimeout > 0) {
+                    currentCommandStart = CurrentTimestamp.get();
+                    long now = System.nanoTime();
+                    cancelAtNs = now + TimeUnit.MILLISECONDS.toNanos(queryTimeout);
+                } else {
+                    currentCommandStart = null;
+                }
             }
         }
-        State currentState = state.get();
-        if(currentState != State.CLOSED) {
-            state.compareAndSet(currentState, command == null ? State.SLEEP : State.RUNNING);
+    }
+
+    private State transitionToState(State targetState, boolean checkSuspended) {
+        State currentState;
+        while((currentState = state.get()) != State.CLOSED &&
+                (!checkSuspended || checkSuspended(currentState)) &&
+                !state.compareAndSet(currentState, targetState)) {/**/}
+        return currentState;
+    }
+
+    private boolean checkSuspended(State currentState) {
+        if (currentState == State.SUSPENDED) {
+            close();
+            throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
         }
+        return true;
     }
 
     /**
@@ -1447,7 +1472,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
 
     @Override
     public String toString() {
-        return "#" + serialId + " (user: " + (user == null ? "<null>" : user.getName()) + ")";
+        return "#" + serialId + " (user: " + (user == null ? "<null>" : user.getName()) + ", " + state.get() + ")";
     }
 
     public void setUndoLogEnabled(boolean b) {
@@ -1524,12 +1549,13 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
      * method returns as soon as the exclusive mode has been disabled.
      */
     public void waitIfExclusiveModeEnabled() {
+        transitionToState(State.RUNNING, true);
         // Even in exclusive mode, we have to let the LOB session proceed, or we
         // will get deadlocks.
         if (database.getLobSession() == this) {
             return;
         }
-        while (!isClosed()) {
+        while (isOpen()) {
             Session exclusive = database.getExclusiveSession();
             if (exclusive == null || exclusive == this) {
                 break;

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1741,11 +1741,12 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
 
     /**
      * Start a new statement within a transaction.
+     * @param command about to be started
      */
-    public void startStatementWithinTransaction() {
+    public void startStatementWithinTransaction(Command command) {
         Transaction transaction = getTransaction();
         if(transaction != null) {
-            transaction.markStatementStart();
+            transaction.markStatementStart(command);
         }
         startStatement = -1;
     }

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1001,7 +1001,8 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
             DbException.throwInternalError();
         }
         if (!locks.isEmpty()) {
-            for (Table t : locks) {
+            Table[] array = locks.toArray(new Table[0]);
+            for (Table t : array) {
                 t.unlock(this);
             }
             locks.clear();

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1775,6 +1775,9 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
             transaction.markStatementStart(command);
         }
         startStatement = -1;
+        if (command != null) {
+            setCurrentCommand(command);
+        }
     }
 
     /**
@@ -1782,6 +1785,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
      * set, and deletes all temporary files held by the result sets.
      */
     public void endStatement() {
+        setCurrentCommand(null);
         if(transaction != null) {
             transaction.markStatementEnd();
         }

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -160,6 +160,10 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         return getFirstLast(true);
     }
 
+    public final K firstKey(Page p) {
+        return getFirstLast(p, true);
+    }
+
     /**
      * Get the last key, or null if the map is empty.
      *
@@ -167,6 +171,10 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      */
     public final K lastKey() {
         return getFirstLast(false);
+    }
+
+    public final K lastKey(Page p) {
+        return getFirstLast(p, false);
     }
 
     /**
@@ -279,9 +287,13 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @param first whether to retrieve the first key
      * @return the key, or null if the map is empty
      */
-    @SuppressWarnings("unchecked")
     private K getFirstLast(boolean first) {
         Page p = getRootPage();
+        return getFirstLast(p, first);
+    }
+
+    @SuppressWarnings("unchecked")
+    private K getFirstLast(Page p, boolean first) {
         if (p.getTotalCount() == 0) {
             return null;
         }
@@ -304,6 +316,10 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         return getMinMax(key, false, true);
     }
 
+    public final K higherKey(Page p, K key) {
+        return getMinMax(p, key, false, true);
+    }
+
     /**
      * Get the smallest key that is larger or equal to this key.
      *
@@ -312,6 +328,10 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      */
     public final K ceilingKey(K key) {
         return getMinMax(key, false, false);
+    }
+
+    public final K ceilingKey(Page p, K key) {
+        return getMinMax(p, key, false, false);
     }
 
     /**
@@ -324,6 +344,10 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         return getMinMax(key, true, false);
     }
 
+    public final K floorKey(Page p, K key) {
+        return getMinMax(p, key, true, false);
+    }
+
     /**
      * Get the largest key that is smaller than the given key, or null if no
      * such key exists.
@@ -333,6 +357,10 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      */
     public final K lowerKey(K key) {
         return getMinMax(key, true, true);
+    }
+
+    public final K lowerKey(Page p, K key) {
+        return getMinMax(p, key, true, true);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
@@ -12,6 +12,7 @@ import org.h2.index.BaseIndex;
 import org.h2.index.Cursor;
 import org.h2.index.IndexType;
 import org.h2.message.DbException;
+import org.h2.mvstore.MVMap;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.result.SortOrder;
@@ -47,6 +48,11 @@ public class MVDelegateIndex extends BaseIndex implements MVIndex {
     @Override
     public void addBufferedRows(List<String> bufferNames) {
         throw DbException.throwInternalError();
+    }
+
+    @Override
+    public MVMap getMVMap() {
+        return mainIndex.getMVMap();
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/MVIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVIndex.java
@@ -8,6 +8,7 @@ package org.h2.mvstore.db;
 import java.util.List;
 
 import org.h2.index.Index;
+import org.h2.mvstore.MVMap;
 import org.h2.result.Row;
 
 /**
@@ -32,4 +33,5 @@ public interface MVIndex extends Index {
      */
     void addBufferedRows(List<String> bufferNames);
 
+    MVMap getMVMap();
 }

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -119,7 +119,7 @@ public class MVPrimaryIndex extends BaseIndex {
             Value oldValue = map.putIfAbsent(key, ValueArray.get(row.getValueList()));
             if (oldValue != null) {
                 int errorCode = ErrorCode.CONCURRENT_UPDATE_1;
-                if (map.get(key) != null) {
+                if (map.getImmediate(key) != null) {
                     // committed
                     errorCode = ErrorCode.DUPLICATE_KEY_1;
                 }
@@ -248,7 +248,7 @@ public class MVPrimaryIndex extends BaseIndex {
     @Override
     public Row getRow(Session session, long key) {
         TransactionMap<Value, Value> map = getMap(session);
-        Value v = map.get(ValueLong.get(key));
+        Value v = map.getFromSnapshot(ValueLong.get(key));
         if (v == null) {
             throw DbException.get(ErrorCode.ROW_NOT_FOUND_IN_PRIMARY_INDEX,
                     getSQL(false), String.valueOf(key));
@@ -316,7 +316,7 @@ public class MVPrimaryIndex extends BaseIndex {
             return new MVStoreCursor(session,
                     Collections.<Entry<Value, Value>> emptyIterator());
         }
-        Value value = map.get(v);
+        Value value = map.getFromSnapshot(v);
         Entry<Value, Value> e = new AbstractMap.SimpleImmutableEntry<Value, Value>(v, value);
         List<Entry<Value, Value>> list = Collections.singletonList(e);
         MVStoreCursor c = new MVStoreCursor(session, list.iterator());

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -20,6 +20,7 @@ import org.h2.index.Cursor;
 import org.h2.index.IndexType;
 import org.h2.message.DbException;
 import org.h2.mvstore.DataUtils;
+import org.h2.mvstore.MVMap;
 import org.h2.mvstore.tx.Transaction;
 import org.h2.mvstore.tx.TransactionMap;
 import org.h2.result.Row;
@@ -413,6 +414,10 @@ public class MVPrimaryIndex extends BaseIndex {
         }
         Transaction t = session.getTransaction();
         return dataMap.getInstance(t);
+    }
+
+    public MVMap getMVMap() {
+        return dataMap.map;
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -37,7 +37,7 @@ import org.h2.value.ValueNull;
 /**
  * A table stored in a MVStore.
  */
-public class MVPrimaryIndex extends BaseIndex {
+public class MVPrimaryIndex extends BaseIndex implements MVIndex {
 
     private final MVTable mvTable;
     private final String mapName;
@@ -361,6 +361,16 @@ public class MVPrimaryIndex extends BaseIndex {
     @Override
     public void checkRename() {
         // ok
+    }
+
+    @Override
+    public void addRowsToBuffer(List<Row> rows, String bufferName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addBufferedRows(List<String> bufferNames) {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -431,6 +431,11 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
         return dataMap.getInstance(t);
     }
 
+    @Override
+    public MVMap getMVMap() {
+        return dataMap.map;
+    }
+
     /**
      * A cursor.
      */

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -214,7 +214,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
             Value rowKey = array[array.length - 1];
             long rowId = rowKey.getLong();
             if (newKey != rowId) {
-                if (map.get(rowData) != null) {
+                if (map.getImmediate(rowData) != null) {
                     // committed
                     throw getDuplicateKeyException(rowKey.toString());
                 }

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -163,7 +163,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
                         continue;
                     }
                     map.remove(key);
-                    if (map.get(k) != null) {
+                    if (map.getImmediate(k) != null) {
                         // committed
                         throw getDuplicateKeyException(k.toString());
                     }

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -5,6 +5,7 @@
  */
 package org.h2.mvstore.db;
 
+import org.h2.mvstore.MVMap;
 import static org.h2.util.geometry.GeometryUtils.MAX_X;
 import static org.h2.util.geometry.GeometryUtils.MAX_Y;
 import static org.h2.util.geometry.GeometryUtils.MIN_X;
@@ -395,6 +396,11 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
         }
         Transaction t = session.getTransaction();
         return dataMap.getInstance(t);
+    }
+
+    @Override
+    public MVMap getMVMap() {
+        return dataMap.map;
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -192,7 +192,11 @@ public class MVTableEngine implements TableEngine {
          */
         DbException convertIllegalStateException(IllegalStateException e) {
             int errorCode = DataUtils.getErrorCode(e.getMessage());
-            if (errorCode == DataUtils.ERROR_FILE_CORRUPT) {
+            if (errorCode == DataUtils.ERROR_CLOSED) {
+                throw DbException.get(
+                        ErrorCode.DATABASE_IS_CLOSED,
+                        e, fileName);
+            } else if (errorCode == DataUtils.ERROR_FILE_CORRUPT) {
                 if (encrypted) {
                     throw DbException.get(
                             ErrorCode.FILE_ENCRYPTION_ERROR_1,
@@ -206,6 +210,10 @@ public class MVTableEngine implements TableEngine {
                 throw DbException.get(
                         ErrorCode.IO_EXCEPTION_1,
                         e, fileName);
+            } else if (errorCode == DataUtils.ERROR_TRANSACTION_ILLEGAL_STATE) {
+                throw DbException.get(
+                        ErrorCode.GENERAL_ERROR_1,
+                        e, e.getMessage());
             } else if (errorCode == DataUtils.ERROR_INTERNAL) {
                 throw DbException.get(
                         ErrorCode.GENERAL_ERROR_1,

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -447,11 +447,17 @@ public class Transaction {
                 store.rollbackTo(this, logId, 0);
             }
         } catch (Throwable e) {
-            ex = e;
-            throw e;
+            int status = getStatus();
+            if (status != STATUS_CLOSED && status != STATUS_COMMITTED) {
+                ex = e;
+                throw e;
+            }
         } finally {
             try {
-                store.endTransaction(this, true);
+                int status = getStatus();
+                if (status != STATUS_CLOSED && status != STATUS_COMMITTED) {
+                    store.endTransaction(this, true);
+                }
             } catch (Throwable e) {
                 if (ex == null) {
                     throw e;

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -319,8 +319,6 @@ public class Transaction {
                     for (Index index : table.getIndexes()) {
                         collectDependensies(maps, index);
                     }
-                } else {
-                    collectDependensies(maps, dependency);
                 }
             }
 
@@ -345,11 +343,7 @@ public class Transaction {
     }
 
     private void collectDependensies(Set<MVMap> maps, DbObject dependency) {
-        if (dependency instanceof MVPrimaryIndex) {
-            MVPrimaryIndex primaryIndex = (MVPrimaryIndex) dependency;
-            MVMap map = primaryIndex.getMVMap();
-            maps.add(map);
-        } else if (dependency instanceof MVIndex) {
+        if (dependency instanceof MVIndex) {
             MVIndex index = (MVIndex) dependency;
             MVMap map = index.getMVMap();
             maps.add(map);

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -507,8 +507,6 @@ public abstract class Table extends SchemaObjectBase {
                 if (e.getErrorCode() == ErrorCode.CONCURRENT_UPDATE_1
                         || e.getErrorCode() == ErrorCode.ROW_NOT_FOUND_WHEN_DELETING_1) {
                     session.rollbackTo(rollback);
-                    session.startStatementWithinTransaction(null);
-                    rollback = session.setSavepoint();
                 }
                 throw e;
             }
@@ -526,8 +524,6 @@ public abstract class Table extends SchemaObjectBase {
             } catch (DbException e) {
                 if (e.getErrorCode() == ErrorCode.CONCURRENT_UPDATE_1) {
                     session.rollbackTo(rollback);
-                    session.startStatementWithinTransaction(null);
-                    rollback = session.setSavepoint();
                 }
                 throw e;
             }

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -507,7 +507,7 @@ public abstract class Table extends SchemaObjectBase {
                 if (e.getErrorCode() == ErrorCode.CONCURRENT_UPDATE_1
                         || e.getErrorCode() == ErrorCode.ROW_NOT_FOUND_WHEN_DELETING_1) {
                     session.rollbackTo(rollback);
-                    session.startStatementWithinTransaction();
+                    session.startStatementWithinTransaction(null);
                     rollback = session.setSavepoint();
                 }
                 throw e;
@@ -526,7 +526,7 @@ public abstract class Table extends SchemaObjectBase {
             } catch (DbException e) {
                 if (e.getErrorCode() == ErrorCode.CONCURRENT_UPDATE_1) {
                     session.rollbackTo(rollback);
-                    session.startStatementWithinTransaction();
+                    session.startStatementWithinTransaction(null);
                     rollback = session.setSavepoint();
                 }
                 throw e;

--- a/h2/src/test/org/h2/test/jdbc/TestBatchUpdates.java
+++ b/h2/src/test/org/h2/test/jdbc/TestBatchUpdates.java
@@ -78,13 +78,13 @@ public class TestBatchUpdates extends TestDb {
         try {
             stat.executeBatch();
         } catch (SQLException e) {
-            assertContains(e.toString(), "TEST_Y");
-            e = e.getNextException();
-            assertNotNull(e);
-            assertContains(e.toString(), "TEST_Y");
+            assertContains(e.toString(), "TEST_X");
             e = e.getNextException();
             assertNotNull(e);
             assertContains(e.toString(), "TEST_X");
+            e = e.getNextException();
+            assertNotNull(e);
+            assertContains(e.toString(), "TEST_Y");
             e = e.getNextException();
             assertNull(e);
         }
@@ -97,13 +97,13 @@ public class TestBatchUpdates extends TestDb {
         try {
             prep.executeBatch();
         } catch (SQLException e) {
-            assertContains(e.toString(), "TEST_Y");
-            e = e.getNextException();
-            assertNotNull(e);
-            assertContains(e.toString(), "TEST_Y");
+            assertContains(e.toString(), "TEST_X");
             e = e.getNextException();
             assertNotNull(e);
             assertContains(e.toString(), "TEST_X");
+            e = e.getNextException();
+            assertNotNull(e);
+            assertContains(e.toString(), "TEST_Y");
             e = e.getNextException();
             assertNull(e);
         }


### PR DESCRIPTION
This issue was brought up by #2080. 
With READ_COMMITTED transaction isolation level each SQL statement within transaction should read from a consistent snapshot of a database, produced by some subset of committed transactions.
Currently each mvstore lookup and/or cursor, within SQL statement execution path, operates on it's own up-to-date committed view, so there is a room for discrepancies.
This PR tries at the beginning of a statement to figure out all MVStore maps involved and save snapshot roots within transaction for subsequent use. Map lookup (get()) is split into two separate operations one operating on a snapshot, and one which deals with up-to-date, updatable map (for uniqueness validation etc.)
Another issue dealt with here is not directly related but also came out of #2080. Transition to exclusive mode (which is employed on every shutdown) forcibly closes existing sessions, disregarding their state, from another thread. This may not quite work and can cause even data corruption if two operations are performed concurrently within the same transaction. This PR switches to a "cooperative" approach. Two new session states are introduced THROTTLED to distinguish from SLEEP, and SUSPENDED with meaning "to be closed ASAP". Now, instead of closing sessions, exclusive one marks all others as suspended, or closes only if they are sleeping.
If any session fails to recognize suspended status and close itself in a timely fashion, it'll be terminated forcefully, the old way.
Finally, PR containing a change to reverse chain of "next" exceptions within batch exception to match chronological order.