### PR TITLE
Memory estimate

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -700,8 +700,9 @@ public class MVStoreTool {
         return newestVersion;
     }
 
-    static MVMap.Builder<Object, Object> getGenericMapBuilder() {
-        return new MVMap.Builder<>().
+    @SuppressWarnings({"rawtypes","unchecked"})
+    static MVMap.Builder<Object,Object> getGenericMapBuilder() {
+        return (MVMap.Builder)new MVMap.Builder<byte[],byte[]>().
                 keyType(GenericDataType.INSTANCE).
                 valueType(GenericDataType.INSTANCE);
     }
@@ -710,36 +711,36 @@ public class MVStoreTool {
      * A data type that can read any data that is persisted, and converts it to
      * a byte array.
      */
-    private static class GenericDataType extends BasicDataType<Object>
+    private static class GenericDataType extends BasicDataType<byte[]>
     {
         static GenericDataType INSTANCE = new GenericDataType();
 
         private GenericDataType() {}
 
         @Override
-        public int compare(Object a, Object b) {
-            throw DataUtils.newUnsupportedOperationException("Can not compare");
+        public boolean isMemoryEstimationAllowed() {
+            return false;
         }
 
         @Override
-        public int getMemory(Object obj) {
-            return obj == null ? 0 : ((byte[]) obj).length * 8;
+        public int getMemory(byte[] obj) {
+            return obj == null ? 0 : obj.length * 8;
         }
 
         @Override
-        public Object[] createStorage(int size) {
-            return new Object[size];
+        public byte[][] createStorage(int size) {
+            return new byte[size][];
         }
 
         @Override
-        public void write(WriteBuffer buff, Object obj) {
+        public void write(WriteBuffer buff, byte[] obj) {
             if (obj != null) {
-                buff.put((byte[]) obj);
+                buff.put(obj);
             }
         }
 
         @Override
-        public Object read(ByteBuffer buff) {
+        public byte[] read(ByteBuffer buff) {
             int len = buff.remaining();
             if (len == 0) {
                 return null;

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -13,7 +13,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.h2.compress.Compressor;
-import org.h2.mvstore.type.DataType;
 import org.h2.util.Utils;
 
 /**
@@ -469,9 +468,9 @@ public abstract class Page<K,V> implements Cloneable
         keys = keys.clone();
         if(isPersistent()) {
             K old = keys[index];
-            int mem = map.estimateMemoryForKey(key);
+            int mem = map.evaluateMemoryForKey(key);
             if (old != null) {
-                mem -= map.estimateMemoryForKey(old);
+                mem -= map.evaluateMemoryForKey(old);
             }
             addMemory(mem);
         }
@@ -521,7 +520,7 @@ public abstract class Page<K,V> implements Cloneable
         keys[index] = key;
 
         if (isPersistent()) {
-            addMemory(MEMORY_POINTER + map.estimateMemoryForKey(key));
+            addMemory(MEMORY_POINTER + map.evaluateMemoryForKey(key));
         }
     }
 
@@ -537,7 +536,7 @@ public abstract class Page<K,V> implements Cloneable
         }
         if(isPersistent()) {
             K old = getKey(index);
-            addMemory(-MEMORY_POINTER - map.estimateMemoryForKey(old));
+            addMemory(-MEMORY_POINTER - map.evaluateMemoryForKey(old));
         }
         K[] newKeys = createKeyStorage(keyCount - 1);
         DataUtils.copyExcept(keys, newKeys, keyCount, index);
@@ -810,7 +809,7 @@ public abstract class Page<K,V> implements Cloneable
      */
     protected int calculateMemory() {
 //*
-        return map.estimateMemoryForKeys(keys, getKeyCount());
+        return map.evaluateMemoryForKeys(keys, getKeyCount());
 /*/
         int keyCount = getKeyCount();
         int mem = keyCount * MEMORY_POINTER;
@@ -1440,8 +1439,8 @@ public abstract class Page<K,V> implements Cloneable
             values = values.clone();
             V old = setValueInternal(index, value);
             if(isPersistent()) {
-                addMemory(map.estimateMemoryForValue(value) -
-                            map.estimateMemoryForValue(old));
+                addMemory(map.evaluateMemoryForValue(value) -
+                            map.evaluateMemoryForValue(old));
             }
             return old;
         }
@@ -1463,7 +1462,7 @@ public abstract class Page<K,V> implements Cloneable
                 values = newValues;
                 setValueInternal(index, value);
                 if (isPersistent()) {
-                    addMemory(MEMORY_POINTER + map.estimateMemoryForValue(value));
+                    addMemory(MEMORY_POINTER + map.evaluateMemoryForValue(value));
                 }
             }
         }
@@ -1480,7 +1479,7 @@ public abstract class Page<K,V> implements Cloneable
             if (values != null) {
                 if(isPersistent()) {
                     V old = getValue(index);
-                    addMemory(-MEMORY_POINTER - map.estimateMemoryForValue(old));
+                    addMemory(-MEMORY_POINTER - map.evaluateMemoryForValue(old));
                 }
                 V[] newValues = createValueStorage(keyCount - 1);
                 DataUtils.copyExcept(values, newValues, keyCount, index);
@@ -1538,7 +1537,7 @@ public abstract class Page<K,V> implements Cloneable
         protected int calculateMemory() {
 //*
             return super.calculateMemory() + PAGE_LEAF_MEMORY +
-                        map.estimateMemoryForValues(values, getKeyCount());
+                        map.evaluateMemoryForValues(values, getKeyCount());
 /*/
             int keyCount = getKeyCount();
             int mem = super.calculateMemory() + PAGE_LEAF_MEMORY + keyCount * MEMORY_POINTER;

--- a/h2/src/main/org/h2/mvstore/type/BasicDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/BasicDataType.java
@@ -34,6 +34,11 @@ public abstract class BasicDataType<T> implements DataType<T> {
     }
 
     @Override
+    public boolean isMemoryEstimationAllowed() {
+        return true;
+    }
+
+    @Override
     public int binarySearch(T key, Object storageObj, int size, int initialGuess) {
         T[] storage = cast(storageObj);
         int low = 0;

--- a/h2/src/main/org/h2/mvstore/type/DataType.java
+++ b/h2/src/main/org/h2/mvstore/type/DataType.java
@@ -37,12 +37,18 @@ public interface DataType<T> extends Comparator<T> {
     int binarySearch(T key, Object storage, int size, int initialGuess);
 
     /**
-     * Estimate the used memory in bytes.
+     * Calculates the amount of used memory in bytes.
      *
      * @param obj the object
      * @return the used memory
      */
     int getMemory(T obj);
+
+    /**
+     * Whether memory estimation based on previosly seen values is allowed/desirable
+     * @return true if memory estimation is allowed
+     */
+    boolean isMemoryEstimationAllowed();
 
     /**
      * Write an object.

--- a/h2/src/main/org/h2/util/MemoryEstimator.java
+++ b/h2/src/main/org/h2/util/MemoryEstimator.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.util;
+
+import static org.h2.engine.Constants.MEMORY_POINTER;
+import org.h2.mvstore.type.DataType;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Class MemoryEstimator.
+ * <UL>
+ * <LI> 12/7/19 10:45 PM initial creation
+ * </UL>
+ *
+ * @author <a href='mailto:andrei.tokar@gmail.com'>Andrei Tokar</a>
+ */
+public final class MemoryEstimator
+{
+    private MemoryEstimator() {}
+
+    public static <T> int estimateMemory(AtomicLong stats, DataType<T> dataType, T data) {
+        long statsData = stats.get();
+        int counter = (int)(statsData & 0xFF);
+        int skipSum = (int)((statsData >> 8) & 0xFFFF);
+        long initialized = statsData & 0x1000000;
+        long sum = statsData >> 32;
+        int mem = 0;
+        int cnt = 0;
+        if (initialized == 0 || counter-- == 0) {
+            cnt = 1;
+            mem = data == null ? 0 : dataType.getMemory(data);
+            long delta = (mem << 8) - sum;
+            if (initialized == 0) {
+                if (++counter == 256) {
+                    initialized = 0x1000000;
+                }
+                sum = (sum * counter + delta + (counter >> 1)) / counter;
+            } else {
+                long absDelta = delta >= 0 ? delta : -delta;
+                int magnitude = calculateMagnitude(sum, absDelta);
+                sum += ((delta >> (7 - magnitude)) + 1) >> 1;
+                counter = ((1 << magnitude) - 1) & 0xFF;
+
+                delta = (counter << 8) - skipSum;
+                skipSum += (delta + 128) >> 8;
+            }
+        }
+        long updatedStatsData = sum << 32 | initialized | (skipSum << 8) | counter;
+        updatedStatsData = updateStatsData(stats, statsData, updatedStatsData, mem, cnt);
+        return (int)(updatedStatsData >> 40);
+    }
+
+    public static <T> int estimateMemory(AtomicLong stats, DataType<T> dataType, T[] storage, int count) {
+        long statsData = stats.get();
+        int counter = (int)(statsData & 0xFF);
+        int skipSum = (int)((statsData >> 8) & 0xFFFF);
+        long initialized = statsData & 0x1000000;
+        long sum = statsData >> 32;
+        int indx = 0;
+        int memSum = 0;
+        if (initialized != 0 && counter >= count) {
+            counter -= count;
+        } else {
+            int cnt = count;
+            while (cnt-- > 0) {
+                T data = storage[indx++];
+                int mem = data == null ? 0 : dataType.getMemory(data);
+                memSum += mem;
+                long delta = (mem << 8) - sum;
+                if (initialized == 0) {
+                    if (++counter == 256) {
+                        initialized = 0x1000000;
+                    }
+                    sum = (sum * counter + delta + (counter >> 1)) / counter;
+                } else {
+                    cnt -= counter;
+                    long absDelta = delta >= 0 ? delta : -delta;
+                    int magnitude = calculateMagnitude(sum, absDelta);
+                    sum += ((delta >> (7 - magnitude)) + 1) >> 1;
+                    counter += ((1 << magnitude) - 1) & 0xFF;
+
+                    delta = (counter << 8) - skipSum;
+                    skipSum += (delta + 128) >> 8;
+                }
+            }
+        }
+        long updatedStatsData = sum << 32 | initialized | (skipSum << 8) | counter;
+        updatedStatsData = updateStatsData(stats, statsData, updatedStatsData, memSum, indx);
+        return ((int)(updatedStatsData >> 40) + MEMORY_POINTER) * count;
+    }
+
+    private static int calculateMagnitude(long sum, long absDelta) {
+        int magnitude = 0;
+        while (absDelta < sum && magnitude < 7) {
+            ++magnitude;
+            absDelta <<= 1;
+        }
+        return magnitude;
+    }
+
+    private static long updateStatsData(AtomicLong stats, long statsData, long updatedStatsData, int itemsMem, int itemsCount) {
+        while (!stats.compareAndSet(statsData, updatedStatsData)) {
+            statsData = stats.get();
+            long sum = statsData >> 32;
+            if (itemsCount > 0) {
+                sum += itemsMem - ((sum * itemsCount + 128) >> 8);
+            }
+            updatedStatsData = (sum << 32) | (statsData & 0x1FFFFFF);
+        }
+        return updatedStatsData;
+    }
+
+    public static int samplingPct(AtomicLong stats) {
+        long statsData = stats.get();
+        int count = (statsData & 0x1000000) == 0 ? (int)(statsData & 0xFF) : 256;
+        int total = (int)((statsData >> 8) & 0xFFFF) + count;
+        return (count * 100 + (total >> 1)) / total;
+    }
+}

--- a/h2/src/main/org/h2/util/MemoryEstimator.java
+++ b/h2/src/main/org/h2/util/MemoryEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
  * and the EPL 1.0 (https://h2database.com/html/license.html).
  * Initial Developer: H2 Group
  */

--- a/h2/src/main/org/h2/util/MemoryEstimator.java
+++ b/h2/src/main/org/h2/util/MemoryEstimator.java
@@ -11,54 +11,97 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Class MemoryEstimator.
- * <UL>
- * <LI> 12/7/19 10:45 PM initial creation
- * </UL>
+ *
+ * Calculation of the amount of memory taken by keys, values and pages of the MVTable
+ * may become expensive operation for complex data types like Row.
+ * On the other hand, result of the calculation is used by page cache to limit it's size
+ * and determine when eviction is needed. Another usage is to trigger auto commit,
+ * based on amount of unsaved changes. In both cases reasonable (lets say ~30%) approximation
+ * would be good enough and do the job.
+ * This class replaces exact calculation with an estimate based on
+ * a sliding window average of last 256 values.
+ * If estimation gets close to the exact value, then next N calculations are skipped
+ * and replaced with the estimate, where N depends on the estimation error.
  *
  * @author <a href='mailto:andrei.tokar@gmail.com'>Andrei Tokar</a>
  */
 public final class MemoryEstimator
 {
+    // Structure of statsData long value:
+    // 0 - 7   skip counter (how many more requests will skip calculation and use estimate instead)
+    // 8 - 23  total number of skips between last 256 calculations
+    //         (used for sampling percentage calculation only)
+    // 24      bit is 0 when window is not completely filled yet, 1 when it become full
+    // 25 - 31 unused
+    // 32 - 63 sliding window sum of estimated values
+
+    private static final int SKIP_SUM_SHIFT = 8;
+    private static final int COUNTER_MASK = (1 << SKIP_SUM_SHIFT) - 1;
+    private static final int SKIP_SUM_MASK = 0xFFFF;
+    private static final int INIT_BIT_SHIFT = 24;
+    private static final int INIT_BIT = 1 << INIT_BIT_SHIFT;
+    private static final int WINDOW_SHIFT = 8;
+    private static final int MAGNITUTE_LIMIT = WINDOW_SHIFT - 1;
+    private static final int WINDOW_SIZE = 1 << WINDOW_SHIFT;
+    private static final int WINDOW_HALF_SIZE = WINDOW_SIZE >> 1;
+    private static final int SUM_SHIFT = 32;
+
     private MemoryEstimator() {}
 
+    /**
+     * Estimates memory size of the data based on previous values.
+     * @param stats AtomicLong holding statistical data about the estimated sequence
+     * @param dataType used for calculation of the next sequence value, if necessary
+     * @param data which size is to be calculated as the next sequence value, if necessary
+     * @param <T> type of the data
+     * @return next estimated or calculated value of the sequence
+     */
     public static <T> int estimateMemory(AtomicLong stats, DataType<T> dataType, T data) {
         long statsData = stats.get();
-        int counter = (int)(statsData & 0xFF);
-        int skipSum = (int)((statsData >> 8) & 0xFFFF);
-        long initialized = statsData & 0x1000000;
-        long sum = statsData >> 32;
+        int counter = getCounter(statsData);
+        int skipSum = getSkipSum(statsData);
+        long initialized = statsData & INIT_BIT;
+        long sum = statsData >> SUM_SHIFT;
         int mem = 0;
         int cnt = 0;
         if (initialized == 0 || counter-- == 0) {
             cnt = 1;
             mem = data == null ? 0 : dataType.getMemory(data);
-            long delta = (mem << 8) - sum;
+            long delta = (mem << WINDOW_SHIFT) - sum;
             if (initialized == 0) {
-                if (++counter == 256) {
-                    initialized = 0x1000000;
+                if (++counter == WINDOW_SIZE) {
+                    initialized = INIT_BIT;
                 }
                 sum = (sum * counter + delta + (counter >> 1)) / counter;
             } else {
                 long absDelta = delta >= 0 ? delta : -delta;
                 int magnitude = calculateMagnitude(sum, absDelta);
-                sum += ((delta >> (7 - magnitude)) + 1) >> 1;
-                counter = ((1 << magnitude) - 1) & 0xFF;
+                sum += ((delta >> (MAGNITUTE_LIMIT - magnitude)) + 1) >> 1;
+                counter = ((1 << magnitude) - 1) & COUNTER_MASK;
 
-                delta = (counter << 8) - skipSum;
-                skipSum += (delta + 128) >> 8;
+                delta = (counter << WINDOW_SHIFT) - skipSum;
+                skipSum += (delta + WINDOW_HALF_SIZE) >> WINDOW_SHIFT;
             }
         }
-        long updatedStatsData = sum << 32 | initialized | (skipSum << 8) | counter;
-        updatedStatsData = updateStatsData(stats, statsData, updatedStatsData, mem, cnt);
-        return (int)(updatedStatsData >> 40);
+        long updatedStatsData = updateStatsData(stats, statsData, counter, skipSum, initialized, sum, cnt, mem);
+        return getAverage(updatedStatsData);
     }
 
+    /**
+     * Estimates memory size of the data set based on previous values.
+     * @param stats AtomicLong holding statistical data about the estimated sequence
+     * @param dataType used for calculation of the next sequence value, if necessary
+     * @param storage of the data set, which size is to be calculated
+     * @param count number of data items in the storage
+     * @param <T> type of the data in the storage
+     * @return next estimated or calculated size of the storage
+     */
     public static <T> int estimateMemory(AtomicLong stats, DataType<T> dataType, T[] storage, int count) {
         long statsData = stats.get();
-        int counter = (int)(statsData & 0xFF);
-        int skipSum = (int)((statsData >> 8) & 0xFFFF);
-        long initialized = statsData & 0x1000000;
-        long sum = statsData >> 32;
+        int counter = getCounter(statsData);
+        int skipSum = getSkipSum(statsData);
+        long initialized = statsData & INIT_BIT;
+        long sum = statsData >> SUM_SHIFT;
         int indx = 0;
         int memSum = 0;
         if (initialized != 0 && counter >= count) {
@@ -69,54 +112,82 @@ public final class MemoryEstimator
                 T data = storage[indx++];
                 int mem = data == null ? 0 : dataType.getMemory(data);
                 memSum += mem;
-                long delta = (mem << 8) - sum;
+                long delta = (mem << WINDOW_SHIFT) - sum;
                 if (initialized == 0) {
-                    if (++counter == 256) {
-                        initialized = 0x1000000;
+                    if (++counter == WINDOW_SIZE) {
+                        initialized = INIT_BIT;
                     }
                     sum = (sum * counter + delta + (counter >> 1)) / counter;
                 } else {
                     cnt -= counter;
                     long absDelta = delta >= 0 ? delta : -delta;
                     int magnitude = calculateMagnitude(sum, absDelta);
-                    sum += ((delta >> (7 - magnitude)) + 1) >> 1;
-                    counter += ((1 << magnitude) - 1) & 0xFF;
+                    sum += ((delta >> (MAGNITUTE_LIMIT - magnitude)) + 1) >> 1;
+                    counter += ((1 << magnitude) - 1) & COUNTER_MASK;
 
-                    delta = (counter << 8) - skipSum;
-                    skipSum += (delta + 128) >> 8;
+                    delta = (counter << WINDOW_SHIFT) - skipSum;
+                    skipSum += (delta + WINDOW_HALF_SIZE) >> WINDOW_SHIFT;
                 }
             }
         }
-        long updatedStatsData = sum << 32 | initialized | (skipSum << 8) | counter;
-        updatedStatsData = updateStatsData(stats, statsData, updatedStatsData, memSum, indx);
-        return ((int)(updatedStatsData >> 40) + MEMORY_POINTER) * count;
+        long updatedStatsData = updateStatsData(stats, statsData, counter, skipSum, initialized, sum, indx, memSum);
+        return (getAverage(updatedStatsData) + MEMORY_POINTER) * count;
+    }
+
+    /**
+     * Calculates percentage of how many times actual calculation happened (vs. estimation)
+     * @param stats AtomicLong holding statistical data about the estimated sequence
+     * @return sampling percentage in range 0 - 100
+     */
+    public static int samplingPct(AtomicLong stats) {
+        long statsData = stats.get();
+        int count = (statsData & INIT_BIT) == 0 ? getCounter(statsData) : WINDOW_SIZE;
+        int total = getSkipSum(statsData) + count;
+        return (count * 100 + (total >> 1)) / total;
     }
 
     private static int calculateMagnitude(long sum, long absDelta) {
         int magnitude = 0;
-        while (absDelta < sum && magnitude < 7) {
+        while (absDelta < sum && magnitude < MAGNITUTE_LIMIT) {
             ++magnitude;
             absDelta <<= 1;
         }
         return magnitude;
     }
 
-    private static long updateStatsData(AtomicLong stats, long statsData, long updatedStatsData, int itemsMem, int itemsCount) {
+    private static long updateStatsData(AtomicLong stats, long statsData,
+                                        int counter, int skipSum, long initialized, long sum,
+                                        int itemsCount, int itemsMem) {
+        return updateStatsData(stats, statsData,
+                                constructStatsData(sum, initialized, skipSum, counter), itemsCount, itemsMem);
+    }
+
+    private static long constructStatsData(long sum, long initialized, int skipSum, int counter) {
+        return (sum << SUM_SHIFT) | initialized | (skipSum << SKIP_SUM_SHIFT) | counter;
+    }
+
+    private static long updateStatsData(AtomicLong stats, long statsData, long updatedStatsData,
+                                        int itemsCount, int itemsMem) {
         while (!stats.compareAndSet(statsData, updatedStatsData)) {
             statsData = stats.get();
-            long sum = statsData >> 32;
+            long sum = statsData >> SUM_SHIFT;
             if (itemsCount > 0) {
-                sum += itemsMem - ((sum * itemsCount + 128) >> 8);
+                sum += itemsMem - ((sum * itemsCount + WINDOW_HALF_SIZE) >> WINDOW_SHIFT);
             }
-            updatedStatsData = (sum << 32) | (statsData & 0x1FFFFFF);
+            updatedStatsData = (sum << SUM_SHIFT) | (statsData & (INIT_BIT | SKIP_SUM_MASK | COUNTER_MASK));
         }
         return updatedStatsData;
     }
 
-    public static int samplingPct(AtomicLong stats) {
-        long statsData = stats.get();
-        int count = (statsData & 0x1000000) == 0 ? (int)(statsData & 0xFF) : 256;
-        int total = (int)((statsData >> 8) & 0xFFFF) + count;
-        return (count * 100 + (total >> 1)) / total;
+    private static int getCounter(long statsData) {
+        return (int)(statsData & COUNTER_MASK);
+    }
+
+    private static int getSkipSum(long statsData) {
+        return (int)((statsData >> SKIP_SUM_SHIFT) & SKIP_SUM_MASK);
+    }
+
+    private static int getAverage(long updatedStatsData) {
+        return (int)(updatedStatsData >> (SUM_SHIFT + WINDOW_SHIFT));
     }
 }

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1442,7 +1442,7 @@ public class TestMVStore extends TestBase {
         }
         assertEquals(1000, m.size());
         // memory calculations were adjusted, so as this out-of-the-thin-air number
-        assertEquals(93635, s.getUnsavedMemory());
+        assertEquals(93639, s.getUnsavedMemory());
         s.commit();
         assertEquals(2, s.getFileStore().getWriteCount());
         s.close();

--- a/h2/src/test/org/h2/test/unit/TestMemoryEstimator.java
+++ b/h2/src/test/org/h2/test/unit/TestMemoryEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
  * and the EPL 1.0 (https://h2database.com/html/license.html).
  * Initial Developer: H2 Group
  */

--- a/h2/src/test/org/h2/test/unit/TestMemoryEstimator.java
+++ b/h2/src/test/org/h2/test/unit/TestMemoryEstimator.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2004-2019 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.test.unit;
+
+import org.h2.mvstore.WriteBuffer;
+import org.h2.mvstore.type.BasicDataType;
+import org.h2.test.TestBase;
+import org.h2.util.MemoryEstimator;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Class TestMemoryEstimator.
+ * <UL>
+ * <LI> 12/7/19 10:38 PM initial creation
+ * </UL>
+ *
+ * @author <a href='mailto:andrei.tokar@gmail.com'>Andrei Tokar</a>
+ */
+public class TestMemoryEstimator extends TestBase
+{
+    /**
+     * Run just this test.
+     *
+     * @param a ignored
+     */
+    public static void main(String... a) throws Exception {
+        TestBase.createCaller().init().test();
+    }
+
+    @Override
+    public void test() {
+        testEstimator();
+        testPageEstimator();
+    }
+
+    private void testEstimator() {
+        Random random = new Random();
+        AtomicLong stat = new AtomicLong();
+        TestDataType dataType = new TestDataType();
+        int sum = 0;
+        int sum2 = 0;
+        int err2 = 0;
+        int size = 10000;
+        for (int i = 0; i < size; i++) {
+            int x = (int)Math.abs(100 + random.nextGaussian() * 30);
+            int y = MemoryEstimator.estimateMemory(stat, dataType, x);
+            sum += x;
+            sum2 += x * x;
+            err2 += (x - y) * (x - y);
+        }
+        int avg = sum / size;
+        double err = Math.sqrt(1.0 * err2 / sum2);
+        int pct = MemoryEstimator.samplingPct(stat);
+        String msg = "Avg=" + avg + ", err=" + err + ", pct=" + pct + " " + (dataType.getCount() * 100 / size);
+        assertTrue(msg, err < 0.3);
+        assertTrue(msg, pct <= 7);
+    }
+
+    private void testPageEstimator() {
+        Random random = new Random();
+        AtomicLong stat = new AtomicLong();
+        TestDataType dataType = new TestDataType();
+        long sum = 0;
+        long sum2 = 0;
+        long err2 = 0;
+        int size = 10000;
+        int pageSz;
+        for (int i = 0; i < size; i+=pageSz) {
+            pageSz = random.nextInt(48) + 1;
+            Integer[] storage = dataType.createStorage(pageSz);
+            int x = 0;
+            for (int k = 0; k < pageSz; k++) {
+                storage[k] = (int)Math.abs(100 + random.nextGaussian() * 30);
+                x += storage[k];
+            }
+            int y = MemoryEstimator.estimateMemory(stat, dataType, storage, pageSz);
+            sum += x;
+            sum2 += x * x;
+            err2 += (x - y) * (x - y);
+        }
+        long avg = sum / size;
+        double err = Math.sqrt(1.0 * err2 / sum2);
+        int pct = MemoryEstimator.samplingPct(stat);
+        String msg = "Avg=" + avg + ", err=" + err + ", pct=" + pct + " " + (dataType.getCount() * 100 / size);
+        assertTrue(msg, err < 0.12);
+        assertTrue(msg, pct <= 4);
+    }
+
+    private static class TestDataType extends BasicDataType<Integer> {
+        private int count;
+
+        public int getCount() {
+            return count;
+        }
+
+        public int getMemory(Integer obj) {
+            ++count;
+            return obj;
+        }
+        public void write(WriteBuffer buff, Integer obj) {}
+        public Integer read(ByteBuffer buff) { return null; }
+        public Integer[] createStorage(int size) { return new Integer[size]; }
+    };
+
+}


### PR DESCRIPTION
Calculation of the amount of memory taken by keys, values and pages of the MVTable may become expensive operation for complex data types like Row. 
On the other hand, result of the calculation is used by page cache to limit it's size and determine when eviction is needed. Another usage is to trigger auto commit based on amount of unsaved changes. In both cases good (lets say ~30%) approximation would do the job.
This PR replace exact calculation with estimation based on a sliding average of last 256 values. If estimation gets close to exact value, then next N calculations are skipped and replaced with the estimate, where N depends on the estimation error.
Average values are not persisted at this point yet.
My tests provided (anecdotal) evidence of 5-10% performance gain.