### PR TITLE
Fix IN condition with row value expressions in its right side

### DIFF
--- a/h2/src/main/org/h2/expression/condition/CompareLike.java
+++ b/h2/src/main/org/h2/expression/condition/CompareLike.java
@@ -248,12 +248,12 @@ public class CompareLike extends Condition {
     public Value getValue(Session session) {
         Value l = left.getValue(session);
         if (l == ValueNull.INSTANCE) {
-            return l;
+            return ValueNull.INSTANCE;
         }
         if (!isInit) {
             Value r = right.getValue(session);
             if (r == ValueNull.INSTANCE) {
-                return r;
+                return ValueNull.INSTANCE;
             }
             String p = r.getString();
             Value e = escape == null ? null : escape.getValue(session);

--- a/h2/src/main/org/h2/expression/condition/ConditionInConstantSet.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInConstantSet.java
@@ -67,7 +67,7 @@ public class ConditionInConstantSet extends Condition {
     public Value getValue(Session session) {
         Value x = left.getValue(session);
         if (x.containsNull()) {
-            return x;
+            return ValueNull.INSTANCE;
         }
         boolean result = valueSet.contains(x);
         if (!result && hasNull) {

--- a/h2/src/main/org/h2/expression/condition/ConditionInParameter.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInParameter.java
@@ -118,7 +118,7 @@ public class ConditionInParameter extends Condition {
     public Value getValue(Session session) {
         Value l = left.getValue(session);
         if (l == ValueNull.INSTANCE) {
-            return l;
+            return ValueNull.INSTANCE;
         }
         return getValue(session, l, parameter.getValue(session));
     }

--- a/h2/src/test/org/h2/test/scripts/predicates/in.sql
+++ b/h2/src/test/org/h2/test/scripts/predicates/in.sql
@@ -341,3 +341,16 @@ SELECT 1 WHERE 1 IN ();
 
 SET MODE Regular;
 > ok
+
+CREATE TABLE TEST(A INT, B INT) AS (VALUES (1, 1), (1, 2), (2, 1), (2, NULL));
+> ok
+
+SELECT * FROM TEST WHERE (A, B) IN ((1, 1), (2, 1), (2, 2), (2, NULL));
+> A B
+> - -
+> 1 1
+> 2 1
+> rows: 2
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
A trivial fix for issue from the mailing list:
https://groups.google.com/forum/#!topic/h2-database/aSwFGdn6ORM

Support for row value expressions in `ConditionInConstantSet` had a bug. A row value expression with a `NULL` value was incorrectly returned instead of plain NULL value that caused a following failure during attempt to cast it to a `BOOLEAN`.

I also changed `return someKnownNullValue` to `return ValueNull.INSTANCE` in few other places for reduce possibility of similar bugs after unlikely, but possible incorrect future changes of `if (something == ValueNull.INSTANCE) return something` to `if (something.containsNull()) return something`.