### PR TITLE
fix(mvstore/MVStore): correctly lock the store

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2155,7 +2155,7 @@ public class MVStore implements AutoCloseable
         sync();
 
         int rewrittenPageCount = 0;
-        storeLock.unlock();
+        storeLock.lock();
         try {
             for (MVMap<?, ?> map : maps.values()) {
                 if (!map.isClosed() && !map.isSingleWriter()) {
@@ -2174,7 +2174,7 @@ public class MVStore implements AutoCloseable
                 rewrittenPageCount += rewriteMetaCount;
             }
         } finally {
-            storeLock.lock();
+            storeLock.unlock();
         }
         commit();
         assert validateRewrite(set);


### PR DESCRIPTION
`MVStore` mixed up the instructions to acquire the `storeLock`. It should be:

```java
 Lock l = ...;
 l.lock();
 try {
   // access the resource protected by this lock
 } finally {
   l.unlock();
 }
```
Reference: https://docs.oracle.com/en/java/javase/13/docs/api/java.base/java/util/concurrent/locks/Lock.html