### PR TITLE
Fix unused result

### DIFF
--- a/h2/src/main/org/h2/tools/Shell.java
+++ b/h2/src/main/org/h2/tools/Shell.java
@@ -554,7 +554,7 @@ public class Shell extends Tool implements Runnable {
                 max = Math.max(max, row[i].length());
             }
             if (len > 1) {
-                Math.min(maxColumnSize, max);
+                max = Math.min(maxColumnSize, max);
             }
             columnSizes[i] = max;
         }


### PR DESCRIPTION
The return value of the `Math.min` function should be used.
(I found this with the [data-flow analyzer](https://github.com/Egor18/jdataflow) I'm working on.)