### PR TITLE
Fix existence check of non-persistent databases

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -294,13 +294,12 @@ public class Database implements DataHandler, CastDataProvider {
                 ci.removeProperty("CACHE_TYPE", Constants.CACHE_TYPE_DEFAULT));
         this.ignoreCatalogs = ci.getProperty("IGNORE_CATALOGS",
                 dbSettings.ignoreCatalogs);
-        openDatabase(traceLevelFile, traceLevelSystemOut, closeAtVmShutdown, ci);
+        openDatabase(traceLevelFile, traceLevelSystemOut, closeAtVmShutdown);
     }
 
-    private void openDatabase(int traceLevelFile, int traceLevelSystemOut,
-            boolean closeAtVmShutdown, ConnectionInfo ci) {
+    private void openDatabase(int traceLevelFile, int traceLevelSystemOut, boolean closeAtVmShutdown) {
         try {
-            open(traceLevelFile, traceLevelSystemOut, ci);
+            open(traceLevelFile, traceLevelSystemOut);
             if (closeAtVmShutdown) {
                 OnExitDatabaseCloser.register(this);
             }
@@ -567,7 +566,7 @@ public class Database implements DataHandler, CastDataProvider {
         trace.info("opening {0} (build {1})", databaseName, Constants.BUILD_ID);
     }
 
-    private synchronized void open(int traceLevelFile, int traceLevelSystemOut, ConnectionInfo ci) {
+    private synchronized void open(int traceLevelFile, int traceLevelSystemOut) {
         if (persistent) {
             String dataFileName = databaseName + Constants.SUFFIX_OLD_DATABASE_FILE;
             boolean existsData = FileUtils.exists(dataFileName);

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -60,10 +60,9 @@ public class Engine implements SessionFactory {
                 database = DATABASES.get(name);
             }
             if (database == null) {
-                String p = ci.getProperty("MV_STORE");
-                boolean exists = p == null ? Database.exists(name)
-                        : Database.exists(name, Utils.parseBoolean(p, true, false));
-                if (!exists) {
+                String p;
+                if (!ci.isPersistent() || !((p = ci.getProperty("MV_STORE")) == null ? Database.exists(name)
+                        : Database.exists(name, Utils.parseBoolean(p, true, false)))) {
                     if (ifExists) {
                         throw DbException.get(ErrorCode.DATABASE_NOT_FOUND_WITH_IF_EXISTS_1, name);
                     }


### PR DESCRIPTION
A fix for issue from the mailing list:
https://groups.google.com/forum/#!topic/h2-database/_NEzauMSRjg

The check of presence shouldn't try to use the name of in-memory database to check presence of the file. In-memory database simply does not exist when there is no such database in the map.

This issue wasn't visible on POSIX systems.