### PR TITLE
Meta table extras

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2046,6 +2046,41 @@ public class MVStore implements AutoCloseable
         return fillRate;
     }
 
+    /**
+     * Get data chunks count.
+     *
+     * @return number of existing chunks in store.
+     */
+    public int getChunkCount() {
+        return chunks.size();
+    }
+
+    /**
+     * Get data pages count.
+     *
+     * @return number of existing pages in store.
+     */
+    public int getPageCount() {
+        int count = 0;
+        for (Chunk chunk : chunks.values()) {
+            count += chunk.pageCount;
+        }
+        return count;
+    }
+
+    /**
+     * Get live data pages count.
+     *
+     * @return number of existing live pages in store.
+     */
+    public int getLivePageCount() {
+        int count = 0;
+        for (Chunk chunk : chunks.values()) {
+            count += chunk.pageCountLive;
+        }
+        return count;
+    }
+
     private int getProjectedFillRate() {
         int vacatedBlocks = 0;
         long maxLengthSum = 1;

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1164,14 +1164,10 @@ public class MetaTable extends Table {
                                 Integer.toString(mvStore.getFillRate()));
                         add(rows, "info.CHUNKS_FILL_RATE",
                                 Integer.toString(mvStore.getChunksFillRate()));
-                        long size;
                         try {
-                            size = fs.getFile().size();
-                        } catch (IOException e) {
-                            throw DbException.convertIOException(e, "Can not get size");
-                        }
-                        add(rows, "info.FILE_SIZE",
-                                Long.toString(size));
+                            add(rows, "info.FILE_SIZE",
+                                    Long.toString(fs.getFile().size()));
+                        } catch (IOException ignore) {/**/}
                         add(rows, "info.CHUNK_COUNT",
                                 Long.toString(mvStore.getChunkCount()));
                         add(rows, "info.PAGE_COUNT",

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1149,28 +1149,44 @@ public class MetaTable extends Table {
                 if (store != null) {
                     MVStore mvStore = store.getMvStore();
                     FileStore fs = mvStore.getFileStore();
-                    add(rows, "info.FILE_WRITE",
-                            Long.toString(fs.getWriteCount()));
-                    add(rows, "info.FILE_READ",
-                            Long.toString(fs.getReadCount()));
-                    add(rows, "info.UPDATE_FAILURE_PERCENT",
-                            String.format(Locale.ENGLISH, "%.2f%%", 100 * mvStore.getUpdateFailureRatio()));
-                    long size;
-                    try {
-                        size = fs.getFile().size();
-                    } catch (IOException e) {
-                        throw DbException.convertIOException(e, "Can not get size");
+                    if (fs != null) {
+                        add(rows, "info.FILE_WRITE",
+                                Long.toString(fs.getWriteCount()));
+                        add(rows, "info.FILE_WRITE_BYTES",
+                                Long.toString(fs.getWriteBytes()));
+                        add(rows, "info.FILE_READ",
+                                Long.toString(fs.getReadCount()));
+                        add(rows, "info.FILE_READ_BYTES",
+                                Long.toString(fs.getReadBytes()));
+                        add(rows, "info.UPDATE_FAILURE_PERCENT",
+                                String.format(Locale.ENGLISH, "%.2f%%", 100 * mvStore.getUpdateFailureRatio()));
+                        add(rows, "info.FILL_RATE",
+                                Integer.toString(mvStore.getFillRate()));
+                        add(rows, "info.CHUNKS_FILL_RATE",
+                                Integer.toString(mvStore.getChunksFillRate()));
+                        long size;
+                        try {
+                            size = fs.getFile().size();
+                        } catch (IOException e) {
+                            throw DbException.convertIOException(e, "Can not get size");
+                        }
+                        add(rows, "info.FILE_SIZE",
+                                Long.toString(size));
+                        add(rows, "info.CHUNK_COUNT",
+                                Long.toString(mvStore.getChunkCount()));
+                        add(rows, "info.PAGE_COUNT",
+                                Long.toString(mvStore.getPageCount()));
+                        add(rows, "info.PAGE_COUNT_LIVE",
+                                Long.toString(mvStore.getLivePageCount()));
+                        add(rows, "info.PAGE_SIZE",
+                                Integer.toString(mvStore.getPageSplitSize()));
+                        add(rows, "info.CACHE_MAX_SIZE",
+                                Integer.toString(mvStore.getCacheSize()));
+                        add(rows, "info.CACHE_SIZE",
+                                Integer.toString(mvStore.getCacheSizeUsed()));
+                        add(rows, "info.CACHE_HIT_RATIO",
+                                Integer.toString(mvStore.getCacheHitRatio()));
                     }
-                    int pageSize = 4 * 1024;
-                    long pageCount = size / pageSize;
-                    add(rows, "info.PAGE_COUNT",
-                            Long.toString(pageCount));
-                    add(rows, "info.PAGE_SIZE",
-                            Integer.toString(mvStore.getPageSplitSize()));
-                    add(rows, "info.CACHE_MAX_SIZE",
-                            Integer.toString(mvStore.getCacheSize()));
-                    add(rows, "info.CACHE_SIZE",
-                            Integer.toString(mvStore.getCacheSizeUsed()));
                 }
             }
             break;

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -203,7 +203,7 @@ public class TestMVTableEngine extends TestDb {
             rs.next();
             int pages = rs.getInt(2);
             // only one lob should remain (but it is small and compressed)
-            assertTrue("p:" + pages, pages < 4);
+            assertTrue("p:" + pages, pages < 7);
         }
     }
 


### PR DESCRIPTION
This PR adds a few rows to INFORMATION_SCHEMA.SETTINGS meta-table - info.FILE_READ_BYTES, info.FILE_WRITE_BYTES to show amount of data in I/O requests,
info.FILL_RATE, info.CHUNKS_FILL_RATE to display occupancy rates for database file, and for seasoned chunks available for compaction, info.CACHE_HIT_RATIO, info.CHUNK_COUNT. Row info.PAGE_COUNT will show actual number of data pages in the store, as opose to number of occupied 4K blocks.