### PR TITLE
Descending MVMap and TransactionMap cursor

### DIFF
--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
  * There are at most 67 million (2^26) chunks,
  * each chunk is at most 2 GB large.
  */
-public class Chunk
+public final class Chunk
 {
 
     /**
@@ -315,7 +315,7 @@ public class Chunk
         if (tocPos > 0) {
             DataUtils.appendMap(buff, ATTR_TOC, tocPos);
         }
-        if (occupancy.nextSetBit(0) >= 0) {
+        if (!occupancy.isEmpty()) {
             DataUtils.appendMap(buff, ATTR_OCCUPANCY,
                     StringUtils.convertBytesToHex(occupancy.toByteArray()));
         }
@@ -361,10 +361,9 @@ public class Chunk
      *
      * @param fileStore to use
      * @param pos page pos
-     * @param expectedMapId expected map id for the page
      * @return ByteBuffer containing page data.
      */
-    ByteBuffer readBufferForPage(FileStore fileStore, int offset,  long pos, int expectedMapId) {
+    ByteBuffer readBufferForPage(FileStore fileStore, int offset, long pos) {
         assert isSaved() : this;
         while (true) {
             long originalBlock = block;

--- a/h2/src/main/org/h2/mvstore/Cursor.java
+++ b/h2/src/main/org/h2/mvstore/Cursor.java
@@ -149,7 +149,7 @@ public final class Cursor<K,V> implements Iterator<K> {
     private static <K,V> CursorPos<K,V> traverseDown(Page<K,V> p, K key) {
         CursorPos<K,V> cursorPos = key == null ? p.getPrependCursorPos(null) : CursorPos.traverseDown(p, key);
         if (cursorPos.index < 0) {
-            cursorPos.index = -cursorPos.index - 1;
+            cursorPos.index = ~cursorPos.index;
         }
         return cursorPos;
     }

--- a/h2/src/main/org/h2/mvstore/Cursor.java
+++ b/h2/src/main/org/h2/mvstore/Cursor.java
@@ -147,7 +147,7 @@ public final class Cursor<K,V> implements Iterator<K> {
             Page<K,V> root = cp.page;
             MVMap<K,V> map = root.map;
             long index = map.getKeyIndex(next());
-            last = map.getKey(index + n);
+            last = map.getKey(index + (reverse ? -n : n));
             this.cursorPos = traverseDown(root, last, reverse);
         }
     }

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -694,7 +694,11 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @return the iterator
      */
     public final Iterator<K> keyIterator(K from) {
-        return new Cursor<>(getRootPage(), from);
+        return cursor(from, null, false);
+    }
+
+    public final Iterator<K> keyIteratorReverse(K from) {
+        return cursor(from, null, true);
     }
 
     final boolean rewritePage(long pagePos) {
@@ -721,7 +725,11 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @return the cursor
      */
     public final Cursor<K, V> cursor(K from) {
-        return new Cursor<>(getRootPage(), from);
+        return cursor(from, null, false);
+    }
+
+    public final Cursor<K, V> cursor(K from, K to, boolean reverse) {
+        return new Cursor<>(getRootPage(), from, to, reverse);
     }
 
     @Override
@@ -731,7 +739,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
 
             @Override
             public Iterator<Entry<K, V>> iterator() {
-                final Cursor<K, V> cursor = new Cursor<>(root, null);
+                final Cursor<K, V> cursor = new Cursor<>(root, null, null, false);
                 return new Iterator<Entry<K, V>>() {
 
                     @Override

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -165,32 +165,12 @@ public class MVMap<K, V> extends AbstractMap<K, V>
     }
 
     /**
-     * Get the first key of this page.
-     *
-     * @param p the page
-     * @return the key, or null
-     */
-    public final K firstKey(Page<K,V> p) {
-        return getFirstLast(p, true);
-    }
-
-    /**
      * Get the last key, or null if the map is empty.
      *
      * @return the last key, or null
      */
     public final K lastKey() {
         return getFirstLast(false);
-    }
-
-    /**
-     * Get the last key of this page.
-     *
-     * @param p the page
-     * @return the key, or null
-     */
-    public final K lastKey(Page<K,V> p) {
-        return getFirstLast(p, false);
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -855,8 +855,8 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @param updatedRootReference the new
      * @return whether updating worked
      */
-    final boolean compareAndSetRoot(RootReference<K,V> expectedRootReference, RootReference<K,V> updatedRootReference)
-    {
+    final boolean compareAndSetRoot(RootReference<K,V> expectedRootReference,
+                                    RootReference<K,V> updatedRootReference) {
         return root.compareAndSet(expectedRootReference, updatedRootReference);
     }
 
@@ -878,8 +878,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
      * @param version to rollback to
      * @return true if rollback was a success, false if there was not enough in-memory history
      */
-    boolean rollbackRoot(long version)
-    {
+    boolean rollbackRoot(long version) {
         RootReference<K,V> rootReference = flushAndGetRoot();
         RootReference<K,V> previous;
         while (rootReference.version >= version && (previous = rootReference.previous) != null) {
@@ -1733,7 +1732,8 @@ public class MVMap<K, V> extends AbstractMap<K, V>
             if (!locked) {
                 if (attempt++ == 0) {
                     beforeWrite();
-                } else if (attempt > 3 || rootReference.isLocked()) {
+                }
+                if (attempt > 3 || rootReference.isLocked()) {
                     rootReference = lockRoot(rootReference, attempt);
                     locked = true;
                 }
@@ -1881,7 +1881,7 @@ public class MVMap<K, V> extends AbstractMap<K, V>
         if (lockedRootReference != null) {
             return lockedRootReference;
         }
-
+        assert !rootReference.isLockedByCurrentThread() : rootReference;
         RootReference<K,V> oldRootReference = rootReference.previous;
         int contention = 1;
         if (oldRootReference != null) {

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2251,7 +2251,7 @@ public class MVStore implements AutoCloseable
                 try {
                     Chunk chunk = getChunk(pos);
                     int pageOffset = DataUtils.getPageOffset(pos);
-                    ByteBuffer buff = chunk.readBufferForPage(fileStore, pageOffset, pos, map.getId());
+                    ByteBuffer buff = chunk.readBufferForPage(fileStore, pageOffset, pos);
                     p = Page.read(buff, pos, map);
                     if (p.pageNo < 0) {
                         p.pageNo = calculatePageNo(pos);

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -1552,7 +1552,7 @@ public abstract class Page<K,V> implements Cloneable
         @Override
         public CursorPos<K,V> getAppendCursorPos(CursorPos<K,V> cursorPos) {
             int keyCount = getKeyCount();
-            return new CursorPos<>(this, -keyCount - 1, cursorPos);
+            return new CursorPos<>(this, ~keyCount, cursorPos);
         }
 
         @Override

--- a/h2/src/main/org/h2/mvstore/type/BasicDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/BasicDataType.java
@@ -61,7 +61,7 @@ public abstract class BasicDataType<T> implements DataType<T> {
             }
             x = (low + high) >>> 1;
         }
-        return -(low + 1);
+        return ~low;
     }
 
     @Override

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -84,6 +84,7 @@ public class TestMVStore extends TestBase {
         testFileHeader();
         testFileHeaderCorruption();
         testIndexSkip();
+        testIndexSkipReverse();
         testMinMaxNextKey();
         testStoreVersion();
         testIterateOldVersion();
@@ -1054,6 +1055,23 @@ public class TestMVStore extends TestBase {
         assertEquals(24, map.keyList().get(12).intValue());
         assertEquals(-14, map.keyList().indexOf(25));
         assertEquals(map.size(), map.keyList().size());
+    }
+
+    private void testIndexSkipReverse() {
+        MVStore s = openStore(null, 4);
+        MVMap<Integer, Integer> map = s.openMap("test");
+        for (int i = 0; i < 100; i += 2) {
+            map.put(i, 10 * i);
+        }
+
+        Cursor<Integer, Integer> c = map.cursor(50, null, true);
+        // skip must reset the root of the cursor
+        c.skip(10);
+        for (int i = 30; i >= 0; i -= 2) {
+            assertTrue(c.hasNext());
+            assertEquals(i, c.next().intValue());
+        }
+        assertFalse(c.hasNext());
     }
 
     private void testMinMaxNextKey() {


### PR DESCRIPTION
This PR implements #2000  (not NavigatableMap yet).
keyCursorReverse() method produces cursor, which iterates map in reversed (descending) order.
Also few minor changes and TestMVStore refactored to use try-with-resource whenever possible / appropriate