### PR TITLE
Catch java.lang.NoClassDefFoundError

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -370,12 +370,7 @@ public class MVStore implements AutoCloseable
         if (this.fileStore != null) {
             retentionTime = this.fileStore.getDefaultRetentionTime();
             // 19 KB memory is about 1 KB storage
-            int kb;
-            try {
-               kb = Math.max(1, Math.min(19, Utils.scaleForAvailableMemory(64))) * 1024;
-            } catch(NoClassDefFoundError ex) {
-                kb = 19 * 1024;     // this equates to 19MB
-            }
+            int kb = Math.max(1, Math.min(19, Utils.scaleForAvailableMemory(64))) * 1024;
             kb = DataUtils.getConfigParam(config, "autoCommitBufferSize", kb);
             autoCommitMemory = kb * 1024;
             autoCompactFillRate = DataUtils.getConfigParam(config, "autoCompactFillRate", 90);

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -370,7 +370,12 @@ public class MVStore implements AutoCloseable
         if (this.fileStore != null) {
             retentionTime = this.fileStore.getDefaultRetentionTime();
             // 19 KB memory is about 1 KB storage
-            int kb = Math.max(1, Math.min(19, Utils.scaleForAvailableMemory(64))) * 1024;
+            int kb;
+            try {
+               kb = Math.max(1, Math.min(19, Utils.scaleForAvailableMemory(64))) * 1024;
+            } catch(NoClassDefFoundError ex) {
+                kb = 19 * 1024;     // this equates to 19MB
+            }
             kb = DataUtils.getConfigParam(config, "autoCommitBufferSize", kb);
             autoCommitMemory = kb * 1024;
             autoCompactFillRate = DataUtils.getConfigParam(config, "autoCompactFillRate", 90);

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -787,6 +787,8 @@ public class Utils {
             return (int) (value * physicalMemorySize / (1024 * 1024 * 1024));
         } catch (Exception e) {
             // ignore
+        } catch(Error error) {
+            // ignore
         }
         return value;
     }

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -787,7 +787,7 @@ public class Utils {
             return (int) (value * physicalMemorySize / (1024 * 1024 * 1024));
         } catch (Exception e) {
             // ignore
-        } catch(Error error) {
+        } catch (Error error) {
             // ignore
         }
         return value;


### PR DESCRIPTION
Catch error and supply sensible default for auto commit memory size when running on older JVM that does not implement ManagementFactory.