### PR TITLE
Fix #2294: default closeDelay set to -1 for autoServer, postgres and remote mode

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -270,7 +270,11 @@ public class Database implements DataHandler, CastDataProvider {
             setEventListenerClass(listener);
         }
         String modeName = ci.removeProperty("MODE", null);
+        boolean postgres = false;
         if (modeName != null) {
+            if ("PostgreSQL".equals(modeName)) {
+                postgres = true;
+            }
             mode = Mode.getInstance(modeName);
             if (mode == null) {
                 throw DbException.get(ErrorCode.UNKNOWN_MODE_1, modeName);
@@ -294,6 +298,9 @@ public class Database implements DataHandler, CastDataProvider {
                 ci.removeProperty("CACHE_TYPE", Constants.CACHE_TYPE_DEFAULT));
         this.ignoreCatalogs = ci.getProperty("IGNORE_CATALOGS",
                 dbSettings.ignoreCatalogs);
+        if (autoServerMode || postgres || ci.isRemote()) {
+            this.closeDelay = -1;
+        }
         openDatabase(traceLevelFile, traceLevelSystemOut, closeAtVmShutdown);
     }
 

--- a/h2/src/test/org/h2/test/server/TestAutoServer.java
+++ b/h2/src/test/org/h2/test/server/TestAutoServer.java
@@ -5,11 +5,15 @@
  */
 package org.h2.test.server;
 
+import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.ErrorCode;
+import org.h2.engine.Database;
+import org.h2.engine.Session;
+import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.util.SortedProperties;
@@ -74,6 +78,12 @@ public class TestAutoServer extends TestDb {
         String user = getUser(), password = getPassword();
         Connection connServer = getConnection(url + ";OPEN_NEW=TRUE",
                 user, password);
+
+        // default closeDelay -1 for autoServer
+        Field closeDelay = Database.class.getDeclaredField("closeDelay");
+        closeDelay.setAccessible(true);
+        assertEquals(-1, ((Number) closeDelay.get(((Session)
+                ((JdbcConnection) connServer).getSession()).getDatabase())).intValue());
 
         int i = ITERATIONS;
         for (; i > 0; i--) {


### PR DESCRIPTION
Fix #2294: default closeDelay set to -1 for autoServer, postgres and remote mode.

This can avoid frequent compaction for large data files, and make H2 more likely to be a general purpose database.