### PR TITLE
do not retry failed DDL commands

### DIFF
--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -298,10 +298,7 @@ public abstract class Command implements CommandInterface {
     }
 
     private long filterConcurrentUpdate(DbException e, long start) {
-        int errorCode = e.getErrorCode();
-        if (errorCode != ErrorCode.CONCURRENT_UPDATE_1 &&
-                errorCode != ErrorCode.ROW_NOT_FOUND_IN_PRIMARY_INDEX &&
-                errorCode != ErrorCode.ROW_NOT_FOUND_WHEN_DELETING_1) {
+        if (!isConcurrentUpdateCode(e)) {
             throw e;
         }
         long now = System.nanoTime();
@@ -327,6 +324,16 @@ public abstract class Command implements CommandInterface {
             }
         }
         return start == 0 ? now : start;
+    }
+    
+    /**
+     * Is this one of the error codes that will trigger a retry in the 
+     * executeUpdate loop?
+     */
+    public static boolean isConcurrentUpdateCode(DbException e) {
+        int errorCode = e.getErrorCode();
+        return errorCode == ErrorCode.CONCURRENT_UPDATE_1 || errorCode == ErrorCode.ROW_NOT_FOUND_IN_PRIMARY_INDEX
+                || errorCode == ErrorCode.ROW_NOT_FOUND_WHEN_DELETING_1;
     }
 
     @Override

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import org.h2.api.ErrorCode;
+import org.h2.command.Command;
 import org.h2.command.CommandInterface;
 import org.h2.constraint.Constraint;
 import org.h2.constraint.ConstraintActionType;
@@ -83,6 +84,11 @@ public class AlterTableAddConstraint extends SchemaCommand {
                 }
             } catch (Throwable ex) {
                 e.addSuppressed(ex);
+            }
+            if (Command.isConcurrentUpdateCode(e)) {
+                // Avoid re-trying this command when it hits the filterConcurrentUpdate
+                // call in CommandContainer#executeUpdate.
+                throw DbException.get(ErrorCode.GENERAL_ERROR_1, e);                
             }
             throw e;
         } finally {

--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -8,6 +8,7 @@ package org.h2.command.ddl;
 import java.util.ArrayList;
 import java.util.HashSet;
 import org.h2.api.ErrorCode;
+import org.h2.command.Command;
 import org.h2.command.CommandInterface;
 import org.h2.command.dml.Insert;
 import org.h2.command.dml.Query;
@@ -178,6 +179,11 @@ public class CreateTable extends CommandWithColumns {
                 }
             } catch (Throwable ex) {
                 e.addSuppressed(ex);
+            }
+            if (Command.isConcurrentUpdateCode(e)) {
+                // Avoid re-trying this command when it hits the filterConcurrentUpdate
+                // call in CommandContainer#executeUpdate.
+                throw DbException.get(ErrorCode.GENERAL_ERROR_1, e);                
             }
             throw e;
         }


### PR DESCRIPTION
failed DDL commands sometimes generate errors which trigger the looping logic in Command, which results in hiding the underlying error