### PR TITLE
Chunk occupancy mask

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -974,8 +974,8 @@ public class Database implements DataHandler, CastDataProvider {
      * @param session the session
      */
     public void verifyMetaLocked(Session session) {
-        if (meta != null && !meta.isLockedExclusivelyBy(session)
-                && lockMode != Constants.LOCK_MODE_OFF) {
+        if (lockMode != Constants.LOCK_MODE_OFF &&
+                meta != null && !meta.isLockedExclusivelyBy(session)) {
             throw DbException.throwInternalError();
         }
     }

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -86,8 +86,7 @@ public class Chunk
      * Offset (from the beginning of the chunk) for the table of content.
      * Table of content is holding a long value for each page in the chunk.
      * This value consists of map id, page offset, page length and page type.
-     * Format is the same as page's position id, but with map id replacing chunk id,
-     * and page offset replacing page sequential number.
+     * Format is the same as page's position id, but with map id replacing chunk id.
      *
      * @see DataUtils#getTocElement(int, int, int, int) for field format details
      */

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -391,31 +391,6 @@ public class Chunk
 
                 ByteBuffer buff = fileStore.readFully(filePos, length);
 
-                int start = buff.position();
-                int remaining = buff.remaining();
-                int pageLength = buff.getInt();
-                if (pageLength > remaining || pageLength < 4) {
-                    throw DataUtils.newIllegalStateException(DataUtils.ERROR_FILE_CORRUPT,
-                            "File corrupted in chunk {0}, expected page length 4..{1}, got {2}", id, remaining,
-                            pageLength);
-                }
-                buff.limit(start + pageLength);
-
-                short check = buff.getShort();
-                int checkTest = DataUtils.getCheckValue(id)
-                        ^ DataUtils.getCheckValue(offset)
-                        ^ DataUtils.getCheckValue(pageLength);
-                if (check != (short) checkTest) {
-                    throw DataUtils.newIllegalStateException(DataUtils.ERROR_FILE_CORRUPT,
-                            "File corrupted in chunk {0}, expected check value {1}, got {2}", id, checkTest, check);
-                }
-
-                int mapId = DataUtils.readVarInt(buff);
-                if (mapId != expectedMapId) {
-                    throw DataUtils.newIllegalStateException(DataUtils.ERROR_FILE_CORRUPT,
-                            "File corrupted in chunk {0}, expected map id {1}, got {2}", id, expectedMapId, mapId);
-                }
-
                 if (originalBlock == block) {
                     return buff;
                 }
@@ -494,7 +469,7 @@ public class Chunk
         if (tocPos > 0) {
             assert pageCount - pageCountLive == occupancy.cardinality()
                     : pageCount + " - " + pageCountLive + " : " + occupancy;
-            assert pageNo >= 0 && pageNo < pageCount;
+            assert pageNo >= 0 && pageNo < pageCount : pageNo + " // " +  pageCount;
             assert !occupancy.get(pageNo);
             occupancy.set(pageNo);
         }

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -88,11 +88,13 @@ public class Chunk
      * This value consists of map id, page offset, page length and page type.
      * Format is the same as page's position id, but with map id replacing chunk id,
      * and page offset replacing page sequential number.
+     *
+     * @see DataUtils#getTocElement(int, int, int, int) for field format details
      */
     int tocPos;
 
     /**
-     * Collectio of "deleted" flags for all pages in the chunk.
+     * Collection of "deleted" flags for all pages in the chunk.
      */
     BitSet occupancy;
 

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -5,6 +5,7 @@
  */
 package org.h2.mvstore;
 
+import org.h2.util.StringUtils;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
@@ -315,7 +316,8 @@ public class Chunk
             DataUtils.appendMap(buff, ATTR_TOC, tocPos);
         }
         if (occupancy.nextSetBit(0) >= 0) {
-            DataUtils.appendMap(buff, ATTR_OCCUPANCY, DataUtils.hexEncodeBytes(occupancy.toByteArray()));
+            DataUtils.appendMap(buff, ATTR_OCCUPANCY,
+                    StringUtils.convertBytesToHex(occupancy.toByteArray()));
         }
         return buff.toString();
     }

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -1149,54 +1149,12 @@ public final class DataUtils {
         }
     }
 
-    public static String hexEncodeBytes(byte[] bytes) {
-        StringBuilder sb = new StringBuilder(bytes.length * 2);
-        for (byte b : bytes) {
-            sb.append(getHexDigitFor(b >> 4));
-            sb.append(getHexDigitFor(b));
-        }
-        return sb.toString();
-    }
-
-    private static char getHexDigitFor(int digit) {
-        digit &= 0xF;
-        return (char)((digit < 10 ? '0' : 'a' - 10) + digit);
-    }
-
     public static byte[] parseHexBytes(Map<String, ?> map, String key) {
         Object v = map.get(key);
         if (v == null) {
             return null;
         }
-        String s = (String)v;
-        try {
-            int length = s.length();
-            byte[] data = new byte[length / 2];
-            for(int i = 0; i < length; i += 2) {
-                data[i / 2] = (byte)((hexValueOf(s.charAt(i)) << 4)
-                                    | hexValueOf(s.charAt(i + 1)));
-            }
-            return data;
-        } catch (NumberFormatException e) {
-            throw newIllegalStateException(ERROR_FILE_CORRUPT,
-                    "Error parsing the value {0}", v, e);
-        }
-    }
-
-    private  static int hexValueOf(char c) {
-        int res = c - '0';
-        if (res > 9) {
-            res = c - 'a';
-            if (res < 0 || res > 5) {
-                res = c - 'A';
-                if (res < 0 || res > 5) {
-                    throw newIllegalStateException(ERROR_FILE_CORRUPT,
-                            "Error parsing the value {0}", c);
-                }
-            }
-            res += 10;
-        }
-        return res;
+        return StringUtils.convertHexToBytes((String)v);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/DataUtils.java
+++ b/h2/src/main/org/h2/mvstore/DataUtils.java
@@ -134,6 +134,11 @@ public final class DataUtils {
     public static final int PAGE_COMPRESSED_HIGH = 2 + 4;
 
     /**
+     * The bit mask for pages with page seqential number.
+     */
+    public static final int PAGE_HAS_PAGE_NO = 8;
+
+    /**
      * The maximum length of a variable size int.
      */
     public static final int MAX_VAR_INT_LEN = 5;
@@ -578,16 +583,6 @@ public final class DataUtils {
     }
 
     /**
-     * Get the sequential 0-based page number within the chunk.
-     *
-     * @param pos the position
-     * @return the page number
-     */
-    public static int getPageNo(long pos) {
-        return (int) (pos >> 6);
-    }
-
-    /**
      * Get the page type from the position.
      *
      * @param pos the position
@@ -633,17 +628,27 @@ public final class DataUtils {
      * (node or leaf).
      *
      * @param chunkId the chunk id
-     * @param pageNo the offset
+     * @param offset the offset
      * @param length the length
      * @param type the page type (1 for node, 0 for leaf)
      * @return the position
      */
-    public static long getPagePos(int chunkId, int pageNo, int length, int type) {
+    public static long getPagePos(int chunkId, int offset, int length, int type) {
         long pos = (long) chunkId << 38;
-        pos |= (long) pageNo << 6;
+        pos |= (long) offset << 6;
         pos |= encodeLength(length) << 1;
         pos |= type;
         return pos;
+    }
+
+    /**
+     * Convert tocElement into pagePos by replacing mapId with chunkId
+     * @param chunkId
+     * @param tocElement
+     * @return
+     */
+    public static long getPagePos(int chunkId, long tocElement) {
+        return (tocElement & 0x3FFFFFFFFFL) | ((long) chunkId << 38);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
+++ b/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
@@ -235,7 +235,12 @@ public class FreeSpaceBitSet {
         // to get approximation without holding a store lock
         int usedBlocks;
         int totalBlocks;
+        // to prevent infinite loop, which I saw once
+        int cnt = 3;
         do {
+            if (--cnt == 0) {
+                return 100;
+            }
             totalBlocks = set.length();
             usedBlocks = set.cardinality();
         } while (totalBlocks != set.length() || usedBlocks > totalBlocks);

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -766,7 +766,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         return writtenPageCount;
     }
 
-    private boolean rewritePage(Page<K,V> p) {
+    boolean rewritePage(Page<K,V> p) {
         if (p.getKeyCount()==0) {
             return true;
         }

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -689,7 +689,8 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         return new Cursor<>(getRootPage(), from);
     }
 
-    final boolean rewritePage(Page<K,V> p) {
+    final boolean rewritePage(long pagePos) {
+        Page<K, V> p = readPage(pagePos);
         if (p.getKeyCount()==0) {
             return true;
         }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -3148,6 +3148,14 @@ public class MVStore implements AutoCloseable
     }
 
     public int getCacheHitRatio() {
+        return getCacheHitRatio(cache);
+    }
+
+    public int getTocCacheHitRatio() {
+        return getCacheHitRatio(chunksToC);
+    }
+
+    private int getCacheHitRatio(CacheLongKeyLIRS<?> cache) {
         if (cache == null) {
             return 0;
         }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2166,10 +2166,9 @@ public class MVStore implements AutoCloseable
     private int compactRewrite(Set<Integer> set) {
         assert storeLock.isHeldByCurrentThread();
         assert currentStoreVersion < 0; // we should be able to do tryCommit() -> store()
-        long now = getTimeSinceCreation();
-        acceptChunkOccupancyChanges(now, currentVersion + 1);
+        acceptChunkOccupancyChanges(getTimeSinceCreation(), currentVersion + 1);
         int rewrittenPageCount = rewriteChunks(set, false);
-        acceptChunkOccupancyChanges(now, currentVersion + 1);
+        acceptChunkOccupancyChanges(getTimeSinceCreation(), currentVersion + 1);
         rewrittenPageCount += rewriteChunks(set, true);
         assert validateRewrite(set);
         return rewrittenPageCount;
@@ -2192,7 +2191,7 @@ public class MVStore implements AutoCloseable
                             int length = DataUtils.getPageMaxLength(tocElement);
                             long pagePos = DataUtils.getPagePos(chunkId, pageNo, length, type);
                             Page page = readPage(map, pagePos);
-                            assert !secondPass || !page.isLeaf();
+//                            assert !secondPass || !page.isLeaf();
                             if (map.rewritePage(page)) {
                                 ++rewrittenPageCount;
                                 if (map == meta) {
@@ -2689,6 +2688,9 @@ public class MVStore implements AutoCloseable
     private void clearCaches() {
         if (cache != null) {
             cache.clear();
+        }
+        if (chunksToC != null) {
+            chunksToC.clear();
         }
     }
 
@@ -3422,6 +3424,7 @@ public class MVStore implements AutoCloseable
             return "RemovedPageInfo{" +
                     "version=" + version +
                     ", chunk=" + getPageChunkId() +
+                    ", pageNo=" + getPageNo() +
                     ", len=" + getPageLength() +
                     (isPinned() ? ", pinned" : "") +
                     '}';

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -956,24 +956,25 @@ public class MVStore implements AutoCloseable
                             // used here as is, re-point our chunk to original
                             // location instead.
                             c.block = test.block;
-                        } else if (!c.isLive()) {
-                            // we can just remove entry from meta, referencing to this chunk,
-                            // but store maybe R/O, and it's not properly started yet,
-                            // so lets make this chunk "dead" and taking no space,
-                            // and it will be automatically removed later.
-                            c.block = Long.MAX_VALUE;
-                            c.len = Integer.MAX_VALUE;
-                            if (c.unused == 0) {
-                                c.unused = creationTime;
-                            }
-                            if (c.unusedAtVersion == 0) {
-                                c.unusedAtVersion = INITIAL_VERSION;
-                            }
-                        } else if (afterFullScan || readChunkHeaderAndFooter(c.block, c.id) == null) {
+                        } else if (c.isLive() && (afterFullScan || readChunkHeaderAndFooter(c.block, c.id) == null)) {
                             // chunk reference is invalid
                             // this "last chunk" candidate is not suitable
                             verified = false;
                             break;
+                        }
+                    }
+                    if (!c.isLive()) {
+                        // we can just remove entry from meta, referencing to this chunk,
+                        // but store maybe R/O, and it's not properly started yet,
+                        // so lets make this chunk "dead" and taking no space,
+                        // and it will be automatically removed later.
+                        c.block = Long.MAX_VALUE;
+                        c.len = Integer.MAX_VALUE;
+                        if (c.unused == 0) {
+                            c.unused = creationTime;
+                        }
+                        if (c.unusedAtVersion == 0) {
+                            c.unusedAtVersion = INITIAL_VERSION;
                         }
                     }
                 }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -3460,7 +3460,7 @@ public class MVStore implements AutoCloseable
          * @return removed page info that contains chunk id, page number, page length and pinned flag
          */
         private static long createRemovedPageInfo(long pagePos, boolean isPinned, int pageNo) {
-            long result = (pagePos & ~((0xFFFFFFFFL << 6) | 1)) | (pageNo << 6);
+            long result = (pagePos & ~((0xFFFFFFFFL << 6) | 1)) | ((pageNo << 6) & 0xFFFFFFFFL);
             if (isPinned) {
                 result |= 1;
             }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -3231,7 +3231,7 @@ public class MVStore implements AutoCloseable
                 if (chunks.remove(chunk.id) != null) {
                     // purge dead pages from cache
                     long[] toc = chunksToC.remove(chunk.id);
-                    if (toc != null) {
+                    if (toc != null && cache != null) {
                         for (int pageNo = 0; pageNo < toc.length; pageNo++) {
                             long tocElement = toc[pageNo];
                             int length = DataUtils.getPageMaxLength(tocElement);

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2281,12 +2281,15 @@ public class MVStore implements AutoCloseable
     }
 
     private long[] getToC(Chunk chunk) {
+        if (chunk.tocPos == 0) {
+            // legacy chunk without table of content
+            return null;
+        }
         long[] toc = chunksToC.get(chunk.id);
         if (toc == null) {
             toc = chunk.readToC(fileStore);
-            if (toc != null) {
-                chunksToC.put(chunk.id, toc, toc.length * 8);
-            }
+            assert toc != null;
+            chunksToC.put(chunk.id, toc, toc.length * 8);
         }
         return toc;
     }

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -110,18 +110,16 @@ public class MVStoreTool {
         }
         long size = FileUtils.size(fileName);
         pw.printf("File %s, %d bytes, %d MB\n", fileName, size, size / 1024 / 1024);
-        FileChannel file = null;
         int blockSize = MVStore.BLOCK_SIZE;
         TreeMap<Integer, Long> mapSizesTotal =
                 new TreeMap<>();
         long pageSizeTotal = 0;
-        try {
-            file = FilePath.get(fileName).open("r");
+        try (FileChannel file = FilePath.get(fileName).open("r")) {
             long fileSize = file.size();
             int len = Long.toHexString(fileSize).length();
             ByteBuffer block = ByteBuffer.allocate(4096);
             long pageCount = 0;
-            for (long pos = 0; pos < fileSize;) {
+            for (long pos = 0; pos < fileSize; ) {
                 block.rewind();
                 // Bugfix - An IllegalStateException that wraps EOFException is
                 // thrown when partial writes happens in the case of power off
@@ -129,7 +127,7 @@ public class MVStoreTool {
                 // So we should skip the broken block at end of the DB file.
                 try {
                     DataUtils.readFully(file, pos, block);
-                } catch (IllegalStateException e){
+                } catch (IllegalStateException e) {
                     pos += blockSize;
                     pw.printf("ERROR illegal position %d%n", pos);
                     continue;
@@ -148,7 +146,7 @@ public class MVStoreTool {
                     continue;
                 }
                 block.position(0);
-                Chunk c = null;
+                Chunk c;
                 try {
                     c = Chunk.readChunkHeader(block, pos);
                 } catch (IllegalStateException e) {
@@ -187,20 +185,24 @@ public class MVStoreTool {
                     int mapId = DataUtils.readVarInt(chunk);
                     int entries = DataUtils.readVarInt(chunk);
                     int type = chunk.get();
+                    if ((type & DataUtils.PAGE_HAS_PAGE_NO) != 0) {
+                        /*int pageNo =*/
+                        DataUtils.readVarInt(chunk);
+                    }
                     boolean compressed = (type & DataUtils.PAGE_COMPRESSED) != 0;
                     boolean node = (type & 1) != 0;
                     if (details) {
                         pw.printf(
                                 "+%0" + len +
-                                "x %s, map %x, %d entries, %d bytes, maxLen %x%n",
+                                        "x %s, map %x, %d entries, %d bytes, maxLen %x%n",
                                 p,
                                 (node ? "node" : "leaf") +
-                                (compressed ? " compressed" : ""),
+                                        (compressed ? " compressed" : ""),
                                 mapId,
                                 node ? entries + 1 : entries,
                                 pageSize,
                                 DataUtils.getPageMaxLength(DataUtils.getPagePos(0, 0, pageSize, 0))
-                                );
+                        );
                     }
                     p += pageSize;
                     Integer mapSize = mapSizes.get(mapId);
@@ -254,8 +256,8 @@ public class MVStoreTool {
                             for (int i = 0; i < entries; i++) {
                                 long cp = children[i];
                                 pw.printf("    %d children < %s @ " +
-                                        "chunk %x +%0" +
-                                        len + "x%n",
+                                                "chunk %x +%0" +
+                                                len + "x%n",
                                         counts[i],
                                         keys[i],
                                         DataUtils.getPageChunkId(cp),
@@ -263,7 +265,7 @@ public class MVStoreTool {
                             }
                             long cp = children[entries];
                             pw.printf("    %d children >= %s @ chunk %x +%0" +
-                                    len + "x%n",
+                                            len + "x%n",
                                     counts[entries],
                                     keys.length >= entries ? null : keys[entries],
                                     DataUtils.getPageChunkId(cp),
@@ -285,7 +287,7 @@ public class MVStoreTool {
                             for (int i = 0; i <= entries; i++) {
                                 long cp = children[i];
                                 pw.printf("    %d children @ chunk %x +%0" +
-                                        len + "x%n",
+                                                len + "x%n",
                                         counts[i],
                                         DataUtils.getPageChunkId(cp),
                                         DataUtils.getPageOffset(cp));
@@ -324,15 +326,8 @@ public class MVStoreTool {
         } catch (IOException e) {
             pw.println("ERROR: " + e);
             e.printStackTrace(pw);
-        } finally {
-            if (file != null) {
-                try {
-                    file.close();
-                } catch (IOException e) {
-                    // ignore
-                }
-            }
         }
+        // ignore
         pw.flush();
     }
 
@@ -576,7 +571,7 @@ public class MVStoreTool {
         long version = Long.MAX_VALUE;
         OutputStream ignore = new OutputStream() {
             @Override
-            public void write(int b) throws IOException {
+            public void write(int b) {
                 // ignore
             }
         };
@@ -644,7 +639,7 @@ public class MVStoreTool {
                     pos += blockSize;
                     continue;
                 }
-                Chunk c = null;
+                Chunk c;
                 try {
                     c = Chunk.readChunkHeader(block, pos);
                 } catch (IllegalStateException e) {

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1212,7 +1212,7 @@ public class MetaTable extends Table {
                         add(session, rows,
                                 "info.FILL_RATE", Integer.toString(mvStore.getFillRate()));
                         add(session, rows,
-                                "info.CHUNKS_FILL_RATE", Integer.toString(mvStore.getChunksFillRate()));
+                                "info.CHUNKS_FILL_RATE", Integer.toString(mvStore.getRewritableChunksFillRate()));
                         try {
                             add(session, rows,
                                     "info.FILE_SIZE", Long.toString(fs.getFile().size()));

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1231,6 +1231,8 @@ public class MetaTable extends Table {
                                 "info.CACHE_SIZE", Integer.toString(mvStore.getCacheSizeUsed()));
                         add(session, rows,
                                 "info.CACHE_HIT_RATIO", Integer.toString(mvStore.getCacheHitRatio()));
+                        add(session, rows, "info.TOC_CACHE_HIT_RATIO",
+                                Integer.toString(mvStore.getTocCacheHitRatio()));
                     }
                 }
             }

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -1212,7 +1212,9 @@ public class MetaTable extends Table {
                         add(session, rows,
                                 "info.FILL_RATE", Integer.toString(mvStore.getFillRate()));
                         add(session, rows,
-                                "info.CHUNKS_FILL_RATE", Integer.toString(mvStore.getRewritableChunksFillRate()));
+                                "info.CHUNKS_FILL_RATE", Integer.toString(mvStore.getChunksFillRate()));
+                        add(session, rows,
+                                "info.CHUNKS_FILL_RATE_RW", Integer.toString(mvStore.getRewritableChunksFillRate()));
                         try {
                             add(session, rows,
                                     "info.FILE_SIZE", Long.toString(fs.getFile().size()));
@@ -1233,6 +1235,8 @@ public class MetaTable extends Table {
                                 "info.CACHE_HIT_RATIO", Integer.toString(mvStore.getCacheHitRatio()));
                         add(session, rows, "info.TOC_CACHE_HIT_RATIO",
                                 Integer.toString(mvStore.getTocCacheHitRatio()));
+                        add(session, rows,
+                                "info.LEAF_RATIO", Integer.toString(mvStore.getLeafRatio()));
                     }
                 }
             }

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1453,7 +1453,7 @@ public class TestMVStore extends TestBase {
         assertEquals(0, m.size());
         s.commit();
         // ensure only nodes are read, but not leaves
-        assertEquals(5, s.getFileStore().getReadCount());
+        assertEquals(6, s.getFileStore().getReadCount());
         assertTrue(s.getFileStore().getWriteCount() < 5);
         s.close();
     }

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1771,6 +1771,7 @@ public class TestMVStore extends TestBase {
         for (int i = 0; i < 10; i++) {
             sleep(1);
             boolean result = s.compact(50, 50 * 1024);
+            s.commit();
             if (!result) {
                 break;
             }


### PR DESCRIPTION
Determination of dead chunks is now done by actual counting of live pages within it, but chunks overwrite - process of moving all live pages from sparsely populated chunks into a new one is still using trees scanning to determine which pages are still live within the chunk. This is extremely expensive in terms of I/O operations.
This PR changes the strategy of this process by introducing "table of content" (ToC) and occupancy bitmask for each chunk. ToC is an array of (map id, page offset, page length) written at the end of each chunk (with it's offset written into chunk header/metadata). ToCs are cached in a separate 1MB LIRR cache. Occupancy bitmask has one bit-per-page set to 1 for the dead pages. It resides in memory as part of a chunk structure and also persisted as part of chunk's metadata. Also sequential page number within a chunk is written at the end of each page.
Maintaining those two structures will fully avoid maps scanning during chunk rewrite, since we can directly enumerate all live pages within the chunk (scanning occupancy bitmask) and find their offset and owning map from ToC.
I did a simple experiment of building table with three UUID indexed fields and 50,000,000 rows in 100,000 row batches with 10 sec intervals in-between to allow for housekeeping. Every 5,000,000 rows SHUTDOW DEFRAG is executed. It show 3-fold reduction in reads and 2-fold write reduction compare to master. Database file growth also slows down significantly.

