### PR TITLE
Parse nested bracketed comments

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2587,9 +2587,9 @@ CHECK (VALUE > 0)
 "Other Grammar","Comments","
 -- anythingUntilEndOfLine | /* anythingUntilEndComment */ | @h2@ // anythingUntilEndOfLine
 ","
-Comments can be used anywhere in a command and are ignored by the database. Line
-comments end with a newline. Block comments cannot be nested, but can be
-multiple lines long.
+Comments can be used anywhere in a command and are ignored by the database.
+Line comments ""--"" and ""//"" end with a newline.
+Block comments ""/* */"" can be nested and can be multiple lines long.
 ","
 // This is a comment
 "

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2325: H2 does not parse nested bracketed comments correctly
+</li>
 <li>Issue #466: Confusion about INFORMATION_SCHEMA content related to UNIQUE constraints
 </li>
 <li>PR #2323: Assorted changes

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -5499,14 +5499,23 @@ public class Parser {
                     command[i + 1] = ' ';
                     startLoop = i;
                     i += 2;
-                    checkRunOver(i, len, startLoop);
-                    while (command[i] != '*' || command[i + 1] != '/') {
-                        command[i++] = ' ';
-                        checkRunOver(i, len, startLoop);
+                    for (int level = 1; level > 0;) {
+                        for (;;) {
+                            checkRunOver(i, len, startLoop);
+                            char ch = command[i];
+                            command[i++] = ' ';
+                            if (ch == '*') {
+                                if (command[i] == '/') {
+                                    level--;
+                                    break;
+                                }
+                            } else if (ch == '/' && command[i] == '*') {
+                                level++;
+                                command[i++] = ' ';
+                            }
+                        }
+                        command[i] = ' ';
                     }
-                    command[i] = ' ';
-                    command[i + 1] = ' ';
-                    i++;
                 } else if (command[i + 1] == '/') {
                     // single line comment
                     changed = true;

--- a/h2/src/main/org/h2/command/ddl/DropDatabase.java
+++ b/h2/src/main/org/h2/command/ddl/DropDatabase.java
@@ -115,7 +115,7 @@ public class DropDatabase extends DefineCommand {
         list.addAll(db.getAllSchemaObjects(DbObject.CONSTANT));
         list.addAll(db.getAllSchemaObjects(DbObject.FUNCTION_ALIAS));
         for (SchemaObject obj : list) {
-            if (obj.isHidden()) {
+            if (!obj.getSchema().isValid() || obj.isHidden()) {
                 continue;
             }
             db.removeSchemaObject(session, obj);

--- a/h2/src/test/org/h2/test/scripts/comments.sql
+++ b/h2/src/test/org/h2/test/scripts/comments.sql
@@ -4,22 +4,19 @@
 --
 
 CALL 1 /* comment */ ;;
-> 1
-> -
-> 1
-> rows: 1
+>> 1
 
 CALL 1 /* comment */ ;
-> 1
-> -
-> 1
-> rows: 1
+>> 1
 
-call /* remark * / * /* ** // end */ 1;
-> 1
-> -
-> 1
-> rows: 1
+call /* remark * / * /* ** // end */*/ 1;
+>> 1
+
+call /*/*/ */*/ 1;
+>> 1
+
+call /*1/*1*/1*/1;
+>> 1
 
 --- remarks/comments/syntax ----------------------------------------------------------------------------------------------
 CREATE TABLE TEST(
@@ -44,6 +41,9 @@ DROP_ TABLE_ TEST_T;
 > exception SYNTAX_ERROR_2
 
 DROP TABLE TEST /*;
+> exception SYNTAX_ERROR_1
+
+call /* remark * / * /* ** // end */ 1;
 > exception SYNTAX_ERROR_1
 
 DROP TABLE TEST;

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -822,4 +822,4 @@ sit sitting sooner hdr considering encounter compete quickack decrementing exhau
 scr ffffl suspend asap ldt lmt movement ago snapshotting paris phenomena backends quirks pgjdbc jupiter grab folds
 umcfo iapi autoloaded derbyshared darkred coral mistyrose lightseagreen unmodifiable posix exc attrs relativize
 quotient niomem niomapped obtaining rare occasions oversynchronizing disallows opponent adversarial broader decent tmv
-prize secured stateful generification
+prize secured stateful generification bracketed


### PR DESCRIPTION
Closes #2325.

Also contains a fix for NPE found by `TestCrashAPI`. Unfortunately, I didn't find a test case.