### PR TITLE
Don't use RandomAccessFile in FilePathNio

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #2235: Don't use RandomAccessFile in FilePathNio
+</li>
 <li>Issue #2233: "Prepared.getObjectId() was called before" when granting on multiple tables
 </li>
 <li>PR #2230: Add factory methods for Row

--- a/h2/src/main/org/h2/store/fs/FilePathAsync.java
+++ b/h2/src/main/org/h2/store/fs/FilePathAsync.java
@@ -64,7 +64,7 @@ class FileAsync extends FileBase {
     FileAsync(String fileName, String mode) throws IOException {
         this.name = fileName;
         channel = AsynchronousFileChannel.open(Paths.get(fileName), FileUtils.modeToOptions(mode), null,
-                FileUtils.NO_ATTIBUTES);
+                FileUtils.NO_ATTRIBUTES);
     }
 
     @Override

--- a/h2/src/main/org/h2/store/fs/FilePathDisk.java
+++ b/h2/src/main/org/h2/store/fs/FilePathDisk.java
@@ -488,6 +488,9 @@ class FileDisk extends FileBase {
 
     @Override
     public int write(ByteBuffer src) throws IOException {
+        if (readOnly) {
+            throw new NonWritableChannelException();
+        }
         int len = src.remaining();
         file.write(src.array(), src.arrayOffset() + src.position(), len);
         src.position(src.position() + len);

--- a/h2/src/main/org/h2/store/fs/FilePathMem.java
+++ b/h2/src/main/org/h2/store/fs/FilePathMem.java
@@ -660,9 +660,9 @@ class FileMemData {
      *
      * @param openReadOnly if the file was opened in read-only mode
      */
-    void touch(boolean openReadOnly) throws IOException {
+    void touch(boolean openReadOnly) {
         if (isReadOnly || openReadOnly) {
-            throw new IOException("Read only");
+            throw new NonWritableChannelException();
         }
         lastModified = System.currentTimeMillis();
     }

--- a/h2/src/main/org/h2/store/fs/FilePathNio.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNio.java
@@ -6,11 +6,8 @@
 package org.h2.store.fs;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.channels.NonWritableChannelException;
+import java.nio.file.Paths;
 
 /**
  * This file system stores files on disk and uses java.nio to access the files.
@@ -20,110 +17,13 @@ public class FilePathNio extends FilePathWrapper {
 
     @Override
     public FileChannel open(String mode) throws IOException {
-        return new FileNio(name.substring(getScheme().length() + 1), mode);
+        return FileChannel.open(Paths.get(name.substring(getScheme().length() + 1)),
+                FileUtils.modeToOptions(mode), FileUtils.NO_ATTIBUTES);
     }
 
     @Override
     public String getScheme() {
         return "nio";
-    }
-
-}
-
-/**
- * File which uses NIO FileChannel.
- */
-class FileNio extends FileBase {
-
-    private final String name;
-    private final FileChannel channel;
-
-    FileNio(String fileName, String mode) throws IOException {
-        this.name = fileName;
-        channel = new RandomAccessFile(fileName, mode).getChannel();
-    }
-
-    @Override
-    public void implCloseChannel() throws IOException {
-        channel.close();
-    }
-
-    @Override
-    public long position() throws IOException {
-        return channel.position();
-    }
-
-    @Override
-    public long size() throws IOException {
-        return channel.size();
-    }
-
-    @Override
-    public int read(ByteBuffer dst) throws IOException {
-        return channel.read(dst);
-    }
-
-    @Override
-    public FileChannel position(long pos) throws IOException {
-        channel.position(pos);
-        return this;
-    }
-
-    @Override
-    public int read(ByteBuffer dst, long position) throws IOException {
-        return channel.read(dst, position);
-    }
-
-    @Override
-    public int write(ByteBuffer src, long position) throws IOException {
-        return channel.write(src, position);
-    }
-
-    @Override
-    public FileChannel truncate(long newLength) throws IOException {
-        long size = channel.size();
-        if (newLength < size) {
-            long pos = channel.position();
-            channel.truncate(newLength);
-            long newPos = channel.position();
-            if (pos < newLength) {
-                // position should stay
-                // in theory, this should not be needed
-                if (newPos != pos) {
-                    channel.position(pos);
-                }
-            } else if (newPos > newLength) {
-                // looks like a bug in this FileChannel implementation, as
-                // the documentation says the position needs to be changed
-                channel.position(newLength);
-            }
-        }
-        return this;
-    }
-
-    @Override
-    public void force(boolean metaData) throws IOException {
-        channel.force(metaData);
-    }
-
-    @Override
-    public int write(ByteBuffer src) throws IOException {
-        try {
-            return channel.write(src);
-        } catch (NonWritableChannelException e) {
-            throw new IOException("read only");
-        }
-    }
-
-    @Override
-    public synchronized FileLock tryLock(long position, long size,
-            boolean shared) throws IOException {
-        return channel.tryLock(position, size, shared);
-    }
-
-    @Override
-    public String toString() {
-        return "nio:" + name;
     }
 
 }

--- a/h2/src/main/org/h2/store/fs/FilePathNio.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNio.java
@@ -18,7 +18,7 @@ public class FilePathNio extends FilePathWrapper {
     @Override
     public FileChannel open(String mode) throws IOException {
         return FileChannel.open(Paths.get(name.substring(getScheme().length() + 1)),
-                FileUtils.modeToOptions(mode), FileUtils.NO_ATTIBUTES);
+                FileUtils.modeToOptions(mode), FileUtils.NO_ATTRIBUTES);
     }
 
     @Override

--- a/h2/src/main/org/h2/store/fs/FilePathNioMapped.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNioMapped.java
@@ -197,6 +197,9 @@ class FileNioMapped extends FileBase {
     }
 
     public synchronized void setFileLength(long newLength) throws IOException {
+        if (mode == MapMode.READ_ONLY) {
+            throw new NonWritableChannelException();
+        }
         checkFileSizeLimit(newLength);
         int oldPos = pos;
         unMap();

--- a/h2/src/main/org/h2/store/fs/FilePathNioMem.java
+++ b/h2/src/main/org/h2/store/fs/FilePathNioMem.java
@@ -644,9 +644,9 @@ class FileNioMemData {
      *
      * @param openReadOnly if the file was opened in read-only mode
      */
-    void touch(boolean openReadOnly) throws IOException {
+    void touch(boolean openReadOnly) {
         if (isReadOnly || openReadOnly) {
-            throw new IOException("Read only");
+            throw new NonWritableChannelException();
         }
         lastModified = System.currentTimeMillis();
     }

--- a/h2/src/main/org/h2/store/fs/FilePathZip.java
+++ b/h2/src/main/org/h2/store/fs/FilePathZip.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.channels.NonWritableChannelException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
@@ -344,7 +345,7 @@ class FileZip extends FileBase {
 
     @Override
     public int write(ByteBuffer src) throws IOException {
-        throw new IOException("File is read-only");
+        throw new NonWritableChannelException();
     }
 
     @Override

--- a/h2/src/main/org/h2/store/fs/FileUtils.java
+++ b/h2/src/main/org/h2/store/fs/FileUtils.java
@@ -12,14 +12,34 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This utility class contains utility functions that use the file system
  * abstraction.
  */
 public class FileUtils {
+
+    private static final Set<? extends OpenOption> R, W, RWS, RWD;
+
+    static final FileAttribute<?>[] NO_ATTIBUTES = new FileAttribute[0];
+
+    static {
+        R = Collections.singleton(StandardOpenOption.READ);
+        W = EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+        RWS = EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE,
+                StandardOpenOption.SYNC);
+        RWD = EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE,
+                StandardOpenOption.DSYNC);
+    }
+
 
     /**
      * Checks if a file exists.
@@ -374,6 +394,27 @@ public class FileUtils {
         do {
             channel.write(src);
         } while (src.remaining() > 0);
+    }
+
+    static Set<? extends OpenOption> modeToOptions(String mode) {
+        Set<? extends OpenOption> options;
+        switch (mode) {
+        case "r":
+            options = R;
+            break;
+        case "rw":
+            options = W;
+            break;
+        case "rws":
+            options = RWS;
+            break;
+        case "rwd":
+            options = RWD;
+            break;
+        default:
+            throw new IllegalArgumentException(mode);
+        }
+        return options;
     }
 
 }

--- a/h2/src/main/org/h2/store/fs/FileUtils.java
+++ b/h2/src/main/org/h2/store/fs/FileUtils.java
@@ -29,7 +29,7 @@ public class FileUtils {
 
     private static final Set<? extends OpenOption> R, W, RWS, RWD;
 
-    static final FileAttribute<?>[] NO_ATTIBUTES = new FileAttribute[0];
+    static final FileAttribute<?>[] NO_ATTRIBUTES = new FileAttribute[0];
 
     static {
         R = Collections.singleton(StandardOpenOption.READ);

--- a/h2/src/test/org/h2/test/unit/TestFileSystem.java
+++ b/h2/src/test/org/h2/test/unit/TestFileSystem.java
@@ -374,7 +374,7 @@ public class TestFileSystem extends TestBase {
                 FileUtils.createTempFile(f, ".tmp", false);
         }};
         final FileChannel channel = FileUtils.open(f, "r");
-        new AssertThrows(IOException.class) {
+        new AssertThrows(NonWritableChannelException.class) {
             @Override
             public void test() throws IOException {
                 channel.write(ByteBuffer.allocate(1));
@@ -574,7 +574,7 @@ public class TestFileSystem extends TestBase {
         FileUtils.readFully(channel, ByteBuffer.wrap(test, 0, 10000));
         assertEquals(buffer, test);
         final FileChannel fc = channel;
-        new AssertThrows(IOException.class) {
+        new AssertThrows(NonWritableChannelException.class) {
             @Override
             public void test() throws Exception {
                 fc.write(ByteBuffer.wrap(test, 0, 10));
@@ -678,7 +678,6 @@ public class TestFileSystem extends TestBase {
         RandomAccessFile ra = new RandomAccessFile(file, "rw");
         FileUtils.delete(s);
         FileChannel f = FileUtils.open(s, "rw");
-        assertEquals(s, f.toString());
         assertEquals(-1, f.read(ByteBuffer.wrap(new byte[1])));
         f.force(true);
         Random random = new Random(seed);


### PR DESCRIPTION
1. `RandomAccessFile` is not used any more in `FilePathNio`. It works in terrible way in recent versions of Java, `String` is converted to a `File`, then to a `Path`, after it back to `String`, and we use RAF only to get a `FileChannel`, but since Java 7 we can create a channel directly.

2. Many implementations of `FileBase` (based on `FileChannel`) returned an `IOException` instead of `NonWritableChannelException` from some methods, and `NonWritableChannelException` from other. Now they return expected exceptions.

3. `FileNio` (second class from `FilePathNio.java`) is removed, the underlying `FileChannel` is used directly. I don't see any good reason to use a wrapper here.

4. H2 is not expected to work on Android before API 26 any more, so untested protection for older versions is removed from `FilePathAsync`.

@grandinj