### PR TITLE
Add USING clause to ALTER COLUMN SET DATA TYPE

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -405,12 +405,17 @@ ALTER SEQUENCE SEQ_ID RESTART WITH 1000
 
 "Commands (DDL)","ALTER TABLE ADD","
 ALTER TABLE @h2@ [ IF EXISTS ] [schemaName.]tableName ADD [ COLUMN ]
-{ @h2@ [ IF NOT EXISTS ] columnName columnDefinition
+{ @h2@ [ IF NOT EXISTS ] columnName columnDefinition @h2@ [ USING initialValueExpression ]
     | @h2@ { ( { columnName columnDefinition | tableConstraintDefinition } [,...] ) } }
 @h2@ [ { { BEFORE | AFTER } columnName } | FIRST ]
 ","
 Adds a new column to a table.
 This command commits an open transaction in this connection.
+
+If USING is specified the provided expression is used to generate initial value of the new column for each row.
+The expression may reference existing columns of the table.
+Otherwise the DEFAULT expression is used, if any.
+If neither USING nor DEFAULT are specified, the NULL is used.
 ","
 ALTER TABLE TEST ADD CREATEDATE TIMESTAMP
 "
@@ -451,7 +456,7 @@ ALTER COLUMN @h2@ [ IF EXISTS ] columnName
     | @h2@ { DROP ON UPDATE }
     | { SET NOT NULL }
     | { DROP NOT NULL } | @c@ { SET NULL }
-    | { SET DATA TYPE dataType }
+    | { SET DATA TYPE dataType @h2@ [ USING newValueExpression ] }
     | @h2@ { SET { VISIBLE | INVISIBLE } } }
 ","
 Changes the data type of a column, rename a column,
@@ -480,7 +485,9 @@ SET NOT NULL sets a column to not allow NULL. Rows may not contains NULL in this
 
 DROP NOT NULL and SET NULL set a column to allow NULL. The row may not be part of a primary key.
 
-SET DATA TYPE changes the data type of a column.
+SET DATA TYPE changes the data type of a column, for each row old value is converted to this data type
+unless USING is specified with a custom expression.
+USING expression may reference previous value of the modified column by its name and values of other columns.
 
 SET INVISIBLE makes the column hidden, i.e. it will not appear in SELECT * results.
 SET VISIBLE has the reverse effect.

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -8504,6 +8504,7 @@ public class Parser {
         Column newColumn = parseColumnForTable(columnName,
                 !preserveNotNull || oldColumn == null || oldColumn.isNullable());
         AlterTableAlterColumn command = new AlterTableAlterColumn(session, schema);
+        parseAlterColumnUsingIf(command);
         command.setTableName(tableName);
         command.setIfTableExists(ifTableExists);
         command.setType(CommandInterface.ALTER_TABLE_ALTER_COLUMN_CHANGE_TYPE);
@@ -8537,6 +8538,7 @@ public class Parser {
             }
         }
         AlterTableAlterColumn command = new AlterTableAlterColumn(session, schema);
+        parseAlterColumnUsingIf(command);
         command.setTableName(tableName);
         command.setIfTableExists(ifTableExists);
         command.setType(CommandInterface.ALTER_TABLE_ALTER_COLUMN_CHANGE_TYPE);
@@ -8562,6 +8564,7 @@ public class Parser {
             boolean ifNotExists = readIfNotExists();
             command.setIfNotExists(ifNotExists);
             parseTableColumnDefinition(command, schema, tableName, false);
+            parseAlterColumnUsingIf(command);
         }
         if (readIf("BEFORE")) {
             command.setAddBefore(readColumnIdentifier());
@@ -8571,6 +8574,12 @@ public class Parser {
             command.setAddFirst();
         }
         return command;
+    }
+
+    private void parseAlterColumnUsingIf(AlterTableAlterColumn command) {
+        if (readIf(USING)) {
+            command.setUsingExpression(readExpression());
+        }
     }
 
     private ConstraintActionType parseAction() {

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -60,7 +60,7 @@ public class Column {
     public static final int NULLABLE_UNKNOWN =
             ResultSetMetaData.columnNullableUnknown;
 
-    private final TypeInfo type;
+    private TypeInfo type;
     private Table table;
     private String name;
     private int columnId;
@@ -691,13 +691,16 @@ public class Column {
      * @return true if the new column is compatible
      */
     public boolean isWideningConversion(Column newColumn) {
-        if (type != newColumn.type) {
+        if (type.getValueType() != newColumn.type.getValueType()) {
             return false;
         }
         if (type.getPrecision() > newColumn.type.getPrecision()) {
             return false;
         }
         if (type.getScale() != newColumn.type.getScale()) {
+            return false;
+        }
+        if (!Objects.equals(type.getExtTypeInfo(), newColumn.type.getExtTypeInfo())) {
             return false;
         }
         if (nullable && !newColumn.nullable) {
@@ -740,6 +743,7 @@ public class Column {
      */
     public void copy(Column source) {
         name = source.name;
+        type = source.type;
         // table is not set
         // columnId is not set
         nullable = source.nullable;

--- a/h2/src/test/org/h2/test/scripts/ddl/alterTableAlterColumn.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/alterTableAlterColumn.sql
@@ -461,3 +461,53 @@ TABLE TEST;
 
 DROP TABLE TEST;
 > ok
+
+CREATE TABLE TEST(A INT) AS VALUES 1, 2, 3;
+> ok
+
+ALTER TABLE TEST ALTER COLUMN A SET DATA TYPE BIGINT USING A * 10;
+> ok
+
+TABLE TEST;
+> A
+> --
+> 10
+> 20
+> 30
+> rows: 3
+
+ALTER TABLE TEST ADD COLUMN B INT NOT NULL USING A + 1;
+> ok
+
+TABLE TEST;
+> A  B
+> -- --
+> 10 11
+> 20 21
+> 30 31
+> rows: 3
+
+ALTER TABLE TEST ADD COLUMN C VARCHAR(2) USING A;
+> ok
+
+TABLE TEST;
+> A  B  C
+> -- -- --
+> 10 11 10
+> 20 21 20
+> 30 31 30
+> rows: 3
+
+ALTER TABLE TEST ALTER COLUMN C SET DATA TYPE VARCHAR(3) USING C || '*';
+> ok
+
+TABLE TEST;
+> A  B  C
+> -- -- ---
+> 10 11 10*
+> 20 21 20*
+> 30 31 30*
+> rows: 3
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
Closes #2348.

Optimization for quick widening conversion is also restored, it was broken with introduction of `TypeInfo`.