### PR TITLE
Fix race condition / performance issue during snapshoting

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1853,8 +1853,8 @@ public class MVStore implements AutoCloseable
             // now we can re-use previously reserved area [leftmostBlock, originalBlockCount),
             // but need to reserve [originalBlockCount, postEvacuationBlockCount)
             for (Chunk c : move) {
-                if (c.block >= originalBlockCount) {
-                    moveChunk(c, originalBlockCount, postEvacuationBlockCount);
+                if (c.block >= originalBlockCount &&
+                        moveChunk(c, originalBlockCount, postEvacuationBlockCount)) {
                     assert c.block < originalBlockCount;
                     movedToEOF = true;
                 }
@@ -1921,6 +1921,7 @@ public class MVStore implements AutoCloseable
         buff.put(readBuff);
         long pos = fileStore.allocate(length, reservedAreaLow, reservedAreaHigh);
         long block = pos / BLOCK_SIZE;
+        // in the absence of a reserved area,
         // block should always move closer to the beginning of the file
         assert reservedAreaHigh > 0 || block <= chunk.block : block + " " + chunk;
         buff.position(0);

--- a/h2/src/main/org/h2/mvstore/RootReference.java
+++ b/h2/src/main/org/h2/mvstore/RootReference.java
@@ -237,6 +237,10 @@ public final class RootReference
         return appendCounter & 0xff;
     }
 
+    public boolean needFlush() {
+        return appendCounter != 0;
+    }
+
     public long getTotalCount() {
         return root.getTotalCount() + getAppendCounter();
     }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -218,9 +218,6 @@ public class Transaction {
     }
 
     RootReference[] getUndoLogRootReferences() {
-        if (undoLogRootReferences == null) {
-            return store.collectUndoLogRootReferences();
-        }
         return undoLogRootReferences;
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -106,10 +106,10 @@ public class TransactionMap<K, V> extends AbstractMap<K, V> {
         } while(committingTransactions != getCommittingTransactions() ||
                 mapRootReference != getRootReference());
 
-        long undoLogsTotalSize = TransactionStore.calculateUndoLogsTotalSize(undoLogRootReferences);
 
         Page mapRootPage = mapRootReference.root;
         long size = mapRootReference.getTotalCount();
+        long undoLogsTotalSize = undoLogRootReferences == null ? size : TransactionStore.calculateUndoLogsTotalSize(undoLogRootReferences);
         // if we are looking at the map without any uncommitted values
         if (undoLogsTotalSize == 0) {
             return size;

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -520,6 +520,8 @@ public class TestMVTableEngine extends TestDb {
                 rs.next();
                 assertEquals(10000, rs.getInt(1));
 
+                stat2.execute("set cache_size 1024");  // causes cache to be cleared, so reads will occur
+
                 stat.execute("insert into test2 select x from system_range(1, 11000)");
                 rs = stat2.executeQuery("explain analyze select count(*) from test");
                 rs.next();


### PR DESCRIPTION
This PR fixes problem introduced in #2119.
There is an optimization in TransactionMap.sizeAsLong(), which tries to avoid map scan if map is big, but all undo logs are small.
In order to provide consistent view, when using this optimization, snapshots of all undo logs were taken at the beginning of each SQL statement.
This presents performance / scalability issue, because operation is potentially expensive and is blindly executed regardless of whether any map size even going to be calculated as part of the SQL statement.
More importantly - it's not even possible to take a snapshot of the map in append mode when append buffer is not empty, and by doing that  (flushing buffer from the non-owning thread), current code may potentially corrupt MVStore.
This PR narrows scope of this optimization to cases when all undo log append buffers are empty.
I do not know, if such optimization even useful at all, unless we limit undo log snapshot collection to only cases when map sizes are going to be calculated (COUNT, PERCENTILE, what else?).
