### PR TITLE
Populate meta with NEW objects even during startup

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -949,8 +949,14 @@ public class Database implements DataHandler, CastDataProvider {
                     if (!cursor.next()) {
                         meta.addRow(session, r);
                     } else {
+                        assert starting;
                         Row oldRow = cursor.get();
-                        meta.updateRow(session, oldRow, r);
+                        MetaRecord rec = new MetaRecord(oldRow);
+                        assert rec.getId() == obj.getId();
+                        assert rec.getObjectType() == obj.getType();
+                        if (!rec.getSQL().equals(obj.getCreateSQL())) {
+                            meta.updateRow(session, oldRow, r);
+                        }
                     }
                 }
             } else if (!starting) {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -938,18 +938,20 @@ public class Database implements DataHandler, CastDataProvider {
         int id = obj.getId();
         if (id > 0 && !obj.isTemporary()) {
             if (isMVStore()) {
-                Row r = meta.getTemplateRow();
-                MetaRecord.populateRowFromDBObject(obj, r);
-                assert objectIds.get(id);
-                if (SysProperties.CHECK) {
-                    verifyMetaLocked(session);
-                }
-                Cursor cursor = metaIdIndex.find(session, r, r);
-                if (!cursor.next()) {
-                    meta.addRow(session, r);
-                } else {
-                    Row oldRow = cursor.get();
-                    meta.updateRow(session, oldRow, r);
+                if (!isReadOnly()) {
+                    Row r = meta.getTemplateRow();
+                    MetaRecord.populateRowFromDBObject(obj, r);
+                    assert objectIds.get(id);
+                    if (SysProperties.CHECK) {
+                        verifyMetaLocked(session);
+                    }
+                    Cursor cursor = metaIdIndex.find(session, r, r);
+                    if (!cursor.next()) {
+                        meta.addRow(session, r);
+                    } else {
+                        Row oldRow = cursor.get();
+                        meta.updateRow(session, oldRow, r);
+                    }
                 }
             } else if (!starting) {
                 Row r = meta.getTemplateRow();

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -944,8 +944,12 @@ public class Database implements DataHandler, CastDataProvider {
                 if (SysProperties.CHECK) {
                     verifyMetaLocked(session);
                 }
-                if (!metaIdIndex.find(session, r, r).next()) {
+                Cursor cursor = metaIdIndex.find(session, r, r);
+                if (!cursor.next()) {
                     meta.addRow(session, r);
+                } else {
+                    Row oldRow = cursor.get();
+                    meta.updateRow(session, oldRow, r);
                 }
             } else if (!starting) {
                 Row r = meta.getTemplateRow();

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -966,7 +966,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
     }
 
     /**
-     * Register table as updated within current transaction.
+     * Register table as locked within current transaction.
      * Table is unlocked on commit or rollback.
      * It also assumes that table will be modified by transaction.
      *

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2765,7 +2765,7 @@ public class MVStore implements AutoCloseable
         if(id > 0) {
             MVMap<?, ?> map = getMap(id);
             if (map == null) {
-                map = openMap(name);
+                map = openMap(name, MVStoreTool.getGenericMapBuilder());
             }
             removeMap(map);
         }

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -710,9 +710,9 @@ public class MVStoreTool {
      * A data type that can read any data that is persisted, and converts it to
      * a byte array.
      */
-    static class GenericDataType implements DataType
+    private static class GenericDataType implements DataType
     {
-        public static GenericDataType INSTANCE = new GenericDataType();
+        static GenericDataType INSTANCE = new GenericDataType();
 
         private GenericDataType() {}
 

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -543,10 +543,7 @@ public class MVStoreTool {
             // created in the process, especially if retention time
             // is set to a lower value, or even 0.
             for (String mapName : source.getMapNames()) {
-                MVMap.Builder<Object, Object> mp =
-                        new MVMap.Builder<>().
-                                keyType(new GenericDataType()).
-                                valueType(new GenericDataType());
+                MVMap.Builder<Object, Object> mp = getGenericMapBuilder();
                 // This is a hack to preserve chunks occupancy rate accounting.
                 // It exposes design deficiency flaw in MVStore related to lack of
                 // map's type metadata.
@@ -703,11 +700,21 @@ public class MVStoreTool {
         return newestVersion;
     }
 
+    static MVMap.Builder<Object, Object> getGenericMapBuilder() {
+        return new MVMap.Builder<>().
+                keyType(GenericDataType.INSTANCE).
+                valueType(GenericDataType.INSTANCE);
+    }
+
     /**
      * A data type that can read any data that is persisted, and converts it to
      * a byte array.
      */
-    static class GenericDataType implements DataType {
+    static class GenericDataType implements DataType
+    {
+        public static GenericDataType INSTANCE = new GenericDataType();
+
+        private GenericDataType() {}
 
         @Override
         public int compare(Object a, Object b) {

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -292,7 +292,6 @@ public class MVTableEngine implements TableEngine {
                 } else if (mapName.startsWith("table.") || mapName.startsWith("index.")) {
                     int id = StringUtils.parseUInt31(mapName, mapName.indexOf('.') + 1, mapName.length());
                     if (!objectIds.get(id)) {
-                        mvStore.openMap(mapName, new MVMap.Builder<>().keyType(new ValueDataType()).valueType(new ValueDataType()));
                         mvStore.removeMap(mapName);
                     }
                 }

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -23,7 +23,6 @@ import org.h2.engine.Session;
 import org.h2.message.DbException;
 import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.FileStore;
-import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.MVStoreTool;
 import org.h2.mvstore.tx.Transaction;

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -23,6 +23,7 @@ import org.h2.engine.Session;
 import org.h2.message.DbException;
 import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.FileStore;
+import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.MVStoreTool;
 import org.h2.mvstore.tx.Transaction;
@@ -291,6 +292,7 @@ public class MVTableEngine implements TableEngine {
                 } else if (mapName.startsWith("table.") || mapName.startsWith("index.")) {
                     int id = StringUtils.parseUInt31(mapName, mapName.indexOf('.') + 1, mapName.length());
                     if (!objectIds.get(id)) {
+                        mvStore.openMap(mapName, new MVMap.Builder<>().keyType(new ValueDataType()).valueType(new ValueDataType()));
                         mvStore.removeMap(mapName);
                     }
                 }


### PR DESCRIPTION
This is a fix  for #2157. 
THe root cause is faulty startup logic . Flag Database.starting is used to avoid population of meta table SYS, because it wrongfully assume that objects are all already there. This is not the case with automatic index creation for referential integrity constraint. While DbObject is created for the new index, meta table is not populated, which causes lookup failure later.