### PR TITLE
Another #2288 CME fix

### DIFF
--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -676,8 +676,8 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         // On rare occasions it can be called concurrently (i.e. from close())
         // whithout proper locking, but instead of oversynchronizing
         // we just skip this optional operation in such case
-        if (Thread.holdsLock(database.isMVStore() ? this : database)
-                && tablesToAnalyze != null) {
+        if (tablesToAnalyze != null &&
+                Thread.holdsLock(database.isMVStore() ? this : database)) {
             // take a local copy and clear because in rare cases we can call
             // back into markTableForAnalyze while iterating here
             HashSet<Table> tablesToAnalyzeLocal = tablesToAnalyze;

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -676,7 +676,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         // On rare occasions it can be called concurrently (i.e. from close())
         // whithout proper locking, but instead of oversynchronizing
         // we just skip this optional operation in such case
-        if (Thread.holdsLock(database.isPersistent() ? this : database)
+        if (Thread.holdsLock(database.isMVStore() ? this : database)
                 && tablesToAnalyze != null) {
             // take a local copy and clear because in rare cases we can call
             // back into markTableForAnalyze while iterating here

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -657,15 +657,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
                 autoCommitAtTransactionEnd = false;
             }
         }
-
-        if (tablesToAnalyze != null) {
-            analyzeTables();
-            if (database.isMVStore()) {
-                // table analysis opens a new transaction(s),
-                // so we need to commit afterwards whatever leftovers might be
-                commit(true);
-            }
-        }
+        analyzeTables();
         endTransaction(forRepeatableRead);
     }
 
@@ -681,16 +673,27 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
     }
 
     private void analyzeTables() {
-        // take a local copy and clear because in rare cases we can call
-        // back into markTableForAnalyze while iterating here
-        HashSet<Table> tablesToAnalyzeLocal = tablesToAnalyze;
-        tablesToAnalyze = null;
-        int rowCount = getDatabase().getSettings().analyzeSample / 10;
-        for (Table table : tablesToAnalyzeLocal) {
-            Analyze.analyzeTable(this, table, rowCount, false);
+        // On rare occasions it can be called concurrently (i.e. from close())
+        // whithout proper locking, but instead of oversynchronizing
+        // we just skip this optional operation in such case
+        if (Thread.holdsLock(database.isPersistent() ? this : database)
+                && tablesToAnalyze != null) {
+            // take a local copy and clear because in rare cases we can call
+            // back into markTableForAnalyze while iterating here
+            HashSet<Table> tablesToAnalyzeLocal = tablesToAnalyze;
+            tablesToAnalyze = null;
+            int rowCount = getDatabase().getSettings().analyzeSample / 10;
+            for (Table table : tablesToAnalyzeLocal) {
+                Analyze.analyzeTable(this, table, rowCount, false);
+            }
+            // analyze can lock the meta
+            database.unlockMeta(this);
+            if (database.isMVStore()) {
+                // table analysis opens a new transaction(s),
+                // so we need to commit afterwards whatever leftovers might be
+                commit(true);
+            }
         }
-        // analyze can lock the meta
-        database.unlockMeta(this);
     }
 
     private void removeTemporaryLobs(boolean onTimeout) {


### PR DESCRIPTION
Fix for #2288 when CME is caused by multi-threaded access, as it is shown by a stack trace posted there.
As @katzyn pointed out, there are situations when this code path is hit without proper locking :
>Session.commit() can be executed without a lock on itself during startup, during shutdown, from recently reimplemented JdbcConnection.setTransactionIsolation(), from the new ABORT_SESSION() function, from JdbcConnection.closeOld() and possibly from other places.

While I disagre on JdbcConnection.setTransactionIsolation() case (it goes through Command.executeUpdate() and acquire lock there), startup case should be safe by it's single-threaded nature, so only one left is forced connection/session closure from another thread. In this case IMHO we can skip table analisys altogether.