### PR TITLE
add PostgreSQL compatible variable STATEMENT_TIMEOUT

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -7528,6 +7528,11 @@ public class Parser {
             readIfEqualOrTo();
             read();
             return new NoOperation(session);
+        } else if (readIf("STATEMENT_TIMEOUT")){
+            // for PostgreSQL compatibility
+            readIfEqualOrTo();
+            read();
+            return new NoOperation(session);
         } else if (readIf("AUTO_SERVER")) {
             readIfEqualOrTo();
             read();

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -7531,8 +7531,9 @@ public class Parser {
         } else if (readIf("STATEMENT_TIMEOUT")){
             // for PostgreSQL compatibility
             readIfEqualOrTo();
-            read();
-            return new NoOperation(session);
+            Set command = new Set(session, SetTypes.QUERY_TIMEOUT);
+            command.setInt(readNonNegativeInt());
+            return command;
         } else if (readIf("AUTO_SERVER")) {
             readIfEqualOrTo();
             read();

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -307,6 +307,18 @@ public class TestCompatibility extends TestDb {
         assertTrue(rs.next());
         assertEquals(new BigDecimal("92233720368547758.07"), rs.getBigDecimal(1));
         assertFalse(rs.next());
+
+        /* Test SET STATEMENT_TIMEOUT */
+        assertEquals(0, stat.getQueryTimeout());
+        conn.close();
+        deleteDb("compatibility");
+        // `stat.getQueryTimeout()` caches the result, so create another connection
+        conn = getConnection("compatibility");
+        stat = conn.createStatement();
+        // `STATEMENT_TIMEOUT` uses milliseconds
+        stat.execute("SET STATEMENT_TIMEOUT TO 30000");
+        // `stat.getQueryTimeout()` returns seconds
+        assertEquals(30, stat.getQueryTimeout());
     }
 
     private void testMySQL() throws SQLException {


### PR DESCRIPTION
The variable `STATEMENT_TIMEOUT` (a synonym for `QUERY_TIMEOUT`) can make H2 be accessed with [HeidiSQL](https://github.com/HeidiSQL/HeidiSQL), a famous database client that supports MySQL, MSSQL and Postgres.

When I first tried HeidiSQL (v10.2.0.5599) to access my Java + H2 application with PG protocol, HeidiSQL sent `SET STATEMENT_TIMEOUT TO <seconds>`  after authentication, and was rejected by H2. After adding `STATEMENT_TIMEOUT` into H2 codes, HeidiSQL successfully creates the connetion and can access H2 data.