### PR TITLE
Clean up some find methods of indexes and fix minor issues with them

### DIFF
--- a/h2/src/main/org/h2/index/BaseIndex.java
+++ b/h2/src/main/org/h2/index/BaseIndex.java
@@ -164,6 +164,16 @@ public abstract class BaseIndex extends SchemaObjectBase implements Index {
         throw DbException.throwInternalError(toString());
     }
 
+    @Override
+    public boolean canGetFirstOrLast() {
+        return false;
+    }
+
+    @Override
+    public Cursor findFirstOrLast(Session session, boolean first) {
+        throw DbException.throwInternalError(toString());
+    }
+
     /**
      * Calculate the cost for the given mask as if this index was a typical
      * b-tree range index. This is the estimated cost required to search one

--- a/h2/src/main/org/h2/index/DualIndex.java
+++ b/h2/src/main/org/h2/index/DualIndex.java
@@ -12,6 +12,7 @@ import org.h2.result.SortOrder;
 import org.h2.table.DualTable;
 import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
+import org.h2.value.Value;
 
 /**
  * An index for the DUAL table.
@@ -45,7 +46,7 @@ public class DualIndex extends VirtualTableIndex {
 
     @Override
     public Cursor findFirstOrLast(Session session, boolean first) {
-        return new DualCursor(session);
+        return new SingleRowCursor(session.createRow(new Value[0], 1));
     }
 
     @Override

--- a/h2/src/main/org/h2/index/LinkedIndex.java
+++ b/h2/src/main/org/h2/index/LinkedIndex.java
@@ -176,18 +176,6 @@ public class LinkedIndex extends BaseIndex {
     }
 
     @Override
-    public boolean canGetFirstOrLast() {
-        return false;
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        // TODO optimization: could get the first or last value (in any case;
-        // maybe not optimized)
-        throw DbException.getUnsupportedException("LINKED");
-    }
-
-    @Override
     public void remove(Session session, Row row) {
         ArrayList<Value> params = Utils.newSmallArrayList();
         StringBuilder builder = new StringBuilder("DELETE FROM ").append(targetTableName).append(" WHERE ");

--- a/h2/src/main/org/h2/index/MetaIndex.java
+++ b/h2/src/main/org/h2/index/MetaIndex.java
@@ -106,16 +106,6 @@ public class MetaIndex extends BaseIndex {
     }
 
     @Override
-    public boolean canGetFirstOrLast() {
-        return false;
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        throw DbException.getUnsupportedException("META");
-    }
-
-    @Override
     public long getRowCount(Session session) {
         return MetaTable.ROW_COUNT_APPROXIMATION;
     }

--- a/h2/src/main/org/h2/index/RangeIndex.java
+++ b/h2/src/main/org/h2/index/RangeIndex.java
@@ -13,6 +13,8 @@ import org.h2.result.SortOrder;
 import org.h2.table.IndexColumn;
 import org.h2.table.RangeTable;
 import org.h2.table.TableFilter;
+import org.h2.value.Value;
+import org.h2.value.ValueLong;
 
 /**
  * An index for the SYSTEM_RANGE table.
@@ -82,8 +84,11 @@ public class RangeIndex extends VirtualTableIndex {
 
     @Override
     public Cursor findFirstOrLast(Session session, boolean first) {
-        long pos = first ? rangeTable.getMin(session) : rangeTable.getMax(session);
-        return new RangeCursor(session, pos, pos);
+        long min = rangeTable.getMin(session);
+        long max = rangeTable.getMax(session);
+        long step = rangeTable.getStep(session);
+        return new SingleRowCursor((step > 0 ? min <= max : min >= max)
+                ? session.createRow(new Value[]{ ValueLong.get(first ^ min >= max ? min : max) }, 1) : null);
     }
 
     @Override

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -415,16 +415,6 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
         return false;
     }
 
-    @Override
-    public boolean canGetFirstOrLast() {
-        return false;
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        throw DbException.getUnsupportedException("VIEW");
-    }
-
     public void setRecursive(boolean value) {
         this.recursive = value;
     }

--- a/h2/src/main/org/h2/index/VirtualConstructedTableIndex.java
+++ b/h2/src/main/org/h2/index/VirtualConstructedTableIndex.java
@@ -54,11 +54,6 @@ public class VirtualConstructedTableIndex extends VirtualTableIndex {
     }
 
     @Override
-    public boolean canGetFirstOrLast() {
-        return false;
-    }
-
-    @Override
     public String getPlanSQL() {
         return table instanceof FunctionTable ? "function" : "table scan";
     }

--- a/h2/src/main/org/h2/index/VirtualTableIndex.java
+++ b/h2/src/main/org/h2/index/VirtualTableIndex.java
@@ -56,11 +56,6 @@ public abstract class VirtualTableIndex extends BaseIndex {
     }
 
     @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        throw DbException.getUnsupportedException("Virtual table");
-    }
-
-    @Override
     public long getRowCount(Session session) {
         return table.getRowCount(session);
     }

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -196,16 +196,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
     }
 
     @Override
-    public Cursor find(TableFilter filter, SearchRow first, SearchRow last) {
-        return find(filter.getSession());
-    }
-
-    @Override
     public Cursor find(Session session, SearchRow first, SearchRow last) {
-        return find(session);
-    }
-
-    private Cursor find(Session session) {
         Iterator<SpatialKey> cursor = spatialMap.keyIterator(null);
         TransactionMap<SpatialKey, Value> map = getMap(session);
         Iterator<SpatialKey> it = new SpatialKeyIterator(map, cursor, false);

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -337,20 +337,6 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
     }
 
     @Override
-    public boolean canGetFirstOrLast() {
-        return true;
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        if (!first) {
-            throw DbException.throwInternalError(
-                    "Spatial Index can only be fetch in ascending order");
-        }
-        return find(session);
-    }
-
-    @Override
     public boolean needRebuild() {
         try {
             return dataMap.sizeAsLongMax() == 0;
@@ -443,15 +429,6 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex {
                 }
             }
             return searchRow;
-        }
-
-        /**
-         * Returns the current key.
-         *
-         * @return the current key
-         */
-        public SpatialKey getKey() {
-            return current;
         }
 
         @Override

--- a/h2/src/main/org/h2/pagestore/db/HashIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/HashIndex.java
@@ -165,16 +165,6 @@ public class HashIndex extends BaseIndex {
     }
 
     @Override
-    public boolean canGetFirstOrLast() {
-        return false;
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        throw DbException.getUnsupportedException("HASH");
-    }
-
-    @Override
     public boolean canScan() {
         return false;
     }

--- a/h2/src/main/org/h2/pagestore/db/NonUniqueHashIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/NonUniqueHashIndex.java
@@ -166,16 +166,6 @@ public class NonUniqueHashIndex extends BaseIndex {
     }
 
     @Override
-    public boolean canGetFirstOrLast() {
-        return false;
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        throw DbException.getUnsupportedException("HASH");
-    }
-
-    @Override
     public boolean canScan() {
         return false;
     }

--- a/h2/src/main/org/h2/pagestore/db/PageDataIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/PageDataIndex.java
@@ -215,11 +215,6 @@ public class PageDataIndex extends PageIndex {
         return p;
     }
 
-    @Override
-    public boolean canGetFirstOrLast() {
-        return false;
-    }
-
     /**
      * Get the key from the row.
      *
@@ -261,11 +256,6 @@ public class PageDataIndex extends PageIndex {
     Cursor find(Session session, long first, long last) {
         PageData root = getPage(rootPageId, 0);
         return root.find(session, first, last);
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        throw DbException.throwInternalError(toString());
     }
 
     long getLastKey() {

--- a/h2/src/main/org/h2/pagestore/db/PageDelegateIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/PageDelegateIndex.java
@@ -48,11 +48,6 @@ public class PageDelegateIndex extends PageIndex {
     }
 
     @Override
-    public boolean canFindNext() {
-        return false;
-    }
-
-    @Override
     public boolean canGetFirstOrLast() {
         return true;
     }
@@ -82,11 +77,6 @@ public class PageDelegateIndex extends PageIndex {
         }
         cursor.next();
         return cursor;
-    }
-
-    @Override
-    public Cursor findNext(Session session, SearchRow higherThan, SearchRow last) {
-        throw DbException.throwInternalError(toString());
     }
 
     @Override

--- a/h2/src/main/org/h2/pagestore/db/ScanIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/ScanIndex.java
@@ -174,16 +174,6 @@ public class ScanIndex extends BaseIndex {
     }
 
     @Override
-    public boolean canGetFirstOrLast() {
-        return false;
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        throw DbException.getUnsupportedException("SCAN");
-    }
-
-    @Override
     public long getRowCountApproximation() {
         return rowCount;
     }

--- a/h2/src/main/org/h2/pagestore/db/SpatialTreeIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/SpatialTreeIndex.java
@@ -212,23 +212,6 @@ public class SpatialTreeIndex extends BaseIndex implements SpatialIndex {
     }
 
     @Override
-    public boolean canGetFirstOrLast() {
-        return true;
-    }
-
-    @Override
-    public Cursor findFirstOrLast(Session session, boolean first) {
-        if (closed) {
-            throw DbException.throwInternalError(toString());
-        }
-        if (!first) {
-            throw DbException.throwInternalError(
-                    "Spatial Index can only be fetch by ascending order");
-        }
-        return find(session);
-    }
-
-    @Override
     public long getRowCount(Session session) {
         return treeMap.sizeAsLong();
     }

--- a/h2/src/main/org/h2/pagestore/db/SpatialTreeIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/SpatialTreeIndex.java
@@ -158,16 +158,7 @@ public class SpatialTreeIndex extends BaseIndex implements SpatialIndex {
     }
 
     @Override
-    public Cursor find(TableFilter filter, SearchRow first, SearchRow last) {
-        return find(filter.getSession());
-    }
-
-    @Override
     public Cursor find(Session session, SearchRow first, SearchRow last) {
-        return find(session);
-    }
-
-    private Cursor find(Session session) {
         return new SpatialCursor(treeMap.keySet().iterator(), table, session);
     }
 

--- a/h2/src/main/org/h2/pagestore/db/TreeIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/TreeIndex.java
@@ -294,16 +294,7 @@ public class TreeIndex extends BaseIndex {
     }
 
     @Override
-    public Cursor find(TableFilter filter, SearchRow first, SearchRow last) {
-        return find(first, last);
-    }
-
-    @Override
     public Cursor find(Session session, SearchRow first, SearchRow last) {
-        return find(first, last);
-    }
-
-    private Cursor find(SearchRow first, SearchRow last) {
         if (first == null) {
             TreeNode x = root, n;
             while (x != null) {

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -1201,11 +1201,6 @@ public class TestTableEngines extends TestDb {
                 }
 
                 @Override
-                public Cursor findFirstOrLast(Session session, boolean first) {
-                    throw DbException.getUnsupportedException("TEST");
-                }
-
-                @Override
                 public Cursor find(Session session, SearchRow first, SearchRow last) {
                     throw DbException.getUnsupportedException("TEST");
                 }
@@ -1213,11 +1208,6 @@ public class TestTableEngines extends TestDb {
                 @Override
                 public void close(Session session) {
                     // do nothing
-                }
-
-                @Override
-                public boolean canGetFirstOrLast() {
-                    return false;
                 }
 
                 @Override

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/max.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/max.sql
@@ -34,3 +34,36 @@ select max(v), max(v) filter (where v <= 8) from test;
 
 drop table test;
 > ok
+
+CREATE TABLE TEST(ID INT PRIMARY KEY, V INT) AS VALUES (1, 1), (2, NULL), (3, 5);
+> ok
+
+CREATE INDEX TEST_IDX ON TEST(V NULLS LAST);
+> ok
+
+EXPLAIN SELECT MAX(V) FROM TEST;
+>> SELECT MAX("V") FROM "PUBLIC"."TEST" /* PUBLIC.TEST_IDX */ /* direct lookup */
+
+SELECT MAX(V) FROM TEST;
+>> 5
+
+DROP TABLE TEST;
+> ok
+
+EXPLAIN SELECT MAX(X) FROM SYSTEM_RANGE(1, 2);
+>> SELECT MAX("X") FROM SYSTEM_RANGE(1, 2) /* range index */ /* direct lookup */
+
+SELECT MAX(X) FROM SYSTEM_RANGE(1, 2, 0);
+> exception STEP_SIZE_MUST_NOT_BE_ZERO
+
+SELECT MAX(X) FROM SYSTEM_RANGE(1, 2);
+>> 2
+
+SELECT MAX(X) FROM SYSTEM_RANGE(2, 1);
+>> null
+
+SELECT MAX(X) FROM SYSTEM_RANGE(1, 2, -1);
+>> null
+
+SELECT MAX(X) FROM SYSTEM_RANGE(2, 1, -1);
+>> 2

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/min.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/min.sql
@@ -34,3 +34,42 @@ select min(v), min(v) filter (where v >= 4) from test;
 
 drop table test;
 > ok
+
+CREATE TABLE TEST(ID INT PRIMARY KEY, V INT);
+> ok
+
+CREATE INDEX TEST_IDX ON TEST(V NULLS FIRST);
+> ok
+
+EXPLAIN SELECT MIN(V) FROM TEST;
+>> SELECT MIN("V") FROM "PUBLIC"."TEST" /* PUBLIC.TEST_IDX */ /* direct lookup */
+
+SELECT MIN(V) FROM TEST;
+>> null
+
+INSERT INTO TEST VALUES (1, 1), (2, NULL), (3, 5);
+> update count: 3
+
+SELECT MIN(V) FROM TEST;
+>> 1
+
+DROP TABLE TEST;
+> ok
+
+EXPLAIN SELECT MIN(X) FROM SYSTEM_RANGE(1, 2);
+>> SELECT MIN("X") FROM SYSTEM_RANGE(1, 2) /* range index */ /* direct lookup */
+
+SELECT MIN(X) FROM SYSTEM_RANGE(1, 2, 0);
+> exception STEP_SIZE_MUST_NOT_BE_ZERO
+
+SELECT MIN(X) FROM SYSTEM_RANGE(1, 2);
+>> 1
+
+SELECT MIN(X) FROM SYSTEM_RANGE(2, 1);
+>> null
+
+SELECT MIN(X) FROM SYSTEM_RANGE(1, 2, -1);
+>> null
+
+SELECT MIN(X) FROM SYSTEM_RANGE(2, 1, -1);
+>> 1


### PR DESCRIPTION
1. Implementations from `BaseIndex` are used when possible to reduce code duplication.

2. `findFirstOrLast()` methods are removed from spatial indexes, they were implemented incorrectly (cursor must be pointed at the first row and not before it) and actually geometries don't have any sane ordering.

3. `MIN` and `MAX` aggregates now can use direct lookups in the range table, old implementation was incorrect and wasn't wired. I decided to fix it and add missing code to make it discoverable by aggregates. New unit tests cover all branches to avoid regressions.