### PR TITLE
Reduce code duplication for datetime API with custom Calendar instances

### DIFF
--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -685,7 +685,7 @@ Another (more dangerous) solution is to set <code>useDatabaseLock</code> to fals
 <p>
 There is a known issue when using the Netbeans SQL Execution Window:
 before executing a query, another query in the form <code>SELECT COUNT(*) FROM &lt;query&gt;</code> is run.
-This is a problem for queries that modify state, such as <code>SELECT SEQ.NEXTVAL</code>.
+This is a problem for queries that modify state, such as <code>SELECT NEXT VALUE FOR SEQ</code>.
 In this case, two sequence values are allocated instead of just one.
 </p>
 

--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -335,7 +335,7 @@ public class CommandContainer extends Command {
     @Override
     public Set<DbObject> getDependencies() {
         HashSet<DbObject> dependencies = new HashSet<>();
-        prepared.collectDependecies(dependencies);
+        prepared.collectDependencies(dependencies);
         return dependencies;
     }
 }

--- a/h2/src/main/org/h2/command/CommandList.java
+++ b/h2/src/main/org/h2/command/CommandList.java
@@ -120,7 +120,7 @@ class CommandList extends Command {
     public Set<DbObject> getDependencies() {
         HashSet<DbObject> dependencies = new HashSet<>();
         for (Prepared prepared : commands) {
-            prepared.collectDependecies(dependencies);
+            prepared.collectDependencies(dependencies);
         }
         return dependencies;
     }

--- a/h2/src/main/org/h2/command/Prepared.java
+++ b/h2/src/main/org/h2/command/Prepared.java
@@ -479,7 +479,7 @@ public abstract class Prepared {
     /**
      * Find and collect all DbObjects, this Prepared depends on.
      *
-     * @param dependencies collection of dependecies to populate
+     * @param dependencies collection of dependencies to populate
      */
-    public void collectDependecies(HashSet<DbObject> dependencies) {}
+    public void collectDependencies(HashSet<DbObject> dependencies) {}
 }

--- a/h2/src/main/org/h2/command/dml/Delete.java
+++ b/h2/src/main/org/h2/command/dml/Delete.java
@@ -238,7 +238,7 @@ public class Delete extends Prepared implements DataChangeStatement {
     }
 
     @Override
-    public void collectDependecies(HashSet<DbObject> dependencies) {
+    public void collectDependencies(HashSet<DbObject> dependencies) {
         ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
         if (condition != null) {
             condition.isEverything(visitor);

--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -487,7 +487,7 @@ public class Insert extends CommandWithValues implements ResultTarget, DataChang
     }
 
     @Override
-    public void collectDependecies(HashSet<DbObject> dependencies) {
+    public void collectDependencies(HashSet<DbObject> dependencies) {
         ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
         if (query != null) {
             query.isEverything(visitor);

--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -26,7 +26,6 @@ import org.h2.result.Row;
 import org.h2.table.Column;
 import org.h2.table.DataChangeDeltaTable.ResultOption;
 import org.h2.table.Table;
-import org.h2.table.TableFilter;
 import org.h2.value.Value;
 
 /**
@@ -340,9 +339,9 @@ public class Merge extends CommandWithValues implements DataChangeStatement {
     }
 
     @Override
-    public void collectDependecies(HashSet<DbObject> dependencies) {
+    public void collectDependencies(HashSet<DbObject> dependencies) {
         if (query != null) {
-            query.collectDependecies(dependencies);
+            query.collectDependencies(dependencies);
         }
     }
 }

--- a/h2/src/main/org/h2/command/dml/MergeUsing.java
+++ b/h2/src/main/org/h2/command/dml/MergeUsing.java
@@ -342,14 +342,14 @@ public class MergeUsing extends Prepared implements DataChangeStatement {
     }
 
     @Override
-    public void collectDependecies(HashSet<DbObject> dependencies) {
+    public void collectDependencies(HashSet<DbObject> dependencies) {
         for (When w : when) {
-            w.collectDependecies(dependencies);
+            w.collectDependencies(dependencies);
         }
         if (query != null) {
-            query.collectDependecies(dependencies);
+            query.collectDependencies(dependencies);
         }
-        targetMatchQuery.collectDependecies(dependencies);
+        targetMatchQuery.collectDependencies(dependencies);
     }
 
     /**
@@ -428,9 +428,9 @@ public class MergeUsing extends Prepared implements DataChangeStatement {
         /**
          * Find and collect all DbObjects, this When object depends on.
          *
-         * @param dependencies collection of dependecies to populate
+         * @param dependencies collection of dependencies to populate
          */
-        abstract void collectDependecies(HashSet<DbObject> dependencies);
+        abstract void collectDependencies(HashSet<DbObject> dependencies);
     }
 
     public static final class WhenMatched extends When {
@@ -546,12 +546,12 @@ public class MergeUsing extends Prepared implements DataChangeStatement {
         }
 
         @Override
-        void collectDependecies(HashSet<DbObject> dependencies) {
+        void collectDependencies(HashSet<DbObject> dependencies) {
             if (updateCommand != null) {
-                updateCommand.collectDependecies(dependencies);
+                updateCommand.collectDependencies(dependencies);
             }
             if (deleteCommand != null) {
-                deleteCommand.collectDependecies(dependencies);
+                deleteCommand.collectDependencies(dependencies);
             }
         }
 
@@ -612,8 +612,8 @@ public class MergeUsing extends Prepared implements DataChangeStatement {
         }
 
         @Override
-        void collectDependecies(HashSet<DbObject> dependencies) {
-            insertCommand.collectDependecies(dependencies);
+        void collectDependencies(HashSet<DbObject> dependencies) {
+            insertCommand.collectDependencies(dependencies);
         }
     }
 }

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -930,7 +930,7 @@ public abstract class Query extends Prepared {
     }
 
     @Override
-    public void collectDependecies(HashSet<DbObject> dependencies) {
+    public void collectDependencies(HashSet<DbObject> dependencies) {
         ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
         isEverything(visitor);
     }

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -335,7 +335,7 @@ public class Update extends Prepared implements DataChangeStatement {
     }
 
     @Override
-    public void collectDependecies(HashSet<DbObject> dependencies) {
+    public void collectDependencies(HashSet<DbObject> dependencies) {
         ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
         if (condition != null) {
             condition.isEverything(visitor);

--- a/h2/src/main/org/h2/expression/function/DateTimeFunctions.java
+++ b/h2/src/main/org/h2/expression/function/DateTimeFunctions.java
@@ -325,13 +325,13 @@ public final class DateTimeFunctions {
             if (v1 instanceof ValueTimestampTimeZone) {
                 offsetMinutes1 = ((ValueTimestampTimeZone) v1).getTimeZoneOffsetMins();
             } else {
-                offsetMinutes1 = DateTimeUtils.getTimeZoneOffsetMillis(null, dateValue1, a1[1]);
+                offsetMinutes1 = DateTimeUtils.getTimeZoneOffsetMillis(null, dateValue1, a1[1]) / 60_000;
             }
             int offsetMinutes2;
             if (v2 instanceof ValueTimestampTimeZone) {
                 offsetMinutes2 = ((ValueTimestampTimeZone) v2).getTimeZoneOffsetMins();
             } else {
-                offsetMinutes2 = DateTimeUtils.getTimeZoneOffsetMillis(null, dateValue2, a2[1]);
+                offsetMinutes2 = DateTimeUtils.getTimeZoneOffsetMillis(null, dateValue2, a2[1]) / 60_000;
             }
             if (field == TIMEZONE_HOUR) {
                 return (offsetMinutes2 / 60) - (offsetMinutes1 / 60);
@@ -728,7 +728,7 @@ public final class DateTimeFunctions {
                 if (date instanceof ValueTimestampTimeZone) {
                     offsetMinutes = ((ValueTimestampTimeZone) date).getTimeZoneOffsetMins();
                 } else {
-                    offsetMinutes = DateTimeUtils.getTimeZoneOffsetMillis(null, dateValue, timeNanos);
+                    offsetMinutes = DateTimeUtils.getTimeZoneOffsetMillis(null, dateValue, timeNanos) / 60_000;
                 }
                 if (field == TIMEZONE_HOUR) {
                     return offsetMinutes / 60;

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -1527,7 +1527,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                             ((ValueTimestampTimeZone) v0).getTimeZoneOffsetMins());
                 }
                 result = ValueString.get(
-                        DateTimeFunctions.formatDateTime(v0.getTimestamp(), v1.getString(), locale, tz),
+                        DateTimeFunctions.formatDateTime(v0.getTimestamp(null), v1.getString(), locale, tz),
                         database);
             }
             break;

--- a/h2/src/main/org/h2/expression/function/ToChar.java
+++ b/h2/src/main/org/h2/expression/function/ToChar.java
@@ -524,7 +524,7 @@ public class ToChar {
         if (!(value instanceof ValueTimestampTimeZone)) {
             TimeZone tz = TimeZone.getDefault();
             if (tzd) {
-                boolean daylight = tz.inDaylightTime(value.getTimestamp());
+                boolean daylight = tz.inDaylightTime(value.getTimestamp(null));
                 return tz.getDisplayName(daylight, TimeZone.SHORT);
             }
             return tz.getID();

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -34,7 +34,6 @@ import org.h2.message.TraceObject;
 import org.h2.result.MergedResult;
 import org.h2.result.ResultInterface;
 import org.h2.result.ResultWithGeneratedKeys;
-import org.h2.util.DateTimeUtils;
 import org.h2.util.IOUtils;
 import org.h2.util.Utils;
 import org.h2.value.DataType;
@@ -421,10 +420,9 @@ public class JdbcPreparedStatement extends JdbcStatement implements
     public void setString(int parameterIndex, String x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setString("+parameterIndex+", "+quote(x)+");");
+                debugCode("setString(" + parameterIndex + ", " + quote(x) + ");");
             }
-            Value v = x == null ? (Value) ValueNull.INSTANCE : ValueString.get(x);
-            setParameter(parameterIndex, v);
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueString.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -438,14 +436,12 @@ public class JdbcPreparedStatement extends JdbcStatement implements
      * @throws SQLException if this object is closed
      */
     @Override
-    public void setBigDecimal(int parameterIndex, BigDecimal x)
-            throws SQLException {
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setBigDecimal("+parameterIndex+", " + quoteBigDecimal(x) + ");");
+                debugCode("setBigDecimal(" + parameterIndex + ", " + quoteBigDecimal(x) + ");");
             }
-            Value v = x == null ? (Value) ValueNull.INSTANCE : ValueDecimal.get(x);
-            setParameter(parameterIndex, v);
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueDecimal.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -459,14 +455,12 @@ public class JdbcPreparedStatement extends JdbcStatement implements
      * @throws SQLException if this object is closed
      */
     @Override
-    public void setDate(int parameterIndex, java.sql.Date x)
-            throws SQLException {
+    public void setDate(int parameterIndex, java.sql.Date x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setDate("+parameterIndex+", " + quoteDate(x) + ");");
+                debugCode("setDate(" + parameterIndex + ", " + quoteDate(x) + ");");
             }
-            Value v = x == null ? (Value) ValueNull.INSTANCE : ValueDate.get(x);
-            setParameter(parameterIndex, v);
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueDate.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -480,14 +474,12 @@ public class JdbcPreparedStatement extends JdbcStatement implements
      * @throws SQLException if this object is closed
      */
     @Override
-    public void setTime(int parameterIndex, java.sql.Time x)
-            throws SQLException {
+    public void setTime(int parameterIndex, java.sql.Time x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setTime("+parameterIndex+", " + quoteTime(x) + ");");
+                debugCode("setTime(" + parameterIndex + ", " + quoteTime(x) + ");");
             }
-            Value v = x == null ? (Value) ValueNull.INSTANCE : ValueTime.get(x);
-            setParameter(parameterIndex, v);
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueTime.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -501,14 +493,12 @@ public class JdbcPreparedStatement extends JdbcStatement implements
      * @throws SQLException if this object is closed
      */
     @Override
-    public void setTimestamp(int parameterIndex, java.sql.Timestamp x)
-            throws SQLException {
+    public void setTimestamp(int parameterIndex, java.sql.Timestamp x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setTimestamp("+parameterIndex+", " + quoteTimestamp(x) + ");");
+                debugCode("setTimestamp(" + parameterIndex + ", " + quoteTimestamp(x) + ");");
             }
-            Value v = x == null ? (Value) ValueNull.INSTANCE : ValueTimestamp.get(x);
-            setParameter(parameterIndex, v);
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueTimestamp.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -526,14 +516,12 @@ public class JdbcPreparedStatement extends JdbcStatement implements
     public void setObject(int parameterIndex, Object x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setObject("+parameterIndex+", x);");
+                debugCode("setObject(" + parameterIndex + ", x);");
             }
             if (x == null) {
-                // throw Errors.getInvalidValueException("null", "x");
                 setParameter(parameterIndex, ValueNull.INSTANCE);
             } else {
-                setParameter(parameterIndex,
-                        DataType.convertToValue(session, x, Value.UNKNOWN));
+                setParameter(parameterIndex, DataType.convertToValue(session, x, Value.UNKNOWN));
             }
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -725,17 +713,15 @@ public class JdbcPreparedStatement extends JdbcStatement implements
      * @throws SQLException if this object is closed
      */
     @Override
-    public void setDate(int parameterIndex, java.sql.Date x, Calendar calendar)
-            throws SQLException {
+    public void setDate(int parameterIndex, java.sql.Date x, Calendar calendar) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setDate("+parameterIndex+", " + quoteDate(x) + ", calendar);");
+                debugCode("setDate(" + parameterIndex + ", " + quoteDate(x) + ", calendar);");
             }
             if (x == null) {
                 setParameter(parameterIndex, ValueNull.INSTANCE);
             } else {
-                setParameter(parameterIndex,
-                        calendar != null ? DateTimeUtils.convertDate(x, calendar) : ValueDate.get(x));
+                setParameter(parameterIndex, ValueDate.get(calendar != null ? calendar.getTimeZone() : null, x));
             }
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -752,17 +738,15 @@ public class JdbcPreparedStatement extends JdbcStatement implements
      * @throws SQLException if this object is closed
      */
     @Override
-    public void setTime(int parameterIndex, java.sql.Time x, Calendar calendar)
-            throws SQLException {
+    public void setTime(int parameterIndex, java.sql.Time x, Calendar calendar) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setTime("+parameterIndex+", " + quoteTime(x) + ", calendar);");
+                debugCode("setTime(" + parameterIndex + ", " + quoteTime(x) + ", calendar);");
             }
             if (x == null) {
                 setParameter(parameterIndex, ValueNull.INSTANCE);
             } else {
-                setParameter(parameterIndex,
-                        calendar != null ? DateTimeUtils.convertTime(x, calendar) : ValueTime.get(x));
+                setParameter(parameterIndex, ValueTime.get(calendar != null ? calendar.getTimeZone() : null, x));
             }
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -779,18 +763,15 @@ public class JdbcPreparedStatement extends JdbcStatement implements
      * @throws SQLException if this object is closed
      */
     @Override
-    public void setTimestamp(int parameterIndex, java.sql.Timestamp x,
-            Calendar calendar) throws SQLException {
+    public void setTimestamp(int parameterIndex, java.sql.Timestamp x, Calendar calendar) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setTimestamp(" + parameterIndex + ", " +
-                        quoteTimestamp(x) + ", calendar);");
+                debugCode("setTimestamp(" + parameterIndex + ", " + quoteTimestamp(x) + ", calendar);");
             }
             if (x == null) {
                 setParameter(parameterIndex, ValueNull.INSTANCE);
             } else {
-                setParameter(parameterIndex,
-                        calendar != null ? DateTimeUtils.convertTimestamp(x, calendar) : ValueTimestamp.get(x));
+                setParameter(parameterIndex, ValueTimestamp.get(calendar != null ? calendar.getTimeZone() : null, x));
             }
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -986,10 +967,9 @@ public class JdbcPreparedStatement extends JdbcStatement implements
     public void setBytes(int parameterIndex, byte[] x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setBytes("+parameterIndex+", "+quoteBytes(x)+");");
+                debugCode("setBytes(" + parameterIndex + ", " + quoteBytes(x) + ");");
             }
-            Value v = x == null ? (Value) ValueNull.INSTANCE : ValueBytes.get(x);
-            setParameter(parameterIndex, v);
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueBytes.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1595,10 +1575,9 @@ public class JdbcPreparedStatement extends JdbcStatement implements
     public void setNString(int parameterIndex, String x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("setNString("+parameterIndex+", "+quote(x)+");");
+                debugCode("setNString(" + parameterIndex + ", " + quote(x) + ");");
             }
-            Value v = x == null ? (Value) ValueNull.INSTANCE : ValueString.get(x);
-            setParameter(parameterIndex, v);
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueString.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -1420,9 +1420,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateBytes(int columnIndex, byte[] x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateBytes("+columnIndex+", x);");
+                debugCode("updateBytes(" + columnIndex + ", x);");
             }
-            update(columnIndex, x == null ? (Value) ValueNull.INSTANCE : ValueBytes.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueBytes.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1439,9 +1439,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateBytes(String columnLabel, byte[] x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateBytes("+quote(columnLabel)+", x);");
+                debugCode("updateBytes(" + quote(columnLabel) + ", x);");
             }
-            update(columnLabel, x == null ? (Value) ValueNull.INSTANCE : ValueBytes.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueBytes.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1651,7 +1651,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateBigDecimal("+columnIndex+", " + quoteBigDecimal(x) + ");");
             }
-            update(columnIndex, x == null ? (Value) ValueNull.INSTANCE
+            update(columnIndex, x == null ? ValueNull.INSTANCE
                     : ValueDecimal.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
@@ -1666,15 +1666,12 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
      * @throws SQLException if the result set is closed or not updatable
      */
     @Override
-    public void updateBigDecimal(String columnLabel, BigDecimal x)
-            throws SQLException {
+    public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateBigDecimal(" + quote(columnLabel) + ", " +
-                        quoteBigDecimal(x) + ");");
+                debugCode("updateBigDecimal(" + quote(columnLabel) + ", " + quoteBigDecimal(x) + ");");
             }
-            update(columnLabel, x == null ? (Value) ValueNull.INSTANCE
-                    : ValueDecimal.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueDecimal.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1691,10 +1688,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateString(int columnIndex, String x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateString("+columnIndex+", "+quote(x)+");");
+                debugCode("updateString(" + columnIndex + ", " + quote(x) + ");");
             }
-            update(columnIndex, x == null ? (Value) ValueNull.INSTANCE
-                    : ValueString.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueString.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1711,10 +1707,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateString(String columnLabel, String x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateString("+quote(columnLabel)+", "+quote(x)+");");
+                debugCode("updateString(" + quote(columnLabel) + ", " + quote(x) + ");");
             }
-            update(columnLabel, x == null ? (Value) ValueNull.INSTANCE
-                    : ValueString.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueString.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1731,9 +1726,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateDate(int columnIndex, Date x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateDate("+columnIndex+", x);");
+                debugCode("updateDate(" + columnIndex + ", x);");
             }
-            update(columnIndex, x == null ? (Value) ValueNull.INSTANCE : ValueDate.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueDate.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1750,9 +1745,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateDate(String columnLabel, Date x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateDate("+quote(columnLabel)+", x);");
+                debugCode("updateDate(" + quote(columnLabel) + ", x);");
             }
-            update(columnLabel, x == null ? (Value) ValueNull.INSTANCE : ValueDate.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueDate.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1769,9 +1764,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateTime(int columnIndex, Time x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateTime("+columnIndex+", x);");
+                debugCode("updateTime(" + columnIndex + ", x);");
             }
-            update(columnIndex, x == null ? (Value) ValueNull.INSTANCE : ValueTime.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueTime.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1788,9 +1783,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateTime(String columnLabel, Time x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateTime("+quote(columnLabel)+", x);");
+                debugCode("updateTime(" + quote(columnLabel) + ", x);");
             }
-            update(columnLabel, x == null ? (Value) ValueNull.INSTANCE : ValueTime.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueTime.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1804,14 +1799,12 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
      * @throws SQLException if the result set is closed or not updatable
      */
     @Override
-    public void updateTimestamp(int columnIndex, Timestamp x)
-            throws SQLException {
+    public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateTimestamp("+columnIndex+", x);");
+                debugCode("updateTimestamp(" + columnIndex + ", x);");
             }
-            update(columnIndex, x == null ? (Value) ValueNull.INSTANCE
-                    : ValueTimestamp.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueTimestamp.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1825,14 +1818,12 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
      * @throws SQLException if the result set is closed or not updatable
      */
     @Override
-    public void updateTimestamp(String columnLabel, Timestamp x)
-            throws SQLException {
+    public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateTimestamp("+quote(columnLabel)+", x);");
+                debugCode("updateTimestamp(" + quote(columnLabel) + ", x);");
             }
-            update(columnLabel, x == null ? (Value) ValueNull.INSTANCE
-                    : ValueTimestamp.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueTimestamp.get(null, x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -3395,10 +3386,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateNString(int columnIndex, String x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateNString("+columnIndex+", "+quote(x)+");");
+                debugCode("updateNString(" + columnIndex + ", " + quote(x) + ");");
             }
-            update(columnIndex, x == null ? (Value)
-                    ValueNull.INSTANCE : ValueString.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueString.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -3415,10 +3405,9 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public void updateNString(String columnLabel, String x) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("updateNString("+quote(columnLabel)+", "+quote(x)+");");
+                debugCode("updateNString(" + quote(columnLabel) + ", " + quote(x) + ");");
             }
-            update(columnLabel, x == null ? (Value) ValueNull.INSTANCE :
-                    ValueString.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueString.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -383,7 +383,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public Date getDate(int columnIndex) throws SQLException {
         try {
             debugCodeCall("getDate", columnIndex);
-            return get(columnIndex).getDate();
+            return get(columnIndex).getDate(null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -401,7 +401,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public Time getTime(int columnIndex) throws SQLException {
         try {
             debugCodeCall("getTime", columnIndex);
-            return get(columnIndex).getTime();
+            return get(columnIndex).getTime(null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -419,7 +419,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public Timestamp getTimestamp(int columnIndex) throws SQLException {
         try {
             debugCodeCall("getTimestamp", columnIndex);
-            return get(columnIndex).getTimestamp();
+            return get(columnIndex).getTimestamp(null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -455,7 +455,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public Date getDate(String columnLabel) throws SQLException {
         try {
             debugCodeCall("getDate", columnLabel);
-            return get(columnLabel).getDate();
+            return get(columnLabel).getDate(null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -473,7 +473,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public Time getTime(String columnLabel) throws SQLException {
         try {
             debugCodeCall("getTime", columnLabel);
-            return get(columnLabel).getTime();
+            return get(columnLabel).getTime(null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -491,7 +491,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     public Timestamp getTimestamp(String columnLabel) throws SQLException {
         try {
             debugCodeCall("getTimestamp", columnLabel);
-            return get(columnLabel).getTimestamp();
+            return get(columnLabel).getTimestamp(null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -884,7 +884,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("getDate(" + columnIndex + ", calendar)");
             }
-            return DateTimeUtils.convertDate(get(columnIndex), calendar);
+            return get(columnIndex).getDate(calendar != null ? calendar.getTimeZone() : null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -901,15 +901,12 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
      *             closed
      */
     @Override
-    public Date getDate(String columnLabel, Calendar calendar)
-            throws SQLException {
+    public Date getDate(String columnLabel, Calendar calendar) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("getDate(" +
-                        StringUtils.quoteJavaString(columnLabel) +
-                        ", calendar)");
+                debugCode("getDate(" + StringUtils.quoteJavaString(columnLabel) + ", calendar)");
             }
-            return DateTimeUtils.convertDate(get(columnLabel), calendar);
+            return get(columnLabel).getDate(calendar != null ? calendar.getTimeZone() : null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -931,7 +928,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("getTime(" + columnIndex + ", calendar)");
             }
-            return DateTimeUtils.convertTime(get(columnIndex), calendar);
+            return get(columnIndex).getTime(calendar != null ? calendar.getTimeZone() : null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -948,15 +945,12 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
      *             closed
      */
     @Override
-    public Time getTime(String columnLabel, Calendar calendar)
-            throws SQLException {
+    public Time getTime(String columnLabel, Calendar calendar) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("getTime(" +
-                        StringUtils.quoteJavaString(columnLabel) +
-                        ", calendar)");
+                debugCode("getTime(" + StringUtils.quoteJavaString(columnLabel) + ", calendar)");
             }
-            return DateTimeUtils.convertTime(get(columnLabel), calendar);
+            return get(columnLabel).getTime(calendar != null ? calendar.getTimeZone() : null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -973,14 +967,12 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
      *             closed
      */
     @Override
-    public Timestamp getTimestamp(int columnIndex, Calendar calendar)
-            throws SQLException {
+    public Timestamp getTimestamp(int columnIndex, Calendar calendar) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getTimestamp(" + columnIndex + ", calendar)");
             }
-            Value value = get(columnIndex);
-            return DateTimeUtils.convertTimestamp(value, calendar, conn);
+            return get(columnIndex).getTimestamp(calendar != null ? calendar.getTimeZone() : null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -996,16 +988,12 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
      *             closed
      */
     @Override
-    public Timestamp getTimestamp(String columnLabel, Calendar calendar)
-            throws SQLException {
+    public Timestamp getTimestamp(String columnLabel, Calendar calendar) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("getTimestamp(" +
-                        StringUtils.quoteJavaString(columnLabel) +
-                        ", calendar)");
+                debugCode("getTimestamp(" + StringUtils.quoteJavaString(columnLabel) + ", calendar)");
             }
-            Value value = get(columnLabel);
-            return DateTimeUtils.convertTimestamp(value, calendar, conn);
+            return get(columnLabel).getTimestamp(calendar != null ? calendar.getTimeZone() : null);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -3284,13 +3272,11 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     }
 
     private Value get(String columnLabel) {
-        int columnIndex = getColumnIndex(columnLabel);
-        return get(columnIndex);
+        return get(getColumnIndex(columnLabel));
     }
 
     private void update(String columnLabel, Value v) {
-        int columnIndex = getColumnIndex(columnLabel);
-        update(columnIndex, v);
+        update(getColumnIndex(columnLabel), v);
     }
 
     private void update(int columnIndex, Value v) {
@@ -3902,16 +3888,16 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
         } else if (type == Double.class) {
             return (T) (Double) value.getDouble();
         } else if (type == Date.class) {
-            return (T) value.getDate();
+            return (T) value.getDate(null);
         } else if (type == Time.class) {
-            return (T) value.getTime();
+            return (T) value.getTime(null);
         } else if (type == Timestamp.class) {
-            return (T) value.getTimestamp();
+            return (T) value.getTimestamp(null);
         } else if (type == java.util.Date.class) {
-            return (T) new java.util.Date(value.getTimestamp().getTime());
+            return (T) new java.util.Date(value.getTimestamp(null).getTime());
         } else if (type == Calendar.class) {
             Calendar calendar = DateTimeUtils.createGregorianCalendar();
-            calendar.setTime(value.getTimestamp());
+            calendar.setTime(value.getTimestamp(calendar.getTimeZone()));
             return (T) calendar;
         } else if (type == UUID.class) {
             return (T) value.getObject();

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -222,7 +222,7 @@ public class FunctionsMySQL extends FunctionsBase {
         Value result;
         switch (info.type) {
         case UNIX_TIMESTAMP:
-            result = ValueInt.get(v0 == null ? unixTimestamp() : unixTimestamp(v0.getTimestamp()));
+            result = ValueInt.get(v0 == null ? unixTimestamp() : unixTimestamp(v0.getTimestamp(null)));
             break;
         case FROM_UNIXTIME:
             result = ValueString.get(

--- a/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
@@ -19,7 +19,9 @@ import org.h2.result.SortOrder;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
+import org.h2.value.Value;
 import org.h2.value.ValueLong;
+import org.h2.value.VersionedValue;
 
 /**
  * An index that delegates indexing to another index.
@@ -51,7 +53,7 @@ public class MVDelegateIndex extends BaseIndex implements MVIndex {
     }
 
     @Override
-    public MVMap getMVMap() {
+    public MVMap<Value, VersionedValue> getMVMap() {
         return mainIndex.getMVMap();
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVIndex.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.h2.index.Index;
 import org.h2.mvstore.MVMap;
 import org.h2.result.Row;
+import org.h2.value.VersionedValue;
 
 /**
  * An index that stores the data in an MVStore.
@@ -33,5 +34,5 @@ public interface MVIndex extends Index {
      */
     void addBufferedRows(List<String> bufferNames);
 
-    MVMap getMVMap();
+    MVMap<?, VersionedValue> getMVMap();
 }

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -33,6 +33,7 @@ import org.h2.value.Value;
 import org.h2.value.ValueArray;
 import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
+import org.h2.value.VersionedValue;
 
 /**
  * A table stored in a MVStore.
@@ -426,7 +427,8 @@ public class MVPrimaryIndex extends BaseIndex implements MVIndex {
         return dataMap.getInstance(t);
     }
 
-    public MVMap getMVMap() {
+    @Override
+    public MVMap<Value, VersionedValue> getMVMap() {
         return dataMap.map;
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -34,6 +34,7 @@ import org.h2.value.Value;
 import org.h2.value.ValueArray;
 import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
+import org.h2.value.VersionedValue;
 
 /**
  * A table stored in a MVStore.
@@ -432,7 +433,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex {
     }
 
     @Override
-    public MVMap getMVMap() {
+    public MVMap<Value, VersionedValue> getMVMap() {
         return dataMap.map;
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -399,7 +399,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
     }
 
     @Override
-    public MVMap getMVMap() {
+    public MVMap<SpatialKey, VersionedValue> getMVMap() {
         return dataMap.map;
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -413,11 +413,11 @@ public class TransactionMap<K, V> extends AbstractMap<K, V> {
         }
     }
 
-    private BitSet getCommittingTransactions() {
+    BitSet getCommittingTransactions() {
         return transaction.getCommittingTransactions();
     }
 
-    private RootReference getRootReference() {
+    RootReference getRootReference() {
         return transaction.getMapRoot(map.getId());
     }
 

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -528,7 +528,7 @@ public class Data {
                 writeVarLong(nanos);
             } else {
                 writeByte(TIME);
-                writeVarLong(DateTimeUtils.getTimeLocalWithoutDst(v.getTime()));
+                writeVarLong(DateTimeUtils.getTimeLocalWithoutDst(v.getTime(null)));
             }
             break;
         case Value.DATE: {
@@ -538,7 +538,7 @@ public class Data {
                 writeVarLong(x);
             } else {
                 writeByte(DATE);
-                long x = DateTimeUtils.getTimeLocalWithoutDst(v.getDate());
+                long x = DateTimeUtils.getTimeLocalWithoutDst(v.getDate(null));
                 writeVarLong(x / MILLIS_PER_MINUTE);
             }
             break;
@@ -555,7 +555,7 @@ public class Data {
                 writeVarLong(millis);
                 writeVarLong(nanos);
             } else {
-                Timestamp ts = v.getTimestamp();
+                Timestamp ts = v.getTimestamp(null);
                 writeByte(TIMESTAMP);
                 writeVarLong(DateTimeUtils.getTimeLocalWithoutDst(ts));
                 writeVarInt(ts.getNanos() % 1_000_000);
@@ -1105,13 +1105,13 @@ public class Data {
                 nanos -= millis * 1_000_000;
                 return 1 + getVarLongLen(millis) + getVarLongLen(nanos);
             }
-            return 1 + getVarLongLen(DateTimeUtils.getTimeLocalWithoutDst(v.getTime()));
+            return 1 + getVarLongLen(DateTimeUtils.getTimeLocalWithoutDst(v.getTime(null)));
         case Value.DATE: {
             if (storeLocalTime) {
                 long dateValue = ((ValueDate) v).getDateValue();
                 return 1 + getVarLongLen(dateValue);
             }
-            long x = DateTimeUtils.getTimeLocalWithoutDst(v.getDate());
+            long x = DateTimeUtils.getTimeLocalWithoutDst(v.getDate(null));
             return 1 + getVarLongLen(x / MILLIS_PER_MINUTE);
         }
         case Value.TIMESTAMP: {
@@ -1124,7 +1124,7 @@ public class Data {
                 return 1 + getVarLongLen(dateValue) + getVarLongLen(millis) +
                         getVarLongLen(nanos);
             }
-            Timestamp ts = v.getTimestamp();
+            Timestamp ts = v.getTimestamp(null);
             return 1 + getVarLongLen(DateTimeUtils.getTimeLocalWithoutDst(ts)) +
                     getVarIntLen(ts.getNanos() % 1_000_000);
         }

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -226,51 +226,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Convert a java.util.Date using the specified calendar.
-     *
-     * @param x the date
-     * @param calendar the calendar
-     * @return the date
-     */
-    public static ValueDate convertDate(Date x, Calendar calendar) {
-        Calendar cal = (Calendar) calendar.clone();
-        cal.setTimeInMillis(x.getTime());
-        long dateValue = dateValueFromCalendar(cal);
-        return ValueDate.fromDateValue(dateValue);
-    }
-
-    /**
-     * Convert the time using the specified calendar.
-     *
-     * @param x the time
-     * @param calendar the calendar
-     * @return the time
-     */
-    public static ValueTime convertTime(Time x, Calendar calendar) {
-        Calendar cal = (Calendar) calendar.clone();
-        cal.setTimeInMillis(x.getTime());
-        long nanos = nanosFromCalendar(cal);
-        return ValueTime.fromNanos(nanos);
-    }
-
-    /**
-     * Convert the timestamp using the specified calendar.
-     *
-     * @param x the time
-     * @param calendar the calendar
-     * @return the timestamp
-     */
-    public static ValueTimestamp convertTimestamp(Timestamp x,
-            Calendar calendar) {
-        Calendar cal = (Calendar) calendar.clone();
-        cal.setTimeInMillis(x.getTime());
-        long dateValue = dateValueFromCalendar(cal);
-        long nanos = nanosFromCalendar(cal);
-        nanos += x.getNanos() % 1_000_000;
-        return ValueTimestamp.fromDateValueAndNanos(dateValue, nanos);
-    }
-
-    /**
      * Parse a date string. The format is: [+|-]year-month-day
      * or [+|-]yyyyMMdd.
      *
@@ -1071,22 +1026,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Calculate the encoded date value from a given calendar.
-     *
-     * @param cal the calendar
-     * @return the date value
-     */
-    private static long dateValueFromCalendar(Calendar cal) {
-        int year = cal.get(Calendar.YEAR);
-        if (cal.get(Calendar.ERA) == GregorianCalendar.BC) {
-            year = 1 - year;
-        }
-        int month = cal.get(Calendar.MONTH) + 1;
-        int day = cal.get(Calendar.DAY_OF_MONTH);
-        return ((long) year << SHIFT_YEAR) | (month << SHIFT_MONTH) | day;
-    }
-
-    /**
      * Convert a time in milliseconds in local time to the nanoseconds since midnight.
      *
      * @param ms the milliseconds
@@ -1099,20 +1038,6 @@ public class DateTimeUtils {
             absoluteDay--;
         }
         return (ms - absoluteDay * MILLIS_PER_DAY) * 1_000_000;
-    }
-
-    /**
-     * Convert a java.util.Calendar to nanoseconds since midnight.
-     *
-     * @param cal the calendar
-     * @return the nanoseconds
-     */
-    private static long nanosFromCalendar(Calendar cal) {
-        int h = cal.get(Calendar.HOUR_OF_DAY);
-        int m = cal.get(Calendar.MINUTE);
-        int s = cal.get(Calendar.SECOND);
-        int millis = cal.get(Calendar.MILLISECOND);
-        return ((((((h * 60L) + m) * 60) + s) * 1000) + millis) * 1000000;
     }
 
     /**

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -589,7 +589,7 @@ public class DataType {
                     }
                 }
                 Date value = rs.getDate(columnIndex);
-                v = value == null ? ValueNull.INSTANCE : ValueDate.get(value);
+                v = value == null ? ValueNull.INSTANCE : ValueDate.get(null, value);
                 break;
             }
             case Value.TIME: {
@@ -603,7 +603,7 @@ public class DataType {
                     }
                 }
                 Time value = rs.getTime(columnIndex);
-                v = value == null ? ValueNull.INSTANCE : ValueTime.get(value);
+                v = value == null ? ValueNull.INSTANCE : ValueTime.get(null, value);
                 break;
             }
             case Value.TIMESTAMP: {
@@ -617,7 +617,7 @@ public class DataType {
                     }
                 }
                 Timestamp value = rs.getTimestamp(columnIndex);
-                v = value == null ? ValueNull.INSTANCE : ValueTimestamp.get(value);
+                v = value == null ? ValueNull.INSTANCE : ValueTimestamp.get(null, value);
                 break;
             }
             case Value.TIMESTAMP_TZ: {
@@ -1214,11 +1214,11 @@ public class DataType {
         } else if (x instanceof byte[]) {
             return ValueBytes.get((byte[]) x);
         } else if (x instanceof Date) {
-            return ValueDate.get((Date) x);
+            return ValueDate.get(null, (Date) x);
         } else if (x instanceof Time) {
-            return ValueTime.get((Time) x);
+            return ValueTime.get(null, (Time) x);
         } else if (x instanceof Timestamp) {
-            return ValueTimestamp.get((Timestamp) x);
+            return ValueTimestamp.get(null, (Timestamp) x);
         } else if (x instanceof java.util.Date) {
             return ValueTimestamp.fromMillis(((java.util.Date) x).getTime());
         } else if (x instanceof java.io.Reader) {

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -18,6 +18,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.TimeZone;
 import org.h2.api.ErrorCode;
 import org.h2.api.IntervalQualifier;
 import org.h2.engine.CastDataProvider;
@@ -553,16 +554,16 @@ public abstract class Value extends VersionedValue {
         return ((ValueBoolean) convertTo(Value.BOOLEAN)).getBoolean();
     }
 
-    public Date getDate() {
-        return ((ValueDate) convertTo(Value.DATE)).getDate();
+    public Date getDate(TimeZone timeZone) {
+        return ((ValueDate) convertTo(Value.DATE)).getDate(timeZone);
     }
 
-    public Time getTime() {
-        return ((ValueTime) convertTo(Value.TIME)).getTime();
+    public Time getTime(TimeZone timeZone) {
+        return ((ValueTime) convertTo(Value.TIME)).getTime(timeZone);
     }
 
-    public Timestamp getTimestamp() {
-        return ((ValueTimestamp) convertTo(Value.TIMESTAMP)).getTimestamp();
+    public Timestamp getTimestamp(TimeZone timeZone) {
+        return ((ValueTimestamp) convertTo(Value.TIMESTAMP)).getTimestamp(timeZone);
     }
 
     public byte[] getBytes() {

--- a/h2/src/main/org/h2/value/ValueDate.java
+++ b/h2/src/main/org/h2/value/ValueDate.java
@@ -9,6 +9,7 @@ import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.TimeZone;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.CastDataProvider;
@@ -88,8 +89,8 @@ public class ValueDate extends Value {
     }
 
     @Override
-    public Date getDate() {
-        return DateTimeUtils.convertDateValueToDate(dateValue);
+    public Date getDate(TimeZone timeZone) {
+        return DateTimeUtils.convertDateValueToDate(timeZone, dateValue);
     }
 
     @Override
@@ -137,7 +138,7 @@ public class ValueDate extends Value {
 
     @Override
     public Object getObject() {
-        return getDate();
+        return getDate(null);
     }
 
     @Override
@@ -150,7 +151,7 @@ public class ValueDate extends Value {
                 // Nothing to do
             }
         }
-        prep.setDate(parameterIndex, getDate());
+        prep.setDate(parameterIndex, getDate(null));
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueDate.java
+++ b/h2/src/main/org/h2/value/ValueDate.java
@@ -50,12 +50,14 @@ public class ValueDate extends Value {
     /**
      * Get or create a date value for the given date.
      *
+     * @param timeZone time zone, or {@code null} for default
      * @param date the date
      * @return the value
      */
-    public static ValueDate get(Date date) {
+    public static ValueDate get(TimeZone timeZone, Date date) {
         long ms = date.getTime();
-        return fromDateValue(DateTimeUtils.dateValueFromLocalMillis(ms + DateTimeUtils.getTimeZoneOffset(ms)));
+        return fromDateValue(DateTimeUtils.dateValueFromLocalMillis(
+                ms + (timeZone == null ? DateTimeUtils.getTimeZoneOffset(ms) : timeZone.getOffset(ms))));
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueNull.java
+++ b/h2/src/main/org/h2/value/ValueNull.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.TimeZone;
 
 import org.h2.engine.CastDataProvider;
 import org.h2.message.DbException;
@@ -74,17 +75,17 @@ public class ValueNull extends Value {
     }
 
     @Override
-    public Date getDate() {
+    public Date getDate(TimeZone timeZone) {
         return null;
     }
 
     @Override
-    public Time getTime() {
+    public Time getTime(TimeZone timeZone) {
         return null;
     }
 
     @Override
-    public Timestamp getTimestamp() {
+    public Timestamp getTimestamp(TimeZone timeZone) {
         return null;
     }
 

--- a/h2/src/main/org/h2/value/ValueTime.java
+++ b/h2/src/main/org/h2/value/ValueTime.java
@@ -9,6 +9,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Types;
+import java.util.TimeZone;
 import org.h2.api.ErrorCode;
 import org.h2.engine.CastDataProvider;
 import org.h2.message.DbException;
@@ -115,8 +116,8 @@ public class ValueTime extends Value {
     }
 
     @Override
-    public Time getTime() {
-        return DateTimeUtils.convertNanoToTime(nanos);
+    public Time getTime(TimeZone timeZone) {
+        return DateTimeUtils.convertNanoToTime(timeZone, nanos);
     }
 
     @Override
@@ -185,7 +186,7 @@ public class ValueTime extends Value {
 
     @Override
     public Object getObject() {
-        return getTime();
+        return getTime(null);
     }
 
     @Override
@@ -198,7 +199,7 @@ public class ValueTime extends Value {
                 // Nothing to do
             }
         }
-        prep.setTime(parameterIndex, getTime());
+        prep.setTime(parameterIndex, getTime(null));
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueTime.java
+++ b/h2/src/main/org/h2/value/ValueTime.java
@@ -74,12 +74,14 @@ public class ValueTime extends Value {
     /**
      * Get or create a time value for the given time.
      *
+     * @param timeZone time zone, or {@code null} for default
      * @param time the time
      * @return the value
      */
-    public static ValueTime get(Time time) {
+    public static ValueTime get(TimeZone timeZone, Time time) {
         long ms = time.getTime();
-        return fromNanos(DateTimeUtils.nanosFromLocalMillis(ms + DateTimeUtils.getTimeZoneOffset(ms)));
+        return fromNanos(DateTimeUtils.nanosFromLocalMillis(
+                ms + (timeZone == null ? DateTimeUtils.getTimeZoneOffset(ms) : timeZone.getOffset(ms))));
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -9,6 +9,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.TimeZone;
 import org.h2.api.ErrorCode;
 import org.h2.engine.CastDataProvider;
 import org.h2.message.DbException;
@@ -167,8 +168,8 @@ public class ValueTimestamp extends Value {
     }
 
     @Override
-    public Timestamp getTimestamp() {
-        return DateTimeUtils.convertDateValueToTimestamp(dateValue, timeNanos);
+    public Timestamp getTimestamp(TimeZone timeZone) {
+        return DateTimeUtils.convertDateValueToTimestamp(timeZone, dateValue, timeNanos);
     }
 
     @Override
@@ -260,7 +261,7 @@ public class ValueTimestamp extends Value {
 
     @Override
     public Object getObject() {
-        return getTimestamp();
+        return getTimestamp(null);
     }
 
     @Override
@@ -273,7 +274,7 @@ public class ValueTimestamp extends Value {
                 // Nothing to do
             }
         }
-        prep.setTimestamp(parameterIndex, getTimestamp());
+        prep.setTimestamp(parameterIndex, getTimestamp(null));
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -79,13 +79,14 @@ public class ValueTimestamp extends Value {
     /**
      * Get or create a timestamp value for the given timestamp.
      *
+     * @param timeZone time zone, or {@code null} for default
      * @param timestamp the timestamp
      * @return the value
      */
-    public static ValueTimestamp get(Timestamp timestamp) {
+    public static ValueTimestamp get(TimeZone timeZone, Timestamp timestamp) {
         long ms = timestamp.getTime();
         long nanos = timestamp.getNanos() % 1_000_000;
-        ms += DateTimeUtils.getTimeZoneOffset(ms);
+        ms += timeZone == null ? DateTimeUtils.getTimeZoneOffset(ms) : timeZone.getOffset(ms);
         long dateValue = DateTimeUtils.dateValueFromLocalMillis(ms);
         nanos += DateTimeUtils.nanosFromLocalMillis(ms);
         return fromDateValueAndNanos(dateValue, nanos);

--- a/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
+++ b/h2/src/main/org/h2/value/ValueTimestampTimeZone.java
@@ -8,6 +8,7 @@ package org.h2.value;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.TimeZone;
 import org.h2.api.ErrorCode;
 import org.h2.api.TimestampWithTimeZone;
 import org.h2.engine.CastDataProvider;
@@ -148,7 +149,7 @@ public class ValueTimestampTimeZone extends Value {
     }
 
     @Override
-    public Timestamp getTimestamp() {
+    public Timestamp getTimestamp(TimeZone timeZone) {
         return DateTimeUtils.convertTimestampTimeZoneToTimestamp(dateValue, timeNanos, timeZoneOffsetMins);
     }
 

--- a/h2/src/test/org/h2/test/db/TestLIRSMemoryConsumption.java
+++ b/h2/src/test/org/h2/test/db/TestLIRSMemoryConsumption.java
@@ -40,7 +40,7 @@ public class TestLIRSMemoryConsumption extends TestDb {
         testMemoryConsumption();
     }
 
-    private void testMemoryConsumption() {
+    private static void testMemoryConsumption() {
         int size = 1_000_000;
         Random rng = new Random();
         CacheLongKeyLIRS.Config config = new CacheLongKeyLIRS.Config();

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1797,7 +1797,7 @@ public class TestMVStore extends TestBase {
         s.close();
     }
 
-    private int getChunkCount(Map<String, String> meta) {
+    private static int getChunkCount(Map<String, String> meta) {
         int chunkCount = 0;
         for (String k : meta.keySet()) {
             if (k.startsWith(DataUtils.META_CHUNK)) {

--- a/h2/src/test/org/h2/test/unit/TestDataPage.java
+++ b/h2/src/test/org/h2/test/unit/TestDataPage.java
@@ -165,10 +165,10 @@ public class TestDataPage extends TestBase implements DataHandler {
             }
             testValue(ValueDecimal.get(new BigDecimal(i * i)));
         }
-        testValue(ValueDate.get(new Date(System.currentTimeMillis())));
-        testValue(ValueDate.get(new Date(0)));
-        testValue(ValueTime.get(new Time(System.currentTimeMillis())));
-        testValue(ValueTime.get(new Time(0)));
+        testValue(ValueDate.get(null, new Date(System.currentTimeMillis())));
+        testValue(ValueDate.get(null, new Date(0)));
+        testValue(ValueTime.get(null, new Time(System.currentTimeMillis())));
+        testValue(ValueTime.get(null, new Time(0)));
         testValue(ValueTimestamp.fromMillis(System.currentTimeMillis()));
         testValue(ValueTimestamp.fromMillis(0));
         testValue(ValueTimestampTimeZone.parse("2000-01-01 10:00:00"));

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -83,7 +83,7 @@ public class TestDate extends TestBase {
         assertEquals("-9999-12-31",
                 ValueDate.parse("-9999-12-31").getString());
         ValueDate d1 = ValueDate.parse("2001-01-01");
-        assertEquals("2001-01-01", d1.getDate().toString());
+        assertEquals("2001-01-01", d1.getDate(null).toString());
         assertEquals("DATE '2001-01-01'", d1.getSQL());
         assertEquals("DATE '2001-01-01'", d1.toString());
         assertEquals(Value.DATE, d1.getValueType());
@@ -128,8 +128,8 @@ public class TestDate extends TestBase {
             assertEquals(ErrorCode.INVALID_DATETIME_CONSTANT_2, ex.getErrorCode());
         }
         ValueTime t1 = ValueTime.parse("11:11:11");
-        assertEquals("11:11:11", t1.getTime().toString());
-        assertEquals("1970-01-01", t1.getDate().toString());
+        assertEquals("11:11:11", t1.getTime(null).toString());
+        assertEquals("1970-01-01", t1.getDate(null).toString());
         assertEquals("TIME '11:11:11'", t1.getSQL());
         assertEquals("TIME '11:11:11'", t1.toString());
         assertEquals("05:35:35.5", t1.multiply(ValueDouble.get(0.5)).getString());
@@ -193,9 +193,9 @@ public class TestDate extends TestBase {
                 "9999-12-31 23:59:59").getString());
 
         ValueTimestamp t1 = ValueTimestamp.parse("2001-01-01 01:01:01.111");
-        assertEquals("2001-01-01 01:01:01.111", t1.getTimestamp().toString());
-        assertEquals("2001-01-01", t1.getDate().toString());
-        assertEquals("01:01:01", t1.getTime().toString());
+        assertEquals("2001-01-01 01:01:01.111", t1.getTimestamp(null).toString());
+        assertEquals("2001-01-01", t1.getDate(null).toString());
+        assertEquals("01:01:01", t1.getTime(null).toString());
         assertEquals("TIMESTAMP '2001-01-01 01:01:01.111'", t1.getSQL());
         assertEquals("TIMESTAMP '2001-01-01 01:01:01.111'", t1.toString());
         assertEquals(Value.TIMESTAMP, t1.getValueType());
@@ -276,13 +276,13 @@ public class TestDate extends TestBase {
         assertEquals(0, ValueTimestamp.parse(
                 "1970-01-01").getTimeNanos());
         assertEquals(0, ValueTimestamp.parse(
-                "1970-01-01 00:00:00.000 UTC").getTimestamp().getTime());
+                "1970-01-01 00:00:00.000 UTC").getTimestamp(null).getTime());
         assertEquals(0, ValueTimestamp.parse(
-                "+1970-01-01T00:00:00.000Z").getTimestamp().getTime());
+                "+1970-01-01T00:00:00.000Z").getTimestamp(null).getTime());
         assertEquals(0, ValueTimestamp.parse(
-                "1970-01-01T00:00:00.000+00:00").getTimestamp().getTime());
+                "1970-01-01T00:00:00.000+00:00").getTimestamp(null).getTime());
         assertEquals(0, ValueTimestamp.parse(
-                "1970-01-01T00:00:00.000-00:00").getTimestamp().getTime());
+                "1970-01-01T00:00:00.000-00:00").getTimestamp(null).getTime());
         new AssertThrows(ErrorCode.INVALID_DATETIME_CONSTANT_2) {
             @Override
             public void test() {
@@ -443,9 +443,9 @@ public class TestDate extends TestBase {
         assertEquals("19999-08-07", d2.getString());
         assertEquals("13:14:15.16", t2.getString());
         ValueTimestamp ts1a = DateTimeUtils.convertTimestamp(
-                ts1.getTimestamp(), DateTimeUtils.createGregorianCalendar());
+                ts1.getTimestamp(null), DateTimeUtils.createGregorianCalendar());
         ValueTimestamp ts2a = DateTimeUtils.convertTimestamp(
-                ts2.getTimestamp(), DateTimeUtils.createGregorianCalendar());
+                ts2.getTimestamp(null), DateTimeUtils.createGregorianCalendar());
         assertEquals("-999-08-07 13:14:15.16", ts1a.getString());
         assertEquals("19999-08-07 13:14:15.16", ts2a.getString());
 

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -75,7 +75,7 @@ public class TestDate extends TestBase {
 
     private void testValueDate() {
         assertEquals("2000-01-01",
-                ValueDate.get(Date.valueOf("2000-01-01")).getString());
+                ValueDate.get(null, Date.valueOf("2000-01-01")).getString());
         assertEquals("0-00-00",
                 ValueDate.fromDateValue(0).getString());
         assertEquals("9999-12-31",
@@ -111,7 +111,7 @@ public class TestDate extends TestBase {
     }
 
     private void testValueTime() {
-        assertEquals("10:20:30", ValueTime.get(Time.valueOf("10:20:30")).getString());
+        assertEquals("10:20:30", ValueTime.get(null, Time.valueOf("10:20:30")).getString());
         assertEquals("00:00:00", ValueTime.fromNanos(0).getString());
         assertEquals("23:59:59", ValueTime.parse("23:59:59").getString());
         assertEquals("11:22:33.444555666", ValueTime.parse("11:22:33.444555666").getString());
@@ -178,19 +178,16 @@ public class TestDate extends TestBase {
     @SuppressWarnings("unlikely-arg-type")
     private void testValueTimestamp() {
         assertEquals(
-                "2001-02-03 04:05:06", ValueTimestamp.get(
-                Timestamp.valueOf(
-                "2001-02-03 04:05:06")).getString());
+                "2001-02-03 04:05:06",
+                ValueTimestamp.get(null, Timestamp.valueOf("2001-02-03 04:05:06")).getString());
         assertEquals(
-                "2001-02-03 04:05:06.001002003", ValueTimestamp.get(
-                Timestamp.valueOf(
-                "2001-02-03 04:05:06.001002003")).getString());
+                "2001-02-03 04:05:06.001002003",
+                ValueTimestamp.get(null, Timestamp.valueOf("2001-02-03 04:05:06.001002003")).getString());
         assertEquals(
                 "0-00-00 00:00:00", ValueTimestamp.fromDateValueAndNanos(0, 0).getString());
         assertEquals(
                 "9999-12-31 23:59:59",
-                ValueTimestamp.parse(
-                "9999-12-31 23:59:59").getString());
+                ValueTimestamp.parse("9999-12-31 23:59:59").getString());
 
         ValueTimestamp t1 = ValueTimestamp.parse("2001-01-01 01:01:01.111");
         assertEquals("2001-01-01 01:01:01.111", t1.getTimestamp(null).toString());
@@ -442,10 +439,9 @@ public class TestDate extends TestBase {
         assertEquals("19999-08-07 13:14:15.16", ts2.getString());
         assertEquals("19999-08-07", d2.getString());
         assertEquals("13:14:15.16", t2.getString());
-        ValueTimestamp ts1a = DateTimeUtils.convertTimestamp(
-                ts1.getTimestamp(null), DateTimeUtils.createGregorianCalendar());
-        ValueTimestamp ts2a = DateTimeUtils.convertTimestamp(
-                ts2.getTimestamp(null), DateTimeUtils.createGregorianCalendar());
+        TimeZone timeZone = DateTimeUtils.createGregorianCalendar().getTimeZone();
+        ValueTimestamp ts1a = ValueTimestamp.get(timeZone, ts1.getTimestamp(null));
+        ValueTimestamp ts2a = ValueTimestamp.get(timeZone, ts2.getTimestamp(null));
         assertEquals("-999-08-07 13:14:15.16", ts1a.getString());
         assertEquals("19999-08-07 13:14:15.16", ts2a.getString());
 

--- a/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
@@ -158,7 +158,7 @@ public class TestDateTimeUtils extends TestBase {
             for (int j = 0; j < 48; j++) {
                 gc.set(year, month - 1, day, j / 2, (j & 1) * 30, 0);
                 long timeMillis = gc.getTimeInMillis();
-                ValueTimestamp ts = DateTimeUtils.convertTimestamp(new Timestamp(timeMillis), gc);
+                ValueTimestamp ts = ValueTimestamp.get(gc.getTimeZone(), new Timestamp(timeMillis));
                 timeMillis += DateTimeUtils.getTimeZoneOffset(timeMillis);
                 assertEquals(ts.getDateValue(), DateTimeUtils.dateValueFromLocalMillis(timeMillis));
                 assertEquals(ts.getTimeNanos(), DateTimeUtils.nanosFromLocalMillis(timeMillis));

--- a/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
+++ b/h2/src/test/org/h2/test/unit/TestTimeStampWithTimeZone.java
@@ -224,7 +224,7 @@ public class TestTimeStampWithTimeZone extends TestDb {
         assertEquals(ts, tstz.convertTo(Value.TIMESTAMP));
         assertEquals(d, tstz.convertTo(Value.DATE));
         assertEquals(t, tstz.convertTo(Value.TIME));
-        assertEquals(ts.getTimestamp(), tstz.getTimestamp());
+        assertEquals(ts.getTimestamp(null), tstz.getTimestamp(null));
         if (testReverse) {
             assertEquals(0, tstz.compareTo(ts.convertTo(Value.TIMESTAMP_TZ), null, null));
             assertEquals(d.convertTo(Value.TIMESTAMP).convertTo(Value.TIMESTAMP_TZ),

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -338,22 +338,22 @@ public class TestValue extends TestDb {
         ValueTimestamp valueTs = ValueTimestamp.parse("2000-01-15 10:20:30.333222111");
         Timestamp ts = Timestamp.valueOf("2000-01-15 10:20:30.333222111");
         assertEquals(ts.toString(), valueTs.getString());
-        assertEquals(ts, valueTs.getTimestamp());
+        assertEquals(ts, valueTs.getTimestamp(null));
         Calendar c = Calendar.getInstance(TimeZone.getTimeZone("Europe/Berlin"));
         c.set(2018, 02, 25, 1, 59, 00);
         c.set(Calendar.MILLISECOND, 123);
         long expected = c.getTimeInMillis();
-        ts = ValueTimestamp.parse("2018-03-25 01:59:00.123123123 Europe/Berlin").getTimestamp();
+        ts = ValueTimestamp.parse("2018-03-25 01:59:00.123123123 Europe/Berlin").getTimestamp(null);
         assertEquals(expected, ts.getTime());
         assertEquals(123123123, ts.getNanos());
-        ts = ValueTimestamp.parse("2018-03-25 01:59:00.123123123+01").getTimestamp();
+        ts = ValueTimestamp.parse("2018-03-25 01:59:00.123123123+01").getTimestamp(null);
         assertEquals(expected, ts.getTime());
         assertEquals(123123123, ts.getNanos());
         expected += 60000; // 1 minute
-        ts = ValueTimestamp.parse("2018-03-25 03:00:00.123123123 Europe/Berlin").getTimestamp();
+        ts = ValueTimestamp.parse("2018-03-25 03:00:00.123123123 Europe/Berlin").getTimestamp(null);
         assertEquals(expected, ts.getTime());
         assertEquals(123123123, ts.getNanos());
-        ts = ValueTimestamp.parse("2018-03-25 03:00:00.123123123+02").getTimestamp();
+        ts = ValueTimestamp.parse("2018-03-25 03:00:00.123123123+02").getTimestamp(null);
         assertEquals(expected, ts.getTime());
         assertEquals(123123123, ts.getNanos());
     }

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -819,4 +819,4 @@ housekeeping trail breadcrumb bets seasoned rewritable rpi eliminating projected
 sparsely shifting vacated evacuation bullet allocations projected evacuatable pin capable rewritable deficiency
 successfull deduplication entrant mvmap sporadic irrelevant interrupts
 sit sitting sooner hdr considering encounter compete quickack decrementing exhausting caveat aschoerk circular ident
-scr ffffl
+scr ffffl suspend asap


### PR DESCRIPTION
Legacy (Java 7 and below) datetime API with system default time zone (frequently used) and with custom user-supplied `Calendar` instances (rarely used) can use the same methods, because actual implementations already accept custom time zones and we need only the time zone from those `Calendar` instances. Many duplicate methods from `DateTimeUtils` were removed.