### PR TITLE
Resolve symlinks in inaccessible paths in FilePathDisk.toRealPath()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2363: Soft links in -baseDir and database path cause error 90028
+</li>
 <li>Issue #2364: TestScript datatypes/timestamp-with-time-zone.sql fails if TZ=Europe/Berlin
 </li>
 <li>Issue #2359: Complete implementation of generated columns

--- a/h2/src/main/org/h2/store/fs/disk/FilePathDisk.java
+++ b/h2/src/main/org/h2/store/fs/disk/FilePathDisk.java
@@ -271,8 +271,25 @@ public class FilePathDisk extends FilePath {
         try {
             return getPath(path.toRealPath().toString());
         } catch (IOException e) {
-            return getPath(path.toAbsolutePath().normalize().toString());
+            /*
+             * File does not exist or isn't accessible, try to get the real path
+             * of parent directory.
+             */
+            return getPath(toRealPath(path.toAbsolutePath().normalize()).toString());
         }
+    }
+
+    private static Path toRealPath(Path path) {
+        Path parent = path.getParent();
+        if (parent == null) {
+            return path;
+        }
+        try {
+            parent = parent.toRealPath();
+        } catch (IOException e) {
+            parent = toRealPath(parent);
+        }
+        return parent.resolve(path.getFileName());
     }
 
     @Override


### PR DESCRIPTION
Closes #2363.