### PR TITLE
Add some additional methods from JDBC 4.2 and return 4.2 as supported version

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -39,7 +39,13 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <asm.version>7.2</asm.version>
+    <jts.version>1.16.1</jts.version>
+    <junit.version>5.5.2</junit.version>
+    <lucene.version>8.2.0</lucene.version>
     <osgi.version>5.0.0</osgi.version>
+    <pgjdbc.version>42.2.8</pgjdbc.version>
+    <servlet.version>4.0.1</servlet.version>
     <slf4j.version>1.7.28</slf4j.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -50,22 +56,22 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <version>${servlet.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
-      <version>8.2.0</version>
+      <version>${lucene.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
-      <version>8.2.0</version>
+      <version>${lucene.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-queryparser</artifactId>
-        <version>8.2.0</version>
+        <version>${lucene.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -85,7 +91,7 @@
     <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
-      <version>1.16.1</version>
+      <version>${jts.version}</version>
     </dependency>
     <!-- END COMPILE DEPENDENCIES !-->
 
@@ -100,19 +106,19 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.8</version>
+      <version>${pgjdbc.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.5.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>7.2</version>
+      <version>${asm.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- END TEST DEPENDENCIES !-->

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -104,9 +104,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -210,7 +210,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.2</version>
         <configuration>
           <archive>
             <manifest>
@@ -247,7 +247,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
+        <version>2.22.2</version>
         <configuration>
           <includes>
             <include>TestAllJunit.java</include>

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -39,8 +39,8 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <osgi.version>4.2.0</osgi.version>
-    <slf4j.version>1.6.0</slf4j.version>
+    <osgi.version>5.0.0</osgi.version>
+    <slf4j.version>1.7.28</slf4j.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.5.jre7</version>
+      <version>42.2.8</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>7.0</version>
+      <version>7.2</version>
       <scope>test</scope>
     </dependency>
     <!-- END TEST DEPENDENCIES !-->

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <version>4.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>

--- a/h2/src/main/org/h2/jdbc/JdbcCallableStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcCallableStatement.java
@@ -19,6 +19,7 @@ import java.sql.Ref;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -1116,6 +1117,38 @@ public class JdbcCallableStatement extends JdbcPreparedStatement implements
     public void setObject(String parameterName, Object x, int targetSqlType,
             int scale) throws SQLException {
         setObject(getIndexForName(parameterName), x, targetSqlType, scale);
+    }
+
+    /**
+     * Sets the value of a parameter. The object is converted, if required, to
+     * the specified data type before sending to the database.
+     * Objects of unknown classes are serialized (on the client side).
+     *
+     * @param parameterName the parameter name
+     * @param x the value, null is allowed
+     * @param targetSqlType the type
+     * @throws SQLException if this object is closed
+     */
+    @Override
+    public void setObject(String parameterName, Object x, SQLType targetSqlType) throws SQLException {
+        setObject(getIndexForName(parameterName), x, targetSqlType);
+    }
+
+    /**
+     * Sets the value of a parameter. The object is converted, if required, to
+     * the specified data type before sending to the database.
+     * Objects of unknown classes are serialized (on the client side).
+     *
+     * @param parameterName the parameter name
+     * @param x the value, null is allowed
+     * @param targetSqlType the type
+     * @param scaleOrLength is ignored
+     * @throws SQLException if this object is closed
+     */
+    @Override
+    public void setObject(String parameterName, Object x, SQLType targetSqlType, int scaleOrLength)
+            throws SQLException {
+        setObject(getIndexForName(parameterName), x, targetSqlType, scaleOrLength);
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -3064,12 +3064,12 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     /**
      * Gets the minor version of the supported JDBC API.
      *
-     * @return the minor version (1)
+     * @return the minor version (2)
      */
     @Override
     public int getJDBCMinorVersion() {
         debugCodeCall("getJDBCMinorVersion");
-        return 1;
+        return 2;
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -20,6 +20,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.sql.SQLXML;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -533,13 +534,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setObject("+parameterIndex+", x, "+targetSqlType+");");
             }
-            int type = DataType.convertSQLTypeToValueType(targetSqlType);
-            if (x == null) {
-                setParameter(parameterIndex, ValueNull.INSTANCE);
-            } else {
-                Value v = DataType.convertToValue(conn.getSession(), x, type);
-                setParameter(parameterIndex, v.convertTo(type, conn, false));
-            }
+            setObjectWithType(parameterIndex, x, DataType.convertSQLTypeToValueType(targetSqlType));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -563,9 +558,64 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setObject("+parameterIndex+", x, "+targetSqlType+", "+scale+");");
             }
-            setObject(parameterIndex, x, targetSqlType);
+            setObjectWithType(parameterIndex, x, DataType.convertSQLTypeToValueType(targetSqlType));
         } catch (Exception e) {
             throw logAndConvert(e);
+        }
+    }
+
+    /**
+     * Sets the value of a parameter. The object is converted, if required, to
+     * the specified data type before sending to the database.
+     * Objects of unknown classes are serialized (on the client side).
+     *
+     * @param parameterIndex the parameter index (1, 2, ...)
+     * @param x the value, null is allowed
+     * @param targetSqlType the SQL type
+     * @throws SQLException if this object is closed
+     */
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+        try {
+            if (isDebugEnabled()) {
+                debugCode("setObject(" + parameterIndex + ", x, " + DataType.sqlTypeToString(targetSqlType) + ");");
+            }
+            setObjectWithType(parameterIndex, x, DataType.convertSQLTypeToValueType(targetSqlType));
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
+    }
+
+    /**
+     * Sets the value of a parameter. The object is converted, if required, to
+     * the specified data type before sending to the database.
+     * Objects of unknown classes are serialized (on the client side).
+     *
+     * @param parameterIndex the parameter index (1, 2, ...)
+     * @param x the value, null is allowed
+     * @param targetSqlType the SQL type
+     * @param scaleOrLength is ignored
+     * @throws SQLException if this object is closed
+     */
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
+        try {
+            if (isDebugEnabled()) {
+                debugCode("setObject(" + parameterIndex + ", x, " + DataType.sqlTypeToString(targetSqlType) + ", "
+                        + scaleOrLength + ");");
+            }
+            setObjectWithType(parameterIndex, x, DataType.convertSQLTypeToValueType(targetSqlType));
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
+    }
+
+    private void setObjectWithType(int parameterIndex, Object x, int type) {
+        if (x == null) {
+            setParameter(parameterIndex, ValueNull.INSTANCE);
+        } else {
+            Value v = DataType.convertToValue(conn.getSession(), x, type);
+            setParameter(parameterIndex, v.convertTo(type, conn, false));
         }
     }
 

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -20,6 +20,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Statement;
@@ -2220,6 +2221,92 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
     }
 
     /**
+     * Updates a column in the current or insert row.
+     *
+     * @param columnIndex (1,2,...)
+     * @param x the value
+     * @param targetSqlType the SQL type
+     * @throws SQLException if the result set is closed or not updatable
+     */
+    @Override
+    public void updateObject(int columnIndex, Object x, SQLType targetSqlType) throws SQLException {
+        try {
+            if (isDebugEnabled()) {
+                debugCode("updateObject(" + columnIndex + ", x, " + DataType.sqlTypeToString(targetSqlType) + ");");
+            }
+            update(columnIndex, convertToValue(x, targetSqlType));
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
+    }
+
+    /**
+     * Updates a column in the current or insert row.
+     *
+     * @param columnIndex (1,2,...)
+     * @param x the value
+     * @param targetSqlType the SQL type
+     * @param scaleOrLength is ignored
+     * @throws SQLException if the result set is closed or not updatable
+     */
+    @Override
+    public void updateObject(int columnIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
+        try {
+            if (isDebugEnabled()) {
+                debugCode("updateObject(" + columnIndex + ", x, " + DataType.sqlTypeToString(targetSqlType) + ", "
+                        + scaleOrLength + ");");
+            }
+            update(columnIndex, convertToValue(x, targetSqlType));
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
+    }
+
+    /**
+     * Updates a column in the current or insert row.
+     *
+     * @param columnLabel the column label
+     * @param x the value
+     * @param targetSqlType the SQL type
+     * @throws SQLException if the result set is closed or not updatable
+     */
+    @Override
+    public void updateObject(String columnLabel, Object x, SQLType targetSqlType) throws SQLException {
+        try {
+            if (isDebugEnabled()) {
+                debugCode("updateObject(" + quote(columnLabel) + ", x, " + DataType.sqlTypeToString(targetSqlType)
+                        + ");");
+            }
+            update(columnLabel, convertToValue(x, targetSqlType));
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
+    }
+
+    /**
+     * Updates a column in the current or insert row.
+     *
+     * @param columnLabel the column label
+     * @param x the value
+     * @param targetSqlType the SQL type
+     * @param scaleOrLength is ignored
+     * @throws SQLException if the result set is closed or not updatable
+     */
+    @Override
+    public void updateObject(String columnLabel, Object x, SQLType targetSqlType, int scaleOrLength)
+            throws SQLException {
+        try {
+            if (isDebugEnabled()) {
+                debugCode("updateObject(" + quote(columnLabel) + ", x, " + DataType.sqlTypeToString(targetSqlType)
+                        + ", " + scaleOrLength + ");");
+            }
+            update(columnLabel, convertToValue(x, targetSqlType));
+        } catch (Exception e) {
+            throw logAndConvert(e);
+        }
+    }
+
+    /**
      * [Not supported]
      */
     @Override
@@ -3974,6 +4061,17 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             patchedRows.remove(rowId);
         } else {
             patchedRows.put(rowId, row);
+        }
+    }
+
+    private Value convertToValue(Object x, SQLType targetSqlType) {
+        checkClosed();
+        if (x == null) {
+            return ValueNull.INSTANCE;
+        } else {
+            int type = DataType.convertSQLTypeToValueType(targetSqlType);
+            Value v = DataType.convertToValue(conn.getSession(), x, type);
+            return v.convertTo(type, conn, false);
         }
     }
 

--- a/h2/src/main/org/h2/util/OsgiDataSourceFactory.java
+++ b/h2/src/main/org/h2/util/OsgiDataSourceFactory.java
@@ -7,6 +7,7 @@ package org.h2.util;
 
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.util.Hashtable;
 import java.util.Properties;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
@@ -288,7 +289,7 @@ public class OsgiDataSourceFactory implements DataSourceFactory {
      */
     static void registerService(BundleContext bundleContext,
             org.h2.Driver driver) {
-        Properties properties = new Properties();
+        Hashtable<String, String> properties = new Hashtable<>();
         properties.put(
                 DataSourceFactory.OSGI_JDBC_DRIVER_CLASS,
                 org.h2.Driver.class.getName());

--- a/h2/src/test/org/h2/test/TestAllJunit.java
+++ b/h2/src/test/org/h2/test/TestAllJunit.java
@@ -5,7 +5,7 @@
  */
 package org.h2.test;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class is a bridge between JUnit and the custom test framework

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -421,7 +421,7 @@ public class TestMetaData extends TestDb {
                 meta.getDriverMinorVersion());
         int majorVersion = 4;
         assertEquals(majorVersion, meta.getJDBCMajorVersion());
-        assertEquals(1, meta.getJDBCMinorVersion());
+        assertEquals(2, meta.getJDBCMinorVersion());
         assertEquals("H2", meta.getDatabaseProductName());
         assertEquals(Connection.TRANSACTION_READ_COMMITTED,
                 meta.getDefaultTransactionIsolation());

--- a/h2/src/test/org/h2/test/unit/TestServlet.java
+++ b/h2/src/test/org/h2/test/unit/TestServlet.java
@@ -342,6 +342,41 @@ public class TestServlet extends TestDb {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public ServletRegistration.Dynamic addJspFile(String servletName, String jspFile) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getSessionTimeout() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setSessionTimeout(int sessionTimeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getRequestCharacterEncoding() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setRequestCharacterEncoding(String encoding) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getResponseCharacterEncoding() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setResponseCharacterEncoding(String encoding) {
+            throw new UnsupportedOperationException();
+        }
+
     }
 
     @Override

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -380,9 +380,9 @@ public class Build extends BuildBase {
         downloadOrVerify("ext/jts-core-1.16.1.jar",
                 "org/locationtech/jts", "jts-core", "1.16.1",
                 "c4922e3566568f49a9219b9f9ece9049ee994c50", offline);
-        downloadOrVerify("ext/junit-4.12.jar",
-                "junit", "junit", "4.12",
-                "2973d150c0dc1fefe998f834810d68f278ea58ec", offline);
+        downloadOrVerify("ext/junit-jupiter-api-5.5.2.jar",
+                "org.junit.jupiter", "junit-jupiter-api", "5.5.2",
+                "6393db7e4c0265152d8fc4ff146633d1a7d36c47", offline);
         downloadUsingMaven("ext/asm-7.2.jar",
                 "org.ow2.asm", "asm", "7.2",
                 "fa637eb67eb7628c915d73762b681ae7ff0b9731");
@@ -674,7 +674,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
                 File.pathSeparator + "ext/asm-7.2.jar" +
-                File.pathSeparator + "ext/junit-4.12.jar",
+                File.pathSeparator + "ext/junit-jupiter-api-5.5.2.jar",
                 "-subpackages", "org.h2");
 
         mkdir("docs/javadocImpl3");
@@ -709,7 +709,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
                 File.pathSeparator + "ext/asm-7.2.jar" +
-                File.pathSeparator + "ext/junit-4.12.jar",
+                File.pathSeparator + "ext/junit-jupiter-api-5.5.2.jar",
                 "-subpackages", "org.h2",
                 "-package",
                 "-docletpath", "bin" + File.pathSeparator + "temp",

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -185,11 +185,11 @@ public class Build extends BuildBase {
             File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
             File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
             File.pathSeparator + "ext/h2mig_pagestore_addon.jar" +
-            File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
-            File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
+            File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
+            File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
             File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-            File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
-            File.pathSeparator + "ext/slf4j-nop-1.6.0.jar" +
+            File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
+            File.pathSeparator + "ext/slf4j-nop-1.7.28.jar" +
             File.pathSeparator + javaToolsJar;
         // Run tests
         execJava(args(
@@ -265,9 +265,9 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
-                File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
+                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
+                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
                 File.pathSeparator + "ext/asm-7.2.jar" +
                 File.pathSeparator + javaToolsJar;
@@ -368,15 +368,15 @@ public class Build extends BuildBase {
         downloadOrVerify("ext/lucene-queryparser-8.2.0.jar",
                 "org/apache/lucene", "lucene-queryparser", "8.2.0",
                 "8925df7b104e78e308e236ff0740a064dd93cadd", offline);
-        downloadOrVerify("ext/slf4j-api-1.6.0.jar",
-                "org/slf4j", "slf4j-api", "1.6.0",
-                "b353147a7d51fcfcd818d8aa6784839783db0915", offline);
-        downloadOrVerify("ext/org.osgi.core-4.2.0.jar",
-                "org/osgi", "org.osgi.core", "4.2.0",
-                "66ab449ff3aa5c4adfc82c89025cc983b422eb95", offline);
-        downloadOrVerify("ext/org.osgi.enterprise-4.2.0.jar",
-                "org/osgi", "org.osgi.enterprise", "4.2.0",
-                "8634dcb0fc62196e820ed0f1062993c377f74972", offline);
+        downloadOrVerify("ext/slf4j-api-1.7.28.jar",
+                "org/slf4j", "slf4j-api", "1.7.28",
+                "2cd9b264f76e3d087ee21bfc99305928e1bdb443", offline);
+        downloadOrVerify("ext/org.osgi.core-5.0.0.jar",
+                "org/osgi", "org.osgi.core", "5.0.0",
+                "6e5e8cd3c9059c08e1085540442a490b59a7783c", offline);
+        downloadOrVerify("ext/org.osgi.enterprise-5.0.0.jar",
+                "org/osgi", "org.osgi.enterprise", "5.0.0",
+                "4f6e081c38b951204e2b6a60d33ab0a90bfa1ad3", offline);
         downloadOrVerify("ext/jts-core-1.16.1.jar",
                 "org/locationtech/jts", "jts-core", "1.16.1",
                 "c4922e3566568f49a9219b9f9ece9049ee994c50", offline);
@@ -416,9 +416,9 @@ public class Build extends BuildBase {
                 "org.postgresql", "postgresql", "42.2.8",
                 "6f394c7df5600d11b221f356ff020440d2ece44f");
         // for TestTraceSystem
-        downloadUsingMaven("ext/slf4j-nop-1.6.0.jar",
-                "org/slf4j", "slf4j-nop", "1.6.0",
-                "4da67bb4a6eea5dc273f99c50ad2333eadb46f86");
+        downloadUsingMaven("ext/slf4j-nop-1.7.28.jar",
+                "org/slf4j", "slf4j-nop", "1.7.28",
+                "e427e2f69d0a8508994e0a754a44d5212fa38b56");
     }
 
     private static String getVersion() {
@@ -665,13 +665,13 @@ public class Build extends BuildBase {
                 "-tag", "h2.resource",
                 "-d", "docs/javadocImpl2",
                 "-classpath", javaToolsJar +
-                File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
+                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
                 File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
+                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
                 File.pathSeparator + "ext/asm-7.2.jar" +
                 File.pathSeparator + "ext/junit-jupiter-api-5.5.2.jar",
@@ -683,13 +683,13 @@ public class Build extends BuildBase {
                 "-tag", "h2.resource",
                 "-d", "docs/javadocImpl3",
                 "-classpath", javaToolsJar +
-                File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
+                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
                 File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
+                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar",
                 "-subpackages", "org.h2.mvstore",
                 "-exclude", "org.h2.mvstore.db");
@@ -700,13 +700,13 @@ public class Build extends BuildBase {
                 File.pathSeparator + "src/test" +
                 File.pathSeparator + "src/tools",
                 "-classpath", javaToolsJar +
-                File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
+                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
                 File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
+                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
                 File.pathSeparator + "ext/asm-7.2.jar" +
                 File.pathSeparator + "ext/junit-jupiter-api-5.5.2.jar",
@@ -966,11 +966,11 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
                 File.pathSeparator + "ext/h2mig_pagestore_addon.jar" +
-                File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
+                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-                File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
-                File.pathSeparator + "ext/slf4j-nop-1.6.0.jar" +
+                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
+                File.pathSeparator + "ext/slf4j-nop-1.7.28.jar" +
                 File.pathSeparator + "ext/asm-7.2.jar" +
                 File.pathSeparator + javaToolsJar;
         int version = getJavaVersion();

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -59,9 +59,9 @@ public class Build extends BuildBase {
         downloadUsingMaven("ext/derbynet-10.10.1.1.jar",
                 "org/apache/derby", "derbynet", "10.10.1.1",
                 "912b08dca73663d4665e09cd317be1218412d93e");
-        downloadUsingMaven("ext/postgresql-42.2.5.jre7",
-                "org.postgresql", "postgresql", "42.2.5.jre7",
-                "ec74f6f7885b7e791f84c7219a97964e9d0121e4");
+        downloadUsingMaven("ext/postgresql-42.2.8",
+                "org.postgresql", "postgresql", "42.2.8",
+                "6f394c7df5600d11b221f356ff020440d2ece44f");
         downloadUsingMaven("ext/mysql-connector-java-5.1.6.jar",
                 "mysql", "mysql-connector-java", "5.1.6",
                 "380ef5226de2c85ff3b38cbfefeea881c5fce09d");
@@ -74,7 +74,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/derby-10.10.1.1.jar" +
                 File.pathSeparator + "ext/derbyclient-10.10.1.1.jar" +
                 File.pathSeparator + "ext/derbynet-10.10.1.1.jar" +
-                File.pathSeparator + "ext/postgresql-42.2.5.jre7" +
+                File.pathSeparator + "ext/postgresql-42.2.8" +
                 File.pathSeparator + "ext/mysql-connector-java-5.1.6.jar";
         StringList args = args("-Xmx128m",
                 "-cp", cp, "org.h2.test.bench.TestPerformance");
@@ -136,10 +136,10 @@ public class Build extends BuildBase {
     public void coverage() {
         compile();
         downloadTest();
-        downloadUsingMaven("ext/org.jacoco.agent-0.8.2.jar",
-                "org.jacoco", "org.jacoco.agent", "0.8.2",
-                "1402427761df5c7601ff6e06280764833ed727b5");
-        try (ZipFile zipFile = new ZipFile(new File("ext/org.jacoco.agent-0.8.2.jar"))) {
+        downloadUsingMaven("ext/org.jacoco.agent-0.8.5.jar",
+                "org.jacoco", "org.jacoco.agent", "0.8.5",
+                "0fd03a8ab78af3dd03b27647067efa72690d4922");
+        try (ZipFile zipFile = new ZipFile(new File("ext/org.jacoco.agent-0.8.5.jar"))) {
             final Enumeration<? extends ZipEntry> e = zipFile.entries();
             while (e.hasMoreElements()) {
                 final ZipEntry zipEntry = e.nextElement();
@@ -154,21 +154,21 @@ public class Build extends BuildBase {
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
-        downloadUsingMaven("ext/org.jacoco.cli-0.8.2.jar",
-                "org.jacoco", "org.jacoco.cli", "0.8.2",
-                "9595c53358d0306900183b5a7e6a70c88171ab4c");
-        downloadUsingMaven("ext/org.jacoco.core-0.8.2.jar",
-                "org.jacoco", "org.jacoco.core", "0.8.2",
-                "977b33afe2344a9ee801fd3317c54d8e1f9d7a79");
-        downloadUsingMaven("ext/org.jacoco.report-0.8.2.jar",
-                "org.jacoco", "org.jacoco.report", "0.8.2",
-                "50e133cdfd2d31ca5702b73615be70f801d3ae26");
-        downloadUsingMaven("ext/asm-commons-7.0.jar",
-                "org.ow2.asm", "asm-commons", "7.0",
-                "478006d07b7c561ae3a92ddc1829bca81ae0cdd1");
-        downloadUsingMaven("ext/asm-tree-7.0.jar",
-                "org.ow2.asm", "asm-tree", "7.0",
-                "29bc62dcb85573af6e62e5b2d735ef65966c4180");
+        downloadUsingMaven("ext/org.jacoco.cli-0.8.5.jar",
+                "org.jacoco", "org.jacoco.cli", "0.8.5",
+                "30155fcd37821879264365693055290dbfe984bb");
+        downloadUsingMaven("ext/org.jacoco.core-0.8.5.jar",
+                "org.jacoco", "org.jacoco.core", "0.8.5",
+                "1ac96769aa83e5492d1a1a694774f6baec4eb704");
+        downloadUsingMaven("ext/org.jacoco.report-0.8.5.jar",
+                "org.jacoco", "org.jacoco.report", "0.8.5",
+                "421e4aab2aaa809d1e66a96feb11f61ea698da19");
+        downloadUsingMaven("ext/asm-commons-7.2.jar",
+                "org.ow2.asm", "asm-commons", "7.2",
+                "ca2954e8d92a05bacc28ff465b25c70e0f512497");
+        downloadUsingMaven("ext/asm-tree-7.2.jar",
+                "org.ow2.asm", "asm-tree", "7.2",
+                "3a23cc36edaf8fc5a89cb100182758ccb5991487");
         downloadUsingMaven("ext/args4j-2.33.jar",
                 "args4j", "args4j", "2.33",
                 "bd87a75374a6d6523de82fef51fc3cfe9baf9fc9");
@@ -179,7 +179,7 @@ public class Build extends BuildBase {
         // JaCoCo does not support multiple versions of the same classes
         delete(files("coverage/bin/META-INF/versions"));
         String cp = "coverage/bin" +
-            File.pathSeparator + "ext/postgresql-42.2.5.jre7" +
+            File.pathSeparator + "ext/postgresql-42.2.8" +
             File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
             File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
             File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
@@ -204,12 +204,12 @@ public class Build extends BuildBase {
         delete(files("coverage/bin/org/h2/sample"));
         // Generate report
         execJava(args("-cp",
-                "ext/org.jacoco.cli-0.8.2.jar" + File.pathSeparator
-                + "ext/org.jacoco.core-0.8.2.jar" + File.pathSeparator
-                + "ext/org.jacoco.report-0.8.2.jar" + File.pathSeparator
-                + "ext/asm-7.0.jar" + File.pathSeparator
-                + "ext/asm-commons-7.0.jar" + File.pathSeparator
-                + "ext/asm-tree-7.0.jar" + File.pathSeparator
+                "ext/org.jacoco.cli-0.8.5.jar" + File.pathSeparator
+                + "ext/org.jacoco.core-0.8.5.jar" + File.pathSeparator
+                + "ext/org.jacoco.report-0.8.5.jar" + File.pathSeparator
+                + "ext/asm-7.2.jar" + File.pathSeparator
+                + "ext/asm-commons-7.2.jar" + File.pathSeparator
+                + "ext/asm-tree-7.2.jar" + File.pathSeparator
                 + "ext/args4j-2.33.jar",
                 "org.jacoco.cli.internal.Main", "report", "coverage/jacoco.exec",
                 "--classfiles", "coverage/bin",
@@ -269,7 +269,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-                File.pathSeparator + "ext/asm-7.0.jar" +
+                File.pathSeparator + "ext/asm-7.2.jar" +
                 File.pathSeparator + javaToolsJar;
         FileList files;
         if (clientOnly) {
@@ -383,9 +383,9 @@ public class Build extends BuildBase {
         downloadOrVerify("ext/junit-4.12.jar",
                 "junit", "junit", "4.12",
                 "2973d150c0dc1fefe998f834810d68f278ea58ec", offline);
-        downloadUsingMaven("ext/asm-7.0.jar",
-                "org.ow2.asm", "asm", "7.0",
-                "d74d4ba0dee443f68fb2dcb7fcdb945a2cd89912");
+        downloadUsingMaven("ext/asm-7.2.jar",
+                "org.ow2.asm", "asm", "7.2",
+                "fa637eb67eb7628c915d73762b681ae7ff0b9731");
     }
 
     private void downloadOrVerify(String target, String group, String artifact,
@@ -412,9 +412,9 @@ public class Build extends BuildBase {
                 "com/h2database", "h2", "1.2.127",
                 "056e784c7cf009483366ab9cd8d21d02fe47031a");
         // for TestPgServer
-        downloadUsingMaven("ext/postgresql-42.2.5.jre7.jar",
-                "org.postgresql", "postgresql", "42.2.5.jre7",
-                "ec74f6f7885b7e791f84c7219a97964e9d0121e4");
+        downloadUsingMaven("ext/postgresql-42.2.8.jar",
+                "org.postgresql", "postgresql", "42.2.8",
+                "6f394c7df5600d11b221f356ff020440d2ece44f");
         // for TestTraceSystem
         downloadUsingMaven("ext/slf4j-nop-1.6.0.jar",
                 "org/slf4j", "slf4j-nop", "1.6.0",
@@ -673,7 +673,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-                File.pathSeparator + "ext/asm-7.0.jar" +
+                File.pathSeparator + "ext/asm-7.2.jar" +
                 File.pathSeparator + "ext/junit-4.12.jar",
                 "-subpackages", "org.h2");
 
@@ -708,7 +708,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/org.osgi.core-4.2.0.jar" +
                 File.pathSeparator + "ext/org.osgi.enterprise-4.2.0.jar" +
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-                File.pathSeparator + "ext/asm-7.0.jar" +
+                File.pathSeparator + "ext/asm-7.2.jar" +
                 File.pathSeparator + "ext/junit-4.12.jar",
                 "-subpackages", "org.h2",
                 "-package",
@@ -960,7 +960,7 @@ public class Build extends BuildBase {
     private void test(boolean travis) {
         downloadTest();
         String cp = "temp" + File.pathSeparator + "bin" +
-                File.pathSeparator + "ext/postgresql-42.2.5.jre7.jar" +
+                File.pathSeparator + "ext/postgresql-42.2.8.jar" +
                 File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
@@ -971,7 +971,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/jts-core-1.16.1.jar" +
                 File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
                 File.pathSeparator + "ext/slf4j-nop-1.6.0.jar" +
-                File.pathSeparator + "ext/asm-7.0.jar" +
+                File.pathSeparator + "ext/asm-7.2.jar" +
                 File.pathSeparator + javaToolsJar;
         int version = getJavaVersion();
         if (version >= 9) {

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -31,6 +31,28 @@ import org.h2.build.doc.XMLParser;
  */
 public class Build extends BuildBase {
 
+    private static final String ASM_VERSION = "7.2";
+
+    private static final String ARGS4J_VERSION = "2.33";
+
+    private static final String JACOCO_VERSION = "0.8.5";
+
+    private static final String JTS_VERSION = "1.16.1";
+
+    private static final String JUNIT_VERSION = "5.5.2";
+
+    private static final String LUCENE_VERSION = "8.2.0";
+
+    private static final String OSGI_VERSION = "5.0.0";
+
+    private static final String PGJDBC_VERSION = "42.2.8";
+
+    private static final String PGJDBC_HASH = "6f394c7df5600d11b221f356ff020440d2ece44f";
+
+    private static final String SERVLET_VERSION = "4.0.1";
+
+    private static final String SLF4J_VERSION = "1.7.28";
+
     private boolean filesMissing;
 
     /**
@@ -59,9 +81,8 @@ public class Build extends BuildBase {
         downloadUsingMaven("ext/derbynet-10.10.1.1.jar",
                 "org/apache/derby", "derbynet", "10.10.1.1",
                 "912b08dca73663d4665e09cd317be1218412d93e");
-        downloadUsingMaven("ext/postgresql-42.2.8",
-                "org.postgresql", "postgresql", "42.2.8",
-                "6f394c7df5600d11b221f356ff020440d2ece44f");
+        downloadUsingMaven("ext/postgresql-" + PGJDBC_VERSION,
+                "org.postgresql", "postgresql", PGJDBC_VERSION, PGJDBC_HASH);
         downloadUsingMaven("ext/mysql-connector-java-5.1.6.jar",
                 "mysql", "mysql-connector-java", "5.1.6",
                 "380ef5226de2c85ff3b38cbfefeea881c5fce09d");
@@ -74,7 +95,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/derby-10.10.1.1.jar" +
                 File.pathSeparator + "ext/derbyclient-10.10.1.1.jar" +
                 File.pathSeparator + "ext/derbynet-10.10.1.1.jar" +
-                File.pathSeparator + "ext/postgresql-42.2.8" +
+                File.pathSeparator + "ext/postgresql-" + PGJDBC_VERSION +
                 File.pathSeparator + "ext/mysql-connector-java-5.1.6.jar";
         StringList args = args("-Xmx128m",
                 "-cp", cp, "org.h2.test.bench.TestPerformance");
@@ -136,10 +157,10 @@ public class Build extends BuildBase {
     public void coverage() {
         compile();
         downloadTest();
-        downloadUsingMaven("ext/org.jacoco.agent-0.8.5.jar",
-                "org.jacoco", "org.jacoco.agent", "0.8.5",
+        downloadUsingMaven("ext/org.jacoco.agent-" + JACOCO_VERSION + ".jar",
+                "org.jacoco", "org.jacoco.agent", JACOCO_VERSION,
                 "0fd03a8ab78af3dd03b27647067efa72690d4922");
-        try (ZipFile zipFile = new ZipFile(new File("ext/org.jacoco.agent-0.8.5.jar"))) {
+        try (ZipFile zipFile = new ZipFile(new File("ext/org.jacoco.agent-" + JACOCO_VERSION + ".jar"))) {
             final Enumeration<? extends ZipEntry> e = zipFile.entries();
             while (e.hasMoreElements()) {
                 final ZipEntry zipEntry = e.nextElement();
@@ -154,23 +175,23 @@ public class Build extends BuildBase {
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
-        downloadUsingMaven("ext/org.jacoco.cli-0.8.5.jar",
-                "org.jacoco", "org.jacoco.cli", "0.8.5",
+        downloadUsingMaven("ext/org.jacoco.cli-" + JACOCO_VERSION + ".jar",
+                "org.jacoco", "org.jacoco.cli", JACOCO_VERSION,
                 "30155fcd37821879264365693055290dbfe984bb");
-        downloadUsingMaven("ext/org.jacoco.core-0.8.5.jar",
-                "org.jacoco", "org.jacoco.core", "0.8.5",
+        downloadUsingMaven("ext/org.jacoco.core-" + JACOCO_VERSION + ".jar",
+                "org.jacoco", "org.jacoco.core", JACOCO_VERSION,
                 "1ac96769aa83e5492d1a1a694774f6baec4eb704");
-        downloadUsingMaven("ext/org.jacoco.report-0.8.5.jar",
-                "org.jacoco", "org.jacoco.report", "0.8.5",
+        downloadUsingMaven("ext/org.jacoco.report-" + JACOCO_VERSION + ".jar",
+                "org.jacoco", "org.jacoco.report", JACOCO_VERSION,
                 "421e4aab2aaa809d1e66a96feb11f61ea698da19");
-        downloadUsingMaven("ext/asm-commons-7.2.jar",
-                "org.ow2.asm", "asm-commons", "7.2",
+        downloadUsingMaven("ext/asm-commons-" + ASM_VERSION + ".jar",
+                "org.ow2.asm", "asm-commons", ASM_VERSION,
                 "ca2954e8d92a05bacc28ff465b25c70e0f512497");
-        downloadUsingMaven("ext/asm-tree-7.2.jar",
-                "org.ow2.asm", "asm-tree", "7.2",
+        downloadUsingMaven("ext/asm-tree-" + ASM_VERSION + ".jar",
+                "org.ow2.asm", "asm-tree", ASM_VERSION,
                 "3a23cc36edaf8fc5a89cb100182758ccb5991487");
-        downloadUsingMaven("ext/args4j-2.33.jar",
-                "args4j", "args4j", "2.33",
+        downloadUsingMaven("ext/args4j-" + ARGS4J_VERSION + ".jar",
+                "args4j", "args4j", ARGS4J_VERSION,
                 "bd87a75374a6d6523de82fef51fc3cfe9baf9fc9");
 
         delete(files("coverage"));
@@ -179,17 +200,17 @@ public class Build extends BuildBase {
         // JaCoCo does not support multiple versions of the same classes
         delete(files("coverage/bin/META-INF/versions"));
         String cp = "coverage/bin" +
-            File.pathSeparator + "ext/postgresql-42.2.8" +
-            File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
-            File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
-            File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
-            File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
+            File.pathSeparator + "ext/postgresql-" + PGJDBC_VERSION +
+            File.pathSeparator + "ext/javax.servlet-api-" + SERVLET_VERSION + ".jar" +
+            File.pathSeparator + "ext/lucene-core-" + LUCENE_VERSION + ".jar" +
+            File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
+            File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
             File.pathSeparator + "ext/h2mig_pagestore_addon.jar" +
-            File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
-            File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
-            File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-            File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
-            File.pathSeparator + "ext/slf4j-nop-1.7.28.jar" +
+            File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
+            File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+            File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
+            File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
+            File.pathSeparator + "ext/slf4j-nop-" + SLF4J_VERSION + ".jar" +
             File.pathSeparator + javaToolsJar;
         // Run tests
         execJava(args(
@@ -204,13 +225,13 @@ public class Build extends BuildBase {
         delete(files("coverage/bin/org/h2/sample"));
         // Generate report
         execJava(args("-cp",
-                "ext/org.jacoco.cli-0.8.5.jar" + File.pathSeparator
-                + "ext/org.jacoco.core-0.8.5.jar" + File.pathSeparator
-                + "ext/org.jacoco.report-0.8.5.jar" + File.pathSeparator
-                + "ext/asm-7.2.jar" + File.pathSeparator
-                + "ext/asm-commons-7.2.jar" + File.pathSeparator
-                + "ext/asm-tree-7.2.jar" + File.pathSeparator
-                + "ext/args4j-2.33.jar",
+                "ext/org.jacoco.cli-" + JACOCO_VERSION + ".jar" + File.pathSeparator
+                + "ext/org.jacoco.core-" + JACOCO_VERSION + ".jar" + File.pathSeparator
+                + "ext/org.jacoco.report-" + JACOCO_VERSION + ".jar" + File.pathSeparator
+                + "ext/asm-" + ASM_VERSION + ".jar" + File.pathSeparator
+                + "ext/asm-commons-" + ASM_VERSION + ".jar" + File.pathSeparator
+                + "ext/asm-tree-" + ASM_VERSION + ".jar" + File.pathSeparator
+                + "ext/args4j-" + ARGS4J_VERSION + ".jar",
                 "org.jacoco.cli.internal.Main", "report", "coverage/jacoco.exec",
                 "--classfiles", "coverage/bin",
                 "--html", "coverage/report", "--sourcefiles", "h2/src/main"));
@@ -261,15 +282,15 @@ public class Build extends BuildBase {
         mkdir("temp");
         download();
         String classpath = "temp" +
-                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
-                File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
-                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
-                File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-                File.pathSeparator + "ext/asm-7.2.jar" +
+                File.pathSeparator + "ext/javax.servlet-api-" + SERVLET_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-core-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
+                File.pathSeparator + "ext/asm-" + ASM_VERSION + ".jar" +
                 File.pathSeparator + javaToolsJar;
         FileList files;
         if (clientOnly) {
@@ -356,35 +377,35 @@ public class Build extends BuildBase {
     }
 
     private void downloadOrVerify(boolean offline) {
-        downloadOrVerify("ext/javax.servlet-api-4.0.1.jar",
-                "javax/servlet", "javax.servlet-api", "4.0.1",
+        downloadOrVerify("ext/javax.servlet-api-" + SERVLET_VERSION + ".jar",
+                "javax/servlet", "javax.servlet-api", SERVLET_VERSION,
                 "a27082684a2ff0bf397666c3943496c44541d1ca", offline);
-        downloadOrVerify("ext/lucene-core-8.2.0.jar",
-                "org/apache/lucene", "lucene-core", "8.2.0",
+        downloadOrVerify("ext/lucene-core-" + LUCENE_VERSION + ".jar",
+                "org/apache/lucene", "lucene-core", LUCENE_VERSION,
                 "f6da40436d3633de272810fae1e339c237adfcf6", offline);
-        downloadOrVerify("ext/lucene-analyzers-common-8.2.0.jar",
-                "org/apache/lucene", "lucene-analyzers-common", "8.2.0",
+        downloadOrVerify("ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar",
+                "org/apache/lucene", "lucene-analyzers-common", LUCENE_VERSION,
                 "8e8abc90572ed74b110c75b546c675153aecc570", offline);
-        downloadOrVerify("ext/lucene-queryparser-8.2.0.jar",
-                "org/apache/lucene", "lucene-queryparser", "8.2.0",
+        downloadOrVerify("ext/lucene-queryparser-" + LUCENE_VERSION + ".jar",
+                "org/apache/lucene", "lucene-queryparser", LUCENE_VERSION,
                 "8925df7b104e78e308e236ff0740a064dd93cadd", offline);
-        downloadOrVerify("ext/slf4j-api-1.7.28.jar",
-                "org/slf4j", "slf4j-api", "1.7.28",
+        downloadOrVerify("ext/slf4j-api-" + SLF4J_VERSION + ".jar",
+                "org/slf4j", "slf4j-api", SLF4J_VERSION,
                 "2cd9b264f76e3d087ee21bfc99305928e1bdb443", offline);
-        downloadOrVerify("ext/org.osgi.core-5.0.0.jar",
-                "org/osgi", "org.osgi.core", "5.0.0",
+        downloadOrVerify("ext/org.osgi.core-" + OSGI_VERSION + ".jar",
+                "org/osgi", "org.osgi.core", OSGI_VERSION,
                 "6e5e8cd3c9059c08e1085540442a490b59a7783c", offline);
-        downloadOrVerify("ext/org.osgi.enterprise-5.0.0.jar",
-                "org/osgi", "org.osgi.enterprise", "5.0.0",
+        downloadOrVerify("ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar",
+                "org/osgi", "org.osgi.enterprise", OSGI_VERSION,
                 "4f6e081c38b951204e2b6a60d33ab0a90bfa1ad3", offline);
-        downloadOrVerify("ext/jts-core-1.16.1.jar",
-                "org/locationtech/jts", "jts-core", "1.16.1",
+        downloadOrVerify("ext/jts-core-" + JTS_VERSION + ".jar",
+                "org/locationtech/jts", "jts-core", JTS_VERSION,
                 "c4922e3566568f49a9219b9f9ece9049ee994c50", offline);
-        downloadOrVerify("ext/junit-jupiter-api-5.5.2.jar",
-                "org.junit.jupiter", "junit-jupiter-api", "5.5.2",
+        downloadOrVerify("ext/junit-jupiter-api-" + JUNIT_VERSION + ".jar",
+                "org.junit.jupiter", "junit-jupiter-api", JUNIT_VERSION,
                 "6393db7e4c0265152d8fc4ff146633d1a7d36c47", offline);
-        downloadUsingMaven("ext/asm-7.2.jar",
-                "org.ow2.asm", "asm", "7.2",
+        downloadUsingMaven("ext/asm-" + ASM_VERSION + ".jar",
+                "org.ow2.asm", "asm", ASM_VERSION,
                 "fa637eb67eb7628c915d73762b681ae7ff0b9731");
     }
 
@@ -412,12 +433,11 @@ public class Build extends BuildBase {
                 "com/h2database", "h2", "1.2.127",
                 "056e784c7cf009483366ab9cd8d21d02fe47031a");
         // for TestPgServer
-        downloadUsingMaven("ext/postgresql-42.2.8.jar",
-                "org.postgresql", "postgresql", "42.2.8",
-                "6f394c7df5600d11b221f356ff020440d2ece44f");
+        downloadUsingMaven("ext/postgresql-" + PGJDBC_VERSION + ".jar",
+                "org.postgresql", "postgresql", PGJDBC_VERSION, PGJDBC_HASH);
         // for TestTraceSystem
-        downloadUsingMaven("ext/slf4j-nop-1.7.28.jar",
-                "org/slf4j", "slf4j-nop", "1.7.28",
+        downloadUsingMaven("ext/slf4j-nop-" + SLF4J_VERSION + ".jar",
+                "org/slf4j", "slf4j-nop", SLF4J_VERSION,
                 "e427e2f69d0a8508994e0a754a44d5212fa38b56");
     }
 
@@ -639,10 +659,10 @@ public class Build extends BuildBase {
         javadoc("-sourcepath", "src/main", "org.h2.jdbc", "org.h2.jdbcx",
                 "org.h2.tools", "org.h2.api", "org.h2.engine", "org.h2.fulltext",
                 "-classpath",
-                "ext/lucene-core-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/jts-core-1.16.1.jar",
+                "ext/lucene-core-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar",
                 "-docletpath", "bin" + File.pathSeparator + "temp",
                 "-doclet", "org.h2.build.doclet.Doclet");
         copy("docs/javadoc", files("src/docsrc/javadoc"), "src/docsrc/javadoc");
@@ -665,16 +685,16 @@ public class Build extends BuildBase {
                 "-tag", "h2.resource",
                 "-d", "docs/javadocImpl2",
                 "-classpath", javaToolsJar +
-                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
-                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
-                File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
-                File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-                File.pathSeparator + "ext/asm-7.2.jar" +
-                File.pathSeparator + "ext/junit-jupiter-api-5.5.2.jar",
+                File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
+                File.pathSeparator + "ext/javax.servlet-api-" + SERVLET_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-core-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
+                File.pathSeparator + "ext/asm-" + ASM_VERSION + ".jar" +
+                File.pathSeparator + "ext/junit-jupiter-api-" + JUNIT_VERSION + ".jar",
                 "-subpackages", "org.h2");
 
         mkdir("docs/javadocImpl3");
@@ -683,14 +703,14 @@ public class Build extends BuildBase {
                 "-tag", "h2.resource",
                 "-d", "docs/javadocImpl3",
                 "-classpath", javaToolsJar +
-                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
-                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
-                File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
-                File.pathSeparator + "ext/jts-core-1.16.1.jar",
+                File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
+                File.pathSeparator + "ext/javax.servlet-api-" + SERVLET_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-core-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar",
                 "-subpackages", "org.h2.mvstore",
                 "-exclude", "org.h2.mvstore.db");
 
@@ -700,16 +720,16 @@ public class Build extends BuildBase {
                 File.pathSeparator + "src/test" +
                 File.pathSeparator + "src/tools",
                 "-classpath", javaToolsJar +
-                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
-                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
-                File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
-                File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-                File.pathSeparator + "ext/asm-7.2.jar" +
-                File.pathSeparator + "ext/junit-jupiter-api-5.5.2.jar",
+                File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
+                File.pathSeparator + "ext/javax.servlet-api-" + SERVLET_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-core-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
+                File.pathSeparator + "ext/asm-" + ASM_VERSION + ".jar" +
+                File.pathSeparator + "ext/junit-jupiter-api-" + JUNIT_VERSION + ".jar",
                 "-subpackages", "org.h2",
                 "-package",
                 "-docletpath", "bin" + File.pathSeparator + "temp",
@@ -908,10 +928,10 @@ public class Build extends BuildBase {
             java("org.h2.build.doc.GenerateHelp", null);
             javadoc("-sourcepath", "src/main", "org.h2.tools", "org.h2.jmx",
                     "-classpath",
-                    "ext/lucene-core-8.2.0.jar" +
-                    File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
-                    File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
-                    File.pathSeparator + "ext/jts-core-1.16.1.jar",
+                    "ext/lucene-core-" + LUCENE_VERSION + ".jar" +
+                    File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
+                    File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
+                    File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar",
                     "-docletpath", "bin" + File.pathSeparator + "temp",
                     "-doclet", "org.h2.build.doclet.ResourceDoclet");
         }
@@ -960,18 +980,18 @@ public class Build extends BuildBase {
     private void test(boolean travis) {
         downloadTest();
         String cp = "temp" + File.pathSeparator + "bin" +
-                File.pathSeparator + "ext/postgresql-42.2.8.jar" +
-                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
-                File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
-                File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
+                File.pathSeparator + "ext/postgresql-" + PGJDBC_VERSION + ".jar" +
+                File.pathSeparator + "ext/javax.servlet-api-" + SERVLET_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-core-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
+                File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/h2mig_pagestore_addon.jar" +
-                File.pathSeparator + "ext/org.osgi.core-5.0.0.jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-5.0.0.jar" +
-                File.pathSeparator + "ext/jts-core-1.16.1.jar" +
-                File.pathSeparator + "ext/slf4j-api-1.7.28.jar" +
-                File.pathSeparator + "ext/slf4j-nop-1.7.28.jar" +
-                File.pathSeparator + "ext/asm-7.2.jar" +
+                File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
+                File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
+                File.pathSeparator + "ext/slf4j-nop-" + SLF4J_VERSION + ".jar" +
+                File.pathSeparator + "ext/asm-" + ASM_VERSION + ".jar" +
                 File.pathSeparator + javaToolsJar;
         int version = getJavaVersion();
         if (version >= 9) {

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -180,7 +180,7 @@ public class Build extends BuildBase {
         delete(files("coverage/bin/META-INF/versions"));
         String cp = "coverage/bin" +
             File.pathSeparator + "ext/postgresql-42.2.8" +
-            File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
+            File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
             File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
             File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
             File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
@@ -261,7 +261,7 @@ public class Build extends BuildBase {
         mkdir("temp");
         download();
         String classpath = "temp" +
-                File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
+                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
@@ -356,9 +356,9 @@ public class Build extends BuildBase {
     }
 
     private void downloadOrVerify(boolean offline) {
-        downloadOrVerify("ext/servlet-api-3.1.0.jar",
-                "javax/servlet", "javax.servlet-api", "3.1.0",
-                "3cd63d075497751784b2fa84be59432f4905bf7c", offline);
+        downloadOrVerify("ext/javax.servlet-api-4.0.1.jar",
+                "javax/servlet", "javax.servlet-api", "4.0.1",
+                "a27082684a2ff0bf397666c3943496c44541d1ca", offline);
         downloadOrVerify("ext/lucene-core-8.2.0.jar",
                 "org/apache/lucene", "lucene-core", "8.2.0",
                 "f6da40436d3633de272810fae1e339c237adfcf6", offline);
@@ -666,7 +666,7 @@ public class Build extends BuildBase {
                 "-d", "docs/javadocImpl2",
                 "-classpath", javaToolsJar +
                 File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
-                File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
+                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
@@ -684,7 +684,7 @@ public class Build extends BuildBase {
                 "-d", "docs/javadocImpl3",
                 "-classpath", javaToolsJar +
                 File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
-                File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
+                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
@@ -701,7 +701,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "src/tools",
                 "-classpath", javaToolsJar +
                 File.pathSeparator + "ext/slf4j-api-1.6.0.jar" +
-                File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
+                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +
@@ -961,7 +961,7 @@ public class Build extends BuildBase {
         downloadTest();
         String cp = "temp" + File.pathSeparator + "bin" +
                 File.pathSeparator + "ext/postgresql-42.2.8.jar" +
-                File.pathSeparator + "ext/servlet-api-3.1.0.jar" +
+                File.pathSeparator + "ext/javax.servlet-api-4.0.1.jar" +
                 File.pathSeparator + "ext/lucene-core-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-analyzers-common-8.2.0.jar" +
                 File.pathSeparator + "ext/lucene-queryparser-8.2.0.jar" +


### PR DESCRIPTION
1. `setObject()` / `updateObject()` methods with `java.sql.SQLType` are now supported. (Support for our own vendor-specific data types is not introduced here).

2. Driver now reports 4.2 as its JDBC version. Many methods from JDBC 4.2 and some from JDBC 4.3 were available in recent releases, but now with (1) we can announce JDBC 4.2 compatibility more or less safely.

3. JaCoCo code coverage and ASM (also used in unit tests) are upgraded to their recent versions, ASM 7.2 should support Java versions up to 14.

4. Java 8 version of PostgreSQL's driver is now used in tests.

5. servlet-api is updated to 4.0.1, but compatibility of our web servlet isn't changed.

6. JUnit is updated to JUnit 5. We don't really use it (only in experimental Maven build), but it's better to have JUnit 5 in the classpath to have the possibility to launch the third-party JUnit 5 tests in the same project in IDE.