### PR TITLE
Fix TRACE_LEVEL_FILE=4 for in-memory databases

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -591,6 +591,13 @@ public class Database implements DataHandler, CastDataProvider {
                 : dbSettings.databaseToLower ? StringUtils.toLowerEnglish(n) : n;
     }
 
+    private void initTraceSystem(int traceLevelFile, int traceLevelSystemOut)  {
+        traceSystem.setLevelFile(traceLevelFile);
+        traceSystem.setLevelSystemOut(traceLevelSystemOut);
+        trace = traceSystem.getTrace(Trace.DATABASE);
+        trace.info("opening {0} (build {1})", databaseName, Constants.BUILD_ID);
+    }
+
     private synchronized void open(int traceLevelFile, int traceLevelSystemOut, ConnectionInfo ci) {
         if (persistent) {
             String dataFileName = databaseName + Constants.SUFFIX_OLD_DATABASE_FILE;
@@ -628,10 +635,7 @@ public class Database implements DataHandler, CastDataProvider {
                 traceSystem = new TraceSystem(databaseName +
                         Constants.SUFFIX_TRACE_FILE);
             }
-            traceSystem.setLevelFile(traceLevelFile);
-            traceSystem.setLevelSystemOut(traceLevelSystemOut);
-            trace = traceSystem.getTrace(Trace.DATABASE);
-            trace.info("opening {0} (build {1})", databaseName, Constants.BUILD_ID);
+            initTraceSystem(traceLevelFile, traceLevelSystemOut);
             if (autoServerMode) {
                 if (readOnly ||
                         fileLockMethod == FileLockMethod.NO ||
@@ -676,12 +680,12 @@ public class Database implements DataHandler, CastDataProvider {
             }
             starting = false;
         } else {
+            traceSystem = new TraceSystem(null);
+            initTraceSystem(traceLevelFile, traceLevelSystemOut);
             if (autoServerMode) {
                 throw DbException.getUnsupportedException(
                         "autoServerMode && inMemory");
             }
-            traceSystem = new TraceSystem(null);
-            trace = traceSystem.getTrace(Trace.DATABASE);
             if (dbSettings.mvStore) {
                 getPageStore();
             }


### PR DESCRIPTION
The DBA sessions for ephemeral databases don't get the trace level settings propagated to them which can lead to inconsistent tracing for those sessions.