### PR TITLE
List licenses separately in POM templates for Maven Central

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2350: License Problem in POM
+</li>
 <li>Issue #2345: Add standard SET TIME ZONE command to set current time zone of the session
 </li>
 <li>PR #2341: Cleanup file backend sync

--- a/h2/src/installer/pom-mvstore-template.xml
+++ b/h2/src/installer/pom-mvstore-template.xml
@@ -9,8 +9,13 @@
     <description>H2 MVStore</description>
     <licenses>
         <license>
-            <name>MPL 2.0 or EPL 1.0</name>
-            <url>https://h2database.com/html/license.html</url>
+            <name>MPL 2.0</name>
+            <url>https://www.mozilla.org/en-US/MPL/2.0/</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>EPL 1.0</name>
+            <url>https://opensource.org/licenses/eclipse-1.0.php</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/h2/src/installer/pom-template.xml
+++ b/h2/src/installer/pom-template.xml
@@ -9,8 +9,13 @@
     <description>H2 Database Engine</description>
     <licenses>
         <license>
-            <name>MPL 2.0 or EPL 1.0</name>
-            <url>https://h2database.com/html/license.html</url>
+            <name>MPL 2.0</name>
+            <url>https://www.mozilla.org/en-US/MPL/2.0/</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>EPL 1.0</name>
+            <url>https://opensource.org/licenses/eclipse-1.0.php</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
Closes #2350.

Previous fix in #609 was incomplete, only file for the experimental build was improved.