### PR TITLE
add setting AUTO_COMPACT_FILL_RATE

### DIFF
--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -63,6 +63,18 @@ public class DbSettings extends SettingsBase {
     public final int analyzeSample = get("ANALYZE_SAMPLE", 10_000);
 
     /**
+     * Database setting <code>AUTO_COMPACT_FILL_RATE</code>
+     * (default: 90, which means 90%, 0 disables auto-compacting).<br />
+     * Set the auto-compact target fill rate. If the average fill rate (the
+     * percentage of the storage space that contains active data) of the
+     * chunks is lower, then the chunks with a low fill rate are re-written.
+     * Also, if the percentage of empty space between chunks is higher than
+     * this value, then chunks at the end of the file are moved. Compaction
+     * stops if the target fill rate is reached.
+     */
+    public final int autoCompactFillRate = get("AUTO_COMPACT_FILL_RATE", 90);
+
+    /**
      * Database setting <code>DATABASE_TO_LOWER</code> (default: false).<br />
      * When set to true unquoted identifiers and short name of database are
      * converted to lower case. Value of this setting should not be changed

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -70,7 +70,8 @@ public class DbSettings extends SettingsBase {
      * chunks is lower, then the chunks with a low fill rate are re-written.
      * Also, if the percentage of empty space between chunks is higher than
      * this value, then chunks at the end of the file are moved. Compaction
-     * stops if the target fill rate is reached.
+     * stops if the target fill rate is reached.<br />
+     * This setting only affects MVStore engine.
      */
     public final int autoCompactFillRate = get("AUTO_COMPACT_FILL_RATE", 90);
 
@@ -167,7 +168,8 @@ public class DbSettings extends SettingsBase {
     /**
      * Database setting <code>MAX_COMPACT_COUNT</code>
      * (default: Integer.MAX_VALUE).<br />
-     * The maximum number of pages to move when closing a database.
+     * The maximum number of pages to move when closing a database.<br />
+     * This setting only affects PageStore engine.
      */
     public final int maxCompactCount = get("MAX_COMPACT_COUNT",
             Integer.MAX_VALUE);

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -3441,7 +3441,7 @@ public class MVStore implements AutoCloseable
          * this value, then chunks at the end of the file are moved. Compaction
          * stops if the target fill rate is reached.
          * <p>
-         * The default value is 40 (40%). The value 0 disables auto-compacting.
+         * The default value is 90 (90%). The value 0 disables auto-compacting.
          * <p>
          *
          * @param percent the target fill rate

--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -71,7 +71,7 @@ public class MVTableEngine implements TableEngine {
                     String dir = FileUtils.getParent(fileName);
                     FileUtils.createDirectories(dir);
                 }
-                int autoCompactFillRate = db.getSettings().maxCompactCount;
+                int autoCompactFillRate = db.getSettings().autoCompactFillRate;
                 if (autoCompactFillRate <= 100) {
                     builder.autoCompactFillRate(autoCompactFillRate);
                 }


### PR DESCRIPTION
This slight change can make MvStore property `autoCompactFillRate` configurable by adding `AUTO_COMPACT_FILL_RATE` into jdbc url.

In version 1.4.200 and previous, according to the code Line 74 in MVTableEngine.java, a workaround is to tune this property by setting `MAX_COMPACT_COUNT`, which seems strange.

During my use of mvstore with 1.4.200, in a frequent insert/delete scenario, I detect heavy disk IO when the mvstore file reaches 1GB or more. `dstat` shows like:

```
----total-cpu-usage---- -dsk/total- -net/total- ---paging-- ---system--
usr sys idl wai hiq siq| read  writ| recv  send|  in   out | int   csw
  9   2  85   0   0   3|1302k  471k|   0     0 |1024B 1116B| 996  6067
 28   7  44  17   0   5|  74M 4096B|3329k 2812k|   0     0 |  24k   14k
  9   6  60  21   0   5| 124M   76k|3242k 2082k|   0     0 |  20k   11k
 69   6  10  11   0   4| 143M   36k|2164k 1505k| 164k    0 |  17k 7952
 19   8  50  19   0   5| 164M   12k|2556k 1974k|   0     0 |  22k   12k
 15   6  58  17   0   3| 112M   88k|3269k 1835k|   0     0 |  20k   12k
```

Note the heavy disk read. Thread dump shows that `MVStore background` thread is busy invoking `MVStore.doMaintenance` to compact empty spaces. Default `autoCompactFillRate` in 1.4.200 is changed to 90%, so in my heavy insert/delete scenario `rewriteChunks` is frequently triggered. When I tune this value to 40% (default value for 1.4.199 and previous), the heavy disk IO disappears.

So it is necessary to make `autoCompactFillRate` configurable:
* Generally, a high rate (e.g. 90%) can save disk spaces;
* In heavy insert/delete scenarios, use a low rate (e.g. 40%) can avoid heavy disk IO.