### PR TITLE
Assorted fixes and other changes in DateTimeUtils

### DIFF
--- a/h2/src/main/org/h2/api/TimestampWithTimeZone.java
+++ b/h2/src/main/org/h2/api/TimestampWithTimeZone.java
@@ -12,7 +12,7 @@ import org.h2.value.ValueTimestampTimeZone;
 /**
  * How we expose "TIMESTAMP WITH TIME ZONE" in our ResultSets.
  */
-public class TimestampWithTimeZone implements Serializable, Cloneable {
+public final class TimestampWithTimeZone implements Serializable, Cloneable {
 
     /**
      * The serial version UID.

--- a/h2/src/main/org/h2/expression/function/DateTimeFunctions.java
+++ b/h2/src/main/org/h2/expression/function/DateTimeFunctions.java
@@ -699,7 +699,7 @@ public final class DateTimeFunctions {
                 return dow;
             }
             case WEEK:
-                GregorianCalendar gc = DateTimeUtils.createGregorianCalendar();
+                GregorianCalendar gc = new GregorianCalendar();
                 return DateTimeUtils.getWeekOfYear(dateValue, gc.getFirstDayOfWeek() - 1,
                         gc.getMinimalDaysInFirstWeek());
             case QUARTER:

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -26,6 +26,7 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -3886,7 +3887,8 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
         } else if (type == java.util.Date.class) {
             return (T) new java.util.Date(value.getTimestamp(null).getTime());
         } else if (type == Calendar.class) {
-            Calendar calendar = DateTimeUtils.createGregorianCalendar();
+            GregorianCalendar calendar = new GregorianCalendar();
+            calendar.setGregorianChange(DateTimeUtils.PROLEPTIC_GREGORIAN_CHANGE);
             calendar.setTime(value.getTimestamp(calendar.getTimeZone()));
             return (T) calendar;
         } else if (type == UUID.class) {

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -15,6 +15,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.Calendar;
 
 import org.h2.api.ErrorCode;
 import org.h2.api.IntervalQualifier;
@@ -126,6 +127,15 @@ public class Data {
     private static final int TIME_TZ = 138;
 
     private static final long MILLIS_PER_MINUTE = 1000 * 60;
+
+    /**
+     * Raw offset doesn't change during DST transitions, but changes during
+     * other transitions that some time zones have. H2 1.4.193 and later
+     * versions use zone offset that is valid for startup time for performance
+     * reasons. Datetime storage code of PageStore has issues with all time zone
+     * transitions, so this buggy logic is preserved as is too.
+     */
+    private static int zoneOffsetMillis = DateTimeUtils.createGregorianCalendar().get(Calendar.ZONE_OFFSET);
 
     /**
      * The data itself.
@@ -528,10 +538,10 @@ public class Data {
                 long millis = nanos / 1_000_000;
                 nanos -= millis * 1_000_000;
                 writeVarLong(millis);
-                writeVarLong(nanos);
+                writeVarInt((int) nanos);
             } else {
                 writeByte(TIME);
-                writeVarLong(DateTimeUtils.getTimeLocalWithoutDst(v.getTime(null)));
+                writeVarLong(v.getTime(null).getTime() + zoneOffsetMillis);
             }
             break;
         case Value.TIME_TZ: {
@@ -550,7 +560,7 @@ public class Data {
                 writeVarLong(x);
             } else {
                 writeByte(DATE);
-                long x = DateTimeUtils.getTimeLocalWithoutDst(v.getDate(null));
+                long x = v.getDate(null).getTime() + zoneOffsetMillis;
                 writeVarLong(x / MILLIS_PER_MINUTE);
             }
             break;
@@ -565,11 +575,11 @@ public class Data {
                 long millis = nanos / 1_000_000;
                 nanos -= millis * 1_000_000;
                 writeVarLong(millis);
-                writeVarLong(nanos);
+                writeVarInt((int) nanos);
             } else {
                 Timestamp ts = v.getTimestamp(null);
                 writeByte(TIMESTAMP);
-                writeVarLong(DateTimeUtils.getTimeLocalWithoutDst(ts));
+                writeVarLong(ts.getTime() + zoneOffsetMillis);
                 writeVarInt(ts.getNanos() % 1_000_000);
             }
             break;
@@ -844,34 +854,22 @@ public class Data {
             BigInteger b = new BigInteger(buff);
             return ValueDecimal.get(new BigDecimal(b, scale));
         }
-        case LOCAL_DATE: {
+        case LOCAL_DATE:
             return ValueDate.fromDateValue(readVarLong());
-        }
         case DATE: {
-            long x = readVarLong() * MILLIS_PER_MINUTE;
-            return ValueDate.fromMillis(DateTimeUtils.getTimeUTCWithoutDst(x));
+            return ValueDate.fromMillis(readVarLong() * MILLIS_PER_MINUTE - zoneOffsetMillis);
         }
-        case LOCAL_TIME: {
-            long nanos = readVarLong() * 1_000_000 + readVarLong();
-            return ValueTime.fromNanos(nanos);
-        }
+        case LOCAL_TIME:
+            return ValueTime.fromNanos(readVarLong() * 1_000_000 + readVarInt());
         case TIME:
-            // need to normalize the year, month and day
-            return ValueTime.fromMillis(
-                    DateTimeUtils.getTimeUTCWithoutDst(readVarLong()));
+            return ValueTime.fromMillis(readVarLong() - zoneOffsetMillis);
         case TIME_TZ:
             return ValueTimeTimeZone.fromNanos(readVarInt() * DateTimeUtils.NANOS_PER_SECOND + readVarInt(),
                     readTimeZone());
-        case LOCAL_TIMESTAMP: {
-            long dateValue = readVarLong();
-            long nanos = readVarLong() * 1_000_000 + readVarLong();
-            return ValueTimestamp.fromDateValueAndNanos(dateValue, nanos);
-        }
-        case TIMESTAMP: {
-            return ValueTimestamp.fromMillis(
-                    DateTimeUtils.getTimeUTCWithoutDst(readVarLong()),
-                    readVarInt() % 1_000_000);
-        }
+        case LOCAL_TIMESTAMP:
+            return ValueTimestamp.fromDateValueAndNanos(readVarLong(), readVarLong() * 1_000_000 + readVarInt());
+        case TIMESTAMP:
+            return ValueTimestamp.fromMillis(readVarLong() - zoneOffsetMillis, readVarInt() % 1_000_000);
         case TIMESTAMP_TZ: {
             long dateValue = readVarLong();
             long nanos = readVarLong();
@@ -1134,7 +1132,7 @@ public class Data {
                 nanos -= millis * 1_000_000;
                 return 1 + getVarLongLen(millis) + getVarLongLen(nanos);
             }
-            return 1 + getVarLongLen(DateTimeUtils.getTimeLocalWithoutDst(v.getTime(null)));
+            return 1 + getVarLongLen(v.getTime(null).getTime() + zoneOffsetMillis);
         case Value.TIME_TZ: {
             ValueTimeTimeZone ts = (ValueTimeTimeZone) v;
             long nanosOfDay = ts.getNanos();
@@ -1147,7 +1145,7 @@ public class Data {
                 long dateValue = ((ValueDate) v).getDateValue();
                 return 1 + getVarLongLen(dateValue);
             }
-            long x = DateTimeUtils.getTimeLocalWithoutDst(v.getDate(null));
+            long x = v.getDate(null).getTime() + zoneOffsetMillis;
             return 1 + getVarLongLen(x / MILLIS_PER_MINUTE);
         }
         case Value.TIMESTAMP: {
@@ -1161,8 +1159,7 @@ public class Data {
                         getVarLongLen(nanos);
             }
             Timestamp ts = v.getTimestamp(null);
-            return 1 + getVarLongLen(DateTimeUtils.getTimeLocalWithoutDst(ts)) +
-                    getVarIntLen(ts.getNanos() % 1_000_000);
+            return 1 + getVarLongLen(ts.getTime() + zoneOffsetMillis) + getVarIntLen(ts.getNanos() % 1_000_000);
         }
         case Value.TIMESTAMP_TZ: {
             ValueTimestampTimeZone ts = (ValueTimestampTimeZone) v;
@@ -1548,6 +1545,14 @@ public class Data {
 
     public DataHandler getHandler() {
         return handler;
+    }
+
+    /**
+     * Reset the cached calendar for default timezone, for example after
+     * changing the default timezone.
+     */
+    public static void resetCalendar() {
+        zoneOffsetMillis = DateTimeUtils.createGregorianCalendar().get(Calendar.ZONE_OFFSET);
     }
 
 }

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -857,12 +857,17 @@ public class Data {
         case LOCAL_DATE:
             return ValueDate.fromDateValue(readVarLong());
         case DATE: {
-            return ValueDate.fromMillis(readVarLong() * MILLIS_PER_MINUTE - zoneOffsetMillis);
+            long ms = readVarLong() * MILLIS_PER_MINUTE - zoneOffsetMillis;
+            return ValueDate.fromDateValue(DateTimeUtils.dateValueFromLocalMillis(
+                    ms + DateTimeUtils.getTimeZoneOffsetMillis(ms)));
         }
         case LOCAL_TIME:
             return ValueTime.fromNanos(readVarLong() * 1_000_000 + readVarInt());
-        case TIME:
-            return ValueTime.fromMillis(readVarLong() - zoneOffsetMillis);
+        case TIME: {
+            long ms = readVarLong() - zoneOffsetMillis;
+            return ValueTime.fromNanos(DateTimeUtils.nanosFromLocalMillis(
+                    ms + DateTimeUtils.getTimeZoneOffsetMillis(ms)));
+        }
         case TIME_TZ:
             return ValueTimeTimeZone.fromNanos(readVarInt() * DateTimeUtils.NANOS_PER_SECOND + readVarInt(),
                     readTimeZone());

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -16,6 +16,7 @@ import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 import org.h2.api.ErrorCode;
 import org.h2.api.IntervalQualifier;
@@ -135,7 +136,7 @@ public class Data {
      * reasons. Datetime storage code of PageStore has issues with all time zone
      * transitions, so this buggy logic is preserved as is too.
      */
-    private static int zoneOffsetMillis = DateTimeUtils.createGregorianCalendar().get(Calendar.ZONE_OFFSET);
+    private static int zoneOffsetMillis = new GregorianCalendar().get(Calendar.ZONE_OFFSET);
 
     /**
      * The data itself.
@@ -1557,7 +1558,7 @@ public class Data {
      * changing the default timezone.
      */
     public static void resetCalendar() {
-        zoneOffsetMillis = DateTimeUtils.createGregorianCalendar().get(Calendar.ZONE_OFFSET);
+        zoneOffsetMillis = new GregorianCalendar().get(Calendar.ZONE_OFFSET);
     }
 
 }

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -78,7 +78,7 @@ public class DateTimeUtils {
      * Gregorian change date for a {@link GregorianCalendar} that represents a
      * proleptic Gregorian calendar.
      */
-    private static final Date PROLEPTIC_GREGORIAN_CHANGE = new Date(Long.MIN_VALUE);
+    public static final Date PROLEPTIC_GREGORIAN_CHANGE = new Date(Long.MIN_VALUE);
 
     /**
      * Date value for 1970-01-01.
@@ -142,22 +142,6 @@ public class DateTimeUtils {
      */
     public static GregorianCalendar createGregorianCalendar() {
         GregorianCalendar c = new GregorianCalendar();
-        c.setGregorianChange(PROLEPTIC_GREGORIAN_CHANGE);
-        return c;
-    }
-
-    /**
-     * Creates a Gregorian calendar for the given timezone using the default
-     * locale. Dates in H2 are represented in a Gregorian calendar. So this
-     * method should be used instead of Calendar.getInstance() to ensure that
-     * the Gregorian calendar is used for all date processing instead of a
-     * default locale calendar that can be non-Gregorian in some locales.
-     *
-     * @param tz timezone for the calendar, is never null
-     * @return a new calendar instance.
-     */
-    public static GregorianCalendar createGregorianCalendar(TimeZone tz) {
-        GregorianCalendar c = new GregorianCalendar(tz);
         c.setGregorianChange(PROLEPTIC_GREGORIAN_CHANGE);
         return c;
     }

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -447,7 +447,12 @@ public class DateTimeUtils {
      * @return local time zone offset
      */
     public static int getTimeZoneOffsetMillis(long ms) {
-        return getTimeZoneOffset(ms / 1000) * 1_000;
+        long seconds = ms / 1_000;
+        // Round toward negative infinity
+        if (ms < 0 && (seconds * 1_000 != ms)) {
+            seconds--;
+        }
+        return getTimeZoneOffset(seconds) * 1_000;
     }
 
     /**

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -132,21 +132,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Creates a Gregorian calendar for the default timezone using the default
-     * locale. Dates in H2 are represented in a Gregorian calendar. So this
-     * method should be used instead of Calendar.getInstance() to ensure that
-     * the Gregorian calendar is used for all date processing instead of a
-     * default locale calendar that can be non-Gregorian in some locales.
-     *
-     * @return a new calendar instance.
-     */
-    public static GregorianCalendar createGregorianCalendar() {
-        GregorianCalendar c = new GregorianCalendar();
-        c.setGregorianChange(PROLEPTIC_GREGORIAN_CHANGE);
-        return c;
-    }
-
-    /**
      * Parse a date string. The format is: [+|-]year-month-day
      * or [+|-]yyyyMMdd.
      *

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -904,29 +904,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Calculate the normalized timestamp.
-     *
-     * @param absoluteDay the absolute day
-     * @param nanos the nanoseconds (may be negative or larger than one day)
-     * @return the timestamp
-     */
-    public static ValueTimestamp normalizeTimestamp(long absoluteDay,
-            long nanos) {
-        if (nanos > NANOS_PER_DAY || nanos < 0) {
-            long d;
-            if (nanos > NANOS_PER_DAY) {
-                d = nanos / NANOS_PER_DAY;
-            } else {
-                d = (nanos - NANOS_PER_DAY + 1) / NANOS_PER_DAY;
-            }
-            nanos -= d * NANOS_PER_DAY;
-            absoluteDay += d;
-        }
-        return ValueTimestamp.fromDateValueAndNanos(
-                dateValueFromAbsoluteDay(absoluteDay), nanos);
-    }
-
-    /**
      * Converts local date value and nanoseconds to timestamp with time zone.
      *
      * @param dateValue

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -300,18 +300,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * See:
-     * https://stackoverflow.com/questions/3976616/how-to-find-nth-occurrence-of-character-in-a-string#answer-3976656
-     */
-    private static int findNthIndexOf(String str, char chr, int n) {
-        int pos = str.indexOf(chr);
-        while (--n > 0 && pos != -1) {
-            pos = str.indexOf(chr, pos + 1);
-        }
-        return pos;
-    }
-
-    /**
      * Parses timestamp value from the specified string.
      *
      * @param s
@@ -330,7 +318,7 @@ public class DateTimeUtils {
             dateEnd = s.indexOf('T');
             if (dateEnd < 0 && provider != null && provider.getMode().allowDB2TimestampFormat) {
                 // DB2 also allows dash between date and time
-                dateEnd = findNthIndexOf(s, '-', 3);
+                dateEnd = s.indexOf('-', s.indexOf('-', s.indexOf('-') + 1) + 1);
             }
         }
         int timeStart;

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -132,16 +132,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Get a time zone provider for the given time zone.
-     *
-     * @param tz the time zone
-     * @return a time zone provider for the given time zone
-     */
-    public static TimeZoneProvider getTimeZone(TimeZone tz) {
-        return TimeZoneProvider.ofId(tz.getID());
-    }
-
-    /**
      * Creates a Gregorian calendar for the default timezone using the default
      * locale. Dates in H2 are represented in a Gregorian calendar. So this
      * method should be used instead of Calendar.getInstance() to ensure that
@@ -526,7 +516,7 @@ public class DateTimeUtils {
      * @return the number of milliseconds (UTC)
      */
     public static long getMillis(TimeZone tz, long dateValue, long timeNanos) {
-        TimeZoneProvider c = tz == null ? getTimeZone() : getTimeZone(tz);
+        TimeZoneProvider c = tz == null ? getTimeZone() : TimeZoneProvider.ofId(tz.getID());
         return c.getEpochSecondsFromLocal(dateValue, timeNanos) * 1_000 + timeNanos / 1_000_000 % 1_000;
     }
 

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -861,12 +861,11 @@ public class DateTimeUtils {
      * @return the nanoseconds
      */
     public static long nanosFromLocalSeconds(long localSeconds) {
-        long absoluteDay = localSeconds / SECONDS_PER_DAY;
-        // Round toward negative infinity
-        if (localSeconds < 0 && (absoluteDay * SECONDS_PER_DAY != localSeconds)) {
-            absoluteDay--;
+        localSeconds %= SECONDS_PER_DAY;
+        if (localSeconds < 0) {
+            localSeconds += SECONDS_PER_DAY;
         }
-        return (localSeconds - absoluteDay * SECONDS_PER_DAY) * NANOS_PER_SECOND;
+        return localSeconds * NANOS_PER_SECOND;
     }
 
     /**
@@ -876,12 +875,11 @@ public class DateTimeUtils {
      * @return the nanoseconds
      */
     public static long nanosFromLocalMillis(long ms) {
-        long absoluteDay = ms / MILLIS_PER_DAY;
-        // Round toward negative infinity
-        if (ms < 0 && (absoluteDay * MILLIS_PER_DAY != ms)) {
-            absoluteDay--;
+        ms %= MILLIS_PER_DAY;
+        if (ms < 0) {
+            ms += MILLIS_PER_DAY;
         }
-        return (ms - absoluteDay * MILLIS_PER_DAY) * 1_000_000;
+        return ms * 1_000_000;
     }
 
     /**
@@ -891,14 +889,9 @@ public class DateTimeUtils {
      * @return the nanos of day within a day
      */
     public static long normalizeNanosOfDay(long nanos) {
-        if (nanos > NANOS_PER_DAY || nanos < 0) {
-            long d;
-            if (nanos > NANOS_PER_DAY) {
-                d = nanos / NANOS_PER_DAY;
-            } else {
-                d = (nanos - NANOS_PER_DAY + 1) / NANOS_PER_DAY;
-            }
-            nanos -= d * NANOS_PER_DAY;
+        nanos %= NANOS_PER_DAY;
+        if (nanos < 0) {
+            nanos += NANOS_PER_DAY;
         }
         return nanos;
     }

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -8,7 +8,6 @@
 package org.h2.util;
 
 import java.sql.Date;
-import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
@@ -107,16 +106,6 @@ public class DateTimeUtils {
 
     private static volatile TimeZoneProvider LOCAL;
 
-    /**
-     * Raw offset doesn't change during DST transitions, but changes during
-     * other transitions that some time zones have. H2 1.4.193 and later
-     * versions use zone offset that is valid for startup time for performance
-     * reasons. This code is now used only by old PageStore engine and its
-     * datetime storage code has issues with all time zone transitions, so this
-     * buggy logic is preserved as is too.
-     */
-    private static int zoneOffsetMillis = createGregorianCalendar().get(Calendar.ZONE_OFFSET);
-
     private DateTimeUtils() {
         // utility class
     }
@@ -127,7 +116,6 @@ public class DateTimeUtils {
      */
     public static void resetCalendar() {
         LOCAL = null;
-        zoneOffsetMillis = createGregorianCalendar().get(Calendar.ZONE_OFFSET);
     }
 
     /**
@@ -614,28 +602,6 @@ public class DateTimeUtils {
             }
         }
         return ValueTimestamp.fromDateValueAndNanos(dateValue, timeNanos);
-    }
-
-    /**
-     * Get the number of milliseconds since 1970-01-01 in the local timezone,
-     * but without daylight saving time into account.
-     *
-     * @param d the date
-     * @return the milliseconds
-     */
-    public static long getTimeLocalWithoutDst(java.util.Date d) {
-        return d.getTime() + zoneOffsetMillis;
-    }
-
-    /**
-     * Convert the number of milliseconds since 1970-01-01 in the local timezone
-     * to UTC, but without daylight saving time into account.
-     *
-     * @param millis the number of milliseconds in the local timezone
-     * @return the number of milliseconds in UTC
-     */
-    public static long getTimeUTCWithoutDst(long millis) {
-        return millis - zoneOffsetMillis;
     }
 
     /**

--- a/h2/src/main/org/h2/util/TimeZoneProvider.java
+++ b/h2/src/main/org/h2/util/TimeZoneProvider.java
@@ -137,7 +137,7 @@ public abstract class TimeZoneProvider {
             year = yearForCalendar(year);
             GregorianCalendar c = cachedCalendar.getAndSet(null);
             if (c == null) {
-                c = DateTimeUtils.createGregorianCalendar(timeZone);
+                c = createCalendar();
             }
             c.clear();
             c.set(Calendar.ERA, GregorianCalendar.AD);
@@ -158,7 +158,7 @@ public abstract class TimeZoneProvider {
             int yearForCalendar = yearForCalendar(year);
             GregorianCalendar c = cachedCalendar.getAndSet(null);
             if (c == null) {
-                c = DateTimeUtils.createGregorianCalendar(timeZone);
+                c = createCalendar();
             }
             c.clear();
             c.set(Calendar.ERA, GregorianCalendar.AD);
@@ -172,6 +172,12 @@ public abstract class TimeZoneProvider {
             long epoch = c.getTimeInMillis();
             cachedCalendar.compareAndSet(null, c);
             return epoch / 1_000 + (year - yearForCalendar) * SECONDS_PER_YEAR;
+        }
+
+        private GregorianCalendar createCalendar() {
+            GregorianCalendar c = new GregorianCalendar(timeZone);
+            c.setGregorianChange(DateTimeUtils.PROLEPTIC_GREGORIAN_CHANGE);
+            return c;
         }
 
         @Override

--- a/h2/src/main/org/h2/value/ValueDate.java
+++ b/h2/src/main/org/h2/value/ValueDate.java
@@ -62,17 +62,6 @@ public class ValueDate extends Value {
     }
 
     /**
-     * Calculate the date value (in the default timezone) from a given time in
-     * milliseconds in UTC.
-     *
-     * @param ms the milliseconds
-     * @return the value
-     */
-    public static ValueDate fromMillis(long ms) {
-        return fromDateValue(DateTimeUtils.dateValueFromLocalMillis(ms + DateTimeUtils.getTimeZoneOffsetMillis(ms)));
-    }
-
-    /**
      * Parse a string to a ValueDate.
      *
      * @param s the string to parse

--- a/h2/src/main/org/h2/value/ValueTime.java
+++ b/h2/src/main/org/h2/value/ValueTime.java
@@ -86,17 +86,6 @@ public class ValueTime extends Value {
     }
 
     /**
-     * Calculate the time value from a given time in
-     * milliseconds in UTC.
-     *
-     * @param ms the milliseconds
-     * @return the value
-     */
-    public static ValueTime fromMillis(long ms) {
-        return fromNanos(DateTimeUtils.nanosFromLocalMillis(ms + DateTimeUtils.getTimeZoneOffsetMillis(ms)));
-    }
-
-    /**
      * Parse a string to a ValueTime.
      *
      * @param s the string to parse

--- a/h2/src/main/org/h2/value/ValueTimestamp.java
+++ b/h2/src/main/org/h2/value/ValueTimestamp.java
@@ -272,17 +272,27 @@ public class ValueTimestamp extends Value {
     @Override
     public Value add(Value v) {
         ValueTimestamp t = (ValueTimestamp) v.convertTo(Value.TIMESTAMP);
-        long d1 = DateTimeUtils.absoluteDayFromDateValue(dateValue);
-        long d2 = DateTimeUtils.absoluteDayFromDateValue(t.dateValue);
-        return DateTimeUtils.normalizeTimestamp(d1 + d2, timeNanos + t.timeNanos);
+        long absoluteDay = DateTimeUtils.absoluteDayFromDateValue(dateValue)
+                + DateTimeUtils.absoluteDayFromDateValue(t.dateValue);
+        long nanos = timeNanos + t.timeNanos;
+        if (nanos >= DateTimeUtils.NANOS_PER_DAY) {
+            nanos -= DateTimeUtils.NANOS_PER_DAY;
+            absoluteDay++;
+        }
+        return ValueTimestamp.fromDateValueAndNanos(DateTimeUtils.dateValueFromAbsoluteDay(absoluteDay), nanos);
     }
 
     @Override
     public Value subtract(Value v) {
         ValueTimestamp t = (ValueTimestamp) v.convertTo(Value.TIMESTAMP);
-        long d1 = DateTimeUtils.absoluteDayFromDateValue(dateValue);
-        long d2 = DateTimeUtils.absoluteDayFromDateValue(t.dateValue);
-        return DateTimeUtils.normalizeTimestamp(d1 - d2, timeNanos - t.timeNanos);
+        long absoluteDay = DateTimeUtils.absoluteDayFromDateValue(dateValue)
+                - DateTimeUtils.absoluteDayFromDateValue(t.dateValue);
+        long nanos = timeNanos - t.timeNanos;
+        if (nanos < 0) {
+            nanos += DateTimeUtils.NANOS_PER_DAY;
+            absoluteDay--;
+        }
+        return ValueTimestamp.fromDateValueAndNanos(DateTimeUtils.dateValueFromAbsoluteDay(absoluteDay), nanos);
     }
 
 }

--- a/h2/src/test/org/h2/test/db/TestDateStorage.java
+++ b/h2/src/test/org/h2/test/db/TestDateStorage.java
@@ -18,6 +18,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
+import org.h2.store.Data;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.test.unit.TestDate;
@@ -55,6 +56,7 @@ public class TestDateStorage extends TestDb {
         Calendar utcCalendar = new GregorianCalendar(new SimpleTimeZone(0, "Z"));
         TimeZone old = TimeZone.getDefault();
         DateTimeUtils.resetCalendar();
+        Data.resetCalendar();
         TimeZone.setDefault(TimeZone.getTimeZone("PST"));
         try {
             // 2010-03-14T02:15:00Z
@@ -144,6 +146,7 @@ public class TestDateStorage extends TestDb {
         } finally {
             TimeZone.setDefault(old);
             DateTimeUtils.resetCalendar();
+            Data.resetCalendar();
         }
         stat.execute("drop table ts");
         stat.execute("drop table t");
@@ -186,6 +189,7 @@ public class TestDateStorage extends TestDb {
                 // println(tz.getID());
                 TimeZone.setDefault(tz);
                 DateTimeUtils.resetCalendar();
+                Data.resetCalendar();
                 for (int d = 101; d < 129; d++) {
                     test(prep, d);
                 }
@@ -193,6 +197,7 @@ public class TestDateStorage extends TestDb {
         } finally {
             TimeZone.setDefault(defaultTimeZone);
             DateTimeUtils.resetCalendar();
+            Data.resetCalendar();
         }
         conn.close();
         deleteDb(getTestName());

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -56,7 +56,6 @@ import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.test.ap.TestAnnotationProcessor;
 import org.h2.tools.SimpleResultSet;
-import org.h2.util.DateTimeUtils;
 import org.h2.util.IOUtils;
 import org.h2.util.StringUtils;
 import org.h2.value.Value;
@@ -1210,7 +1209,7 @@ public class TestFunctions extends TestDb implements AggregateFunction {
     }
 
     private void testToDate(Session session) {
-        GregorianCalendar calendar = DateTimeUtils.createGregorianCalendar();
+        GregorianCalendar calendar = new GregorianCalendar();
         int year = calendar.get(Calendar.YEAR);
         int month = calendar.get(Calendar.MONTH) + 1;
         // Default date in Oracle is the first day of the current month

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -36,6 +36,7 @@ import org.h2.api.IntervalQualifier;
 import org.h2.api.Trigger;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
+import org.h2.store.Data;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.util.DateTimeUtils;
@@ -827,6 +828,7 @@ public class TestPreparedStatement extends TestDb {
         TimeZone old = TimeZone.getDefault();
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+01"));
         DateTimeUtils.resetCalendar();
+        Data.resetCalendar();
         try {
             localDate = parseLocalDate("1582-10-05");
             prep.setObject(1, localDate);
@@ -849,6 +851,7 @@ public class TestPreparedStatement extends TestDb {
         } finally {
             TimeZone.setDefault(old);
             DateTimeUtils.resetCalendar();
+            Data.resetCalendar();
         }
     }
 

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -34,6 +34,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import org.h2.api.ErrorCode;
@@ -42,8 +43,6 @@ import org.h2.api.IntervalQualifier;
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
-import org.h2.test.unit.TestDateTimeUtils;
-import org.h2.util.DateTimeUtils;
 import org.h2.util.IOUtils;
 import org.h2.util.JSR310;
 import org.h2.util.MathUtils;
@@ -1486,8 +1485,8 @@ public class TestResultSet extends TestDb {
                 "D DATE, T TIME, TS TIMESTAMP(9))");
         PreparedStatement prep = conn.prepareStatement(
                 "INSERT INTO TEST VALUES(?, ?, ?, ?)");
-        Calendar regular = DateTimeUtils.createGregorianCalendar();
-        Calendar other = null;
+        GregorianCalendar regular = new GregorianCalendar();
+        GregorianCalendar other = null;
         // search a locale that has a _different_ raw offset
         long testTime = java.sql.Date.valueOf("2001-02-03").getTime();
         for (String s : TimeZone.getAvailableIDs()) {
@@ -1499,7 +1498,7 @@ public class TestResultSet extends TestDb {
             if (rawOffsetDiff != 0 && rawOffsetDiff != 1000 * 60 * 60 * 24) {
                 if (regular.getTimeZone().getOffset(testTime) !=
                         zone.getOffset(testTime)) {
-                    other = TestDateTimeUtils.createGregorianCalendar(zone);
+                    other = new GregorianCalendar(zone);
                     break;
                 }
             }

--- a/h2/src/test/org/h2/test/jdbc/TestResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestResultSet.java
@@ -42,6 +42,7 @@ import org.h2.api.IntervalQualifier;
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
+import org.h2.test.unit.TestDateTimeUtils;
 import org.h2.util.DateTimeUtils;
 import org.h2.util.IOUtils;
 import org.h2.util.JSR310;
@@ -1498,7 +1499,7 @@ public class TestResultSet extends TestDb {
             if (rawOffsetDiff != 0 && rawOffsetDiff != 1000 * 60 * 60 * 24) {
                 if (regular.getTimeZone().getOffset(testTime) !=
                         zone.getOffset(testTime)) {
-                    other = DateTimeUtils.createGregorianCalendar(zone);
+                    other = TestDateTimeUtils.createGregorianCalendar(zone);
                     break;
                 }
             }

--- a/h2/src/test/org/h2/test/synth/TestCrashAPI.java
+++ b/h2/src/test/org/h2/test/synth/TestCrashAPI.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Comparator;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,7 +46,6 @@ import org.h2.test.synth.sql.RandomGen;
 import org.h2.tools.Backup;
 import org.h2.tools.DeleteDbFiles;
 import org.h2.tools.Restore;
-import org.h2.util.DateTimeUtils;
 import org.h2.util.MathUtils;
 
 /**
@@ -503,7 +503,7 @@ public class TestCrashAPI extends TestDb implements Runnable {
             // TODO should use generated savepoints
             return null;
         } else if (type == Calendar.class) {
-            return DateTimeUtils.createGregorianCalendar();
+            return new GregorianCalendar();
         } else if (type == java.net.URL.class) {
             return null;
         } else if (type == java.math.BigDecimal.class) {

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -335,7 +335,7 @@ public class TestDate extends TestBase {
                         assertFalse(valid);
                     } else if (d < 1 || d > 31) {
                         assertFalse(valid);
-                    } else if (y != 1582 && d >= 1 && d <= 27) {
+                    } else if (d <= 27) {
                         assertTrue(valid);
                     } else {
                         if (y <= 0) {
@@ -448,7 +448,7 @@ public class TestDate extends TestBase {
             assertEquals("19999-08-07 13:14:15.16", ts2.getString());
             assertEquals("19999-08-07", d2.getString());
             assertEquals("13:14:15.16", t2.getString());
-            TimeZone timeZone = DateTimeUtils.createGregorianCalendar().getTimeZone();
+            TimeZone timeZone = TimeZone.getDefault();
             ValueTimestamp ts1a = ValueTimestamp.get(timeZone, ts1.getTimestamp(null));
             ValueTimestamp ts2a = ValueTimestamp.get(timeZone, ts2.getTimestamp(null));
             assertEquals("-999-08-07 13:14:15.16", ts1a.getString());

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -459,15 +459,6 @@ public class TestDate extends TestBase {
                 DateTimeUtils.resetCalendar();
             }
         }
-
-        // test for bug on Java 1.8.0_60 in "Europe/Moscow" timezone.
-        // Doesn't affect most other timezones
-        long millis = 1407437460000L;
-        long ms = DateTimeUtils.getTimeUTCWithoutDst(millis);
-        ms += DateTimeUtils.getTimeZoneOffsetMillis(ms);
-        long result1 = DateTimeUtils.nanosFromLocalMillis(ms);
-        long result2 = DateTimeUtils.nanosFromLocalMillis(ms);
-        assertEquals(result1, result2);
     }
 
 }

--- a/h2/src/test/org/h2/test/unit/TestDate.java
+++ b/h2/src/test/org/h2/test/unit/TestDate.java
@@ -325,7 +325,7 @@ public class TestDate extends TestBase {
     }
 
     private void testValidDate() {
-        Calendar c = DateTimeUtils.createGregorianCalendar(DateTimeUtils.UTC);
+        Calendar c = TestDateTimeUtils.createGregorianCalendar(DateTimeUtils.UTC);
         c.setLenient(false);
         for (int y = -2000; y < 3000; y++) {
             for (int m = -3; m <= 14; m++) {

--- a/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
@@ -25,6 +25,22 @@ import org.h2.value.ValueTimestamp;
 public class TestDateTimeUtils extends TestBase {
 
     /**
+     * Creates a Gregorian calendar for the given timezone using the default
+     * locale. Dates in H2 are represented in a Gregorian calendar. So this
+     * method should be used instead of Calendar.getInstance() to ensure that
+     * the Gregorian calendar is used for all date processing instead of a
+     * default locale calendar that can be non-Gregorian in some locales.
+     *
+     * @param tz timezone for the calendar, is never null
+     * @return a new calendar instance.
+     */
+    public static GregorianCalendar createGregorianCalendar(TimeZone tz) {
+        GregorianCalendar c = new GregorianCalendar(tz);
+        c.setGregorianChange(DateTimeUtils.PROLEPTIC_GREGORIAN_CHANGE);
+        return c;
+    }
+
+    /**
      * Run just this test.
      *
      * @param a
@@ -66,7 +82,7 @@ public class TestDateTimeUtils extends TestBase {
      * {@link DateTimeUtils#getIsoDayOfWeek(long)}.
      */
     private void testDayOfWeek() {
-        GregorianCalendar gc = DateTimeUtils.createGregorianCalendar(DateTimeUtils.UTC);
+        GregorianCalendar gc = createGregorianCalendar(DateTimeUtils.UTC);
         for (int i = -1_000_000; i <= 1_000_000; i++) {
             gc.clear();
             gc.setTimeInMillis(i * 86400000L);

--- a/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
@@ -67,6 +67,7 @@ public class TestDateTimeUtils extends TestBase {
         testUTC2Value(false);
         testConvertScale();
         testParseInterval();
+        testGetTimeZoneOffset();
     }
 
     private void testParseTimeNanosDB2Format() {
@@ -302,6 +303,25 @@ public class TestDateTimeUtils extends TestBase {
         }
         b.append(full).append("' ").append(qualifier);
         assertEquals(b.toString(), expected.getString());
+    }
+
+    private void testGetTimeZoneOffset() {
+        TimeZone old = TimeZone.getDefault();
+        TimeZone timeZone = TimeZone.getTimeZone("Europe/Paris");
+        TimeZone.setDefault(timeZone);
+        DateTimeUtils.resetCalendar();
+        try {
+            long n = -1111971600;
+            assertEquals(3_600, DateTimeUtils.getTimeZoneOffset(n - 1));
+            assertEquals(3_600_000, DateTimeUtils.getTimeZoneOffsetMillis(n * 1_000 - 1));
+            assertEquals(0, DateTimeUtils.getTimeZoneOffset(n));
+            assertEquals(0, DateTimeUtils.getTimeZoneOffsetMillis(n * 1_000));
+            assertEquals(0, DateTimeUtils.getTimeZoneOffset(n + 1));
+            assertEquals(0, DateTimeUtils.getTimeZoneOffsetMillis(n * 1_000 + 1));
+        } finally {
+            TimeZone.setDefault(old);
+            DateTimeUtils.resetCalendar();
+        }
     }
 
 }

--- a/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestDateTimeUtils.java
@@ -25,11 +25,8 @@ import org.h2.value.ValueTimestamp;
 public class TestDateTimeUtils extends TestBase {
 
     /**
-     * Creates a Gregorian calendar for the given timezone using the default
-     * locale. Dates in H2 are represented in a Gregorian calendar. So this
-     * method should be used instead of Calendar.getInstance() to ensure that
-     * the Gregorian calendar is used for all date processing instead of a
-     * default locale calendar that can be non-Gregorian in some locales.
+     * Creates a proleptic Gregorian calendar for the given timezone using the
+     * default locale.
      *
      * @param tz timezone for the calendar, is never null
      * @return a new calendar instance.

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.h2.api.ErrorCode;
+import org.h2.store.Data;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.tools.Server;
@@ -486,6 +487,7 @@ public class TestPgServer extends TestDb {
              */
             TimeZone.setDefault(TimeZone.getTimeZone("GMT+01"));
             DateTimeUtils.resetCalendar();
+            Data.resetCalendar();
         }
         try {
             Server server = createPgServer(
@@ -544,6 +546,7 @@ public class TestPgServer extends TestDb {
             if (JSR310.PRESENT) {
                 TimeZone.setDefault(old);
                 DateTimeUtils.resetCalendar();
+                Data.resetCalendar();
             }
         }
     }


### PR DESCRIPTION
1. Minor issues with time zone offsets before 1970-01-01 near transitions are fixed.

2. Some methods of `DateTimeUtils` are simplified.

3. Some PageStore-only code was moved to `store.Data`.