### PR TITLE
Add FileChannel.lock in the connection URL summary

### DIFF
--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -287,7 +287,7 @@ This is achieved using different database URLs. Settings in the URLs are not cas
 <tr>
     <td><a href="#database_file_locking">File locking methods</a></td>
     <td class="notranslate">
-        jdbc:h2:&lt;url&gt;;FILE_LOCK={FILE|SOCKET|NO}<br />
+        jdbc:h2:&lt;url&gt;;FILE_LOCK={FILE|SOCKET|FS|NO}<br />
         jdbc:h2:file:~/private;CIPHER=AES;FILE_LOCK=SOCKET<br />
     </td>
 </tr>


### PR DESCRIPTION
FileChannel.lock (FS) wasn't mentioned in the connection URL summary table.