### PR TITLE
Add NETWORK_TIMEOUT setting for SO_TIMEOUT

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -7494,6 +7494,10 @@ public class Parser {
             readIfEqualOrTo();
             read();
             return new NoOperation(session);
+        } else if (readIf("NETWORK_TIMEOUT")){
+            readIfEqualOrTo();
+            read();
+            return new NoOperation(session);
         } else if (readIf("AUTO_SERVER")) {
             readIfEqualOrTo();
             read();

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -98,7 +98,7 @@ public class ConnectionInfo implements Cloneable {
                 "IFEXISTS", "INIT", "FORBID_CREATION", "PASSWORD", "RECOVER", "RECOVER_TEST",
                 "USER", "AUTO_SERVER", "AUTO_SERVER_PORT", "NO_UPGRADE",
                 "AUTO_RECONNECT", "OPEN_NEW", "PAGE_SIZE", "PASSWORD_HASH", "JMX",
-                "SCOPE_GENERATED_KEYS", "AUTHREALM", "AUTHZPWD" };
+                "SCOPE_GENERATED_KEYS", "AUTHREALM", "AUTHZPWD", "NETWORK_TIMEOUT"};
         HashSet<String> set = new HashSet<>(128);
         set.addAll(SetTypes.getTypes());
         for (String key : connectionTime) {

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -117,7 +117,7 @@ public class SessionRemote extends SessionWithState implements DataHandler {
     private Transfer initTransfer(ConnectionInfo ci, String db, String server)
             throws IOException {
         Socket socket = NetUtils.createSocket(server,
-                Constants.DEFAULT_TCP_PORT, ci.isSSL());
+                Constants.DEFAULT_TCP_PORT, ci.isSSL(), ci.getProperty("NETWORK_TIMEOUT",0 ));
         Transfer trans = new Transfer(this, socket);
         trans.setSSL(ci.isSSL());
         trans.init();

--- a/h2/src/main/org/h2/util/NetUtils.java
+++ b/h2/src/main/org/h2/util/NetUtils.java
@@ -67,7 +67,21 @@ public class NetUtils {
      * @return the socket
      */
     public static Socket createSocket(String server, int defaultPort,
-            boolean ssl) throws IOException {
+                                      boolean ssl) throws IOException {
+        return createSocket(server, defaultPort, ssl, 0);
+    }
+    /**
+     * Create a client socket that is connected to the given address and port.
+     *
+     * @param server to connect to (including an optional port)
+     * @param defaultPort the default port (if not specified in the server
+     *            address)
+     * @param ssl if SSL should be used
+     * @param networkTimeout socket so timeout
+     * @return the socket
+     */
+    public static Socket createSocket(String server, int defaultPort,
+            boolean ssl, int networkTimeout) throws IOException {
         int port = defaultPort;
         // IPv6: RFC 2732 format is '[a:b:c:d:e:f:g:h]' or
         // '[a:b:c:d:e:f:g:h]:port'
@@ -80,7 +94,7 @@ public class NetUtils {
             server = server.substring(0, idx);
         }
         InetAddress address = InetAddress.getByName(server);
-        return createSocket(address, port, ssl);
+        return createSocket(address, port, ssl, networkTimeout);
     }
 
     /**
@@ -92,6 +106,19 @@ public class NetUtils {
      * @return the socket
      */
     public static Socket createSocket(InetAddress address, int port, boolean ssl)
+        throws IOException {
+        return createSocket(address, port, ssl, 0);
+    }
+    /**
+     * Create a client socket that is connected to the given address and port.
+     *
+     * @param address the address to connect to
+     * @param port the port
+     * @param ssl if SSL should be used
+     * @param networkTimeout socket so timeout
+     * @return the socket
+     */
+    public static Socket createSocket(InetAddress address, int port, boolean ssl, int networkTimeout)
             throws IOException {
         long start = System.nanoTime();
         for (int i = 0;; i++) {
@@ -100,6 +127,7 @@ public class NetUtils {
                     return CipherFactory.createSocket(address, port);
                 }
                 Socket socket = new Socket();
+                socket.setSoTimeout(networkTimeout);
                 socket.connect(new InetSocketAddress(address, port),
                         SysProperties.SOCKET_CONNECT_TIMEOUT);
                 return socket;


### PR DESCRIPTION
Socket SO_TIMEOUT is a core and important config in socket
communication. It helps developers to adjust read timeout
value according to bussiness and scenario they actually needs.

In Java, when SO_TIMEOUT set to a non-zero timeout, the read()
call associated with the socket stream will block util timeout is
reached, then throws a java.net.SocketTimeoutException. Otherwise,
when SO_TIMEOUT set to a zero timeout, the socket SO_TIMEOUT will be
interpreted as an infinite timeout. Zero timeout is the default setting.

Most of the time, use a default zero timeout with creating a new socket
is tranquil, But not everytime.

Developer need this config in these scenes (It may be more than):

	- Long responding lead to socket connections accumulation.

	- Socket read block with infinite read timeout and finally not to be released leads to leak in NFS.
	  Associate readings:
(https://access.redhat.com/solutions/3053801?spm=a2c4g.11186623.2.12.5ca22e518bdfck)
(https://access.redhat.com/solutions/1427473?spm=a2c4g.11186623.2.13.5ca22e518bdfck)

	- Prevent the client socket from being blocked because the server's data is not returned(Application or Other Unknown underlying bugs).

Signed-off-by: Dyrone Teng <dyroneteng@gmail.com>