### PR TITLE
Issue 2144

### DIFF
--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1571,7 +1571,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         /*
          * This implementation needs to be lock-free.
          */
-        if (locks.isEmpty()) {
+        if (database.getLockMode() == Constants.LOCK_MODE_OFF || locks.isEmpty()) {
             return Collections.emptySet();
         }
         /*

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -946,6 +946,17 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
     }
 
     /**
+     * Register table as updated within current transaction.
+     *
+     * @param table the table to register
+     */
+    public void registerTable(Table table) {
+        if (!locks.contains(table)) {
+            locks.add(table);
+        }
+    }
+
+    /**
      * Add an undo log entry to this session.
      *
      * @param table the table

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -931,12 +931,13 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
     }
 
     /**
-     * Add a lock for the given table. The object is unlocked on commit or
-     * rollback.
+     * Register table as updated within current transaction.
+     * Table is unlocked on commit or rollback.
+     * It also assumes that table will be modified by transaction.
      *
      * @param table the table that is locked
      */
-    public void addLock(Table table) {
+    public void registerTableAsLocked(Table table) {
         if (SysProperties.CHECK) {
             if (locks.contains(table)) {
                 DbException.throwInternalError(table.toString());
@@ -947,10 +948,11 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
 
     /**
      * Register table as updated within current transaction.
+     * This is used instead of table locking when lock mode is LOCK_MODE_OFF.
      *
-     * @param table the table to register
+     * @param table to register
      */
-    public void registerTable(Table table) {
+    public void registerTableAsUpdated(Table table) {
         if (!locks.contains(table)) {
             locks.add(table);
         }

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -131,6 +131,7 @@ public class MVTable extends RegularTable {
             boolean forceLockEvenInMvcc) {
         int lockMode = database.getLockMode();
         if (lockMode == Constants.LOCK_MODE_OFF) {
+            session.registerTable(this);
             return false;
         }
         if (!forceLockEvenInMvcc) {

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -131,7 +131,7 @@ public class MVTable extends RegularTable {
             boolean forceLockEvenInMvcc) {
         int lockMode = database.getLockMode();
         if (lockMode == Constants.LOCK_MODE_OFF) {
-            session.registerTable(this);
+            session.registerTableAsUpdated(this);
             return false;
         }
         if (!forceLockEvenInMvcc) {
@@ -251,7 +251,7 @@ public class MVTable extends RegularTable {
             if (exclusive) {
                 if (lockSharedSessions.isEmpty()) {
                     traceLock(session, exclusive, TraceLockEvent.TRACE_LOCK_ADDED_FOR, NO_EXTRA_INFO);
-                    session.addLock(this);
+                    session.registerTableAsLocked(this);
                     lockExclusiveSession = session;
                     if (SysProperties.THREAD_DEADLOCK_DETECTOR) {
                         if (EXCLUSIVE_LOCKS.get() == null) {
@@ -275,7 +275,7 @@ public class MVTable extends RegularTable {
             } else {
                 if (lockSharedSessions.putIfAbsent(session, session) == null) {
                     traceLock(session, exclusive, TraceLockEvent.TRACE_LOCK_OK, NO_EXTRA_INFO);
-                    session.addLock(this);
+                    session.registerTableAsLocked(this);
                     if (SysProperties.THREAD_DEADLOCK_DETECTOR) {
                         ArrayList<String> list = SHARED_LOCKS.get();
                         if (list == null) {

--- a/h2/src/main/org/h2/pagestore/db/PageStoreTable.java
+++ b/h2/src/main/org/h2/pagestore/db/PageStoreTable.java
@@ -404,7 +404,7 @@ public class PageStoreTable extends RegularTable {
             if (lockExclusiveSession == null) {
                 if (lockSharedSessions.isEmpty()) {
                     traceLock(session, exclusive, "added for");
-                    session.addLock(this);
+                    session.registerTableAsLocked(this);
                     lockExclusiveSession = session;
                     return true;
                 } else if (lockSharedSessions.size() == 1 &&
@@ -429,7 +429,7 @@ public class PageStoreTable extends RegularTable {
                 }
                 if (!lockSharedSessions.containsKey(session)) {
                     traceLock(session, exclusive, "ok");
-                    session.addLock(this);
+                    session.registerTableAsLocked(this);
                     lockSharedSessions.put(session, session);
                 }
                 return true;


### PR DESCRIPTION
Fix for #2144 
Session.locks collection is reused in LOCK_MODE_OFF case as a set of updated tables.