### PR TITLE
Update some hyperlinks and use https in them where possible

### DIFF
--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -924,7 +924,7 @@ An implementation of the ADO.NET interface is available in the open source proje
 <h3>Using the JDBC API on .NET</h3>
 <ul><li>Install the .NET Framework from <a href="https://www.microsoft.com">Microsoft</a>.
     Mono has not yet been tested.
-</li><li>Install <a href="http://www.ikvm.net">IKVM.NET</a>.
+</li><li>Install <a href="https://www.ikvm.net">IKVM.NET</a>.
 </li><li>Copy the <code>h2*.jar</code> file to <code>ikvm/bin</code>
 </li><li>Run the H2 Console using:
     <code>ikvm -jar h2*.jar</code>

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -57,15 +57,14 @@ To use this database, it is not required to install this software however.
 </p>
 <ul><li>Mac OS X and Windows
 </li><li><a href="https://www.oracle.com/technetwork/java/javase/downloads/index.html">Oracle JDK Version 8</a>
-</li><li><a href="http://www.eclipse.org">Eclipse</a>
+</li><li><a href="https://www.eclipse.org">Eclipse</a>
 </li><li>Eclipse Plugins:
-    <a href="http://subclipse.tigris.org">Subclipse</a>,
     <a href="https://checkstyle.github.io/eclipse-cs/">Eclipse Checkstyle Plug-in</a>,
-    <a href="http://www.eclemma.org">EclEmma Java Code Coverage</a>
+    <a href="https://www.eclemma.org">EclEmma Java Code Coverage</a>
 </li><li><a href="https://www.mozilla.com/firefox">Mozilla Firefox</a>
-</li><li><a href="http://www.openoffice.org">OpenOffice</a>
-</li><li><a href="http://nsis.sourceforge.net">NSIS</a> (Nullsoft Scriptable Install System)
-</li><li><a href="http://maven.apache.org">Maven</a>
+</li><li><a href="https://www.openoffice.org">OpenOffice</a>
+</li><li><a href="https://nsis.sourceforge.net">NSIS</a> (Nullsoft Scriptable Install System)
+</li><li><a href="https://maven.apache.org">Maven</a>
 </li></ul>
 
 <h2 id="building">Building the Software</h2>
@@ -173,7 +172,7 @@ Afterwards, you can include the database in your Maven 2 project as a dependency
 <p>
 To create an Eclipse project for H2, use the following steps:
 </p>
-<ul><li>Install Git and <a href="http://www.eclipse.org">Eclipse</a>.
+<ul><li>Install Git and <a href="https://www.eclipse.org">Eclipse</a>.
 </li><li>Get the H2 source code from Github:<br />
     <code>git clone https://github.com/h2database/h2database</code>
 </li><li>Download all dependencies:<br />
@@ -262,7 +261,7 @@ or if  you have a feature request:
     and the root cause stack trace(s).
 </li><li>When sending source code, please use a public web clipboard such as
     <a href="https://pastebin.com/">Pastebin</a> or
-    <a href="http://www.mysticpaste.com/new">Mystic Paste</a>
+    <a href="https://mysticpaste.com/new">Mystic Paste</a>
     to avoid formatting problems.
     Please keep test cases as simple and short as possible,
     but so that the problem can still be reproduced.
@@ -288,7 +287,7 @@ or if  you have a feature request:
     <code>-XX:+HeapDumpOnOutOfMemoryError</code>
     (to create a heap dump file on out of memory)
     and a memory analysis tool such as the
-    <a href="http://www.eclipse.org/mat">Eclipse Memory Analyzer (MAT)</a>.
+    <a href="https://www.eclipse.org/mat/">Eclipse Memory Analyzer (MAT)</a>.
 </li><li>It may take a few days to get an answers. Please do not double post.
 </li></ul>
 

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -235,7 +235,7 @@ If you'd like to contribute bug fixes or new features, please consider the follo
 <p>
 For legal reasons, patches need to be public in the form of an
     <a href="https://github.com/h2database/h2database/issues">issue report or attachment</a> or in the form of an email
-    to the <a href="https://groups.google.com/group/h2-database">group</a>.
+    to the <a href="https://groups.google.com/forum/#!forum/h2-database">group</a>.
 Significant contributions need to include the following statement:
 </p>
 <p>
@@ -277,7 +277,7 @@ or if  you have a feature request:
     <a href="https://www.google.com/drive/">Google Drive</a>.
 </li><li>Google Group versus issue tracking:
     Use the
-    <a href="http://groups.google.com/group/h2-database">Google Group</a>
+    <a href="https://groups.google.com/forum/#!forum/h2-database">Google Group</a>
     for questions or if you are not sure it's a bug.
     If you are sure it's a bug, you can create an
     <a href="https://github.com/h2database/h2database/issues">issue</a>,

--- a/h2/src/docsrc/html/download-archive.html
+++ b/h2/src/docsrc/html/download-archive.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!--
+Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+and the EPL 1.0 (https://h2database.com/html/license.html).
+Initial Developer: H2 Group
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<head><meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>
+Archive Downloads
+</title>
+<link rel="stylesheet" type="text/css" href="stylesheet.css" />
+<!-- [search] { -->
+<script type="text/javascript" src="navigation.js"></script>
+</head><body onload="frameMe();">
+<table class="content"><tr class="content"><td class="content"><div class="contentDiv">
+<!-- } -->
+
+<h1>Archive Downloads</h1>
+
+<h2>Maven Central</h2>
+
+<p><a href="https://search.maven.org/search?q=g:com.h2database%20AND%20a:h2&core=gav">H2 database</a></p>
+<p><a href="https://search.maven.org/search?q=g:com.h2database%20AND%20a:h2-mvstore&core=gav">MVStore</a></p>
+
+<h2>Distribution</h2>
+
+<table>
+<tbody>
+<tr><td>1.4.200</td>
+<td><a href="https://h2database.com/h2-setup-2019-10-14.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2019-10-14.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.199</td>
+<td><a href="https://h2database.com/h2-setup-2019-03-13.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2019-03-13.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.198</td>
+<td><a href="https://h2database.com/h2-setup-2019-02-22.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2019-02-22.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.197</td>
+<td><a href="https://h2database.com/h2-setup-2018-03-18.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2018-03-18.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.196</td>
+<td><a href="https://h2database.com/h2-setup-2017-06-10.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2017-06-10.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.195</td>
+<td><a href="https://h2database.com/h2-setup-2017-04-23.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2017-04-23.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.194</td>
+<td><a href="https://h2database.com/h2-setup-2017-03-10.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2017-03-10.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.193</td>
+<td><a href="https://h2database.com/h2-setup-2016-10-31.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2016-10-31.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.192</td>
+<td><a href="https://h2database.com/h2-setup-2016-05-26.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2016-05-26.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.191</td>
+<td><a href="https://h2database.com/h2-setup-2016-01-21.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2016-01-21.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.190</td>
+<td><a href="https://h2database.com/h2-setup-2015-10-11.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2015-10-11.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.189</td>
+<td><a href="https://h2database.com/h2-setup-2015-09-13.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2015-09-13.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.188</td>
+<td><a href="https://h2database.com/h2-setup-2015-08-01.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2015-08-01.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.187</td>
+<td><a href="https://h2database.com/h2-setup-2015-04-10.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2015-04-10.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.186</td>
+<td><a href="https://h2database.com/h2-setup-2015-03-02.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2015-03-02.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.185</td>
+<td><a href="https://h2database.com/h2-setup-2015-01-16.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2015-01-16.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.184</td>
+<td><a href="https://h2database.com/h2-setup-2014-12-19.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-12-19.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.183</td>
+<td><a href="https://h2database.com/h2-setup-2014-12-13.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-12-13.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.182</td>
+<td><a href="https://h2database.com/h2-setup-2014-10-17.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-10-17.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.181</td>
+<td><a href="https://h2database.com/h2-setup-2014-08-06.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-08-06.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.180</td>
+<td><a href="https://h2database.com/h2-setup-2014-07-13.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-07-13.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.179</td>
+<td><a href="https://h2database.com/h2-setup-2014-06-23.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-06-23.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.178</td>
+<td><a href="https://h2database.com/h2-setup-2014-05-02.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-05-02.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.177</td>
+<td><a href="https://h2database.com/h2-setup-2014-04-12.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-04-12.zip">Platform-Independent Zip</a></td>
+</tr>
+<tr><td>1.4.176</td>
+<td><a href="https://h2database.com/h2-setup-2014-04-05.exe">Windows Installer</a></td>
+<td><a href="https://h2database.com/h2-2014-04-05.zip">Platform-Independent Zip</a></td>
+</tr>
+</tbody>
+</table>
+
+<h2>Older releases</h2>
+<p>
+<a href="https://code.google.com/archive/p/h2database/downloads">Platform-Independent Zip</a><br />
+</p>
+
+<!-- [close] { --></div></td></tr></table><!-- } --><!-- analytics --></body></html>
+

--- a/h2/src/docsrc/html/download.html
+++ b/h2/src/docsrc/html/download.html
@@ -35,7 +35,7 @@ Downloads
 
 <h3>Old Versions</h3>
 <p>
-<a href="http://code.google.com/p/h2database/downloads/list">Platform-Independent Zip</a><br />
+<a href="https://code.google.com/archive/p/h2database/downloads">Platform-Independent Zip</a><br />
 </p>
 
 <h3>Jar File</h3>
@@ -69,7 +69,7 @@ For details about changes, see the <a href="changelog.html">Change Log</a>.
 <p>
 <a href="https://h2database.com/html/newsfeed-atom.xml">Atom Feed</a><br />
 <a href="https://h2database.com/html/newsfeed-rss.xml">RSS Feed</a><br />
-<a href="https://h2database.com/html/doap-h2.rdf">DOAP File</a> (<a href="http://en.wikipedia.org/wiki/DOAP">what is this</a>)
+<a href="https://h2database.com/html/doap-h2.rdf">DOAP File</a> (<a href="https://en.wikipedia.org/wiki/DOAP">what is this</a>)
 </p>
 
 <!-- [close] { --></div></td></tr></table><!-- } --><!-- analytics --></body></html>

--- a/h2/src/docsrc/html/download.html
+++ b/h2/src/docsrc/html/download.html
@@ -33,9 +33,9 @@ Downloads
 <a href="https://h2database.com/h2-${stableVersionDate}.zip">Platform-Independent Zip</a><br />
 </p>
 
-<h3>Old Versions</h3>
+<h3>Archive Downloads</h3>
 <p>
-<a href="https://code.google.com/archive/p/h2database/downloads">Platform-Independent Zip</a><br />
+<a href="download-archive.html">Archive Downloads</a>
 </p>
 
 <h3>Jar File</h3>

--- a/h2/src/docsrc/html/fragments.html
+++ b/h2/src/docsrc/html/fragments.html
@@ -89,9 +89,7 @@ translate -->
 <b>Support</b><br />
 <a href="faq.html">FAQ</a><br />
 <a href="sourceError.html">Error Analyzer</a><br />
-<a href="https://groups.google.com/group/h2-database">Google Group (English)</a><br />
-<a href="https://groups.google.co.jp/group/h2-database-jp">Google Group (Japanese)</a><br />
-<a href="https://groups.google.com/group/h2-cn">Google Group (Chinese)</a><br />
+<a href="https://groups.google.com/forum/#!forum/h2-database">Google Group</a><br />
 <br />
 <b>Appendix</b><br />
 <a href="history.html">History &amp; Roadmap</a><br />

--- a/h2/src/docsrc/html/history.html
+++ b/h2/src/docsrc/html/history.html
@@ -100,16 +100,16 @@ Donators are:
 <ul>
 <li>Martin Wildam, Austria
 </li><li><a href="http://www.tagtraum.com">tagtraum industries incorporated, USA</a>
-</li><li><a href="http://www.timewriter.com">TimeWriter, Netherlands</a>
-</li><li><a href="http://cognitect.com">Cognitect, USA</a>
-</li><li><a href="http://www.code42.com">Code 42 Software, Inc., Minneapolis</a>
-</li><li><a href="http://www.codelutin.com">Code Lutin, France</a>
+</li><li><a href="https://www.timewriter.com">TimeWriter, Netherlands</a>
+</li><li><a href="https://cognitect.com">Cognitect, USA</a>
+</li><li><a href="https://www.code42.com">Code 42 Software, Inc., Minneapolis</a>
+</li><li><a href="https://www.codelutin.com">Code Lutin, France</a>
 </li><li><a href="http://www.netsuxxess.de">NetSuxxess GmbH, Germany</a>
-</li><li><a href="http://pokercopilot.com">Poker Copilot, Steve McLeod, Germany</a>
-</li><li><a href="http://skycash.com">SkyCash, Poland</a>
-</li><li><a href="http://lumber-mill.co.jp">Lumber-mill, Inc., Japan</a>
-</li><li><a href="http://www.stockmarketeye.com">StockMarketEye, USA</a>
-</li><li><a href="http://www.eckenfelder.de">Eckenfelder GmbH &amp; Co.KG, Germany</a>
+</li><li><a href="https://pokercopilot.com">Poker Copilot, Steve McLeod, Germany</a>
+</li><li><a href="https://www.skycash.com">SkyCash, Poland</a>
+</li><li><a href="https://lumber-mill.co.jp">Lumber-mill, Inc., Japan</a>
+</li><li><a href="https://www.stockmarketeye.com">StockMarketEye, USA</a>
+</li><li><a href="https://www.eckenfelder.de">Eckenfelder GmbH &amp; Co.KG, Germany</a>
 </li><li>Jun Iyama, Japan
 </li><li>Steven Branda, USA
 </li><li>Anthony Goubard, Netherlands
@@ -125,7 +125,7 @@ Donators are:
 </li><li>Elisabetta Berlini, Italy
 </li><li>William Gilbert, USA
 </li><li>Antonio Dieguez Rojas, Chile
-</li><li><a href="http://ontologyworks.com">Ontology Works, USA</a>
+</li><li><a href="https://www.ontologyworks.com">Ontology Works, USA</a>
 </li><li>Pete Haidinyak, USA
 </li><li>William Osmond, USA
 </li><li>Joachim Ansorg, Germany

--- a/h2/src/docsrc/html/license.html
+++ b/h2/src/docsrc/html/license.html
@@ -30,8 +30,8 @@ License
 
 <h2 id="summary">Summary and License FAQ</h2>
 <p>
-H2 is dual licensed and available under the MPL 2.0 (<a href="http://www.mozilla.org/MPL/2.0">Mozilla Public License Version 2.0</a>)
-or under the EPL 1.0  (<a href="http://opensource.org/licenses/eclipse-1.0.php">Eclipse Public License</a>).
+H2 is dual licensed and available under the MPL 2.0 (<a href="https://www.mozilla.org/MPL/2.0">Mozilla Public License Version 2.0</a>)
+or under the EPL 1.0  (<a href="https://opensource.org/licenses/eclipse-1.0.php">Eclipse Public License</a>).
 There is a license FAQ for both the MPL and the EPL.
 </p>
 <ul>
@@ -47,7 +47,7 @@ There is a license FAQ for both the MPL and the EPL.
 However, nobody is allowed to rename H2, modify it a little, and sell it as a database engine without telling the customers it is in fact H2.
 This happened to HSQLDB: a company called 'bungisoft' copied HSQLDB, renamed it to 'RedBase', and tried to sell it,
 hiding the fact that it was in fact just HSQLDB. It seems 'bungisoft' does not exist any more, but you can use the
-<a href="http://www.archive.org">Wayback Machine</a> and visit old web pages of <code>http://www.bungisoft.com</code>.
+<a href="https://archive.org/">Wayback Machine</a> and visit old web pages of <code>http://www.bungisoft.com</code>.
 </p><p>
 About porting the source code to another language (for example C# or C++): converted source code (even if done manually) stays under the same
 copyright and license as the original code. The copyright of the ported source code does not (automatically) go to the person who ported the code.
@@ -158,7 +158,7 @@ https://h2database.com/html/license.html
 <pre>
 This Source Code Form is subject to the terms of the Mozilla
 Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, you can obtain one at http://mozilla.org/MPL/2.0
+with this file, you can obtain one at https://mozilla.org/MPL/2.0
 </pre>
 <p>If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.</p>
 <p>You may add additional accurate notices of copyright ownership.</p>
@@ -395,9 +395,9 @@ to a jury trial in any resulting litigation.
 
 <h2 id="eccn">Export Control Classification Number (ECCN)</h2>
 <p>
-As far as we know, the <a href="http://www.bis.doc.gov/licensing/exportingbasics.htm">U.S. Export Control Classification Number (ECCN)</a> for this software is <code>5D002</code>.
+As far as we know, the <a href="https://www.bis.doc.gov/licensing/exportingbasics.htm">U.S. Export Control Classification Number (ECCN)</a> for this software is <code>5D002</code>.
 However, for legal reasons, we can make no warranty that this information is correct.
-For details, see also the <a href="http://www.apache.org/licenses/exports/">Apache Software Foundation Export Classifications page</a>.
+For details, see also the <a href="https://www.apache.org/licenses/exports/">Apache Software Foundation Export Classifications page</a>.
 </p>
 
 <!-- [close] { --></div></td></tr></table><!-- } --><!-- analytics --></body></html>

--- a/h2/src/docsrc/html/links.html
+++ b/h2/src/docsrc/html/links.html
@@ -36,7 +36,7 @@ If you want to add a link, please send it to the support email address or post i
 
 <h2 id="quotes">Quotes</h2>
 <p>
-<a href="http://groups.google.com/group/h2-database/browse_thread/thread/adee024b8af85931/1edbc4a601146ec6">
+<a href="https://groups.google.com/forum/#!topic/h2-database/re4CS4r4WTE">
 Quote</a>:
 "This is by far the easiest and fastest database that I have ever used.
 Originally the web application that I am working on is using SQL server.

--- a/h2/src/docsrc/html/links.html
+++ b/h2/src/docsrc/html/links.html
@@ -45,34 +45,34 @@ Thanks..... "
 </p>
 
 <h2 id="books">Books</h2>
-<a href="http://code.google.com/p/seaminaction/wiki/GettingStarted">
+<a href="https://code.google.com/archive/p/seaminaction/wikis/GettingStarted.wiki">
 Seam In Action</a>
 
 <h2 id="extensions">Extensions</h2>
-<a href="http://grails.org/H2+Database+Plugin">
+<a href="https://grails.org/plugin/h2">
 Grails H2 Database Plugin</a>
 <br />
-<a href="http://code.google.com/p/h2osgi">
+<a href="https://code.google.com/archive/p/h2osgi/">
 h2osgi: OSGi for the H2 Database</a>
 <br />
-<a href="http://code.google.com/p/h2sharp">
+<a href="https://code.google.com/archive/p/h2sharp/">
 H2Sharp: ADO.NET interface for the H2 database engine</a>
 <br />
 <a href="http://www.h2gis.org">
 A spatial extension of the H2 database.</a>
 
 <h2 id="blog">Blog Articles, Videos</h2>
-<a href="http://www.youtube.com/watch?v=mlWM0r3SKkg">
+<a href="https://www.youtube.com/watch?v=mlWM0r3SKkg">
 Youtube: Minecraft 1.7.3 / How to install Bukkit Server with xAuth and H2</a><br />
 <a href="http://blog.zvikico.com/2009/12/analyzing-csvs-with-h2.html">
 Analyzing CSVs with H2 in under 10 minutes (2009-12-07)</a><br />
-<a href="http://sbdevel.wordpress.com/2009/06/15/efficient-sorting-and-iteration-on-large-databases">
+<a href="https://sbdevel.wordpress.com/2009/06/15/efficient-sorting-and-iteration-on-large-databases/">
 Efficient sorting and iteration on large databases (2009-06-15)</a><br />
 <a href="http://blog.flexive.org/2008/12/05/porting-flexive-to-the-h2-database">
 Porting Flexive to the H2 Database (2008-12-05)</a><br />
 <a href="http://blogs.sun.com/theaquarium/entry/h2_database_with_glassfish">
 H2 Database with GlassFish (2008-11-24)</a><br />
-<a href="http://zvikico.typepad.com/problog/2008/04">
+<a href="https://zvikico.typepad.com/problog/2008/04/">
 H2 Database - Performance Tracing (2008-04-30)</a><br />
 <a href="http://www.encorewiki.org/display/encore/Open+Source+Databases+Comparison">
 Open Source Databases Comparison (2007-09-11)</a><br />
@@ -86,13 +86,13 @@ David Coldrick's Weblog: New Version of H2 Database Released (2007-01-06)</a><br
 The Codist: Write Your Own Database, Again (2006-11-13)</a><br />
 
 <h2>Project Pages</h2>
-<a href="http://www.ohloh.net/projects/3924?p=H2+Database+Engine">
+<a href="https://www.openhub.net/p/3924?p=H2+Database+Engine">
 Ohloh</a><br />
-<a href="http://freshmeat.net/projects/h2">
+<a href="http://freshmeat.sourceforge.net/projects/h2">
 Freshmeat Project Page</a><br />
-<a href="http://en.wikipedia.org/wiki/H2_%28DBMS%29">
+<a href="https://en.wikipedia.org/wiki/H2_%28DBMS%29">
 Wikipedia</a><br />
-<a href="http://java-source.net/open-source/database-engines/h2">
+<a href="https://java-source.net/open-source/database-engines/h2">
 Java Source Net</a><br />
 <a href="http://packman.links2linux.org/package/h2">
 Linux Package Manager</a><br />
@@ -109,7 +109,7 @@ DB Solo</a><br />
 SQL query tool.
 </p>
 
-<p><a href="http://www.dbvis.com">
+<p><a href="https://www.dbvis.com">
 DbVisualizer</a><br />
 Database tool.
 </p>
@@ -119,7 +119,7 @@ Execute Query</a><br />
 Database utility written in Java.
 </p>
 
-<p><a href="http://flywaydb.org">
+<p><a href="https://flywaydb.org">
 Flyway</a><br />
 The agile database migration framework for Java.
 </p>
@@ -140,17 +140,17 @@ HenPlus</a><br />
 HenPlus is a SQL shell written in Java.
 </p>
 
-<p><a href="http://github.com/maginatics/jdbclint">
+<p><a href="https://github.com/maginatics/jdbclint">
 JDBC lint</a><br />
 Helps write correct and efficient code when using the JDBC API.
 </p>
 
-<p><a href="http://www.openoffice.org">
+<p><a href="https://www.openoffice.org">
 OpenOffice</a><br />
 Base is OpenOffice.org's database application. It provides access to relational data sources.
 </p>
 
-<p><a href="http://www.razorsql.com">
+<p><a href="https://www.razorsql.com">
 RazorSQL</a><br />
 An SQL query tool, database browser, SQL editor, and database administration tool.
 </p>
@@ -160,7 +160,7 @@ SQL Developer</a><br />
 Universal Database Frontend.
 </p>
 
-<p><a href="http://sql-workbench.net">
+<p><a href="https://sql-workbench.eu">
 SQL Workbench/J</a><br />
 Free DBMS-independent SQL tool.
 </p>
@@ -170,7 +170,7 @@ SQuirreL SQL Client</a><br />
 Graphical tool to view the structure of a database, browse the data, issue SQL commands etc.
 </p>
 
-<p><a href="http://dbcopyplugin.sf.net">
+<p><a href="http://dbcopyplugin.sourceforge.net/">
 SQuirreL DB Copy Plugin</a><br />
 Tool to copy data from one database to another.
 </p>
@@ -182,7 +182,7 @@ AccuProcess</a><br />
 Visual business process modeling and simulation software for business users.
 </p>
 
-<p><a href="http://www.adeptiabpm.com">
+<p><a href="https://adeptia.com">
 Adeptia BPM</a><br />
 A Business Process Management (BPM) suite to quickly and easily automate business processes and workflows.
 </p>
@@ -192,7 +192,7 @@ Adeptia Integration</a><br />
 Process-centric, services-based application integration suite.
 </p>
 
-<p><a href="http://aejaks.sf.net">
+<p><a href="http://aejaks.sourceforge.net">
 Aejaks</a><br />
 A server-side scripting environment to build AJAX enabled web applications.
 </p>
@@ -202,17 +202,17 @@ Axiom Stack</a><br />
 A web framework that let's you write dynamic web applications with Zen-like simplicity.
 </p>
 
-<p><a href="http://cayenne.apache.org">
+<p><a href="https://cayenne.apache.org">
 Apache Cayenne</a><br />
 Open source persistence framework providing object-relational mapping (ORM) and remoting services.
 </p>
 
-<p><a href="http://jackrabbit.apache.org">
+<p><a href="https://jackrabbit.apache.org/jcr/index.html">
 Apache Jackrabbit</a><br />
 Open source implementation of the Java Content Repository API (JCR).
 </p>
 
-<p><a href="http://incubator.apache.org/openjpa">
+<p><a href="https://openjpa.apache.org">
 Apache OpenJPA</a><br />
 Open source implementation of the Java Persistence API (JPA).
 </p>
@@ -222,7 +222,7 @@ AppFuse</a><br />
 Helps building web applications.
 </p>
 
-<p><a href="http://www.bgblitz.com">
+<p><a href="https://www.bgblitz.com">
 BGBlitz</a><br />
 The Swiss army knife of Backgammon.
 </p>
@@ -238,7 +238,7 @@ Bookmarks Portlet</a><br />
 JSR 168 compliant bookmarks management portlet application.
 </p>
 
-<p><a href="http://www.claros.org">
+<p><a href="https://github.com/umutgokbayrak/Claros">
 Claros inTouch</a><br />
 Ajax communication suite with mail, addresses, notes, IM, and rss reader.
 </p>
@@ -269,7 +269,7 @@ Dinamica Framework</a><br />
 Ajax/J2EE framework for RAD development (mainly oriented toward hispanic markets).
 </p>
 
-<p><a href="http://dhis2.org">
+<p><a href="https://www.dhis2.org">
 District Health Information Software 2 (DHIS)</a><br />
 The DHIS 2 is a tool for collection, validation, analysis, and presentation of aggregate statistical data,
 tailored (but not limited) to integrated health information management activities.
@@ -280,7 +280,7 @@ Ebean ORM Persistence Layer</a><br />
 Open source Java Object Relational Mapping tool.
 </p>
 
-<p><a href="http://wiki.eclipse.org/CDO">
+<p><a href="https://wiki.eclipse.org/CDO">
 Eclipse CDO</a><br />
 The CDO (Connected Data Objects) Model Repository is a distributed shared model framework for EMF models,
 and a fast server-based O/R mapping solution.
@@ -291,7 +291,7 @@ Fabric3</a><br />
 Fabric3 is a project implementing a federated service network based on the Service Component Architecture specification (http://www.osoa.org).
 </p>
 
-<p><a href="http://code.google.com/p/fit4data">
+<p><a href="https://code.google.com/archive/p/fit4data/">
 FIT4Data</a><br />
 A testing framework for data management applications built on the Java implementation of FIT.
 </p>
@@ -306,7 +306,7 @@ GeoServer</a><br />
 GeoServer is a Java-based software server that allows users to view and edit geospatial data. Using open standards set forth by the Open Geospatial Consortium (OGC), GeoServer allows for great flexibility in map creation and data sharing.
 </p>
 
-<p><a href="http://code.google.com/p/gbif-providertoolkit">
+<p><a href="https://github.com/gbif/ipt">
 GBIF Integrated Publishing Toolkit (IPT)</a><br />
 The GBIF IPT is an open source, Java based web application that connects and serves
 three types of biodiversity data: taxon primary occurrence data,
@@ -323,7 +323,7 @@ Golden T Studios</a><br />
 Fun-to-play games with a simple interface.
 </p>
 
-<p><a href="http://www.gridgain.com">
+<p><a href="https://www.gridgain.com">
 GridGain</a><br />
 GridGain is easy to use Cloud Application Platform that enables development of
 highly scalable distributed Java and Scala applications
@@ -340,12 +340,12 @@ HA-JDBC</a><br />
 High-Availability JDBC: A JDBC proxy that provides light-weight, transparent, fault tolerant clustering capability to any underlying JDBC driver.
 </p>
 
-<p><a href="http://hibernate.org">
+<p><a href="https://hibernate.org">
 Hibernate</a><br />
 Relational persistence for idiomatic Java (O-R mapping tool).
 </p>
 
-<p><a href="http://www.willuhn.de/projects/hibiscus">
+<p><a href="https://www.willuhn.de/products/hibiscus/">
 Hibicius</a><br />
 Online Banking Client for the HBCI protocol.
 </p>
@@ -367,12 +367,12 @@ Jaspa</a><br />
 Java Spatial. Jaspa potentially brings around 200 spatial functions.
 </p>
 
-<p><a href="http://code.google.com/p/javasimon">
+<p><a href="https://github.com/virgo47/javasimon">
 Java Simon</a><br />
 Simple Monitoring API.
 </p>
 
-<p><a href="http://www.jboss.org/jbossjbpm">
+<p><a href="https://www.jbpm.org">
 JBoss jBPM</a><br />
 A platform for executable process languages ranging from business process management (BPM) over workflow to service orchestration.
 </p>
@@ -393,7 +393,7 @@ Java Geographic Resources Analysis Support System.
 Free, multi platform, open source GIS based on the GIS framework of uDig.
 </p>
 
-<p><a href="http://jena.sourceforge.net">
+<p><a href="https://jena.apache.org">
 Jena</a><br />
 Java framework for building Semantic Web applications.
 </p>
@@ -403,7 +403,7 @@ JMatter</a><br />
 Framework for constructing workgroup business applications based on the Naked Objects Architectural Pattern.
 </p>
 
-<p><a href="http://www.jooq.org">
+<p><a href="https://www.jooq.org">
 jOOQ (JOOQ Object Oriented Querying)</a><br />
 jOOQ is a fluent API for typesafe SQL query construction and execution
 </p>
@@ -413,7 +413,7 @@ Liftweb</a><br />
 A Scala-based, secure, developer friendly web framework.
 </p>
 
-<p><a href="http://liquibase.org">
+<p><a href="https://www.liquibase.org">
 LiquiBase</a><br />
 A tool to manage database changes and refactorings.
 </p>
@@ -423,7 +423,7 @@ Luntbuild</a><br />
 Build automation and management tool.
 </p>
 
-<p><a href="http://code.google.com/p/localdb">
+<p><a href="https://code.google.com/archive/p/localdb/">
 localdb</a><br />
 A tool that locates the full file path of the folder containing the database files.
 </p>
@@ -449,7 +449,7 @@ Myna Application Server</a><br />
 Java web app that provides dynamic web content and Java libraries access from JavaScript.
 </p>
 
-<p><a href="http://www.codewave.de/mytunesrss.php">
+<p><a href="https://www.codewave.de/mytunesrss.php">
 MyTunesRss</a><br />
 MyTunesRSS lets you listen to your music wherever you are.
 </p>
@@ -485,7 +485,7 @@ understand how it relates to the rest of the application, thus,
 understand the application structure.
 </p>
 
-<p><a href="http://www.ontologyworks.com">
+<p><a href="https://www.ontologyworks.com">
 Ontology Works</a><br />
 This company provides semantic technologies including deductive
 information repositories (the Ontology Works Knowledge Servers),
@@ -510,7 +510,7 @@ OpenGroove</a><br />
 OpenGroove is a groupware program that allows users to synchronize data.
 </p>
 
-<p><a href="http://code.google.com/p/opensocial-development-environment">
+<p><a href="https://code.google.com/archive/p/opensocial-development-environment/">
 OpenSocial Development Environment (OSDE)</a><br />
 Development tool for OpenSocial application.
 </p>
@@ -522,10 +522,10 @@ J2EE Application Server.
 
 <p><a href="http://fluid-forms.com/FluidLibs">
 P5H2</a><br />
-A library for the <a href="http://www.processing.org">Processing</a> programming language and environment.
+A library for the <a href="https://www.processing.org">Processing</a> programming language and environment.
 </p>
 
-<p><a href="http://www.phase-6.de">
+<p><a href="https://www.phase-6.de">
 Phase-6</a><br />
 A computer based learning software.
 </p>
@@ -545,7 +545,7 @@ PolePosition</a><br />
 Open source database benchmark.
 </p>
 
-<p><a href="http://poormans.sourceforge.net/index.html">
+<p><a href="https://github.com/th-schwarz/pmcms/">
 Poormans</a><br />
 Very basic CMS running as a SWT application and generating static html pages.
 </p>
@@ -556,7 +556,7 @@ Railo is an alternative engine for the Cold Fusion Markup Language, that compile
 programmed in CFML into Java bytecode and executes it on a servlet engine.
 </p>
 
-<p><a href="http://www.razuna.com">
+<p><a href="https://www.razuna.com">
 Razuna</a><br />
 Open source Digital Asset Management System with integrated Web Content Management.
 </p>
@@ -576,7 +576,7 @@ Scriptella</a><br />
 ETL (Extract-Transform-Load) and script execution tool.
 </p>
 
-<p><a href="http://www.seasar.org">
+<p><a href="https://www.seasar.org">
 Sesar</a><br />
 Dependency Injection Container with Aspect Oriented Programming.
 </p>
@@ -591,7 +591,7 @@ SeQuaLite</a><br />
 A free, light-weight, java data access framework.
 </p>
 
-<p><a href="http://code.google.com/p/shapelogic">
+<p><a href="https://code.google.com/archive/p/shapelogic/">
 ShapeLogic</a><br />
 Toolkit for declarative programming, image processing and computer vision.
 </p>
@@ -616,7 +616,7 @@ SymmetricDS</a><br />
 A web-enabled, database independent, data synchronization/replication software.
 </p>
 
-<p><a href="http://www.smartfoxserver.com">
+<p><a href="https://www.smartfoxserver.com">
 SmartFoxServer</a><br />
 Platform for developing multiuser applications and games with Macromedia Flash.
 </p>
@@ -631,7 +631,7 @@ sormula</a><br />
 Simple object relational mapping.
 </p>
 
-<p><a href="http://www.springfuse.com">
+<p><a href="https://www.springfuse.com">
 Springfuse</a><br />
 Code generation For Spring, Spring MVC &amp; Hibernate.
 </p>
@@ -658,10 +658,10 @@ StreamCruncher</a><br />
 Event (stream) processing kernel.
 </p>
 
-<p><a href="http://www.suse.com/products/suse-manager">
+<p><a href="https://www.suse.com/products/suse-manager/">
 SUSE Manager, part of Linux Enterprise Server 11</a><br />
 The SUSE Manager
-<a href="http://www.suse.com/blogs/suse-manager-eases-the-buden-of-compliance">
+<a href="https://www.suse.com/c/suse-manager-eases-the-buden-of-compliance/">
 eases the burden of compliance</a> with regulatory requirements and corporate policies.
 </p>
 
@@ -670,7 +670,7 @@ Tune Backup</a><br />
 Easy-to-use backup solution for your iTunes library.
 </p>
 
-<p><a href="http://www.timewriter.com">
+<p><a href="https://www.timewriter.com">
 TimeWriter</a><br />
 TimeWriter is a very flexible program for time administration / time tracking.
 The older versions used dBase tables.
@@ -678,7 +678,7 @@ The new version 5 is completely rewritten, now using the H2 database.
 TimeWriter is delivered in Dutch and English.
 </p>
 
-<p><a href="http://www.weblica.ch">
+<p><a href="https://www.weblica.ch">
 weblica</a><br />
 Desktop CMS.
 </p>
@@ -688,7 +688,7 @@ Web of Web</a><br />
 Collaborative and realtime interactive media platform for the web.
 </p>
 
-<p><a href="http://code.google.com/p/werkzeugkasten">
+<p><a href="https://code.google.com/archive/p/werkzeugkasten/">
 Werkzeugkasten</a><br />
 Minimum Java Toolset.
 </p>
@@ -699,7 +699,7 @@ View providers driven applications is a Java based application framework
 for building applications composed from server components - view providers.
 </p>
 
-<p><a href="http://sourceforge.net/projects/volunteerbase">
+<p><a href="https://sourceforge.net/projects/volunteerbase/">
 Volunteer database</a><br />
 A database front end to register volunteers, partnership and donation for a Non Profit organization.
 </p>

--- a/h2/src/docsrc/html/mainWeb.html
+++ b/h2/src/docsrc/html/mainWeb.html
@@ -61,8 +61,7 @@ Welcome to H2, the Java SQL database. The main features of H2 are:
                 <h2 style="margin-top: 1em;">Support</h2>
                 <p>
                     <a href="https://stackoverflow.com/questions/tagged/h2">Stack Overflow (tag H2)</a><br /><br />
-                    <a href="https://groups.google.com/forum/#!forum/h2-database">Google Group English</a>,
-                    <a href="https://groups.google.com/forum/#!forum/h2-database-jp">Japanese</a><br /><br />
+                    <a href="https://groups.google.com/forum/#!forum/h2-database">Google Group</a><br /><br />
                     For non-technical issues, use: <br />
                     <script type="text/javascript">
                     <!--

--- a/h2/src/docsrc/html/mvstore.html
+++ b/h2/src/docsrc/html/mvstore.html
@@ -605,7 +605,7 @@ This mechanism is called copy-on-write, and is similar to how the
 Chunks without live pages are marked as free, so the space can be re-used by more recent chunks.
 Because not all chunks are of the same size, there can be a number of free blocks in front of a chunk
 for some time (until a small chunk is written or the chunks are compacted).
-There is a <a href="http://stackoverflow.com/questions/13650134/after-how-many-seconds-are-file-system-write-buffers-typically-flushed">
+There is a <a href="https://stackoverflow.com/questions/13650134/after-how-many-seconds-are-file-system-write-buffers-typically-flushed">
 delay of 45 seconds</a> (by default) before a free chunk is overwritten,
 to ensure new versions are persisted first.
 </p>

--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -473,7 +473,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>MySQL compatibility: update test1 t1, test2 t2 set t1.name=t2.name where t1.id=t2.id.
 </li><li>Issue 283: Improve performance of H2 on Android.
 </li><li>Support INSERT INTO / UPDATE / MERGE ... RETURNING to retrieve the generated key(s).
-</li><li>Column compression option - see http://groups.google.com/group/h2-database/browse_thread/thread/3e223504e52671fa/243da82244343f5d
+</li><li>Column compression option - see https://groups.google.com/forum/#!topic/h2-database/PiI1BOUmcfo
 </li><li>MS SQL Server compatibility: support @@ROWCOUNT.
 </li><li>Issue 311: Serialized lock mode: executeQuery of write operations fails.
 </li><li>PostgreSQL compatibility: support PgAdmin III (specially the function current_setting).

--- a/h2/src/docsrc/html/roadmap.html
+++ b/h2/src/docsrc/html/roadmap.html
@@ -68,7 +68,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Rebuild index functionality to shrink index size and improve performance.
 </li><li>Console: add accesskey to most important commands (A, AREA, BUTTON, INPUT, LABEL, LEGEND, TEXTAREA).
 </li><li>Test performance again with SQL Server, Oracle, DB2.
-</li><li>Test with Spatial DB in a box / JTS: http://www.opengeospatial.org/standards/sfs - OpenGIS Implementation Specification.
+</li><li>Test with Spatial DB in a box / JTS: https://www.opengeospatial.org/standards/sfs - OpenGIS Implementation Specification.
 </li><li>Find a tool to view large text file (larger than 100 MB), with find, page up and down (like less), truncate before / after.
 </li><li>Implement, test, document XAConnection and so on.
 </li><li>Pluggable data type (for streaming, hashing, compression, validation, conversion, encryption).
@@ -106,8 +106,10 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Support Oracle functions: TO_NUMBER.
 </li><li>Work on the Java to C converter.
 </li><li>The HELP information schema can be directly exposed in the Console.
-</li><li>Support Oracle CONNECT BY in some way: http://www.adp-gmbh.ch/ora/sql/connect_by.html http://philip.greenspun.com/sql/trees.html
-</li><li>SQL 2003: http://www.wiscorp.com/sql_2003_standard.zip
+</li><li>Support Oracle CONNECT BY in some way:
+    https://renenyffenegger.ch/notes/development/databases/Oracle/SQL/select/hierarchical-queries/start-with_connect-by/index
+    https://philip.greenspun.com/sql/trees.html
+</li><li>SQL 2003: https://www.wiscorp.com/sql_2003_standard.zip
 </li><li>Version column (number/sequence and timestamp based).
 </li><li>Test and document UPDATE TEST SET (ID, NAME) = (SELECT ID*10, NAME || '!' FROM TEST T WHERE T.ID=TEST.ID).
 </li><li>Max memory rows / max undo log size: use block count / row size not row count.
@@ -170,12 +172,12 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>In the MySQL and PostgreSQL mode, use lower case identifiers by default (DatabaseMetaData.storesLowerCaseIdentifiers = true)
 </li><li>Support multiple directories (on different hard drives) for the same database
 </li><li>Server protocol: use challenge response authentication, but client sends hash(user+password) encrypted with response
-</li><li>Support native XML data type - see http://en.wikipedia.org/wiki/SQL/XML
+</li><li>Support native XML data type - see https://en.wikipedia.org/wiki/SQL/XML
 </li><li>Support triggers with a string property or option: SpringTrigger, OSGITrigger
 </li><li>MySQL compatibility: update test1 t1, test2 t2 set t1.id = t2.id where t1.id = t2.id;
 </li><li>Ability to resize the cache array when resizing the cache
 </li><li>Time based cache writing (one second after writing the log)
-</li><li>Check state of H2 driver for DDLUtils: http://issues.apache.org/jira/browse/DDLUTILS-185
+</li><li>Check state of H2 driver for DDLUtils: https://issues.apache.org/jira/browse/DDLUTILS-185
 </li><li>Index usage for REGEXP LIKE.
 </li><li>Compatibility: add a role DBA (like ADMIN).
 </li><li>Support compatibility for jdbc:hsqldb:res:
@@ -187,7 +189,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Document SET SEARCH_PATH, BEGIN, EXECUTE, parameters
 </li><li>Server: use one listener (detect if the request comes from an PG or TCP client)
 </li><li>Optimize SELECT MIN(ID), MAX(ID), COUNT(*) FROM TEST WHERE ID BETWEEN 100 AND 200
-</li><li>Sequence: PostgreSQL compatibility (rename, create) http://www.postgresql.org/docs/8.2/static/sql-altersequence.html
+</li><li>Sequence: PostgreSQL compatibility (rename, create) https://www.postgresql.org/docs/8.2/sql-altersequence.html
 </li><li>Support a special trigger on all tables to allow building a transaction log reader.
 </li><li>File system with a background writer thread; test if this is faster
 </li><li>Better document the source code (high level documentation).
@@ -211,7 +213,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Write an article about SQLInjection (h2/src/docsrc/html/images/SQLInjection.txt)
 </li><li>Convert SQL-injection-2.txt to html document, include SQLInjection.java sample
 </li><li>Support OUT parameters in user-defined procedures.
-</li><li>Web site design: http://www.igniterealtime.org/projects/openfire/index.jsp
+</li><li>Web site design: https://www.igniterealtime.org/projects/openfire/index.jsp
 </li><li>HSQLDB compatibility: Openfire server uses: CREATE SCHEMA PUBLIC AUTHORIZATION DBA;
     CREATE USER SA PASSWORD ""; GRANT DBA TO SA; SET SCHEMA PUBLIC
 </li><li>Translation: use ${.} in help.csv
@@ -256,7 +258,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Sequences: CURRVAL should be session specific. Compatibility with PostgreSQL.
 </li><li>Index creation using deterministic functions.
 </li><li>ANALYZE: for unique indexes that allow null, count the number of null.
-</li><li>MySQL compatibility: multi-table delete: DELETE .. FROM .. [,...] USING - See http://dev.mysql.com/doc/refman/5.0/en/delete.html
+</li><li>MySQL compatibility: multi-table delete: DELETE .. FROM .. [,...] USING - See https://dev.mysql.com/doc/refman/5.0/en/delete.html
 </li><li>AUTO_SERVER: support changing IP addresses (disable a network while the database is open).
 </li><li>Avoid using java.util.Calendar internally because it's slow, complicated, and buggy.
 </li><li>Support TRUNCATE .. CASCADE like PostgreSQL.
@@ -268,11 +270,11 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Replace information_schema tables with regular tables that are automatically re-built when needed. Use indexes.
 </li><li>Issue 50: Oracle compatibility: support calling 0-parameters functions without parenthesis. Make constants obsolete.
 </li><li>MySQL, HSQLDB compatibility: support where 'a'=1 (not supported by Derby, PostgreSQL)
-</li><li>Finer granularity for SLF4J trace - See http://code.google.com/p/h2database/issues/detail?id=62
+</li><li>Finer granularity for SLF4J trace - See https://code.google.com/archive/p/h2database/issues/62
 </li><li>Add database creation date and time to the database.
 </li><li>Support ASSERTION.
 </li><li>MySQL compatibility: support comparing 1='a'
-</li><li>Support PostgreSQL lock modes: http://www.postgresql.org/docs/8.3/static/explicit-locking.html
+</li><li>Support PostgreSQL lock modes: https://www.postgresql.org/docs/8.3/explicit-locking.html
 </li><li>PostgreSQL compatibility: test DbVisualizer and Squirrel SQL using a new PostgreSQL JDBC driver.
 </li><li>RunScript should be able to read from system in (or quite mode for Shell).
 </li><li>Natural join: support select x from dual natural join dual.
@@ -298,9 +300,9 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Batch parameter for INSERT, UPDATE, and DELETE, and commit after each batch. See also MySQL DELETE.
 </li><li>Use a lazy and auto-close input stream (open resource when reading, close on eof).
 </li><li>Connection pool: 'reset session' command (delete temp tables, rollback, auto-commit true).
-</li><li>Improve SQL documentation, see http://www.w3schools.com/sql/
+</li><li>Improve SQL documentation, see https://www.w3schools.com/sql/
 </li><li>MySQL compatibility: DatabaseMetaData.stores*() methods should return the same values. Test with SquirrelSQL.
-</li><li>Sybase/DB2/Oracle compatibility: support out parameters in stored procedures - See http://code.google.com/p/h2database/issues/detail?id=83
+</li><li>Sybase/DB2/Oracle compatibility: support out parameters in stored procedures - See https://code.google.com/archive/p/h2database/issues/83
 </li><li>Combine Server and Console tool (only keep Server).
 </li><li>Store the Lucene index in the database itself.
 </li><li>HSQLDB compatibility: CREATE FUNCTION (maybe using a Function interface).
@@ -310,7 +312,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Compatibility: Java functions with SQL/PSM (Persistent Stored Modules) - need to find the documentation.
 </li><li>CACHE_SIZE: automatically use a fraction of Runtime.maxMemory - maybe automatically the second level cache.
 </li><li>PostgreSQL compatibility: when in PG mode, treat BYTEA data like PG.
-</li><li>Support =ANY(array) as in PostgreSQL. See also http://www.postgresql.org/docs/8.0/interactive/arrays.html
+</li><li>Support =ANY(array) as in PostgreSQL. See also https://www.postgresql.org/docs/8.0/arrays.html
 </li><li>IBM DB2 compatibility: support PREVIOUS VALUE FOR sequence.
 </li><li>Compatibility: use different LIKE ESCAPE characters depending on the mode (disable for Derby, HSQLDB, DB2, Oracle, MSSQLServer).
 </li><li>FTP: document the server, including -ftpTask option to execute / kill remote processes
@@ -394,7 +396,7 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
     PostgreSQL uses name order, which was judged to be more convenient.
     Derby: triggers are fired in the order in which they were created.
 </li><li>PostgreSQL compatibility: combine "users" and "roles". See:
-    http://www.postgresql.org/docs/8.1/interactive/user-manag.html
+    https://www.postgresql.org/docs/8.1/user-manag.html
 </li><li>Improve documentation of system properties: only list the property names, default values, and description.
 </li><li>Support running totals / cumulative sum using SUM(..) OVER(..).
 </li><li>Improve object memory size calculation. Use constants for known VMs, or use reflection to call java.lang.instrument.Instrumentation.getObjectSize(Object objectToSize)
@@ -467,8 +469,8 @@ See also <a href="build.html#providing_patches">Providing Patches</a>.
 </li><li>Adding a primary key should make the columns 'not null' unless if there is a row with null
     (compatibility with MySQL, PostgreSQL, HSQLDB; not Derby).
 </li><li>ARRAY data type: support Integer[] and so on in Java functions (currently only Object[] is supported).
-</li><li>MySQL compatibility: LOCK TABLES a READ, b READ - see also http://dev.mysql.com/doc/refman/5.0/en/lock-tables.html
-</li><li>The HTML to PDF converter should use http://code.google.com/p/wkhtmltopdf/
+</li><li>MySQL compatibility: LOCK TABLES a READ, b READ - see also https://dev.mysql.com/doc/refman/5.0/en/lock-tables.html
+</li><li>The HTML to PDF converter should use https://wkhtmltopdf.org
 </li><li>Issue 303: automatically convert "X NOT IN(SELECT...)" to "NOT EXISTS(...)".
 </li><li>MySQL compatibility: update test1 t1, test2 t2 set t1.name=t2.name where t1.id=t2.id.
 </li><li>Issue 283: Improve performance of H2 on Android.

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -665,7 +665,7 @@ To use H2 within Glassfish, copy the h2*.jar to the directory <code>glassfish/gl
 <p>
 To use H2 in EclipseLink, use the platform class <code>org.eclipse.persistence.platform.database.H2Platform</code>.
 If this platform is not available in your version of EclipseLink, you can use the OraclePlatform instead in many case.
-See also <a href="http://wiki.eclipse.org/EclipseLink/Development/Incubator/Extensions/H2Platform">H2Platform</a>.
+See also <a href="https://wiki.eclipse.org/EclipseLink/Development/Incubator/Extensions/H2Platform">H2Platform</a>.
 </p>
 
 <h2 id="using_activemq">Using Apache ActiveMQ</h2>
@@ -1192,7 +1192,7 @@ Another solution to use H2 in NeoOffice is:
 </li></ul>
 <p>
 This can be done by create it using the NetBeans OpenOffice plugin.
-See also <a href="http://wiki.services.openoffice.org/wiki/Extensions_development_java">Extensions Development</a>.
+See also <a href="https://wiki.openoffice.org/wiki/Extensions_development_java">Extensions Development</a>.
 </p>
 
 <h2 id="web_start">Java Web Start / JNLP</h2>
@@ -1216,7 +1216,7 @@ Still, using a connection pool improves performance if you open and close connec
 A simple connection pool is included in H2. It is based on the
 <a href="http://www.source-code.biz/miniconnectionpoolmanager/">Mini Connection Pool Manager</a>
 from Christian d'Heureuse. There are other, more complex, open source connection pools available,
-for example the <a href="http://commons.apache.org/proper/commons-dbcp/">Apache Commons DBCP</a>.
+for example the <a href="https://commons.apache.org/proper/commons-dbcp/">Apache Commons DBCP</a>.
 For H2, it is about twice as faster to get a connection from the built-in connection pool than to get
 one using <code>DriverManager.getConnection()</code>.The build-in connection pool is used as follows:
 </p>

--- a/h2/src/installer/release.txt
+++ b/h2/src/installer/release.txt
@@ -75,6 +75,9 @@ Update newsfeed.sql:
     * (146, '1.4.197', '2017-06-10'),
     * remove oldest entry in that list
 
+Update download-archive.html:
+    * add new version under Distribution section
+
 ## Skipped
 
 * Minor version change: change sourceError.html and source.html

--- a/h2/src/main/org/h2/api/ErrorCode.java
+++ b/h2/src/main/org/h2/api/ErrorCode.java
@@ -317,7 +317,7 @@ public class ErrorCode {
      * sessions are also possible. To solve deadlock problems, an application
      * should lock tables always in the same order, such as always lock table A
      * before locking table B. For details, see <a
-     * href="http://en.wikipedia.org/wiki/Deadlock">Wikipedia Deadlock</a>.
+     * href="https://en.wikipedia.org/wiki/Deadlock">Wikipedia Deadlock</a>.
      */
     public static final int DEADLOCK_1 = 40001;
 

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -315,9 +315,7 @@ public class Mode {
         mode.nullConcatIsNull = true;
         mode.allowPlusForStringConcat = true;
         // HSQLDB does not support client info properties. See
-        // http://hsqldb.org/doc/apidocs/
-        //     org/hsqldb/jdbc/JDBCConnection.html#
-        //     setClientInfo%28java.lang.String,%20java.lang.String%29
+        // http://hsqldb.org/doc/apidocs/org/hsqldb/jdbc/JDBCConnection.html#setClientInfo-java.lang.String-java.lang.String-
         mode.supportedClientInfoPropertiesRegEx = null;
         add(mode);
 
@@ -356,9 +354,7 @@ public class Mode {
         mode.onDuplicateKeyUpdate = true;
         mode.replaceInto = true;
         // MySQL allows to use any key for client info entries. See
-        // http://grepcode.com/file/repo1.maven.org/maven2/mysql/
-        //     mysql-connector-java/5.1.24/com/mysql/jdbc/
-        //     JDBC4CommentClientInfoProvider.java
+        // https://github.com/mysql/mysql-connector-j/blob/5.1.47/src/com/mysql/jdbc/JDBC4CommentClientInfoProvider.java
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile(".*");
         mode.charToBinaryInUtf8 = true;

--- a/h2/src/main/org/h2/engine/QueryStatisticsData.java
+++ b/h2/src/main/org/h2/engine/QueryStatisticsData.java
@@ -142,8 +142,8 @@ public class QueryStatisticsData {
         public double rowCountMean;
 
         // Using Welford's method, see also
-        // http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
-        // http://www.johndcook.com/standard_deviation.html
+        // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+        // https://www.johndcook.com/blog/standard_deviation/
 
         private double executionTimeM2Nanos;
         private double rowCountM2;

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -282,7 +282,7 @@ public class SysProperties {
      * If enabled, use the reflection hack to un-map the mapped file if
      * possible. If disabled, System.gc() is called in a loop until the object
      * is garbage collected. See also
-     * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4724038
+     * https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4724038
      */
     public static final boolean NIO_CLEANER_HACK =
             Utils.getProperty("h2.nioCleanerHack", false);
@@ -387,7 +387,7 @@ public class SysProperties {
      * System property <code>h2.socketConnectRetry</code> (default: 16).<br />
      * The number of times to retry opening a socket. Windows sometimes fails
      * to open a socket, see bug
-     * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6213296
+     * https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6213296
      */
     public static final int SOCKET_CONNECT_RETRY =
             Utils.getProperty("h2.socketConnectRetry", 16);

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataDefault.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataDefault.java
@@ -72,8 +72,8 @@ class AggregateDataDefault extends AggregateData {
         case VAR_POP:
         case VAR_SAMP: {
             // Using Welford's method, see also
-            // http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
-            // http://www.johndcook.com/standard_deviation.html
+            // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+            // https://www.johndcook.com/standard_deviation.html
             double x = v.getDouble();
             if (count == 1) {
                 mean = x;

--- a/h2/src/main/org/h2/fulltext/FullTextLucene.java
+++ b/h2/src/main/org/h2/fulltext/FullTextLucene.java
@@ -302,7 +302,7 @@ public class FullTextLucene extends FullText {
                     IndexWriterConfig conf = new IndexWriterConfig(analyzer);
                     conf.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
                     IndexWriter writer = new IndexWriter(indexDir, conf);
-                    //see http://wiki.apache.org/lucene-java/NearRealtimeSearch
+                    //see https://cwiki.apache.org/confluence/display/lucene/NearRealtimeSearch
                     access = new IndexAccess(writer);
                 } catch (IndexFormatTooOldException e) {
                     reindex(conn);

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -72,7 +72,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
     public String getDatabaseProductName() {
         debugCodeCall("getDatabaseProductName");
         // This value must stay like that, see
-        // http://opensource.atlassian.com/projects/hibernate/browse/HHH-2682
+        // https://hibernate.atlassian.net/browse/HHH-2682
         return "H2";
     }
 

--- a/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
@@ -9,7 +9,7 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation, either
  * version 3 of the License, or (at your option) any later version.
- * See http://www.gnu.org/licenses/lgpl.html
+ * See https://www.gnu.org/licenses/lgpl-3.0.html
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -62,7 +62,7 @@ public class FunctionsMySQL extends FunctionsBase {
     /**
      * Format replacements for MySQL date formats.
      * See
-     * http://dev.mysql.com/doc/refman/5.1/en/date-and-time-functions.html#function_date-format
+     * https://dev.mysql.com/doc/refman/5.1/en/date-and-time-functions.html#function_date-format
      */
     private static final String[] FORMAT_REPLACE = {
             "%a", "EEE",
@@ -117,7 +117,7 @@ public class FunctionsMySQL extends FunctionsBase {
 
     /**
      * See
-     * http://dev.mysql.com/doc/refman/5.1/en/date-and-time-functions.html#function_from-unixtime
+     * https://dev.mysql.com/doc/refman/5.1/en/date-and-time-functions.html#function_from-unixtime
      *
      * @param seconds The current timestamp in seconds.
      * @return a formatted date/time String in the format "yyyy-MM-dd HH:mm:ss".
@@ -130,7 +130,7 @@ public class FunctionsMySQL extends FunctionsBase {
 
     /**
      * See
-     * http://dev.mysql.com/doc/refman/5.1/en/date-and-time-functions.html#function_from-unixtime
+     * https://dev.mysql.com/doc/refman/5.1/en/date-and-time-functions.html#function_from-unixtime
      *
      * @param seconds The current timestamp in seconds.
      * @param format The format of the date/time String to return.

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -27,7 +27,7 @@ import org.h2.mvstore.DataUtils;
  * <p>
  * This class implements an approximation of the LIRS replacement algorithm
  * invented by Xiaodong Zhang and Song Jiang as described in
- * http://www.cse.ohio-state.edu/~zhang/lirs-sigmetrics-02.html with a few
+ * https://web.cse.ohio-state.edu/~zhang.574/lirs-sigmetrics-02.html with a few
  * smaller changes: An additional queue for non-resident entries is used, to
  * prevent unbound memory usage. The maximum size of this queue is at most the
  * size of the rest of the stack. About 6.25% of the mapped entries are cold.

--- a/h2/src/main/org/h2/security/CipherFactory.java
+++ b/h2/src/main/org/h2/security/CipherFactory.java
@@ -277,7 +277,7 @@ public class CipherFactory {
             // if you have a keystore file.
             // This code is (hopefully) more Java version independent
             // than using keystores directly. See also:
-            // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4887561
+            // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4887561
             // (1.4.2 cannot read keystore written with 1.4.1)
             // --- generated code start ---
 

--- a/h2/src/main/org/h2/server/pg/PgServer.java
+++ b/h2/src/main/org/h2/server/pg/PgServer.java
@@ -30,9 +30,9 @@ import org.h2.util.Tool;
 
 /**
  * This class implements a subset of the PostgreSQL protocol as described here:
- * http://developer.postgresql.org/pgdocs/postgres/protocol.html
+ * https://www.postgresql.org/docs/devel/protocol.html
  * The PostgreSQL catalog is described here:
- * http://www.postgresql.org/docs/7.4/static/catalogs.html
+ * https://www.postgresql.org/docs/7.4/catalogs.html
  *
  * @author Thomas Mueller
  * @author Sergi Vladykin 2009-07-03 (convertType)

--- a/h2/src/main/org/h2/server/web/WebThread.java
+++ b/h2/src/main/org/h2/server/web/WebThread.java
@@ -291,7 +291,7 @@ class WebThread extends WebApp implements Runnable {
                 boolean isWebKit = lower.contains("webkit/");
                 if (isWebKit && session != null) {
                     // workaround for what seems to be a WebKit bug:
-                    // http://code.google.com/p/chromium/issues/detail?id=6402
+                    // https://bugs.chromium.org/p/chromium/issues/detail?id=6402
                     session.put("frame-border", "1");
                     session.put("frameset-border", "2");
                 }

--- a/h2/src/main/org/h2/store/fs/FilePathDisk.java
+++ b/h2/src/main/org/h2/store/fs/FilePathDisk.java
@@ -254,7 +254,7 @@ public class FilePathDisk extends FilePath {
         }
         // File.canWrite() does not respect windows user permissions,
         // so we must try to open it using the mode "rw".
-        // See also http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4420020
+        // See also https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4420020
         RandomAccessFile r = null;
         try {
             r = new RandomAccessFile(file, "rw");

--- a/h2/src/main/org/h2/store/fs/FilePathNioMapped.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNioMapped.java
@@ -76,7 +76,7 @@ class FileNioMapped extends FileBase {
         mapped.force();
 
         // need to dispose old direct buffer, see bug
-        // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4724038
+        // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4724038
 
         if (SysProperties.NIO_CLEANER_HACK) {
             if (MemoryUnmapper.unmap(mapped)) {

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -217,7 +217,7 @@ public class TableLink extends Table {
         } catch (Exception e) {
             // Some ODBC bridge drivers don't support it:
             // some combinations of "DataDirect SequeLink(R) for JDBC"
-            // http://www.datadirect.com/index.ssp
+            // https://www.progress.com/odbc/sequelink
         }
         try (ResultSet rs = meta.getIndexInfo(null, originalSchema, originalTable, false, true)) {
             readIndexes(rs, columnMap, pkName);

--- a/h2/src/main/org/h2/util/MathUtils.java
+++ b/h2/src/main/org/h2/util/MathUtils.java
@@ -66,7 +66,7 @@ public class MathUtils {
             return cachedSecureRandom;
         }
         // Workaround for SecureRandom problem as described in
-        // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6202721
+        // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6202721
         // Can not do that in a static initializer block, because
         // threads are not started until after the initializer block exits
         try {

--- a/h2/src/main/org/h2/util/geometry/EWKBUtils.java
+++ b/h2/src/main/org/h2/util/geometry/EWKBUtils.java
@@ -38,7 +38,7 @@ import org.h2.util.geometry.GeometryUtils.Target;
  * extensions. This class can read dimension system marks in both OGC WKB and
  * EWKB formats, but always writes them in EWKB format. SRID support from EWKB
  * is implemented. As an addition POINT EMPTY is stored with NaN values as
- * specified in <a href="http://www.geopackage.org/spec/">OGC 12-128r15</a>.
+ * specified in <a href="https://www.geopackage.org/spec/">OGC 12-128r15</a>.
  * </p>
  */
 public final class EWKBUtils {

--- a/h2/src/test/org/h2/samples/newsfeed.sql
+++ b/h2/src/test/org/h2/samples/newsfeed.sql
@@ -118,7 +118,7 @@ $$<rdf:RDF xmlns="http://usefulinc.com/ns/doap#" xmlns:rdf="http://www.w3.org/19
             <location rdf:resource="https://github.com/h2database/h2database"/>
         </SVNRepository>
     </repository>
-    <mailing-list rdf:resource="http://groups.google.com/group/h2-database"/>
+    <mailing-list rdf:resource="https://groups.google.com/forum/#!forum/h2-database"/>
 $$ ||
     GROUP_CONCAT(
         XMLNODE('release', NULL,

--- a/h2/src/tools/org/h2/build/code/CheckTextFiles.java
+++ b/h2/src/tools/org/h2/build/code/CheckTextFiles.java
@@ -185,7 +185,10 @@ public class CheckTextFiles {
                             lineLength--;
                         }
                         if (lineLength > MAX_SOURCE_LINE_SIZE) {
-                            fail(file, "line too long: " + lineLength, line);
+                            String s = new String(data, startLinePos, lineLength).trim();
+                            if (!s.startsWith("// http://") && !s.startsWith("// https://")) {
+                                fail(file, "line too long: " + lineLength, line);
+                            }
                         }
                     }
                     startLinePos = i;

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -820,3 +820,4 @@ sparsely shifting vacated evacuation bullet allocations projected evacuatable pi
 successfull deduplication entrant mvmap sporadic irrelevant interrupts
 sit sitting sooner hdr considering encounter compete quickack decrementing exhausting caveat aschoerk circular ident
 scr ffffl suspend asap ldt lmt movement ago snapshotting paris phenomena backends quirks pgjdbc jupiter grab folds
+umcfo

--- a/h2/src/tools/org/h2/dev/cache/CacheLIRS.java
+++ b/h2/src/tools/org/h2/dev/cache/CacheLIRS.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * <p>
  * This class implements an approximation of the LIRS replacement algorithm
  * invented by Xiaodong Zhang and Song Jiang as described in
- * http://www.cse.ohio-state.edu/~zhang/lirs-sigmetrics-02.html with a few
+ * https://web.cse.ohio-state.edu/~zhang.574/lirs-sigmetrics-02.html with a few
  * smaller changes: An additional queue for non-resident entries is used, to
  * prevent unbound memory usage. The maximum size of this queue is at most the
  * size of the rest of the stack. About 6.25% of the mapped entries are cold.

--- a/h2/src/tools/org/h2/dev/ftp/server/FtpServer.java
+++ b/h2/src/tools/org/h2/dev/ftp/server/FtpServer.java
@@ -28,7 +28,7 @@ import org.h2.util.Tool;
 /**
  * Small FTP Server. Intended for ad-hoc networks in a secure environment.
  * Remote connections are possible.
- * See also http://cr.yp.to/ftp.html http://www.ftpguide.com/
+ * See also https://cr.yp.to/ftp.html http://www.ftpguide.com/
  */
 public class FtpServer extends Tool implements Service {
 

--- a/h2/src/tools/org/h2/dev/net/PgTcpRedirect.java
+++ b/h2/src/tools/org/h2/dev/net/PgTcpRedirect.java
@@ -37,7 +37,7 @@ public class PgTcpRedirect {
         // MySQL protocol:
         // http://www.redferni.uklinux.net/mysql/MySQL-Protocol.html
         // PostgreSQL protocol:
-        // http://developer.postgresql.org/pgdocs/postgres/protocol.html
+        // https://www.postgresql.org/docs/devel/protocol.html
         // int portServer = 9083, portClient = 9084;
         // int portServer = 3306, portClient = 3307;
         // H2 PgServer
@@ -385,7 +385,7 @@ public class PgTcpRedirect {
                         break;
                     }
                     String msg = readStringNull(dataIn);
-                    // http://developer.postgresql.org/pgdocs/postgres/protocol-error-fields.html
+                    // https://www.postgresql.org/docs/devel/protocol-error-fields.html
                     // S Severity
                     // C Code: the SQLSTATE code
                     // M Message
@@ -420,7 +420,7 @@ public class PgTcpRedirect {
                         break;
                     }
                     String msg = readStringNull(dataIn);
-                    // http://developer.postgresql.org/pgdocs/postgres/protocol-error-fields.html
+                    // https://www.postgresql.org/docs/devel/protocol-error-fields.html
                     // S Severity
                     // C Code: the SQLSTATE code
                     // M Message

--- a/h2/src/tools/org/h2/jcr/jcr-sql2.html
+++ b/h2/src/tools/org/h2/jcr/jcr-sql2.html
@@ -47,7 +47,7 @@ The diagrams are created with a small <a href="Create.java">Java program</a>
 and this <a href="help.csv">BNF</a>. The program uses the BNF parser / converter
 of the <a href="https://h2database.com">H2 database engine</a>.
 </p><p>
-Please send feedback to the <a href="http://jackrabbit.apache.org/mailing-lists.html">Jackrabbit User List</a>.
+Please send feedback to the <a href="https://jackrabbit.apache.org/jcr/mailing-lists.html">Jackrabbit User List</a>.
 </p>
 
 <c:forEach var="item" items="grammar">


### PR DESCRIPTION
1. Hyperlinks to Java bugs, PostgreSQL documentation, Google Code archive, and some other sites are updated.

2. `https:` is used in hyperlinks to other web sites when it is supported.

3. Links to Japanese and Chinese groups are removed (#2174).

Other dead links aren't touched. Actually we have a lot of them.