### PR TITLE
Follow up REPEATABLE_READ-related changes

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -252,26 +252,13 @@ public class TransactionMap<K, V> extends AbstractMap<K,V> {
     @Override
     public V putIfAbsent(K key, V value) {
         DataUtils.checkArgument(value != null, "The value may not be null");
-        if (!transaction.isolationLevel.allowNonRepeatableRead()) {
-            V oldValue = getFromSnapshot(key);
-            if (oldValue != null) {
-                VersionedValue<V> data = map.get(key);
-                if (data == null) {
-                    return oldValue;
-                } else {
-                    long id = data.getOperationId();
-                    if (id != 0 && TransactionStore.getTransactionId(id) == transaction.transactionId) {
-                        oldValue = data.getCurrentValue();
-                        if (oldValue != null) {
-                            return oldValue;
-                        }
-                    }
-                }
-            }
-        }
         TxDecisionMaker<V> decisionMaker = new TxDecisionMaker.PutIfAbsentDecisionMaker<>(map.getId(), key, value,
-                transaction);
-        return set(key, decisionMaker);
+                transaction, this::getFromSnapshot);
+        V result = set(key, decisionMaker);
+        if (decisionMaker.getDecision() == MVMap.Decision.ABORT) {
+            result = decisionMaker.getLastValue();
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
Those are followup changes for #2371 (PR #2374 ). 
Push REPEATABLE_READ-related changes into PutIfAbsentDecisionMaker to avoid duplicate B-tree descend.