### PR TITLE
prevent creation of empty leaves in MVRTree

### DIFF
--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -27,14 +27,14 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
     /**
      * The spatial key type.
      */
-    final SpatialDataType keyType;
+    private final SpatialDataType keyType;
 
     private boolean quadraticSplit;
 
     public MVRTreeMap(Map<String, Object> config) {
         super(config);
         keyType = (SpatialDataType) config.get("key");
-        quadraticSplit = Boolean.valueOf(String.valueOf(config.get("quadraticSplit")));
+        quadraticSplit = Boolean.parseBoolean(String.valueOf(config.get("quadraticSplit")));
     }
 
     private MVRTreeMap(MVRTreeMap<V> source) {
@@ -199,7 +199,7 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
     @SuppressWarnings("unchecked")
     private V operate(Page p, Object key, V value, DecisionMaker<? super V> decisionMaker,
                         Collection<Page> removedPages) {
-        V result = null;
+        V result;
         if (p.isLeaf()) {
             int index = -1;
             int keyCount = p.getKeyCount();
@@ -211,8 +211,9 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
             result = index < 0 ? null : (V)p.getValue(index);
             Decision decision = decisionMaker.decide(result, value);
             switch (decision) {
-                case REPEAT: break;
-                case ABORT: break;
+                case REPEAT:
+                case ABORT:
+                    break;
                 case REMOVE:
                     if(index >= 0) {
                         p.remove(index);
@@ -231,90 +232,58 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
             return result;
         }
 
-        // p is a node
-        if(value == null)
-        {
-            for (int i = 0; i < p.getKeyCount(); i++) {
-                if (contains(p, i, key)) {
-                    Page cOld = p.getChildPage(i);
-                    // this will mark the old page as deleted
-                    // so we need to update the parent in any case
-                    // (otherwise the old page might be deleted again)
-                    if (removedPages != null) {
-                        removedPages.add(cOld);
-                    }
-                    Page c = cOld.copy();
-                    long oldSize = c.getTotalCount();
-                    result = operate(c, key, value, decisionMaker, removedPages);
-                    p.setChild(i, c);
-                    if (oldSize == c.getTotalCount()) {
-                        decisionMaker.reset();
-                        continue;
-                    }
-                    if (c.getTotalCount() == 0) {
-                        // this child was deleted
-                        p.remove(i);
-                        if (removedPages != null) {
-                            removedPages.add(p);
-                        }
-                        break;
-                    }
-                    Object oldBounds = p.getKey(i);
-                    if (!keyType.isInside(key, oldBounds)) {
-                        p.setKey(i, getBounds(c));
-                    }
+        // p is an internal node
+        int index = -1;
+        for (int i = 0; i < p.getKeyCount(); i++) {
+            if (contains(p, i, key)) {
+                Page c = p.getChildPage(i);
+                if(get(c, key) != null) {
+                    index = i;
                     break;
                 }
+                if(index < 0) {
+                    index = i;
+                }
             }
-        } else {
-            int index = -1;
+        }
+        if (index < 0) {
+            // a new entry, we don't know where to add yet
+            float min = Float.MAX_VALUE;
             for (int i = 0; i < p.getKeyCount(); i++) {
-                if (contains(p, i, key)) {
-                    Page c = p.getChildPage(i);
-                    if(get(c, key) != null) {
-                        index = i;
-                        break;
-                    }
-                    if(index < 0) {
-                        index = i;
-                    }
+                Object k = p.getKey(i);
+                float areaIncrease = keyType.getAreaIncrease(k, key);
+                if (areaIncrease < min) {
+                    index = i;
+                    min = areaIncrease;
                 }
             }
-            if (index < 0) {
-                // a new entry, we don't know where to add yet
-                float min = Float.MAX_VALUE;
-                for (int i = 0; i < p.getKeyCount(); i++) {
-                    Object k = p.getKey(i);
-                    float areaIncrease = keyType.getAreaIncrease(k, key);
-                    if (areaIncrease < min) {
-                        index = i;
-                        min = areaIncrease;
-                    }
-                }
+        }
+        Page c = p.getChildPage(index);
+        if (removedPages != null) {
+            removedPages.add(c);
+        }
+        c = c.copy();
+        if (c.getKeyCount() > store.getKeysPerPage() || c.getMemory() > store.getMaxPageSize()
+                && c.getKeyCount() > 4) {
+            // split on the way down
+            Page split = split(c);
+            p.setKey(index, getBounds(c));
+            p.setChild(index, c);
+            p.insertNode(index, getBounds(split), split);
+            // now we are not sure where to add
+            result = operate(p, key, value, decisionMaker, removedPages);
+        } else {
+            result = operate(c, key, value, decisionMaker, removedPages);
+            Object bounds = p.getKey(index);
+            if (!keyType.contains(bounds, key)) {
+                bounds = keyType.createBoundingBox(bounds);
+                keyType.increaseBounds(bounds, key);
+                p.setKey(index, bounds);
             }
-            Page c = p.getChildPage(index);
-            if (removedPages != null) {
-                removedPages.add(c);
-            }
-            c = c.copy();
-            if (c.getKeyCount() > store.getKeysPerPage() || c.getMemory() > store.getMaxPageSize()
-                    && c.getKeyCount() > 4) {
-                // split on the way down
-                Page split = split(c);
-                p.setKey(index, getBounds(c));
+            if (c.getTotalCount() > 0) {
                 p.setChild(index, c);
-                p.insertNode(index, getBounds(split), split);
-                // now we are not sure where to add
-                result = operate(p, key, value, decisionMaker, removedPages);
             } else {
-                result = operate(c, key, value, decisionMaker, removedPages);
-                Object bounds = p.getKey(index);
-                if (!keyType.contains(bounds, key)) {
-                    bounds = keyType.createBoundingBox(bounds);
-                    keyType.increaseBounds(bounds, key);
-                    p.setKey(index, bounds);
-                }
-                p.setChild(index, c);
+                p.remove(index);
             }
         }
         return result;
@@ -548,7 +517,7 @@ public final class MVRTreeMap<V> extends MVMap<SpatialKey, V> {
         /**
          * Fetch the next entry if there is one.
          */
-        protected void fetchNext() {
+        void fetchNext() {
             while (pos != null) {
                 Page p = pos.page;
                 if (p.isLeaf()) {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -311,13 +311,11 @@ public class TransactionMap<K, V> extends AbstractMap<K, V> {
         do {
             sequenceNumWhenStarted = store.openTransactions.get().getVersion();
             assert transaction.getBlockerId() == 0;
-            // although second parameter (value) is not really used,
-            // since TxDecisionMaker has it embedded,
-            // MVRTreeMap has weird traversal logic based on it,
-            // and any non-null value will do
             @SuppressWarnings("unchecked")
             K k = (K) key;
-            result = map.operate(k, VersionedValue.DUMMY, decisionMaker);
+            // second parameter (value) is not really used,
+            // since TxDecisionMaker has it embedded
+            result = map.operate(k, null, decisionMaker);
 
             MVMap.Decision decision = decisionMaker.getDecision();
             assert decision != null;

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -484,11 +484,9 @@ public class TransactionStore {
                     if (map != null) { // might be null if map was removed later
                         Object key = op[1];
                         commitDecisionMaker.setUndoKey(undoKey);
-                        // although second parameter (value) is not really
-                        // used by CommitDecisionMaker, MVRTreeMap has weird
-                        // traversal logic based on it, and any non-null
-                        // value will do, to signify update, not removal
-                        map.operate(key, VersionedValue.DUMMY, commitDecisionMaker);
+                        // second parameter (value) is not really
+                        // used by CommitDecisionMaker
+                        map.operate(key, null, commitDecisionMaker);
                     }
                 }
                 undoLog.clear();

--- a/h2/src/main/org/h2/value/VersionedValue.java
+++ b/h2/src/main/org/h2/value/VersionedValue.java
@@ -13,11 +13,6 @@ package org.h2.value;
  */
 public class VersionedValue {
 
-    /**
-     * Used when we don't care about a VersionedValue instance.
-     */
-    public static final VersionedValue DUMMY = new VersionedValue();
-
     protected VersionedValue() {}
 
     public boolean isCommitted() {

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -6,6 +6,7 @@
 package org.h2.test.store;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -77,7 +78,9 @@ public class TestMVTableEngine extends TestDb {
         testMinMaxWithNull();
         testTimeout();
         testExplainAnalyze();
-        testTransactionLogEmptyAfterCommit();
+        if (!config.memory) {
+            testTransactionLogEmptyAfterCommit();
+        }
         testShrinkDatabaseFile();
         testTwoPhaseCommit();
         testRecover();
@@ -631,7 +634,8 @@ public class TestMVTableEngine extends TestDb {
             stat.execute("shutdown immediately");
         } catch (Exception ignore) {/**/}
 
-        String file = getTestName() + Constants.SUFFIX_MV_FILE;
+        String file = getBaseDir() + "/" + getTestName() + Constants.SUFFIX_MV_FILE;
+        assertTrue(new File(file).exists());
         try (MVStore store = MVStore.open(file)) {
             TransactionStore t = new TransactionStore(store);
             t.init();


### PR DESCRIPTION
This PR fixes the issue reported in #2225. While #2225 deal with consequent failure due to existence of empty leafs in MVRTree, this PR removes the root cause for this corruption, and simplify code in the process.
Also unrelated TestMVTableEngine fix is included, where wrong file was created/picked up.