### PR TITLE
build(maven): add spotbugs

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -260,8 +260,40 @@
           </includes>
         </configuration>
       </plugin>
-
     </plugins>
   </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.8.2</version>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.1.12.2</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+          <failOnError>false</failOnError>
+          <!--          <includeFilterFile>${session.executionRootDirectory}/spotbugs-security-include.xml</includeFilterFile>-->
+          <!--          <excludeFilterFile>${session.executionRootDirectory}/spotbugs-security-exclude.xml</excludeFilterFile>-->
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.10.1</version>
+            </plugin>
+            <plugin>
+              <groupId>com.mebigfatguy.sb-contrib</groupId>
+              <artifactId>sb-contrib</artifactId>
+              <version>7.4.7</version>
+            </plugin>
+          </plugins>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 
 </project>


### PR DESCRIPTION
Adds SpotBugs (https://spotbugs.github.io/, https://github.com/spotbugs/spotbugs) to the Maven build. SpotBugs is a static code analysis tool for Java with many extensible inspections. It's the successor of the unmaintained FindBugs.

The Maven plugin is configured to simply generate the report and does not act as a build breaker.

The report can be generated with `mvn compile site` and can be found afterwards under `h2/target/site/spotbugs.html`.

I plan to submit fixes for the reported SpotBugs issues.