### PR TITLE
Add own implementation of SQLType

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2194: Add own enumeration of data types to API
+</li>
+<li>PR #2408: Descending MVMap and TransactionMap cursor
+</li>
 <li>Issue #2399: Cast to ARRAY with a nested ARRAY does not check the maximum cardinality of the nested ARRAY
 </li>
 <li>Issue #2402: Remove old ValueLob and DbUpgrade

--- a/h2/src/main/org/h2/api/H2Type.java
+++ b/h2/src/main/org/h2/api/H2Type.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.api;
+
+import java.sql.SQLType;
+
+import org.h2.value.Value;
+
+/**
+ * Data types of H2.
+ */
+public enum H2Type implements SQLType {
+
+    // Exact numeric data types
+
+    /**
+     * The TINYINT data type.
+     */
+    TINYINT("TINYINT", Value.TINYINT),
+
+    /**
+     * The SMALLINT data type.
+     */
+    SMALLINT("SMALLINT", Value.SMALLINT),
+
+    /**
+     * The INTEGER data type.
+     */
+    INTEGER("INTEGER", Value.INTEGER),
+
+    /**
+     * The BIGINT data type.
+     */
+    BIGINT("BIGINT", Value.BIGINT),
+
+    /**
+     * The NUMERIC data type.
+     */
+    NUMERIC("NUMERIC", Value.NUMERIC),
+
+    // Approximate numeric data types
+
+    /**
+     * The REAL data type.
+     */
+    REAL("REAL", Value.REAL),
+
+    /**
+     * The DOUBLE data type.
+     */
+    DOUBLE("DOUBLE", Value.DOUBLE),
+
+    // Character strings
+
+    /**
+     * The CHAR data type.
+     */
+    CHAR("CHAR", Value.CHAR),
+
+    /**
+     * The VARCHAR data type.
+     */
+    VARCHAR("VARCHAR", Value.VARCHAR),
+
+    /**
+     * The VARCHAR_IGNORECASE data type.
+     */
+    VARCHAR_IGNORECASE("VARCHAR_IGNORECASE", Value.VARCHAR_IGNORECASE),
+
+    /**
+     * The CLOB data type.
+     */
+    CLOB("CLOB", Value.CLOB),
+
+    // Date-time data types
+
+    /**
+     * The DATE data type.
+     */
+    DATE("DATE", Value.DATE),
+
+    /**
+     * The TIME data type.
+     */
+    TIME("TIME", Value.TIME),
+
+    /**
+     * The TIME WITH TIME ZONE data type.
+     */
+    TIME_WITH_TIME_ZONE("TIME WITH TIME ZONE", Value.TIME_TZ),
+
+    /**
+     * The TIMESTAMP data type.
+     */
+    TIMESTAMP("TIMESTAMP", Value.TIMESTAMP),
+
+    /**
+     * The TIMESTAMP WITH TIME ZONE data type.
+     */
+    TIMESTAMP_WITH_TIME_ZONE("TIMESTAMP WITH TIME ZONE", Value.TIMESTAMP_TZ),
+
+    // Intervals
+
+    /**
+     * The INTERVAL YEAR data type.
+     */
+    INTERVAL_YEAR("INTERVAL YEAR", Value.INTERVAL_YEAR),
+
+    /**
+     * The INTERVAL MONTH data type.
+     */
+    INTERVAL_MONTH("INTERVAL MONTH", Value.INTERVAL_MONTH),
+
+    /**
+     * The INTERVAL DAY data type.
+     */
+    INTERVAL_DAY("INTERVAL DAY", Value.INTERVAL_DAY),
+
+    /**
+     * The INTERVAL HOUR data type.
+     */
+    INTERVAL_HOUR("INTERVAL HOUR", Value.INTERVAL_HOUR),
+
+    /**
+     * The INTERVAL MINUTE data type.
+     */
+    INTERVAL_MINUTE("INTERVAL MINUTE", Value.INTERVAL_MINUTE),
+
+    /**
+     * The INTERVAL SECOND data type.
+     */
+    INTERVAL_SECOND("INTERVAL SECOND", Value.INTERVAL_SECOND),
+
+    /**
+     * The INTERVAL YEAR TO MONTH data type.
+     */
+    INTERVAL_YEAR_TO_MONTH("INTERVAL YEAR TO MONTH", Value.INTERVAL_YEAR_TO_MONTH),
+
+    /**
+     * The INTERVAL DAY TO HOUR data type.
+     */
+    INTERVAL_DAY_TO_HOUR("INTERVAL DAY TO HOUR", Value.INTERVAL_DAY_TO_HOUR),
+
+    /**
+     * The INTERVAL DAY TO MINUTE data type.
+     */
+    INTERVAL_DAY_TO_MINUTE("INTERVAL DAY TO MINUTE", Value.INTERVAL_DAY_TO_MINUTE),
+
+    /**
+     * The INTERVAL DAY TO SECOND data type.
+     */
+    INTERVAL_DAY_TO_SECOND("INTERVAL DAY_TO_SECOND", Value.INTERVAL_DAY_TO_SECOND),
+
+    /**
+     * The INTERVAL HOUR TO MINUTE data type.
+     */
+    INTERVAL_HOUR_TO_MINUTE("INTERVAL HOUR TO MINUTE", Value.INTERVAL_HOUR_TO_MINUTE),
+
+    /**
+     * The INTERVAL HOUR TO SECOND data type.
+     */
+    INTERVAL_HOUR_TO_SECOND("INTERVAL HOUR TO SECOND", Value.INTERVAL_HOUR_TO_SECOND),
+
+    /**
+     * The INTERVAL MINUTE TO SECOND data type.
+     */
+    INTERVAL_MINUTE_TO_SECOND("INTERVAL MINUTE TO SECOND", Value.INTERVAL_MINUTE_TO_SECOND),
+
+    // Boolean
+
+    /**
+     * The BOOLEAN data type
+     */
+    BOOLEAN("BOOLEAN", Value.BOOLEAN),
+
+    // Binary strings
+
+    /**
+     * The VARBINARY data type.
+     */
+    VARBINARY("VARBINARY", Value.VARBINARY),
+
+    /**
+     * The BLOB data type.
+     */
+    BLOB("BLOB", Value.BLOB),
+
+    // Collections
+
+    /**
+     * The ARRAY data type.
+     */
+    ARRAY("ARRAY", Value.ARRAY),
+
+    // Row
+
+    /**
+     * The ROW data type.
+     */
+    ROW("ROW", Value.ROW),
+
+    // Result set for table functions
+
+    /**
+     * The RESULT_SET data type.
+     */
+    RESULT_SET("RESULT_SET", Value.RESULT_SET),
+
+    // Other JDBC
+
+    /**
+     * The JAVA_OBJECT data type.
+     */
+    JAVA_OBJECT("JAVA_OBJECT", Value.JAVA_OBJECT),
+
+    // Other non-standard
+
+    /**
+     * The ENUM data type.
+     */
+    ENUM("ENUM", Value.ENUM),
+
+    /**
+     * The GEOMETRY data type.
+     */
+    GEOMETRY("GEOMETRY", Value.GEOMETRY),
+
+    /**
+     * The JSON data type.
+     */
+    JSON("JSON", Value.JSON),
+
+    /**
+     * The UUID data type.
+     */
+    UUID("UUID", Value.UUID),
+
+    ;
+
+    private final String name;
+
+    private Integer valueType;
+
+    private H2Type(String name, int valueType) {
+        this.name = name;
+        this.valueType = valueType;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getVendor() {
+        return "com.h2database";
+    }
+
+    /**
+     * Returns the vendor specific type number for the data type. The returned
+     * value is actual only for the current version of H2.
+     *
+     * @return the vendor specific data type
+     */
+    @Override
+    public Integer getVendorTypeNumber() {
+        return valueType;
+    }
+
+}

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -2733,7 +2733,7 @@ public class Parser {
                 boolean canBeNumber = !readIf(EQUAL);
                 SelectOrderBy order = new SelectOrderBy();
                 Expression expr = readExpression();
-                if (canBeNumber && expr instanceof ValueExpression && expr.getType().getValueType() == Value.INT) {
+                if (canBeNumber && expr instanceof ValueExpression && expr.getType().getValueType() == Value.INTEGER) {
                     order.columnIndexExpr = expr;
                 } else if (expr instanceof Parameter) {
                     recompileAlways = true;
@@ -4021,7 +4021,7 @@ public class Parser {
             }
             if (readIf(WITH)) {
                 read("ORDINALITY");
-                columns.add(new Column("NORD", Value.INT));
+                columns.add(new Column("NORD", Value.INTEGER));
             }
             TableFunction tf = (TableFunction) function;
             tf.setColumns(columns);
@@ -5871,7 +5871,7 @@ public class Parser {
                 column.setPrimaryKey(true);
             }
         } else if (readIf("SERIAL")) {
-            column = new Column(columnName, TypeInfo.TYPE_INT, "SERIAL");
+            column = new Column(columnName, TypeInfo.TYPE_INTEGER, "SERIAL");
             parseAutoIncrement(column);
             // PostgreSQL compatibility
             if (!database.getMode().serialColumnIsNotPK) {

--- a/h2/src/main/org/h2/command/dml/Explain.java
+++ b/h2/src/main/org/h2/command/dml/Explain.java
@@ -7,8 +7,8 @@ package org.h2.command.dml;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.Map.Entry;
+import java.util.TreeMap;
 import org.h2.command.CommandInterface;
 import org.h2.command.Prepared;
 import org.h2.engine.Database;
@@ -23,7 +23,7 @@ import org.h2.result.ResultInterface;
 import org.h2.table.Column;
 import org.h2.util.HasSQL;
 import org.h2.value.Value;
-import org.h2.value.ValueString;
+import org.h2.value.ValueVarchar;
 
 /**
  * This class represents the statement
@@ -137,7 +137,7 @@ public class Explain extends Prepared {
     }
 
     private void add(String text) {
-        result.addRow(ValueString.get(text));
+        result.addRow(ValueVarchar.get(text));
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/Query.java
+++ b/h2/src/main/org/h2/command/dml/Query.java
@@ -35,7 +35,7 @@ import org.h2.util.HasSQL;
 import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
 
 /**
@@ -510,7 +510,7 @@ public abstract class Query extends Prepared {
                 continue;
             }
             int idx = initExpression(session, expressions, expressionSQL, e, visible, mustBeInResult, filters);
-            o.columnIndexExpr = ValueExpression.get(ValueInt.get(idx + 1));
+            o.columnIndexExpr = ValueExpression.get(ValueInteger.get(idx + 1));
             o.expression = expressions.get(idx).getNonAliasExpression();
         }
     }

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -59,7 +59,7 @@ import org.h2.util.MathUtils;
 import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 import org.h2.value.Value;
-import org.h2.value.ValueString;
+import org.h2.value.ValueVarchar;
 
 /**
  * This class represents the statement
@@ -703,10 +703,10 @@ public class ScriptCommand extends ScriptBase {
             }
             out.write(buffer, 0, len);
             if (!insert) {
-                result.addRow(ValueString.get(s));
+                result.addRow(ValueVarchar.get(s));
             }
         } else {
-            result.addRow(ValueString.get(s));
+            result.addRow(ValueVarchar.get(s));
         }
     }
 

--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -33,7 +33,7 @@ import org.h2.util.TimeZoneProvider;
 import org.h2.value.CompareMode;
 import org.h2.value.DataType;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
 
 /**
@@ -667,7 +667,7 @@ public class Set extends Prepared {
     }
 
     public void setInt(int value) {
-        this.expression = ValueExpression.get(ValueInt.get(value));
+        this.expression = ValueExpression.get(ValueInteger.get(value));
     }
 
     public void setExpression(Expression expression) {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -87,7 +87,7 @@ import org.h2.value.CaseInsensitiveConcurrentMap;
 import org.h2.value.CaseInsensitiveMap;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueTimestampTimeZone;
 
 /**
@@ -1060,7 +1060,7 @@ public class Database implements DataHandler, CastDataProvider {
     public void removeMeta(Session session, int id) {
         if (id > 0 && !starting) {
             SearchRow r = meta.getRowFactory().createRow();
-            r.setValue(0, ValueInt.get(id));
+            r.setValue(0, ValueInteger.get(id));
             boolean wasLocked = lockMeta(session);
             try {
                 Cursor cursor = metaIdIndex.find(session, r, r);
@@ -1607,7 +1607,7 @@ public class Database implements DataHandler, CastDataProvider {
 
     private void checkMetaFree(Session session, int id) {
         SearchRow r = meta.getRowFactory().createRow();
-        r.setValue(0, ValueInt.get(id));
+        r.setValue(0, ValueInteger.get(id));
         Cursor cursor = metaIdIndex.find(session, r, r);
         if (cursor.next()) {
             DbException.throwInternalError();

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -640,11 +640,11 @@ public class Database implements DataHandler, CastDataProvider {
         lobSession = new Session(this, systemUser, ++nextSessionId);
         CreateTableData data = new CreateTableData();
         ArrayList<Column> cols = data.columns;
-        Column columnId = new Column("ID", Value.INT);
+        Column columnId = new Column("ID", Value.INTEGER);
         columnId.setNullable(false);
         cols.add(columnId);
-        cols.add(new Column("HEAD", Value.INT));
-        cols.add(new Column("TYPE", Value.INT));
+        cols.add(new Column("HEAD", Value.INTEGER));
+        cols.add(new Column("TYPE", Value.INTEGER));
         cols.add(new Column("SQL", Value.VARCHAR));
         boolean create = true;
         if (pageStore != null) {

--- a/h2/src/main/org/h2/engine/MetaRecord.java
+++ b/h2/src/main/org/h2/engine/MetaRecord.java
@@ -13,8 +13,8 @@ import org.h2.command.Prepared;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.result.SearchRow;
-import org.h2.value.ValueInt;
-import org.h2.value.ValueString;
+import org.h2.value.ValueInteger;
+import org.h2.value.ValueVarchar;
 
 /**
  * A record in the system table of the database.
@@ -51,10 +51,10 @@ public class MetaRecord implements Comparable<MetaRecord> {
      *            search row
      */
     public static void populateRowFromDBObject(DbObject obj, SearchRow r) {
-        r.setValue(0, ValueInt.get(obj.getId()));
-        r.setValue(1, ValueInt.get(0));
-        r.setValue(2, ValueInt.get(obj.getType()));
-        r.setValue(3, ValueString.get(obj.getCreateSQL()));
+        r.setValue(0, ValueInteger.get(obj.getId()));
+        r.setValue(1, ValueInteger.get(0));
+        r.setValue(2, ValueInteger.get(obj.getType()));
+        r.setValue(3, ValueVarchar.get(obj.getCreateSQL()));
     }
 
     public MetaRecord(SearchRow r) {

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -57,11 +57,11 @@ import org.h2.util.TimeZoneProvider;
 import org.h2.util.Utils;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueLob;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueString;
 import org.h2.value.ValueTimestampTimeZone;
+import org.h2.value.ValueVarchar;
 import org.h2.value.VersionedValue;
 
 /**
@@ -99,8 +99,8 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
     private int lockTimeout;
 
     private WeakHashMap<Sequence, Value> currentValueFor;
-    private Value lastIdentity = ValueLong.get(0);
-    private Value lastScopeIdentity = ValueLong.get(0);
+    private Value lastIdentity = ValueBigint.get(0);
+    private Value lastScopeIdentity = ValueBigint.get(0);
     private Value lastTriggerIdentity;
 
     private int firstUncommittedLog = Session.LOG_WRITTEN;
@@ -1682,7 +1682,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
             if (transaction == null || !transaction.hasChanges()) {
                 return ValueNull.INSTANCE;
             }
-            return ValueString.get(Long.toString(getTransaction().getSequenceNum()));
+            return ValueVarchar.get(Long.toString(getTransaction().getSequenceNum()));
         }
         if (!database.isPersistent()) {
             return ValueNull.INSTANCE;
@@ -1690,7 +1690,7 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
         if (undoLog == null || undoLog.size() == 0) {
             return ValueNull.INSTANCE;
         }
-        return ValueString.get(firstUncommittedLog + "-" + firstUncommittedPos +
+        return ValueVarchar.get(firstUncommittedLog + "-" + firstUncommittedPos +
                 "-" + id);
     }
 

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -41,10 +41,10 @@ import org.h2.util.Utils;
 import org.h2.value.CompareMode;
 import org.h2.value.Transfer;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueLob;
-import org.h2.value.ValueString;
 import org.h2.value.ValueTimestampTimeZone;
+import org.h2.value.ValueVarchar;
 
 /**
  * The client side part of a session when using the server mode. This object
@@ -898,7 +898,7 @@ public class SessionRemote extends SessionWithState implements DataHandler {
             }
         } else {
             try (CommandInterface command = prepareCommand("SET LOCK_MODE ?", 0)) {
-                command.getParameters().get(0).setValue(ValueInt.get(isolationLevel.getLockMode()), false);
+                command.getParameters().get(0).setValue(ValueInteger.get(isolationLevel.getLockMode()), false);
                 command.executeUpdate(null);
             }
         }
@@ -913,9 +913,9 @@ public class SessionRemote extends SessionWithState implements DataHandler {
                     "SELECT NAME, `VALUE` FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME IN (?, ?, ?)",
                     Integer.MAX_VALUE)) {
                 ArrayList<? extends ParameterInterface> parameters = command.getParameters();
-                parameters.get(0).setValue(ValueString.get("DATABASE_TO_UPPER"), false);
-                parameters.get(1).setValue(ValueString.get("DATABASE_TO_LOWER"), false);
-                parameters.get(2).setValue(ValueString.get("CASE_INSENSITIVE_IDENTIFIERS"), false);
+                parameters.get(0).setValue(ValueVarchar.get("DATABASE_TO_UPPER"), false);
+                parameters.get(1).setValue(ValueVarchar.get("DATABASE_TO_LOWER"), false);
+                parameters.get(2).setValue(ValueVarchar.get("CASE_INSENSITIVE_IDENTIFIERS"), false);
                 try (ResultInterface result = command.executeQuery(Integer.MAX_VALUE, false)) {
                     while (result.next()) {
                         Value[] row = result.currentRow();
@@ -952,8 +952,8 @@ public class SessionRemote extends SessionWithState implements DataHandler {
                     "SELECT NAME, `VALUE` FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME IN (?, ?)",
                     Integer.MAX_VALUE)) {
                 ArrayList<? extends ParameterInterface> parameters = command.getParameters();
-                parameters.get(0).setValue(ValueString.get("MODE"), false);
-                parameters.get(1).setValue(ValueString.get("TIME ZONE"), false);
+                parameters.get(0).setValue(ValueVarchar.get("MODE"), false);
+                parameters.get(1).setValue(ValueVarchar.get("TIME ZONE"), false);
                 try (ResultInterface result = command.executeQuery(Integer.MAX_VALUE, false)) {
                     while (result.next()) {
                         Value[] row = result.currentRow();

--- a/h2/src/main/org/h2/expression/BinaryOperation.java
+++ b/h2/src/main/org/h2/expression/BinaryOperation.java
@@ -173,7 +173,7 @@ public class BinaryOperation extends Expression {
             if (dataType == Value.NUMERIC) {
                 optimizeNumeric(leftType, rightType);
             } else if (dataType == Value.ENUM) {
-                type = TypeInfo.TYPE_INT;
+                type = TypeInfo.TYPE_INTEGER;
             } else if (DataType.isStringType(dataType)
                     && opType == OpType.PLUS && session.getDatabase().getMode().allowPlusForStringConcat) {
                 return new ConcatenationOperation(left, right).optimize(session);
@@ -321,7 +321,7 @@ public class BinaryOperation extends Expression {
                 r = t;
             }
             switch (l) {
-            case Value.INT: {
+            case Value.INTEGER: {
                 // Oracle date add
                 return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
                         ValueExpression.get(ValueString.get("DAY")), left, right).optimize(session);
@@ -348,7 +348,7 @@ public class BinaryOperation extends Expression {
             case Value.TIMESTAMP:
             case Value.TIMESTAMP_TZ:
                 switch (r) {
-                case Value.INT: {
+                case Value.INTEGER: {
                     if (forcedType != null) {
                         throw getUnexpectedForcedTypeException();
                     }

--- a/h2/src/main/org/h2/expression/BinaryOperation.java
+++ b/h2/src/main/org/h2/expression/BinaryOperation.java
@@ -14,10 +14,10 @@ import org.h2.table.TableFilter;
 import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
-import org.h2.value.ValueDecimal;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueString;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueVarchar;
 
 /**
  * A mathematical expression, or string concatenation.
@@ -220,7 +220,7 @@ public class BinaryOperation extends Expression {
             break;
         case DIVIDE:
             // Precision and scale are implementation-defined.
-            scale = ValueDecimal.getQuotientScale(leftScale, rightPrecision, rightScale);
+            scale = ValueNumeric.getQuotientScale(leftScale, rightPrecision, rightScale);
             // Divider can be effectively multiplied by no more than
             // 10^rightScale, so add rightScale to its precision and adjust the
             // result to the changes in scale.
@@ -321,20 +321,21 @@ public class BinaryOperation extends Expression {
                 r = t;
             }
             switch (l) {
-            case Value.INTEGER: {
+            case Value.INTEGER:
                 // Oracle date add
                 return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
-                        ValueExpression.get(ValueString.get("DAY")), left, right).optimize(session);
-            }
+                        ValueExpression.get(ValueVarchar.get("DAY")), left, right).optimize(session);
             case Value.NUMERIC:
             case Value.REAL:
-            case Value.DOUBLE: {
+            case Value.DOUBLE:
                 // Oracle date add
-                return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
-                        ValueExpression.get(ValueString.get("SECOND")),
-                        new BinaryOperation(OpType.MULTIPLY, ValueExpression.get(ValueInt.get(60 * 60 * 24)), left),
-                        right).optimize(session);
-            }
+                return Function
+                        .getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
+                                ValueExpression.get(ValueVarchar.get("SECOND")),
+                                new BinaryOperation(OpType.MULTIPLY,
+                                        ValueExpression.get(ValueInteger.get(60 * 60 * 24)), left),
+                                right)
+                        .optimize(session);
             case Value.TIME:
             case Value.TIME_TZ:
                 if (DataType.isDateTimeType(r)) {
@@ -354,7 +355,7 @@ public class BinaryOperation extends Expression {
                     }
                     // Oracle date subtract
                     return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
-                            ValueExpression.get(ValueString.get("DAY")), //
+                            ValueExpression.get(ValueVarchar.get("DAY")), //
                             new UnaryOperation(right), //
                             left).optimize(session);
                 }
@@ -366,9 +367,9 @@ public class BinaryOperation extends Expression {
                     }
                     // Oracle date subtract
                     return Function.getFunctionWithArgs(session.getDatabase(), Function.DATEADD,
-                                ValueExpression.get(ValueString.get("SECOND")),
+                                ValueExpression.get(ValueVarchar.get("SECOND")),
                                 new UnaryOperation(new BinaryOperation(OpType.MULTIPLY, //
-                                        ValueExpression.get(ValueInt.get(60 * 60 * 24)), right)), //
+                                        ValueExpression.get(ValueInteger.get(60 * 60 * 24)), right)), //
                                 left).optimize(session);
                 }
                 case Value.TIME:

--- a/h2/src/main/org/h2/expression/ConcatenationOperation.java
+++ b/h2/src/main/org/h2/expression/ConcatenationOperation.java
@@ -14,9 +14,9 @@ import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
-import org.h2.value.ValueBytes;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueString;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
 
 /**
  * Character string concatenation as in {@code 'Hello' || 'World'}, binary
@@ -63,7 +63,7 @@ public class ConcatenationOperation extends Expression {
             int leftLength = leftBytes.length, rightLength = rightBytes.length;
             byte[] bytes = Arrays.copyOf(leftBytes, leftLength + rightLength);
             System.arraycopy(rightBytes, 0, bytes, leftLength, rightLength);
-            return ValueBytes.getNoCopy(bytes);
+            return ValueVarbinary.getNoCopy(bytes);
         }
         default: {
             if (l == ValueNull.INSTANCE) {
@@ -80,7 +80,7 @@ public class ConcatenationOperation extends Expression {
             String s1 = l.getString(), s2 = r.getString();
             StringBuilder buff = new StringBuilder(s1.length() + s2.length());
             buff.append(s1).append(s2);
-            return ValueString.get(buff.toString());
+            return ValueVarchar.get(buff.toString());
         }
         }
     }

--- a/h2/src/main/org/h2/expression/IntervalOperation.java
+++ b/h2/src/main/org/h2/expression/IntervalOperation.java
@@ -30,9 +30,9 @@ import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueDate;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
 import org.h2.value.ValueTime;
 import org.h2.value.ValueTimeTimeZone;
 import org.h2.value.ValueTimestampTimeZone;
@@ -207,8 +207,8 @@ public class IntervalOperation extends Expression {
                     opType == IntervalOpType.INTERVAL_PLUS_INTERVAL ? a1.add(a2) : a1.subtract(a2));
         }
         case INTERVAL_DIVIDE_INTERVAL:
-            return ValueDecimal.get(IntervalUtils.intervalToAbsolute((ValueInterval) l)).divide(
-                    ValueDecimal.get(IntervalUtils.intervalToAbsolute((ValueInterval) r)),
+            return ValueNumeric.get(IntervalUtils.intervalToAbsolute((ValueInterval) l)).divide(
+                    ValueNumeric.get(IntervalUtils.intervalToAbsolute((ValueInterval) r)),
                     DataType.isYearMonthIntervalType(l.getValueType()) ? INTERVAL_YEAR_DIGITS : INTERVAL_DAY_DIGITS);
         case DATETIME_PLUS_INTERVAL:
         case DATETIME_MINUS_INTERVAL:

--- a/h2/src/main/org/h2/expression/Parameter.java
+++ b/h2/src/main/org/h2/expression/Parameter.java
@@ -16,7 +16,7 @@ import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueBoolean;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueString;
+import org.h2.value.ValueVarchar;
 
 /**
  * A parameter of a prepared statement.
@@ -87,7 +87,7 @@ public class Parameter extends Expression implements ParameterInterface {
     @Override
     public Expression optimize(Session session) {
         if (session.getDatabase().getMode().treatEmptyStringsAsNull) {
-            if (value instanceof ValueString && value.getString().isEmpty()) {
+            if (value instanceof ValueVarchar && value.getString().isEmpty()) {
                 value = ValueNull.INSTANCE;
             }
         }

--- a/h2/src/main/org/h2/expression/Rownum.java
+++ b/h2/src/main/org/h2/expression/Rownum.java
@@ -12,7 +12,7 @@ import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 
 /**
  * Represents the ROWNUM function.
@@ -30,7 +30,7 @@ public class Rownum extends Expression {
 
     @Override
     public Value getValue(Session session) {
-        return ValueLong.get(prepared.getCurrentRowNumber());
+        return ValueBigint.get(prepared.getCurrentRowNumber());
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/UnaryOperation.java
+++ b/h2/src/main/org/h2/expression/UnaryOperation.java
@@ -50,7 +50,7 @@ public class UnaryOperation extends Expression {
         if (type.getValueType() == Value.UNKNOWN) {
             type = TypeInfo.TYPE_NUMERIC_FLOATING_POINT;
         } else if (type.getValueType() == Value.ENUM) {
-            type = TypeInfo.TYPE_INT;
+            type = TypeInfo.TYPE_INTEGER;
         }
         if (arg.isConstant()) {
             return ValueExpression.get(getValue(session));

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -42,14 +42,14 @@ import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueJson;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueRow;
-import org.h2.value.ValueString;
+import org.h2.value.ValueVarchar;
 
 /**
  * Implements the integrated aggregate functions, such as COUNT, MAX, SUM.
@@ -351,7 +351,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
         case COUNT:
         case COUNT_ALL:
             Table table = select.getTopTableFilter().getTable();
-            return ValueLong.get(table.getRowCount(session));
+            return ValueBigint.get(table.getRowCount(session));
         case MIN:
         case MAX: {
             boolean first = aggregateType == AggregateType.MIN;
@@ -403,7 +403,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
         switch (aggregateType) {
         case COUNT:
             if (distinct) {
-                return ValueLong.get(((AggregateDataCollecting) data).getCount());
+                return ValueBigint.get(((AggregateDataCollecting) data).getCount());
             }
             break;
         case SUM:
@@ -526,7 +526,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
             switch (aggregateType) {
             case RANK:
             case DENSE_RANK:
-                return ValueInt.get(1);
+                return ValueInteger.get(1);
             case PERCENT_RANK:
                 return ValueDouble.ZERO;
             case CUME_DIST:
@@ -561,7 +561,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
                 int nm = number - 1;
                 v = nm == 0 ? ValueDouble.ZERO : ValueDouble.get((double) nm / (size - 1));
             } else {
-                v = ValueLong.get(number);
+                v = ValueBigint.get(number);
             }
             if (sort.compare(row, arg) == 0) {
                 return v;
@@ -613,7 +613,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
             }
             builder.append(s);
         }
-        return ValueString.get(builder.toString());
+        return ValueVarchar.get(builder.toString());
     }
 
     private static Value getHistogram(Session session, AggregateData data) {
@@ -625,7 +625,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
         int i = 0;
         for (Entry<Value, LongDataCounter> entry : distinctValues.entrySet()) {
             LongDataCounter d = entry.getValue();
-            values[i] = ValueRow.get(new Value[] { entry.getKey(), ValueLong.get(d.count) });
+            values[i] = ValueRow.get(new Value[] { entry.getKey(), ValueBigint.get(d.count) });
             i++;
         }
         Database db = session.getDatabase();
@@ -715,7 +715,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
         case COUNT:
             if (args[0].isConstant()) {
                 if (args[0].getValue(session) == ValueNull.INSTANCE) {
-                    return ValueExpression.get(ValueLong.get(0L));
+                    return ValueExpression.get(ValueBigint.get(0L));
                 }
                 if (!distinct) {
                     Aggregate aggregate = new Aggregate(AggregateType.COUNT_ALL, new Expression[0], select, false);

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -764,7 +764,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
             switch (type.getValueType()) {
             case Value.TINYINT:
             case Value.SMALLINT:
-            case Value.INT:
+            case Value.INTEGER:
             case Value.BIGINT:
             case Value.NUMERIC:
             case Value.DOUBLE:

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataCount.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataCount.java
@@ -7,7 +7,7 @@ package org.h2.expression.aggregate;
 
 import org.h2.engine.Session;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueNull;
 
 /**
@@ -32,7 +32,7 @@ class AggregateDataCount extends AggregateData {
 
     @Override
     Value getValue(Session session) {
-        return ValueLong.get(count);
+        return ValueBigint.get(count);
     }
 
 }

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataDefault.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataDefault.java
@@ -9,9 +9,9 @@ import org.h2.engine.Session;
 import org.h2.message.DbException;
 import org.h2.value.DataType;
 import org.h2.value.Value;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
 
 /**
@@ -105,14 +105,14 @@ class AggregateDataDefault extends AggregateData {
             if (value == null) {
                 value = v.convertTo(dataType);
             } else {
-                value = ValueLong.get(value.getLong() & v.getLong()).convertTo(dataType);
+                value = ValueBigint.get(value.getLong() & v.getLong()).convertTo(dataType);
             }
             break;
         case BIT_OR:
             if (value == null) {
                 value = v.convertTo(dataType);
             } else {
-                value = ValueLong.get(value.getLong() | v.getLong()).convertTo(dataType);
+                value = ValueBigint.get(value.getLong() | v.getLong()).convertTo(dataType);
             }
             break;
         default:
@@ -177,8 +177,8 @@ class AggregateDataDefault extends AggregateData {
             return ValueNull.INSTANCE;
         }
         int type = Value.getHigherOrder(a.getValueType(), Value.BIGINT);
-        Value b = ValueLong.get(by).convertTo(type);
-        a = a.convertTo(type).divide(b, ValueLong.PRECISION);
+        Value b = ValueBigint.get(by).convertTo(type);
+        a = a.convertTo(type).divide(b, ValueBigint.PRECISION);
         return a;
     }
 

--- a/h2/src/main/org/h2/expression/aggregate/Percentile.java
+++ b/h2/src/main/org/h2/expression/aggregate/Percentile.java
@@ -29,9 +29,9 @@ import org.h2.util.IntervalUtils;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
 import org.h2.value.ValueDate;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
 import org.h2.value.ValueTime;
 import org.h2.value.ValueTimeTimeZone;
 import org.h2.value.ValueTimestamp;
@@ -257,16 +257,16 @@ final class Percentile {
         case Value.TINYINT:
         case Value.SMALLINT:
         case Value.INTEGER:
-            return ValueDecimal.get(
+            return ValueNumeric.get(
                     interpolateDecimal(BigDecimal.valueOf(v0.getInt()), BigDecimal.valueOf(v1.getInt()), factor));
         case Value.BIGINT:
-            return ValueDecimal.get(
+            return ValueNumeric.get(
                     interpolateDecimal(BigDecimal.valueOf(v0.getLong()), BigDecimal.valueOf(v1.getLong()), factor));
         case Value.NUMERIC:
-            return ValueDecimal.get(interpolateDecimal(v0.getBigDecimal(), v1.getBigDecimal(), factor));
+            return ValueNumeric.get(interpolateDecimal(v0.getBigDecimal(), v1.getBigDecimal(), factor));
         case Value.REAL:
         case Value.DOUBLE:
-            return ValueDecimal.get(
+            return ValueNumeric.get(
                     interpolateDecimal(
                             BigDecimal.valueOf(v0.getDouble()), BigDecimal.valueOf(v1.getDouble()), factor));
         case Value.TIME: {

--- a/h2/src/main/org/h2/expression/aggregate/Percentile.java
+++ b/h2/src/main/org/h2/expression/aggregate/Percentile.java
@@ -256,7 +256,7 @@ final class Percentile {
         switch (dataType) {
         case Value.TINYINT:
         case Value.SMALLINT:
-        case Value.INT:
+        case Value.INTEGER:
             return ValueDecimal.get(
                     interpolateDecimal(BigDecimal.valueOf(v0.getInt()), BigDecimal.valueOf(v1.getInt()), factor));
         case Value.BIGINT:

--- a/h2/src/main/org/h2/expression/analysis/DataAnalysisOperation.java
+++ b/h2/src/main/org/h2/expression/analysis/DataAnalysisOperation.java
@@ -20,7 +20,7 @@ import org.h2.result.SortOrder;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 
 /**
  * A base class for data analysis operations such as aggregates and window
@@ -478,7 +478,7 @@ public abstract class DataAnalysisOperation extends Expression {
                 array[ne++] = bound.getValue().getValue(session);
             }
         }
-        array[ne] = ValueInt.get(groupRowId);
+        array[ne] = ValueInteger.get(groupRowId);
         @SuppressWarnings("unchecked")
         ArrayList<Value[]> data = (ArrayList<Value[]>) getWindowData(session, groupData, true);
         data.add(array);

--- a/h2/src/main/org/h2/expression/analysis/WindowFrame.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFrame.java
@@ -326,7 +326,7 @@ public final class WindowFrame {
             break;
         case Value.TINYINT:
         case Value.SMALLINT:
-        case Value.INT:
+        case Value.INTEGER:
         case Value.BIGINT:
         case Value.NUMERIC:
         case Value.DOUBLE:

--- a/h2/src/main/org/h2/expression/analysis/WindowFunction.java
+++ b/h2/src/main/org/h2/expression/analysis/WindowFunction.java
@@ -18,8 +18,8 @@ import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
 
 /**
@@ -187,7 +187,7 @@ public class WindowFunction extends DataAnalysisOperation {
         switch (type) {
         case ROW_NUMBER:
             for (int i = 0, size = ordered.size(); i < size;) {
-                result.put(ordered.get(i)[rowIdColumn].getInt(), ValueLong.get(++i));
+                result.put(ordered.get(i)[rowIdColumn].getInt(), ValueBigint.get(++i));
             }
             break;
         case RANK:
@@ -237,7 +237,7 @@ public class WindowFunction extends DataAnalysisOperation {
                 int nm = number - 1;
                 v = nm == 0 ? ValueDouble.ZERO : ValueDouble.get((double) nm / (size - 1));
             } else {
-                v = ValueLong.get(number);
+                v = ValueBigint.get(number);
             }
             result.put(row[rowIdColumn].getInt(), v);
         }
@@ -277,7 +277,7 @@ public class WindowFunction extends DataAnalysisOperation {
             } else {
                 v = i / (perTile + 1) + 1;
             }
-            result.put(orderedData.get(i)[rowIdColumn].getInt(), ValueLong.get(v));
+            result.put(orderedData.get(i)[rowIdColumn].getInt(), ValueBigint.get(v));
         }
     }
 

--- a/h2/src/main/org/h2/expression/condition/CompareLike.java
+++ b/h2/src/main/org/h2/expression/condition/CompareLike.java
@@ -24,7 +24,7 @@ import org.h2.value.DataType;
 import org.h2.value.Value;
 import org.h2.value.ValueBoolean;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueString;
+import org.h2.value.ValueVarchar;
 
 /**
  * Pattern matching comparison expression: WHERE NAME LIKE ?
@@ -138,7 +138,7 @@ public class CompareLike extends Condition {
             }
             if (isFullMatch()) {
                 // optimization for X LIKE 'Hello': convert to X = 'Hello'
-                Value value = ValueString.get(patternString);
+                Value value = ValueVarchar.get(patternString);
                 Expression expr = ValueExpression.get(value);
                 return new Comparison(Comparison.EQUAL, left, expr).optimize(session);
             }
@@ -219,7 +219,7 @@ public class CompareLike extends Condition {
         String begin = buff.toString();
         if (maxMatch == patternLength) {
             filter.addIndexCondition(IndexCondition.get(Comparison.EQUAL, l,
-                    ValueExpression.get(ValueString.get(begin))));
+                    ValueExpression.get(ValueVarchar.get(begin))));
         } else {
             // TODO check if this is correct according to Unicode rules
             // (code points)
@@ -227,7 +227,7 @@ public class CompareLike extends Condition {
             if (begin.length() > 0) {
                 filter.addIndexCondition(IndexCondition.get(
                         Comparison.BIGGER_EQUAL, l,
-                        ValueExpression.get(ValueString.get(begin))));
+                        ValueExpression.get(ValueVarchar.get(begin))));
                 char next = begin.charAt(begin.length() - 1);
                 // search the 'next' unicode character (or at least a character
                 // that is higher)
@@ -236,7 +236,7 @@ public class CompareLike extends Condition {
                     if (compareMode.compareString(begin, end, ignoreCase) == -1) {
                         filter.addIndexCondition(IndexCondition.get(
                                 Comparison.SMALLER, l,
-                                ValueExpression.get(ValueString.get(end))));
+                                ValueExpression.get(ValueVarchar.get(end))));
                         break;
                     }
                 }

--- a/h2/src/main/org/h2/expression/function/DateTimeFunctions.java
+++ b/h2/src/main/org/h2/expression/function/DateTimeFunctions.java
@@ -55,9 +55,9 @@ import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueDate;
-import org.h2.value.ValueDecimal;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueInterval;
+import org.h2.value.ValueNumeric;
 import org.h2.value.ValueTime;
 import org.h2.value.ValueTimeTimeZone;
 import org.h2.value.ValueTimestamp;
@@ -381,7 +381,7 @@ public final class DateTimeFunctions {
         Value result;
         int field = getDatePart(part);
         if (field != EPOCH) {
-            result = ValueInt.get(getIntDatePart(session, value, field));
+            result = ValueInteger.get(getIntDatePart(session, value, field));
         } else {
             // Case where we retrieve the EPOCH time.
             if (value instanceof ValueInterval) {
@@ -395,9 +395,9 @@ public final class DateTimeFunctions {
                     if (interval.isNegative()) {
                         bi = bi.negate();
                     }
-                    return ValueDecimal.get(bi);
+                    return ValueNumeric.get(bi);
                 } else {
-                    return ValueDecimal.get(new BigDecimal(IntervalUtils.intervalToAbsolute(interval))
+                    return ValueNumeric.get(new BigDecimal(IntervalUtils.intervalToAbsolute(interval))
                             .divide(BD_NANOS_PER_SECOND));
                 }
             }
@@ -410,11 +410,11 @@ public final class DateTimeFunctions {
             if (value instanceof ValueTime) {
                 // In order to retrieve the EPOCH time we only have to convert the time
                 // in nanoseconds (previously retrieved) in seconds.
-                result = ValueDecimal.get(BigDecimal.valueOf(timeNanos).divide(BD_NANOS_PER_SECOND));
+                result = ValueNumeric.get(BigDecimal.valueOf(timeNanos).divide(BD_NANOS_PER_SECOND));
             } else if (value instanceof ValueDate) {
                 // Case where the value is of type date '2000:01:01', we have to retrieve the
                 // total number of days and multiply it by the number of seconds in a day.
-                result = ValueDecimal.get(BigInteger.valueOf(DateTimeUtils.absoluteDayFromDateValue(dateValue))
+                result = ValueNumeric.get(BigInteger.valueOf(DateTimeUtils.absoluteDayFromDateValue(dateValue))
                         .multiply(BI_SECONDS_PER_DAY));
             } else {
                 BigDecimal bd = BigDecimal.valueOf(timeNanos).divide(BD_NANOS_PER_SECOND).add(BigDecimal
@@ -425,17 +425,17 @@ public final class DateTimeFunctions {
                     // We retrieve the time zone offset in seconds
                     // Sum the time in nanoseconds and the total number of days in seconds
                     // and adding the timeZone offset in seconds.
-                    result = ValueDecimal.get(bd.subtract(
+                    result = ValueNumeric.get(bd.subtract(
                             BigDecimal.valueOf(((ValueTimestampTimeZone) value).getTimeZoneOffsetSeconds())));
                 } else if (value instanceof ValueTimeTimeZone) {
-                    result = ValueDecimal.get(bd.subtract(
+                    result = ValueNumeric.get(bd.subtract(
                             BigDecimal.valueOf(((ValueTimeTimeZone) value).getTimeZoneOffsetSeconds())));
                 } else {
                     // By default, we have the date and the time ('2000:01:01 10:00:00') if no type
                     // is given.
                     // We just have to sum the time in nanoseconds and the total number of days in
                     // seconds.
-                    result = ValueDecimal.get(bd);
+                    result = ValueNumeric.get(bd);
                 }
             }
         }

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -262,7 +262,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunction("ROUND", ROUND, VAR_ARGS, Value.NULL);
         addFunction("ROUNDMAGIC", ROUNDMAGIC, 1, Value.DOUBLE);
         addFunction("RSHIFT", RSHIFT, 2, Value.BIGINT);
-        addFunction("SIGN", SIGN, 1, Value.INT);
+        addFunction("SIGN", SIGN, 1, Value.INTEGER);
         addFunction("SIN", SIN, 1, Value.DOUBLE);
         addFunction("SINH", SINH, 1, Value.DOUBLE);
         addFunction("SQRT", SQRT, 1, Value.DOUBLE);
@@ -277,31 +277,31 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunctionNotDeterministic("SECURE_RAND", SECURE_RAND, 1, Value.VARBINARY);
         addFunction("COMPRESS", COMPRESS, VAR_ARGS, Value.VARBINARY);
         addFunction("EXPAND", EXPAND, 1, Value.VARBINARY);
-        addFunction("ZERO", ZERO, 0, Value.INT);
+        addFunction("ZERO", ZERO, 0, Value.INTEGER);
         addFunctionNotDeterministic("RANDOM_UUID", RANDOM_UUID, 0, Value.UUID);
         addFunctionNotDeterministic("UUID", RANDOM_UUID, 0, Value.UUID);
         addFunction("ORA_HASH", ORA_HASH, VAR_ARGS, Value.BIGINT);
         // string
-        addFunction("ASCII", ASCII, 1, Value.INT);
+        addFunction("ASCII", ASCII, 1, Value.INTEGER);
         addFunction("BIT_LENGTH", BIT_LENGTH, 1, Value.BIGINT);
         addFunction("CHAR", CHAR, 1, Value.VARCHAR);
         addFunction("CHR", CHAR, 1, Value.VARCHAR);
-        addFunction("CHAR_LENGTH", CHAR_LENGTH, 1, Value.INT);
+        addFunction("CHAR_LENGTH", CHAR_LENGTH, 1, Value.INTEGER);
         // same as CHAR_LENGTH
-        addFunction("CHARACTER_LENGTH", CHAR_LENGTH, 1, Value.INT);
+        addFunction("CHARACTER_LENGTH", CHAR_LENGTH, 1, Value.INTEGER);
         addFunctionWithNull("CONCAT", CONCAT, VAR_ARGS, Value.VARCHAR);
         addFunctionWithNull("CONCAT_WS", CONCAT_WS, VAR_ARGS, Value.VARCHAR);
-        addFunction("DIFFERENCE", DIFFERENCE, 2, Value.INT);
+        addFunction("DIFFERENCE", DIFFERENCE, 2, Value.INTEGER);
         addFunction("HEXTORAW", HEXTORAW, 1, Value.NULL);
         addFunctionWithNull("INSERT", INSERT, 4, Value.VARCHAR);
         addFunction("LCASE", LCASE, 1, Value.VARCHAR);
         addFunction("LEFT", LEFT, 2, Value.VARCHAR);
         addFunction("LENGTH", LENGTH, 1, Value.BIGINT);
         // 2 or 3 arguments
-        addFunction("LOCATE", LOCATE, VAR_ARGS, Value.INT);
+        addFunction("LOCATE", LOCATE, VAR_ARGS, Value.INTEGER);
         // same as LOCATE with 2 arguments
-        addFunction("POSITION", LOCATE, 2, Value.INT);
-        addFunction("INSTR", INSTR, VAR_ARGS, Value.INT);
+        addFunction("POSITION", LOCATE, 2, Value.INTEGER);
+        addFunction("INSTR", INSTR, VAR_ARGS, Value.INTEGER);
         addFunction("LTRIM", LTRIM, VAR_ARGS, Value.VARCHAR);
         addFunction("OCTET_LENGTH", OCTET_LENGTH, 1, Value.BIGINT);
         addFunction("RAWTOHEX", RAWTOHEX, 1, Value.VARCHAR);
@@ -316,7 +316,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunction("UCASE", UCASE, 1, Value.VARCHAR);
         addFunction("LOWER", LOWER, 1, Value.VARCHAR);
         addFunction("UPPER", UPPER, 1, Value.VARCHAR);
-        addFunction("POSITION", POSITION, 2, Value.INT);
+        addFunction("POSITION", POSITION, 2, Value.INTEGER);
         addFunction("TRIM", TRIM, VAR_ARGS, Value.VARCHAR);
         addFunction("STRINGENCODE", STRINGENCODE, 1, Value.VARCHAR);
         addFunction("STRINGDECODE", STRINGDECODE, 1, Value.VARCHAR);
@@ -367,47 +367,47 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunction("DAYNAME", DAY_NAME,
                 1, Value.VARCHAR);
         addFunction("DAY", DAY_OF_MONTH,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("DAY_OF_MONTH", DAY_OF_MONTH,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("DAY_OF_WEEK", DAY_OF_WEEK,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("DAY_OF_YEAR", DAY_OF_YEAR,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("DAYOFMONTH", DAY_OF_MONTH,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("DAYOFWEEK", DAY_OF_WEEK,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("DAYOFYEAR", DAY_OF_YEAR,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("HOUR", HOUR,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("MINUTE", MINUTE,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("MONTH", MONTH,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("MONTHNAME", MONTH_NAME,
                 1, Value.VARCHAR);
         addFunction("QUARTER", QUARTER,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("SECOND", SECOND,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("WEEK", WEEK,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("YEAR", YEAR,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("EXTRACT", EXTRACT,
-                2, Value.INT);
+                2, Value.INTEGER);
         addFunctionWithNull("FORMATDATETIME", FORMATDATETIME,
                 VAR_ARGS, Value.VARCHAR);
         addFunctionWithNull("PARSEDATETIME", PARSEDATETIME,
                 VAR_ARGS, Value.TIMESTAMP);
         addFunction("ISO_YEAR", ISO_YEAR,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("ISO_WEEK", ISO_WEEK,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("ISO_DAY_OF_WEEK", ISO_DAY_OF_WEEK,
-                1, Value.INT);
+                1, Value.INTEGER);
         addFunction("DATE_TRUNC", DATE_TRUNC, 2, Value.NULL);
         // system
         addFunctionNotDeterministic("CURRENT_CATALOG", CURRENT_CATALOG, 0, Value.VARCHAR, false);
@@ -430,7 +430,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunction("DATABASE_PATH", DATABASE_PATH,
                 0, Value.VARCHAR);
         addFunctionNotDeterministic("LOCK_TIMEOUT", LOCK_TIMEOUT,
-                0, Value.INT);
+                0, Value.INTEGER);
         addFunctionWithNull("IFNULL", IFNULL,
                 2, Value.NULL);
         addFunctionWithNull("ISNULL", IFNULL,
@@ -464,19 +464,19 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         addFunction("CSVREAD", CSVREAD,
                 VAR_ARGS, Value.RESULT_SET, false, false, true, false);
         addFunction("CSVWRITE", CSVWRITE,
-                VAR_ARGS, Value.INT, false, false, true, false);
+                VAR_ARGS, Value.INTEGER, false, false, true, false);
         addFunctionNotDeterministic("MEMORY_FREE", MEMORY_FREE,
-                0, Value.INT);
+                0, Value.INTEGER);
         addFunctionNotDeterministic("MEMORY_USED", MEMORY_USED,
-                0, Value.INT);
+                0, Value.INTEGER);
         addFunctionNotDeterministic("LOCK_MODE", LOCK_MODE,
-                0, Value.INT);
+                0, Value.INTEGER);
         addFunctionNotDeterministic("CURRENT_SCHEMA", CURRENT_SCHEMA, 0, Value.VARCHAR, false);
         addFunctionNotDeterministic("SCHEMA", CURRENT_SCHEMA, 0, Value.VARCHAR);
         addFunctionNotDeterministic("SESSION_ID", SESSION_ID,
-                0, Value.INT);
-        addFunction("CARDINALITY", CARDINALITY, 1, Value.INT);
-        addFunction("ARRAY_LENGTH", CARDINALITY, 1, Value.INT);
+                0, Value.INTEGER);
+        addFunction("CARDINALITY", CARDINALITY, 1, Value.INTEGER);
+        addFunction("ARRAY_LENGTH", CARDINALITY, 1, Value.INTEGER);
         addFunctionNotDeterministic("LINK_SCHEMA", LINK_SCHEMA,
                 6, Value.RESULT_SET);
         addFunctionWithNull("LEAST", LEAST,
@@ -1496,7 +1496,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                         database);
                 break;
             case Value.SMALLINT:
-            case Value.INT:
+            case Value.INTEGER:
             case Value.BIGINT:
             case Value.NUMERIC:
             case Value.DOUBLE:
@@ -1884,7 +1884,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             switch (valueType) {
             case Value.TINYINT:
             case Value.SMALLINT:
-            case Value.INT:
+            case Value.INTEGER:
                 bd = BigDecimal.valueOf(value.getInt());
                 break;
             case Value.BIGINT:
@@ -2703,7 +2703,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                 typeInfo = TypeInfo.getTypeInfo(Value.NUMERIC, ValueLong.PRECISION + ValueTimestamp.MAXIMUM_SCALE,
                         ValueTimestamp.MAXIMUM_SCALE, null);
             } else {
-                typeInfo = TypeInfo.TYPE_INT;
+                typeInfo = TypeInfo.TYPE_INTEGER;
             }
             break;
         }
@@ -2857,7 +2857,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             TypeInfo type = p0.getType();
             typeInfo = type;
             if (typeInfo.getValueType() == Value.NULL) {
-                typeInfo = TypeInfo.TYPE_INT;
+                typeInfo = TypeInfo.TYPE_INTEGER;
             }
             break;
         }

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -80,24 +80,24 @@ import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
-import org.h2.value.ValueBytes;
 import org.h2.value.ValueCollectionBase;
 import org.h2.value.ValueDate;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueFloat;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueJson;
 import org.h2.value.ValueLob;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
 import org.h2.value.ValueResultSet;
-import org.h2.value.ValueString;
 import org.h2.value.ValueTime;
 import org.h2.value.ValueTimestamp;
 import org.h2.value.ValueTimestampTimeZone;
 import org.h2.value.ValueUuid;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
 
 /**
  * This class implements most built-in functions of this database.
@@ -760,7 +760,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             result = ValueDouble.get(roundMagic(v0.getDouble()));
             break;
         case SIGN:
-            result = ValueInt.get(v0.getSignum());
+            result = ValueInteger.get(v0.getSignum());
             break;
         case SIN:
             result = ValueDouble.get(Math.sin(v0.getDouble()));
@@ -778,15 +778,15 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             result = ValueDouble.get(Math.tanh(v0.getDouble()));
             break;
         case SECURE_RAND:
-            result = ValueBytes.getNoCopy(
+            result = ValueVarbinary.getNoCopy(
                     MathUtils.secureRandomBytes(v0.getInt()));
             break;
         case EXPAND:
-            result = ValueBytes.getNoCopy(
+            result = ValueVarbinary.getNoCopy(
                     CompressTool.getInstance().expand(v0.getBytesNoCopy()));
             break;
         case ZERO:
-            result = ValueInt.get(0);
+            result = ValueInteger.get(0);
             break;
         case RANDOM_UUID:
             result = ValueUuid.getNewRandom();
@@ -797,22 +797,22 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             if (s.isEmpty()) {
                 result = ValueNull.INSTANCE;
             } else {
-                result = ValueInt.get(s.charAt(0));
+                result = ValueInteger.get(s.charAt(0));
             }
             break;
         }
         case BIT_LENGTH:
-            result = ValueLong.get(16 * length(v0));
+            result = ValueBigint.get(16 * length(v0));
             break;
         case CHAR:
-            result = ValueString.get(String.valueOf((char) v0.getInt()), database);
+            result = ValueVarchar.get(String.valueOf((char) v0.getInt()), database);
             break;
         case CHAR_LENGTH:
         case LENGTH:
-            result = ValueLong.get(length(v0));
+            result = ValueBigint.get(length(v0));
             break;
         case OCTET_LENGTH:
-            result = ValueLong.get(2 * length(v0));
+            result = ValueBigint.get(2 * length(v0));
             break;
         case CONCAT_WS:
         case CONCAT: {
@@ -836,12 +836,12 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                             && !StringUtils.isNullOrEmpty(tmp)) {
                         tmp = separator + tmp;
                     }
-                    result = ValueString.get(result.getString() + tmp, database);
+                    result = ValueVarchar.get(result.getString() + tmp, database);
                 }
             }
             if (info.type == CONCAT_WS) {
                 if (separator != null && result == ValueNull.INSTANCE) {
-                    result = ValueString.get("", database);
+                    result = ValueVarchar.get("", database);
                 }
             }
             break;
@@ -853,13 +853,13 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         case LCASE:
             // TODO this is locale specific, need to document or provide a way
             // to set the locale
-            result = ValueString.get(v0.getString().toLowerCase(), database);
+            result = ValueVarchar.get(v0.getString().toLowerCase(), database);
             break;
         case RAWTOHEX:
-            result = ValueString.get(rawToHex(v0, database.getMode()), database);
+            result = ValueVarchar.get(rawToHex(v0, database.getMode()), database);
             break;
         case SOUNDEX:
-            result = ValueString.get(getSoundex(v0.getString()), database);
+            result = ValueVarchar.get(getSoundex(v0.getString()), database);
             break;
         case SPACE: {
             int len = Math.max(0, v0.getInt());
@@ -867,36 +867,36 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             for (int i = len - 1; i >= 0; i--) {
                 chars[i] = ' ';
             }
-            result = ValueString.get(new String(chars), database);
+            result = ValueVarchar.get(new String(chars), database);
             break;
         }
         case UPPER:
         case UCASE:
             // TODO this is locale specific, need to document or provide a way
             // to set the locale
-            result = ValueString.get(v0.getString().toUpperCase(), database);
+            result = ValueVarchar.get(v0.getString().toUpperCase(), database);
             break;
         case STRINGENCODE:
-            result = ValueString.get(StringUtils.javaEncode(v0.getString()), database);
+            result = ValueVarchar.get(StringUtils.javaEncode(v0.getString()), database);
             break;
         case STRINGDECODE:
-            result = ValueString.get(StringUtils.javaDecode(v0.getString()), database);
+            result = ValueVarchar.get(StringUtils.javaDecode(v0.getString()), database);
             break;
         case STRINGTOUTF8:
-            result = ValueBytes.getNoCopy(v0.getString().
+            result = ValueVarbinary.getNoCopy(v0.getString().
                     getBytes(StandardCharsets.UTF_8));
             break;
         case UTF8TOSTRING:
-            result = ValueString.get(new String(v0.getBytesNoCopy(), StandardCharsets.UTF_8), database);
+            result = ValueVarchar.get(new String(v0.getBytesNoCopy(), StandardCharsets.UTF_8), database);
             break;
         case XMLCOMMENT:
-            result = ValueString.get(StringUtils.xmlComment(v0.getString()), database);
+            result = ValueVarchar.get(StringUtils.xmlComment(v0.getString()), database);
             break;
         case XMLCDATA:
-            result = ValueString.get(StringUtils.xmlCData(v0.getString()), database);
+            result = ValueVarchar.get(StringUtils.xmlCData(v0.getString()), database);
             break;
         case XMLSTARTDOC:
-            result = ValueString.get(StringUtils.xmlStartDoc(), database);
+            result = ValueVarchar.get(StringUtils.xmlStartDoc(), database);
             break;
         case CURRENT_DATE:
             result = session.currentTimestamp().convertToDate(session);
@@ -921,7 +921,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             break;
         case DAY_NAME: {
             int dayOfWeek = DateTimeUtils.getSundayDayOfWeek(DateTimeUtils.dateAndTimeFromValue(v0, session)[0]);
-            result = ValueString.get(DateTimeFunctions.getMonthsAndWeeks(1)[dayOfWeek], database);
+            result = ValueVarchar.get(DateTimeFunctions.getMonthsAndWeeks(1)[dayOfWeek], database);
             break;
         }
         case DAY_OF_MONTH:
@@ -937,19 +937,19 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         case SECOND:
         case WEEK:
         case YEAR:
-            result = ValueInt.get(DateTimeFunctions.getIntDatePart(session, v0, info.type));
+            result = ValueInteger.get(DateTimeFunctions.getIntDatePart(session, v0, info.type));
             break;
         case MONTH_NAME: {
             int month = DateTimeUtils.monthFromDateValue(DateTimeUtils.dateAndTimeFromValue(v0, session)[0]);
-            result = ValueString.get(DateTimeFunctions.getMonthsAndWeeks(0)[month - 1], database);
+            result = ValueVarchar.get(DateTimeFunctions.getMonthsAndWeeks(0)[month - 1], database);
             break;
         }
         case CURRENT_CATALOG:
-            result = ValueString.get(database.getShortName(), database);
+            result = ValueVarchar.get(database.getShortName(), database);
             break;
         case USER:
         case CURRENT_USER:
-            result = ValueString.get(session.getUser().getName(), database);
+            result = ValueVarchar.get(session.getUser().getName(), database);
             break;
         case IDENTITY:
             result = session.getLastIdentity();
@@ -965,14 +965,14 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             break;
         case DATABASE_PATH: {
             String path = database.getDatabasePath();
-            result = path == null ? (Value) ValueNull.INSTANCE : ValueString.get(path, database);
+            result = path == null ? (Value) ValueNull.INSTANCE : ValueVarchar.get(path, database);
             break;
         }
         case LOCK_TIMEOUT:
-            result = ValueInt.get(session.getLockTimeout());
+            result = ValueInteger.get(session.getLockTimeout());
             break;
         case DISK_SPACE_USED:
-            result = ValueLong.get(getDiskSpaceUsed(session, v0));
+            result = ValueBigint.get(getDiskSpaceUsed(session, v0));
             break;
         case ESTIMATED_ENVELOPE:
             result = getEstimatedEnvelope(session, v0, values[1]);
@@ -986,20 +986,20 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             break;
         case MEMORY_FREE:
             session.getUser().checkAdmin();
-            result = ValueInt.get(Utils.getMemoryFree());
+            result = ValueInteger.get(Utils.getMemoryFree());
             break;
         case MEMORY_USED:
             session.getUser().checkAdmin();
-            result = ValueInt.get(Utils.getMemoryUsed());
+            result = ValueInteger.get(Utils.getMemoryUsed());
             break;
         case LOCK_MODE:
-            result = ValueInt.get(database.getLockMode());
+            result = ValueInteger.get(database.getLockMode());
             break;
         case CURRENT_SCHEMA:
-            result = ValueString.get(session.getCurrentSchemaName(), database);
+            result = ValueVarchar.get(session.getCurrentSchemaName(), database);
             break;
         case SESSION_ID:
-            result = ValueInt.get(session.getId());
+            result = ValueInteger.get(session.getId());
             break;
         case IFNULL: {
             result = v0;
@@ -1134,7 +1134,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         case CARDINALITY: {
             Value[] list = getArray(v0);
             if (list != null) {
-                result = ValueInt.get(list.length);
+                result = ValueInteger.get(list.length);
             } else {
                 result = ValueNull.INSTANCE;
             }
@@ -1186,9 +1186,9 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         if (t == Value.DOUBLE || t == Value.REAL) {
             double v = v0.getDouble();
             v = floor ? Math.floor(v) : Math.ceil(v);
-            result = t == Value.DOUBLE ? ValueDouble.get(v) : ValueFloat.get((float) v);
+            result = t == Value.DOUBLE ? ValueDouble.get(v) : ValueReal.get((float) v);
         } else {
-            result = ValueDecimal
+            result = ValueNumeric
                     .get(v0.getBigDecimal().setScale(0, floor ? RoundingMode.FLOOR : RoundingMode.CEILING));
         }
         return result;
@@ -1322,32 +1322,32 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                     Math.atan2(v0.getDouble(), v1.getDouble()));
             break;
         case BITAND:
-            result = ValueLong.get(v0.getLong() & v1.getLong());
+            result = ValueBigint.get(v0.getLong() & v1.getLong());
             break;
         case BITGET:
             result = ValueBoolean.get((v0.getLong() & (1L << v1.getInt())) != 0);
             break;
         case BITNOT:
-            result = ValueLong.get(~v0.getLong());
+            result = ValueBigint.get(~v0.getLong());
             break;
         case BITOR:
-            result = ValueLong.get(v0.getLong() | v1.getLong());
+            result = ValueBigint.get(v0.getLong() | v1.getLong());
             break;
         case BITXOR:
-            result = ValueLong.get(v0.getLong() ^ v1.getLong());
+            result = ValueBigint.get(v0.getLong() ^ v1.getLong());
             break;
         case LSHIFT:
-            result = ValueLong.get(v0.getLong() << v1.getInt());
+            result = ValueBigint.get(v0.getLong() << v1.getInt());
             break;
         case RSHIFT:
-            result = ValueLong.get(v0.getLong() >> v1.getInt());
+            result = ValueBigint.get(v0.getLong() >> v1.getInt());
             break;
         case MOD: {
             long x = v1.getLong();
             if (x == 0) {
                 throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
             }
-            result = ValueLong.get(v0.getLong() % x);
+            result = ValueBigint.get(v0.getLong() % x);
             break;
         }
         case POWER:
@@ -1364,11 +1364,11 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             result = getHash(v0.getString(), v1, v2 == null ? 1 : v2.getInt());
             break;
         case ENCRYPT:
-            result = ValueBytes.getNoCopy(encrypt(v0.getString(),
+            result = ValueVarbinary.getNoCopy(encrypt(v0.getString(),
                     v1.getBytesNoCopy(), v2.getBytesNoCopy()));
             break;
         case DECRYPT:
-            result = ValueBytes.getNoCopy(decrypt(v0.getString(),
+            result = ValueVarbinary.getNoCopy(decrypt(v0.getString(),
                     v1.getBytesNoCopy(), v2.getBytesNoCopy()));
             break;
         case COMPRESS: {
@@ -1376,7 +1376,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             if (v1 != null) {
                 algorithm = v1.getString();
             }
-            result = ValueBytes.getNoCopy(CompressTool.getInstance().
+            result = ValueVarbinary.getNoCopy(CompressTool.getInstance().
                     compress(v0.getBytesNoCopy(), algorithm));
             break;
         }
@@ -1386,33 +1386,33 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                     v2 == null ? 0L : v2.getLong());
             break;
         case DIFFERENCE:
-            result = ValueInt.get(getDifference(
+            result = ValueInteger.get(getDifference(
                     v0.getString(), v1.getString()));
             break;
         case INSERT: {
             if (v1 == ValueNull.INSTANCE || v2 == ValueNull.INSTANCE) {
                 result = v1;
             } else {
-                result = ValueString.get(insert(v0.getString(), v1.getInt(), v2.getInt(), v3.getString()), database);
+                result = ValueVarchar.get(insert(v0.getString(), v1.getInt(), v2.getInt(), v3.getString()), database);
             }
             break;
         }
         case LEFT:
-            result = ValueString.get(left(v0.getString(), v1.getInt()), database);
+            result = ValueVarchar.get(left(v0.getString(), v1.getInt()), database);
             break;
         case LOCATE: {
             int start = v2 == null ? 0 : v2.getInt();
-            result = ValueInt.get(locate(v0.getString(), v1.getString(), start));
+            result = ValueInteger.get(locate(v0.getString(), v1.getString(), start));
             break;
         }
         case INSTR: {
             int start = v2 == null ? 0 : v2.getInt();
-            result = ValueInt.get(locate(v1.getString(), v0.getString(), start));
+            result = ValueInteger.get(locate(v1.getString(), v0.getString(), start));
             break;
         }
         case REPEAT: {
             int count = Math.max(0, v1.getInt());
-            result = ValueString.get(repeat(v0.getString(), count), database);
+            result = ValueVarchar.get(repeat(v0.getString(), count), database);
             break;
         }
         case REPLACE:
@@ -1426,33 +1426,33 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                 if (s2 == null) {
                     s2 = "";
                 }
-                result = ValueString.get(StringUtils.replaceAll(s0, s1, s2), database);
+                result = ValueVarchar.get(StringUtils.replaceAll(s0, s1, s2), database);
             }
             break;
         case RIGHT:
-            result = ValueString.get(right(v0.getString(), v1.getInt()), database);
+            result = ValueVarchar.get(right(v0.getString(), v1.getInt()), database);
             break;
         case LTRIM:
-            result = ValueString.get(StringUtils.trim(v0.getString(), true, false, v1 == null ? " " : v1.getString()),
+            result = ValueVarchar.get(StringUtils.trim(v0.getString(), true, false, v1 == null ? " " : v1.getString()),
                     database);
             break;
         case TRIM:
-            result = ValueString.get(StringUtils.trim(v0.getString(),
+            result = ValueVarchar.get(StringUtils.trim(v0.getString(),
                     (flags & TRIM_LEADING) != 0, (flags & TRIM_TRAILING) != 0, v1 == null ? " " : v1.getString()),
                     database);
             break;
         case RTRIM:
-            result = ValueString.get(StringUtils.trim(v0.getString(), false, true, v1 == null ? " " : v1.getString()),
+            result = ValueVarchar.get(StringUtils.trim(v0.getString(), false, true, v1 == null ? " " : v1.getString()),
                     database);
             break;
         case SUBSTRING:
             result = substring(v0, v1, v2);
             break;
         case POSITION:
-            result = ValueInt.get(locate(v0.getString(), v1.getString(), 0));
+            result = ValueInteger.get(locate(v0.getString(), v1.getString(), 0));
             break;
         case XMLATTR:
-            result = ValueString.get(StringUtils.xmlAttr(v0.getString(), v1.getString()), database);
+            result = ValueVarchar.get(StringUtils.xmlAttr(v0.getString(), v1.getString()), database);
             break;
         case XMLNODE: {
             String attr = v1 == null ?
@@ -1461,7 +1461,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                     null : v2 == ValueNull.INSTANCE ? null : v2.getString();
             boolean indent = v3 == null ?
                     true : v3.getBoolean();
-            result = ValueString.get(StringUtils.xmlNode(v0.getString(), attr, content, indent), database);
+            result = ValueVarchar.get(StringUtils.xmlNode(v0.getString(), attr, content, indent), database);
             break;
         }
         case REGEXP_REPLACE: {
@@ -1473,12 +1473,12 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             break;
         }
         case RPAD:
-            result = ValueString.get(
+            result = ValueVarchar.get(
                     StringUtils.pad(v0.getString(), v1.getInt(), v2 == null ? null : v2.getString(), true),
                     database);
             break;
         case LPAD:
-            result = ValueString.get(
+            result = ValueVarchar.get(
                     StringUtils.pad(v0.getString(), v1.getInt(), v2 == null ? null : v2.getString(), false),
                     database);
             break;
@@ -1488,7 +1488,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             case Value.DATE:
             case Value.TIMESTAMP:
             case Value.TIMESTAMP_TZ:
-                result = ValueString.get(
+                result = ValueVarchar.get(
                         ToChar.toCharDateTime(session,
                         v0,
                         v1 == null ? null : v1.getString(),
@@ -1501,13 +1501,13 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             case Value.NUMERIC:
             case Value.DOUBLE:
             case Value.REAL:
-                result = ValueString.get(ToChar.toChar(v0.getBigDecimal(),
+                result = ValueVarchar.get(ToChar.toChar(v0.getBigDecimal(),
                         v1 == null ? null : v1.getString(),
                         v2 == null ? null : v2.getString()),
                         database);
                 break;
             default:
-                result = ValueString.get(v0.getString(), database);
+                result = ValueVarchar.get(v0.getString(), database);
             }
             break;
         case TO_DATE:
@@ -1530,20 +1530,20 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                 matching = replacement;
                 replacement = t;
             }
-            result = ValueString.get(translate(v0.getString(), matching, replacement), database);
+            result = ValueVarchar.get(translate(v0.getString(), matching, replacement), database);
             break;
         }
         case QUOTE_IDENT:
-            result = ValueString.get(StringUtils.quoteIdentifier(v0.getString()), database);
+            result = ValueVarchar.get(StringUtils.quoteIdentifier(v0.getString()), database);
             break;
         case H2VERSION:
-            result = ValueString.get(Constants.VERSION, database);
+            result = ValueVarchar.get(Constants.VERSION, database);
             break;
         case DATEADD:
             result = DateTimeFunctions.dateadd(session, v0.getString(), v1.getLong(), v2);
             break;
         case DATEDIFF:
-            result = ValueLong.get(DateTimeFunctions.datediff(session, v0.getString(), v1, v2));
+            result = ValueBigint.get(DateTimeFunctions.datediff(session, v0.getString(), v1, v2));
             break;
         case DATE_TRUNC:
             result = DateTimeFunctions.truncateDate(session, v0.getString(), v1);
@@ -1563,7 +1563,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                     tz = DateTimeUtils.timeZoneNameFromOffsetSeconds(
                             ((ValueTimestampTimeZone) v0).getTimeZoneOffsetSeconds());
                 }
-                result = ValueString.get(DateTimeFunctions.formatDateTime(
+                result = ValueVarchar.get(DateTimeFunctions.formatDateTime(
                         LegacyDateTimeUtils.toTimestamp(session, null, v0), v1.getString(), locale, tz), database);
             }
             break;
@@ -1705,7 +1705,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             try {
                 int rows = csv.write(conn, v0.getString(), v1.getString(),
                         charset);
-                result = ValueInt.get(rows);
+                result = ValueInteger.get(rows);
             } catch (SQLException e) {
                 throw DbException.convert(e);
             }
@@ -1753,7 +1753,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             try {
                 OutputStream fileOutputStream = Files.newOutputStream(Paths.get(fileName));
                 try (InputStream in = v0.getInputStream()) {
-                    result = ValueLong.get(IOUtils.copyAndClose(in,
+                    result = ValueBigint.get(IOUtils.copyAndClose(in,
                             fileOutputStream));
                 }
             } catch (IOException e) {
@@ -1766,9 +1766,9 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             break;
         case XMLTEXT:
             if (v1 == null) {
-                result = ValueString.get(StringUtils.xmlText(v0.getString()), database);
+                result = ValueVarchar.get(StringUtils.xmlText(v0.getString()), database);
             } else {
-                result = ValueString.get(StringUtils.xmlText(v0.getString(), v1.getBoolean()), database);
+                result = ValueVarchar.get(StringUtils.xmlText(v0.getString(), v1.getBoolean()), database);
             }
             break;
         case REGEXP_LIKE: {
@@ -1814,10 +1814,10 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             result = ValueDouble.get(bd.doubleValue());
             break;
         case Value.REAL:
-            result = ValueFloat.get(bd.floatValue());
+            result = ValueReal.get(bd.floatValue());
             break;
         default:
-            result = ValueDecimal.get(bd);
+            result = ValueNumeric.get(bd);
         }
         return result;
     }
@@ -1853,9 +1853,9 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                     d *= f;
                     d = (d < 0 ? Math.ceil(d) : Math.floor(d)) / f;
                 }
-                result = t == Value.DOUBLE ? ValueDouble.get(d) : ValueFloat.get((float) d);
+                result = t == Value.DOUBLE ? ValueDouble.get(d) : ValueReal.get((float) d);
             } else {
-                result = ValueDecimal.get(v0.getBigDecimal().setScale(scale, RoundingMode.DOWN));
+                result = ValueNumeric.get(v0.getBigDecimal().setScale(scale, RoundingMode.DOWN));
             }
             break;
         }
@@ -1872,7 +1872,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         if (DataType.getDataType(valueType).supportsPrecision) {
             if (precision < t.getPrecision()) {
                 if (valueType == Value.NUMERIC) {
-                    return ValueDecimal.get(value.getBigDecimal().round(new MathContext(
+                    return ValueNumeric.get(value.getBigDecimal().round(new MathContext(
                             MathUtils.convertLongToInt(precision))));
                 } else {
                     return value.castTo(TypeInfo.getTypeInfo(valueType, precision, t.getScale(), t.getExtTypeInfo()),
@@ -1898,7 +1898,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                 return value;
             }
             bd = bd.round(new MathContext(MathUtils.convertLongToInt(precision)));
-            return ValueDecimal.get(bd).convertTo(valueType);
+            return ValueNumeric.get(bd).convertTo(valueType);
         }
         return value;
     }
@@ -2021,7 +2021,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         for (int i = 1; i < iterations; i++) {
             b = md.digest(b);
         }
-        return ValueBytes.getNoCopy(b);
+        return ValueVarbinary.getNoCopy(b);
     }
 
     private Value substring(Value stringValue, Value startValue, Value lengthValue) {
@@ -2041,14 +2041,14 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             start = Math.max(start, 1);
             end = Math.min(end, sl + 1);
             if (start > sl || end <= start) {
-                return ValueBytes.EMPTY;
+                return ValueVarbinary.EMPTY;
             }
             start--;
             end--;
             if (start == 0 && end == s.length) {
                 return stringValue.convertTo(TypeInfo.TYPE_VARBINARY);
             }
-            return ValueBytes.getNoCopy(Arrays.copyOfRange(s, start, end));
+            return ValueVarbinary.getNoCopy(Arrays.copyOfRange(s, start, end));
         } else {
             String s = stringValue.getString();
             int sl = s.length();
@@ -2065,9 +2065,9 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             start = Math.max(start, 1);
             end = Math.min(end, sl + 1);
             if (start > sl || end <= start) {
-                return database.getMode().treatEmptyStringsAsNull ? ValueNull.INSTANCE : ValueString.EMPTY;
+                return database.getMode().treatEmptyStringsAsNull ? ValueNull.INSTANCE : ValueVarchar.EMPTY;
             }
-            return ValueString.get(s.substring(start - 1, end - 1), null);
+            return ValueVarchar.get(s.substring(start - 1, end - 1), null);
         }
     }
 
@@ -2147,7 +2147,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
 
     private static Value hexToRaw(String s, Database database) {
         if (database.getMode().getEnum() == ModeEnum.Oracle) {
-            return ValueBytes.get(StringUtils.convertHexToBytes(s));
+            return ValueVarbinary.get(StringUtils.convertHexToBytes(s));
         }
         int len = s.length();
         if (len % 4 != 0) {
@@ -2162,7 +2162,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
                 throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, s);
             }
         }
-        return ValueString.get(buff.toString(), database);
+        return ValueVarchar.get(buff.toString(), database);
     }
 
     private static int getDifference(String s1, String s2) {
@@ -2288,7 +2288,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         }
         long hc = Bits.readLong(md.digest(), 0);
         // Strip sign and use modulo operation to get value from 0 to bucket inclusive
-        return ValueLong.get((hc & Long.MAX_VALUE) % (bucket + 1));
+        return ValueBigint.get((hc & Long.MAX_VALUE) % (bucket + 1));
     }
 
     private static MessageDigest hashImpl(Value value, String algorithm) {
@@ -2353,7 +2353,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         int flags = makeRegexpFlags(regexpMode, isInPostgreSqlMode);
         try {
             Matcher matcher = Pattern.compile(regexp, flags).matcher(input);
-            return ValueString.get(isInPostgreSqlMode && (regexpMode == null || regexpMode.indexOf('g') < 0) ?
+            return ValueVarchar.get(isInPostgreSqlMode && (regexpMode == null || regexpMode.indexOf('g') < 0) ?
                     matcher.replaceFirst(replacement) : matcher.replaceAll(replacement),
                     database);
         } catch (PatternSyntaxException e) {
@@ -2700,7 +2700,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
         }
         case EXTRACT: {
             if (p0.isConstant() && DateTimeFunctions.getDatePart(p0.getValue(session).getString()) == Function.EPOCH) {
-                typeInfo = TypeInfo.getTypeInfo(Value.NUMERIC, ValueLong.PRECISION + ValueTimestamp.MAXIMUM_SCALE,
+                typeInfo = TypeInfo.getTypeInfo(Value.NUMERIC, ValueBigint.PRECISION + ValueTimestamp.MAXIMUM_SCALE,
                         ValueTimestamp.MAXIMUM_SCALE, null);
             } else {
                 typeInfo = TypeInfo.TYPE_INTEGER;
@@ -3109,7 +3109,7 @@ public class Function extends Expression implements FunctionCall, ExpressionWith
             break;
         }
         case EXTRACT: {
-            ValueString v = (ValueString) ((ValueExpression) args[0]).getValue(null);
+            ValueVarchar v = (ValueVarchar) ((ValueExpression) args[0]).getValue(null);
             builder.append(v.getString()).append(" FROM ");
             args[1].getSQL(builder, sqlFlags);
             break;

--- a/h2/src/main/org/h2/expression/function/TableFunction.java
+++ b/h2/src/main/org/h2/expression/function/TableFunction.java
@@ -18,7 +18,7 @@ import org.h2.table.Column;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueCollectionBase;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueResultSet;
 
@@ -132,7 +132,7 @@ public class TableFunction extends Function {
                     r[j] = v;
                 }
                 if (addNumber) {
-                    r[len] = ValueInt.get(row + 1);
+                    r[len] = ValueInteger.get(row + 1);
                 }
                 result.addRow(r);
             }

--- a/h2/src/main/org/h2/index/RangeCursor.java
+++ b/h2/src/main/org/h2/index/RangeCursor.java
@@ -9,7 +9,7 @@ import org.h2.message.DbException;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 
 /**
  * The cursor implementation for the range index.
@@ -50,7 +50,7 @@ class RangeCursor implements Cursor {
         } else {
             current += step;
         }
-        currentRow = Row.get(new Value[]{ValueLong.get(current)}, 1);
+        currentRow = Row.get(new Value[]{ValueBigint.get(current)}, 1);
         return step > 0 ? current <= end : current >= end;
     }
 

--- a/h2/src/main/org/h2/index/RangeIndex.java
+++ b/h2/src/main/org/h2/index/RangeIndex.java
@@ -15,7 +15,7 @@ import org.h2.table.IndexColumn;
 import org.h2.table.RangeTable;
 import org.h2.table.TableFilter;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 
 /**
  * An index for the SYSTEM_RANGE table.
@@ -89,7 +89,7 @@ public class RangeIndex extends VirtualTableIndex {
         long max = rangeTable.getMax(session);
         long step = rangeTable.getStep(session);
         return new SingleRowCursor((step > 0 ? min <= max : min >= max)
-                ? Row.get(new Value[]{ ValueLong.get(first ^ min >= max ? min : max) }, 1) : null);
+                ? Row.get(new Value[]{ ValueBigint.get(first ^ min >= max ? min : max) }, 1) : null);
     }
 
     @Override

--- a/h2/src/main/org/h2/jdbc/JdbcArray.java
+++ b/h2/src/main/org/h2/jdbc/JdbcArray.java
@@ -19,7 +19,7 @@ import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueNull;
 
 /**
@@ -272,7 +272,7 @@ public class JdbcArray extends TraceObject implements Array {
             Value[] values = array.getList();
             count = checkRange(index, count, values.length);
             for (int i = (int) index; i < index + count; i++) {
-                rs.addRow(ValueLong.get(i), values[i - 1]);
+                rs.addRow(ValueBigint.get(i), values[i - 1]);
             }
         }
         return new JdbcResultSet(conn, null, null, rs, id, false, true, false);

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -40,8 +40,8 @@ import org.h2.engine.ConnectionInfo;
 import org.h2.engine.Constants;
 import org.h2.engine.IsolationLevel;
 import org.h2.engine.Mode;
-import org.h2.engine.SessionInterface.StaticSettings;
 import org.h2.engine.SessionInterface;
+import org.h2.engine.SessionInterface.StaticSettings;
 import org.h2.engine.SessionRemote;
 import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
@@ -54,13 +54,13 @@ import org.h2.util.TimeZoneProvider;
 import org.h2.value.CompareMode;
 import org.h2.value.DataType;
 import org.h2.value.Value;
-import org.h2.value.ValueBytes;
 import org.h2.value.ValueCollectionBase;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueResultSet;
-import org.h2.value.ValueString;
 import org.h2.value.ValueTimestampTimeZone;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
 
 /**
  * <p>
@@ -731,7 +731,7 @@ public class JdbcConnection extends TraceObject implements Connection, JdbcConne
             setQueryTimeout = prepareCommand("SET QUERY_TIMEOUT ?",
                     setQueryTimeout);
             setQueryTimeout.getParameters().get(0)
-                    .setValue(ValueInt.get(seconds * 1000), false);
+                    .setValue(ValueInteger.get(seconds * 1000), false);
             setQueryTimeout.executeUpdate(null);
             queryTimeoutCache = seconds;
         } catch (Exception e) {
@@ -751,7 +751,7 @@ public class JdbcConnection extends TraceObject implements Connection, JdbcConne
                                 + "WHERE NAME=?",
                         getQueryTimeout);
                 getQueryTimeout.getParameters().get(0)
-                        .setValue(ValueString.get("QUERY_TIMEOUT"), false);
+                        .setValue(ValueVarchar.get("QUERY_TIMEOUT"), false);
                 ResultInterface result = getQueryTimeout.executeQuery(0, false);
                 result.next();
                 int queryTimeout = result.currentRow()[0].getInt();
@@ -1520,7 +1520,7 @@ public class JdbcConnection extends TraceObject implements Connection, JdbcConne
             int id = getNextId(TraceObject.CLOB);
             debugCodeAssign("Clob", TraceObject.CLOB, id, "createClob()");
             checkClosed();
-            return new JdbcClob(this, ValueString.EMPTY, JdbcLob.State.NEW, id);
+            return new JdbcClob(this, ValueVarchar.EMPTY, JdbcLob.State.NEW, id);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1537,7 +1537,7 @@ public class JdbcConnection extends TraceObject implements Connection, JdbcConne
             int id = getNextId(TraceObject.BLOB);
             debugCodeAssign("Blob", TraceObject.BLOB, id, "createClob()");
             checkClosed();
-            return new JdbcBlob(this, ValueBytes.EMPTY, JdbcLob.State.NEW, id);
+            return new JdbcBlob(this, ValueVarbinary.EMPTY, JdbcLob.State.NEW, id);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1554,7 +1554,7 @@ public class JdbcConnection extends TraceObject implements Connection, JdbcConne
             int id = getNextId(TraceObject.CLOB);
             debugCodeAssign("NClob", TraceObject.CLOB, id, "createNClob()");
             checkClosed();
-            return new JdbcClob(this, ValueString.EMPTY, JdbcLob.State.NEW, id);
+            return new JdbcClob(this, ValueVarchar.EMPTY, JdbcLob.State.NEW, id);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1571,7 +1571,7 @@ public class JdbcConnection extends TraceObject implements Connection, JdbcConne
             int id = getNextId(TraceObject.SQLXML);
             debugCodeAssign("SQLXML", TraceObject.SQLXML, id, "createSQLXML()");
             checkClosed();
-            return new JdbcSQLXML(this, ValueString.EMPTY, JdbcLob.State.NEW, id);
+            return new JdbcSQLXML(this, ValueVarchar.EMPTY, JdbcLob.State.NEW, id);
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -25,8 +25,8 @@ import org.h2.message.TraceObject;
 import org.h2.result.SimpleResult;
 import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
-import org.h2.value.ValueInt;
-import org.h2.value.ValueString;
+import org.h2.value.ValueInteger;
+import org.h2.value.ValueVarchar;
 
 /**
  * Represents the meta data for a database.
@@ -3218,8 +3218,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
         // Non-standard column
         result.addColumn("VALUE", "VALUE", TypeInfo.TYPE_VARCHAR);
         for (Entry<Object, Object> entry : clientInfo.entrySet()) {
-            result.addRow(ValueString.get((String) entry.getKey()), ValueInt.get(Integer.MAX_VALUE),
-                    ValueString.EMPTY, ValueString.EMPTY, ValueString.get((String) entry.getValue()));
+            result.addRow(ValueVarchar.get((String) entry.getKey()), ValueInteger.get(Integer.MAX_VALUE),
+                    ValueVarchar.EMPTY, ValueVarchar.EMPTY, ValueVarchar.get((String) entry.getValue()));
         }
         int id = getNextId(TraceObject.RESULT_SET);
         if (isDebugEnabled()) {

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -3212,7 +3212,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
         Properties clientInfo = conn.getClientInfo();
         SimpleResult result = new SimpleResult();
         result.addColumn("NAME", "NAME", TypeInfo.TYPE_VARCHAR);
-        result.addColumn("MAX_LEN", "MAX_LEN", TypeInfo.TYPE_INT);
+        result.addColumn("MAX_LEN", "MAX_LEN", TypeInfo.TYPE_INTEGER);
         result.addColumn("DEFAULT_VALUE", "DEFAULT_VALUE", TypeInfo.TYPE_VARCHAR);
         result.addColumn("DESCRIPTION", "DESCRIPTION", TypeInfo.TYPE_VARCHAR);
         // Non-standard column

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -40,17 +40,17 @@ import org.h2.util.LegacyDateTimeUtils;
 import org.h2.util.Utils;
 import org.h2.value.DataType;
 import org.h2.value.Value;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
-import org.h2.value.ValueByte;
-import org.h2.value.ValueBytes;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueFloat;
-import org.h2.value.ValueInt;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueShort;
-import org.h2.value.ValueString;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
+import org.h2.value.ValueSmallint;
+import org.h2.value.ValueTinyint;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
 
 /**
  * Represents a prepared statement.
@@ -388,7 +388,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setInt("+parameterIndex+", "+x+");");
             }
-            setParameter(parameterIndex, ValueInt.get(x));
+            setParameter(parameterIndex, ValueInteger.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -407,7 +407,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setString(" + parameterIndex + ", " + quote(x) + ");");
             }
-            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueString.get(x));
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueVarchar.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -426,7 +426,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setBigDecimal(" + parameterIndex + ", " + quoteBigDecimal(x) + ");");
             }
-            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueDecimal.get(x));
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueNumeric.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -648,7 +648,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setByte("+parameterIndex+", "+x+");");
             }
-            setParameter(parameterIndex, ValueByte.get(x));
+            setParameter(parameterIndex, ValueTinyint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -667,7 +667,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setShort("+parameterIndex+", (short) "+x+");");
             }
-            setParameter(parameterIndex, ValueShort.get(x));
+            setParameter(parameterIndex, ValueSmallint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -686,7 +686,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setLong("+parameterIndex+", "+x+"L);");
             }
-            setParameter(parameterIndex, ValueLong.get(x));
+            setParameter(parameterIndex, ValueBigint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -705,7 +705,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setFloat("+parameterIndex+", "+x+"f);");
             }
-            setParameter(parameterIndex, ValueFloat.get(x));
+            setParameter(parameterIndex, ValueReal.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -991,7 +991,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setBytes(" + parameterIndex + ", " + quoteBytes(x) + ");");
             }
-            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueBytes.get(x));
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueVarbinary.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1579,7 +1579,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
             if (isDebugEnabled()) {
                 debugCode("setNString(" + parameterIndex + ", " + quote(x) + ");");
             }
-            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueString.get(x));
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueVarchar.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -56,18 +56,18 @@ import org.h2.value.CompareMode;
 import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
-import org.h2.value.ValueByte;
-import org.h2.value.ValueBytes;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueFloat;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueInterval;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueShort;
-import org.h2.value.ValueString;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
+import org.h2.value.ValueSmallint;
+import org.h2.value.ValueTinyint;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
 
 /**
  * <p>
@@ -783,7 +783,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
                 throw DbException.getInvalidValueException("scale", scale);
             }
             BigDecimal bd = get(columnLabel).getBigDecimal();
-            return bd == null ? null : ValueDecimal.setScale(bd, scale);
+            return bd == null ? null : ValueNumeric.setScale(bd, scale);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -812,7 +812,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
                 throw DbException.getInvalidValueException("scale", scale);
             }
             BigDecimal bd = get(columnIndex).getBigDecimal();
-            return bd == null ? null : ValueDecimal.setScale(bd, scale);
+            return bd == null ? null : ValueNumeric.setScale(bd, scale);
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1396,7 +1396,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateByte("+columnIndex+", "+x+");");
             }
-            update(columnIndex, ValueByte.get(x));
+            update(columnIndex, ValueTinyint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1415,7 +1415,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateByte("+columnLabel+", "+x+");");
             }
-            update(columnLabel, ValueByte.get(x));
+            update(columnLabel, ValueTinyint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1434,7 +1434,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateBytes(" + columnIndex + ", x);");
             }
-            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueBytes.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueVarbinary.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1453,7 +1453,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateBytes(" + quote(columnLabel) + ", x);");
             }
-            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueBytes.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueVarbinary.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1472,7 +1472,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateShort("+columnIndex+", (short) "+x+");");
             }
-            update(columnIndex, ValueShort.get(x));
+            update(columnIndex, ValueSmallint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1491,7 +1491,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateShort("+quote(columnLabel)+", (short) "+x+");");
             }
-            update(columnLabel, ValueShort.get(x));
+            update(columnLabel, ValueSmallint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1510,7 +1510,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateInt("+columnIndex+", "+x+");");
             }
-            update(columnIndex, ValueInt.get(x));
+            update(columnIndex, ValueInteger.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1529,7 +1529,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateInt("+quote(columnLabel)+", "+x+");");
             }
-            update(columnLabel, ValueInt.get(x));
+            update(columnLabel, ValueInteger.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1548,7 +1548,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateLong("+columnIndex+", "+x+"L);");
             }
-            update(columnIndex, ValueLong.get(x));
+            update(columnIndex, ValueBigint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1567,7 +1567,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateLong("+quote(columnLabel)+", "+x+"L);");
             }
-            update(columnLabel, ValueLong.get(x));
+            update(columnLabel, ValueBigint.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1586,7 +1586,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateFloat("+columnIndex+", "+x+"f);");
             }
-            update(columnIndex, ValueFloat.get(x));
+            update(columnIndex, ValueReal.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1605,7 +1605,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateFloat("+quote(columnLabel)+", "+x+"f);");
             }
-            update(columnLabel, ValueFloat.get(x));
+            update(columnLabel, ValueReal.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1664,7 +1664,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
                 debugCode("updateBigDecimal("+columnIndex+", " + quoteBigDecimal(x) + ");");
             }
             update(columnIndex, x == null ? ValueNull.INSTANCE
-                    : ValueDecimal.get(x));
+                    : ValueNumeric.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1683,7 +1683,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateBigDecimal(" + quote(columnLabel) + ", " + quoteBigDecimal(x) + ");");
             }
-            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueDecimal.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueNumeric.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1702,7 +1702,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateString(" + columnIndex + ", " + quote(x) + ");");
             }
-            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueString.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueVarchar.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1721,7 +1721,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateString(" + quote(columnLabel) + ", " + quote(x) + ");");
             }
-            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueString.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueVarchar.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -3478,7 +3478,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateNString(" + columnIndex + ", " + quote(x) + ");");
             }
-            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueString.get(x));
+            update(columnIndex, x == null ? ValueNull.INSTANCE : ValueVarchar.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -3497,7 +3497,7 @@ public class JdbcResultSet extends TraceObject implements ResultSet, JdbcResultS
             if (isDebugEnabled()) {
                 debugCode("updateNString(" + quote(columnLabel) + ", " + quote(x) + ");");
             }
-            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueString.get(x));
+            update(columnLabel, x == null ? ValueNull.INSTANCE : ValueVarchar.get(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -22,12 +22,12 @@ import org.h2.util.DateTimeUtils;
 import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueString;
 import org.h2.value.ValueTimestamp;
 import org.h2.value.ValueTimestampTimeZone;
+import org.h2.value.ValueVarchar;
 
 /**
  * This class implements some MySQL-specific functions.
@@ -226,10 +226,10 @@ public class FunctionsMySQL extends FunctionsBase {
         Value result;
         switch (info.type) {
         case UNIX_TIMESTAMP:
-            result = ValueInt.get(unixTimestamp(session, v0 == null ? session.currentTimestamp() : v0));
+            result = ValueInteger.get(unixTimestamp(session, v0 == null ? session.currentTimestamp() : v0));
             break;
         case FROM_UNIXTIME:
-            result = ValueString.get(
+            result = ValueVarchar.get(
                     v1 == null ? fromUnixTime(v0.getInt()) : fromUnixTime(v0.getInt(), v1.getString()));
             break;
         case DATE:
@@ -256,7 +256,7 @@ public class FunctionsMySQL extends FunctionsBase {
                 result = session.getLastIdentity();
             } else {
                 if (v0 == ValueNull.INSTANCE) {
-                    session.setLastIdentity(ValueLong.get(0));
+                    session.setLastIdentity(ValueBigint.get(0));
                     result = v0;
                 } else {
                     result = v0.convertToBigint(null);

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -43,7 +43,7 @@ public class FunctionsMySQL extends FunctionsBase {
 
     static {
         FUNCTIONS.put("UNIX_TIMESTAMP", new FunctionInfo("UNIX_TIMESTAMP", UNIX_TIMESTAMP,
-                VAR_ARGS, Value.INT, false, false, true, false));
+                VAR_ARGS, Value.INTEGER, false, false, true, false));
         FUNCTIONS.put("FROM_UNIXTIME", new FunctionInfo("FROM_UNIXTIME", FROM_UNIXTIME,
                 VAR_ARGS, Value.VARCHAR, false, true, true, false));
         FUNCTIONS.put("DATE", new FunctionInfo("DATE", DATE,

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -5,7 +5,6 @@
  */
 package org.h2.mvstore.db;
 
-import org.h2.mvstore.MVMap;
 import static org.h2.util.geometry.GeometryUtils.MAX_X;
 import static org.h2.util.geometry.GeometryUtils.MAX_Y;
 import static org.h2.util.geometry.GeometryUtils.MIN_X;
@@ -23,6 +22,7 @@ import org.h2.index.IndexCondition;
 import org.h2.index.IndexType;
 import org.h2.index.SpatialIndex;
 import org.h2.message.DbException;
+import org.h2.mvstore.MVMap;
 import org.h2.mvstore.Page;
 import org.h2.mvstore.rtree.MVRTreeMap;
 import org.h2.mvstore.rtree.MVRTreeMap.RTreeCursor;
@@ -37,8 +37,8 @@ import org.h2.table.Column;
 import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
 import org.h2.value.Value;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueGeometry;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
 import org.h2.value.VersionedValue;
 
@@ -148,7 +148,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex<S
             }
         }
         try {
-            map.put(key, ValueLong.get(0));
+            map.put(key, ValueBigint.get(0));
         } catch (IllegalStateException e) {
             throw mvTable.convertException(e);
         }

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -73,44 +73,44 @@ import org.h2.value.ValueUuid;
 public final class ValueDataType extends BasicDataType<Value> implements StatefulDataType<Database> {
 
     private static final byte NULL = 0;
-    private static final byte BYTE = 2;
-    private static final byte SHORT = 3;
-    private static final byte INT = 4;
-    private static final byte LONG = 5;
-    private static final byte DECIMAL = 6;
+    private static final byte TINYINT = 2;
+    private static final byte SMALLINT = 3;
+    private static final byte INTEGER = 4;
+    private static final byte BIGINT = 5;
+    private static final byte NUMERIC = 6;
     private static final byte DOUBLE = 7;
-    private static final byte FLOAT = 8;
+    private static final byte REAL = 8;
     private static final byte TIME = 9;
     private static final byte DATE = 10;
     private static final byte TIMESTAMP = 11;
-    private static final byte BYTES = 12;
-    private static final byte STRING = 13;
-    private static final byte STRING_IGNORECASE = 14;
+    private static final byte VARBINARY = 12;
+    private static final byte VARCHAR = 13;
+    private static final byte VARCHAR_IGNORECASE = 14;
     private static final byte BLOB = 15;
     private static final byte CLOB = 16;
     private static final byte ARRAY = 17;
     private static final byte RESULT_SET = 18;
     private static final byte JAVA_OBJECT = 19;
     private static final byte UUID = 20;
-    private static final byte STRING_FIXED = 21;
+    private static final byte CHAR = 21;
     private static final byte GEOMETRY = 22;
     private static final byte TIMESTAMP_TZ = 24;
     private static final byte ENUM = 25;
     private static final byte INTERVAL = 26;
     private static final byte ROW = 27;
     private static final byte INT_0_15 = 32;
-    private static final byte LONG_0_7 = 48;
-    private static final byte DECIMAL_0_1 = 56;
-    private static final byte DECIMAL_SMALL_0 = 58;
-    private static final byte DECIMAL_SMALL = 59;
+    private static final byte BIGINT_0_7 = 48;
+    private static final byte NUMERIC_0_1 = 56;
+    private static final byte NUMERIC_SMALL_0 = 58;
+    private static final byte NUMERIC_SMALL = 59;
     private static final byte DOUBLE_0_1 = 60;
-    private static final byte FLOAT_0_1 = 62;
+    private static final byte REAL_0_1 = 62;
     private static final byte BOOLEAN_FALSE = 64;
     private static final byte BOOLEAN_TRUE = 65;
     private static final byte INT_NEG = 66;
-    private static final byte LONG_NEG = 67;
-    private static final byte STRING_0_31 = 68;
-    private static final int BYTES_0_31 = 100;
+    private static final byte BIGINT_NEG = 67;
+    private static final byte VARCHAR_0_31 = 68;
+    private static final int VARBINARY_0_31 = 100;
     private static final int SPATIAL_KEY_2D = 132;
     // 133 was used for CUSTOM_DATA_TYPE
     private static final int JSON = 134;
@@ -286,20 +286,20 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             buff.put(v.getBoolean() ? BOOLEAN_TRUE : BOOLEAN_FALSE);
             break;
         case Value.TINYINT:
-            buff.put(BYTE).put(v.getByte());
+            buff.put(TINYINT).put(v.getByte());
             break;
         case Value.SMALLINT:
-            buff.put(SHORT).putShort(v.getShort());
+            buff.put(SMALLINT).putShort(v.getShort());
             break;
         case Value.ENUM:
-        case Value.INT: {
+        case Value.INTEGER: {
             int x = v.getInt();
             if (x < 0) {
                 buff.put(INT_NEG).putVarInt(-x);
             } else if (x < 16) {
                 buff.put((byte) (INT_0_15 + x));
             } else {
-                buff.put(type == Value.INT ? INT : ENUM).putVarInt(x);
+                buff.put(type == Value.INTEGER ? INTEGER : ENUM).putVarInt(x);
             }
             break;
         }
@@ -311,25 +311,25 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         case Value.NUMERIC: {
             BigDecimal x = v.getBigDecimal();
             if (BigDecimal.ZERO.equals(x)) {
-                buff.put(DECIMAL_0_1);
+                buff.put(NUMERIC_0_1);
             } else if (BigDecimal.ONE.equals(x)) {
-                buff.put((byte) (DECIMAL_0_1 + 1));
+                buff.put((byte) (NUMERIC_0_1 + 1));
             } else {
                 int scale = x.scale();
                 BigInteger b = x.unscaledValue();
                 int bits = b.bitLength();
                 if (bits <= 63) {
                     if (scale == 0) {
-                        buff.put(DECIMAL_SMALL_0).
+                        buff.put(NUMERIC_SMALL_0).
                             putVarLong(b.longValue());
                     } else {
-                        buff.put(DECIMAL_SMALL).
+                        buff.put(NUMERIC_SMALL).
                             putVarInt(scale).
                             putVarLong(b.longValue());
                     }
                 } else {
                     byte[] bytes = b.toByteArray();
-                    buff.put(DECIMAL).
+                    buff.put(NUMERIC).
                         putVarInt(scale).
                         putVarInt(bytes.length).
                         put(bytes);
@@ -406,10 +406,10 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             byte[] b = v.getBytesNoCopy();
             int len = b.length;
             if (len < 32) {
-                buff.put((byte) (BYTES_0_31 + len)).
+                buff.put((byte) (VARBINARY_0_31 + len)).
                     put(b);
             } else {
-                buff.put(BYTES).
+                buff.put(VARBINARY).
                     putVarInt(b.length).
                     put(b);
             }
@@ -426,20 +426,20 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             String s = v.getString();
             int len = s.length();
             if (len < 32) {
-                buff.put((byte) (STRING_0_31 + len)).
+                buff.put((byte) (VARCHAR_0_31 + len)).
                     putStringData(s, len);
             } else {
-                buff.put(STRING);
+                buff.put(VARCHAR);
                 writeString(buff, s);
             }
             break;
         }
         case Value.VARCHAR_IGNORECASE:
-            buff.put(STRING_IGNORECASE);
+            buff.put(VARCHAR_IGNORECASE);
             writeString(buff, v.getString());
             break;
         case Value.CHAR:
-            buff.put(STRING_FIXED);
+            buff.put(CHAR);
             writeString(buff, v.getString());
             break;
         case Value.DOUBLE: {
@@ -460,13 +460,13 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         case Value.REAL: {
             float x = v.getFloat();
             if (x == 1.0f) {
-                buff.put((byte) (FLOAT_0_1 + 1));
+                buff.put((byte) (REAL_0_1 + 1));
             } else {
                 int f = Float.floatToIntBits(x);
                 if (f == ValueFloat.ZERO_BITS) {
-                    buff.put(FLOAT_0_1);
+                    buff.put(REAL_0_1);
                 } else {
-                    buff.put(FLOAT).
+                    buff.put(REAL).
                         putVarInt(Integer.reverse(f));
                 }
             }
@@ -600,11 +600,11 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
 
     public static void writeLong(WriteBuffer buff, long x) {
         if (x < 0) {
-            buff.put(LONG_NEG).putVarLong(-x);
+            buff.put(BIGINT_NEG).putVarLong(-x);
         } else if (x < 8) {
-            buff.put((byte) (LONG_0_7 + x));
+            buff.put((byte) (BIGINT_0_7 + x));
         } else {
-            buff.put(LONG).putVarLong(x);
+            buff.put(BIGINT).putVarLong(x);
         }
     }
 
@@ -643,29 +643,29 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         case INT_NEG:
             return ValueInt.get(-readVarInt(buff));
         case ENUM:
-        case INT:
+        case INTEGER:
             return ValueInt.get(readVarInt(buff));
-        case LONG_NEG:
+        case BIGINT_NEG:
             return ValueLong.get(-readVarLong(buff));
-        case LONG:
+        case BIGINT:
             return ValueLong.get(readVarLong(buff));
-        case BYTE:
+        case TINYINT:
             return ValueByte.get(buff.get());
-        case SHORT:
+        case SMALLINT:
             return ValueShort.get(buff.getShort());
-        case DECIMAL_0_1:
+        case NUMERIC_0_1:
             return ValueDecimal.ZERO;
-        case DECIMAL_0_1 + 1:
+        case NUMERIC_0_1 + 1:
             return ValueDecimal.ONE;
-        case DECIMAL_SMALL_0:
+        case NUMERIC_SMALL_0:
             return ValueDecimal.get(BigDecimal.valueOf(
                     readVarLong(buff)));
-        case DECIMAL_SMALL: {
+        case NUMERIC_SMALL: {
             int scale = readVarInt(buff);
             return ValueDecimal.get(BigDecimal.valueOf(
                     readVarLong(buff), scale));
         }
-        case DECIMAL: {
+        case NUMERIC: {
             int scale = readVarInt(buff);
             int len = readVarInt(buff);
             byte[] buff2 = Utils.newBytes(len);
@@ -700,7 +700,7 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             int tz = readTimeZone(buff);
             return ValueTimestampTimeZone.fromDateValueAndNanos(dateValue, nanos, tz);
         }
-        case BYTES: {
+        case VARBINARY: {
             int len = readVarInt(buff);
             byte[] b = Utils.newBytes(len);
             buff.get(b, 0, len);
@@ -714,11 +714,11 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         }
         case UUID:
             return ValueUuid.get(buff.getLong(), buff.getLong());
-        case STRING:
+        case VARCHAR:
             return ValueString.get(readString(buff));
-        case STRING_IGNORECASE:
+        case VARCHAR_IGNORECASE:
             return ValueStringIgnoreCase.get(readString(buff));
-        case STRING_FIXED:
+        case CHAR:
             return ValueStringFixed.get(readString(buff));
         case INTERVAL: {
             int ordinal = buff.get();
@@ -729,9 +729,9 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             return ValueInterval.from(IntervalQualifier.valueOf(ordinal), negative, readVarLong(buff),
                     ordinal < 5 ? 0 : readVarLong(buff));
         }
-        case FLOAT_0_1:
+        case REAL_0_1:
             return ValueFloat.ZERO;
-        case FLOAT_0_1 + 1:
+        case REAL_0_1 + 1:
             return ValueFloat.ONE;
         case DOUBLE_0_1:
             return ValueDouble.ZERO;
@@ -739,7 +739,7 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             return ValueDouble.ONE;
         case DOUBLE:
             return ValueDouble.get(Double.longBitsToDouble(Long.reverse(readVarLong(buff))));
-        case FLOAT:
+        case REAL:
             return ValueFloat.get(Float.intBitsToFloat(Integer.reverse(readVarInt(buff))));
         case BLOB:
         case CLOB: {
@@ -825,15 +825,15 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         default:
             if (type >= INT_0_15 && type < INT_0_15 + 16) {
                 return ValueInt.get(type - INT_0_15);
-            } else if (type >= LONG_0_7 && type < LONG_0_7 + 8) {
-                return ValueLong.get(type - LONG_0_7);
-            } else if (type >= BYTES_0_31 && type < BYTES_0_31 + 32) {
-                int len = type - BYTES_0_31;
+            } else if (type >= BIGINT_0_7 && type < BIGINT_0_7 + 8) {
+                return ValueLong.get(type - BIGINT_0_7);
+            } else if (type >= VARBINARY_0_31 && type < VARBINARY_0_31 + 32) {
+                int len = type - VARBINARY_0_31;
                 byte[] b = Utils.newBytes(len);
                 buff.get(b, 0, len);
                 return ValueBytes.getNoCopy(b);
-            } else if (type >= STRING_0_31 && type < STRING_0_31 + 32) {
-                return ValueString.get(readString(buff, type - STRING_0_31));
+            } else if (type >= VARCHAR_0_31 && type < VARCHAR_0_31 + 32) {
+                return ValueString.get(readString(buff, type - VARCHAR_0_31));
             }
             throw DbException.get(ErrorCode.FILE_CORRUPTED_1, "type: " + type);
         }

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -5,7 +5,6 @@
  */
 package org.h2.mvstore.db;
 
-import org.h2.mvstore.DataUtils;
 import static org.h2.mvstore.DataUtils.readString;
 import static org.h2.mvstore.DataUtils.readVarInt;
 import static org.h2.mvstore.DataUtils.readVarLong;
@@ -20,6 +19,7 @@ import org.h2.engine.CastDataProvider;
 import org.h2.engine.Database;
 import org.h2.engine.Mode;
 import org.h2.message.DbException;
+import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.WriteBuffer;
 import org.h2.mvstore.rtree.SpatialDataType;
 import org.h2.mvstore.rtree.SpatialKey;
@@ -39,33 +39,33 @@ import org.h2.value.CompareMode;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
-import org.h2.value.ValueByte;
-import org.h2.value.ValueBytes;
+import org.h2.value.ValueChar;
 import org.h2.value.ValueCollectionBase;
 import org.h2.value.ValueDate;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueFloat;
 import org.h2.value.ValueGeometry;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueJavaObject;
 import org.h2.value.ValueJson;
 import org.h2.value.ValueLob;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
 import org.h2.value.ValueResultSet;
 import org.h2.value.ValueRow;
-import org.h2.value.ValueShort;
-import org.h2.value.ValueString;
-import org.h2.value.ValueStringFixed;
-import org.h2.value.ValueStringIgnoreCase;
+import org.h2.value.ValueSmallint;
 import org.h2.value.ValueTime;
 import org.h2.value.ValueTimeTimeZone;
 import org.h2.value.ValueTimestamp;
 import org.h2.value.ValueTimestampTimeZone;
+import org.h2.value.ValueTinyint;
 import org.h2.value.ValueUuid;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
+import org.h2.value.ValueVarcharIgnoreCase;
 
 /**
  * A row type.
@@ -463,7 +463,7 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
                 buff.put((byte) (REAL_0_1 + 1));
             } else {
                 int f = Float.floatToIntBits(x);
-                if (f == ValueFloat.ZERO_BITS) {
+                if (f == ValueReal.ZERO_BITS) {
                     buff.put(REAL_0_1);
                 } else {
                     buff.put(REAL).
@@ -595,7 +595,7 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
                 writeValue(buff, row.getValue(i), false);
             }
         }
-        writeValue(buff, ValueLong.get(row.getKey()), false);
+        writeValue(buff, ValueBigint.get(row.getKey()), false);
     }
 
     public static void writeLong(WriteBuffer buff, long x) {
@@ -641,28 +641,28 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         case BOOLEAN_FALSE:
             return ValueBoolean.FALSE;
         case INT_NEG:
-            return ValueInt.get(-readVarInt(buff));
+            return ValueInteger.get(-readVarInt(buff));
         case ENUM:
         case INTEGER:
-            return ValueInt.get(readVarInt(buff));
+            return ValueInteger.get(readVarInt(buff));
         case BIGINT_NEG:
-            return ValueLong.get(-readVarLong(buff));
+            return ValueBigint.get(-readVarLong(buff));
         case BIGINT:
-            return ValueLong.get(readVarLong(buff));
+            return ValueBigint.get(readVarLong(buff));
         case TINYINT:
-            return ValueByte.get(buff.get());
+            return ValueTinyint.get(buff.get());
         case SMALLINT:
-            return ValueShort.get(buff.getShort());
+            return ValueSmallint.get(buff.getShort());
         case NUMERIC_0_1:
-            return ValueDecimal.ZERO;
+            return ValueNumeric.ZERO;
         case NUMERIC_0_1 + 1:
-            return ValueDecimal.ONE;
+            return ValueNumeric.ONE;
         case NUMERIC_SMALL_0:
-            return ValueDecimal.get(BigDecimal.valueOf(
+            return ValueNumeric.get(BigDecimal.valueOf(
                     readVarLong(buff)));
         case NUMERIC_SMALL: {
             int scale = readVarInt(buff);
-            return ValueDecimal.get(BigDecimal.valueOf(
+            return ValueNumeric.get(BigDecimal.valueOf(
                     readVarLong(buff), scale));
         }
         case NUMERIC: {
@@ -671,7 +671,7 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             byte[] buff2 = Utils.newBytes(len);
             buff.get(buff2, 0, len);
             BigInteger b = new BigInteger(buff2);
-            return ValueDecimal.get(new BigDecimal(b, scale));
+            return ValueNumeric.get(new BigDecimal(b, scale));
         }
         case DATE: {
             return ValueDate.fromDateValue(readVarLong(buff));
@@ -704,7 +704,7 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             int len = readVarInt(buff);
             byte[] b = Utils.newBytes(len);
             buff.get(b, 0, len);
-            return ValueBytes.getNoCopy(b);
+            return ValueVarbinary.getNoCopy(b);
         }
         case JAVA_OBJECT: {
             int len = readVarInt(buff);
@@ -715,11 +715,11 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         case UUID:
             return ValueUuid.get(buff.getLong(), buff.getLong());
         case VARCHAR:
-            return ValueString.get(readString(buff));
+            return ValueVarchar.get(readString(buff));
         case VARCHAR_IGNORECASE:
-            return ValueStringIgnoreCase.get(readString(buff));
+            return ValueVarcharIgnoreCase.get(readString(buff));
         case CHAR:
-            return ValueStringFixed.get(readString(buff));
+            return ValueChar.get(readString(buff));
         case INTERVAL: {
             int ordinal = buff.get();
             boolean negative = ordinal < 0;
@@ -730,9 +730,9 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
                     ordinal < 5 ? 0 : readVarLong(buff));
         }
         case REAL_0_1:
-            return ValueFloat.ZERO;
+            return ValueReal.ZERO;
         case REAL_0_1 + 1:
-            return ValueFloat.ONE;
+            return ValueReal.ONE;
         case DOUBLE_0_1:
             return ValueDouble.ZERO;
         case DOUBLE_0_1 + 1:
@@ -740,7 +740,7 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         case DOUBLE:
             return ValueDouble.get(Double.longBitsToDouble(Long.reverse(readVarLong(buff))));
         case REAL:
-            return ValueFloat.get(Float.intBitsToFloat(Integer.reverse(readVarInt(buff))));
+            return ValueReal.get(Float.intBitsToFloat(Integer.reverse(readVarInt(buff))));
         case BLOB:
         case CLOB: {
             int smallLen = readVarInt(buff);
@@ -824,16 +824,16 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
         }
         default:
             if (type >= INT_0_15 && type < INT_0_15 + 16) {
-                return ValueInt.get(type - INT_0_15);
+                return ValueInteger.get(type - INT_0_15);
             } else if (type >= BIGINT_0_7 && type < BIGINT_0_7 + 8) {
-                return ValueLong.get(type - BIGINT_0_7);
+                return ValueBigint.get(type - BIGINT_0_7);
             } else if (type >= VARBINARY_0_31 && type < VARBINARY_0_31 + 32) {
                 int len = type - VARBINARY_0_31;
                 byte[] b = Utils.newBytes(len);
                 buff.get(b, 0, len);
-                return ValueBytes.getNoCopy(b);
+                return ValueVarbinary.getNoCopy(b);
             } else if (type >= VARCHAR_0_31 && type < VARCHAR_0_31 + 32) {
-                return ValueString.get(readString(buff, type - VARCHAR_0_31));
+                return ValueVarchar.get(readString(buff, type - VARCHAR_0_31));
             }
             throw DbException.get(ErrorCode.FILE_CORRUPTED_1, "type: " + type);
         }

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -819,8 +819,8 @@ public class TransactionMap<K, V> extends AbstractMap<K,V> {
      */
     private static final class CommittedIterator<K,V,X> extends TMIterator<K,V,X>
     {
-        CommittedIterator(TransactionMap<K, V> transactionMap, K from, K to, boolean reverese, boolean forEntries) {
-            super(transactionMap, from, to, transactionMap.getSnapshot(), reverese, forEntries);
+        CommittedIterator(TransactionMap<K, V> transactionMap, K from, K to, boolean reverse, boolean forEntries) {
+            super(transactionMap, from, to, transactionMap.getSnapshot(), reverse, forEntries);
             fetchNext();
         }
 
@@ -974,7 +974,7 @@ public class TransactionMap<K, V> extends AbstractMap<K,V> {
         X current;
 
         TMIterator(TransactionMap<K, V> transactionMap, K from, K to, Snapshot<K, VersionedValue<V>> snapshot,
-                   boolean reverse, boolean forEntries) {
+                boolean reverse, boolean forEntries) {
             Transaction transaction = transactionMap.getTransaction();
             this.transactionId = transaction.transactionId;
             this.forEntries = forEntries;

--- a/h2/src/main/org/h2/pagestore/PageStore.java
+++ b/h2/src/main/org/h2/pagestore/PageStore.java
@@ -56,8 +56,8 @@ import org.h2.util.IntIntHashMap;
 import org.h2.util.StringUtils;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
-import org.h2.value.ValueString;
+import org.h2.value.ValueInteger;
+import org.h2.value.ValueVarchar;
 
 /**
  * This class represents a file that is organized as a number of pages. Page 0
@@ -1795,12 +1795,12 @@ public class PageStore implements CacheWriter {
             }
             options.append(',').append(mode.isBinaryUnsigned()).append(',').append(mode.isUuidUnsigned());
             Row row = metaTable.getTemplateRow();
-            row.setValue(0, ValueInt.get(index.getId()));
-            row.setValue(1, ValueInt.get(type));
-            row.setValue(2, ValueInt.get(table.getId()));
-            row.setValue(3, ValueInt.get(index.getRootPageId()));
-            row.setValue(4, ValueString.get(options.toString()));
-            row.setValue(5, ValueString.get(columnList));
+            row.setValue(0, ValueInteger.get(index.getId()));
+            row.setValue(1, ValueInteger.get(type));
+            row.setValue(2, ValueInteger.get(table.getId()));
+            row.setValue(3, ValueInteger.get(index.getRootPageId()));
+            row.setValue(4, ValueVarchar.get(options.toString()));
+            row.setValue(5, ValueVarchar.get(columnList));
             row.setKey(index.getId() + 1);
             metaIndex.add(session, row);
         }

--- a/h2/src/main/org/h2/pagestore/PageStore.java
+++ b/h2/src/main/org/h2/pagestore/PageStore.java
@@ -1591,10 +1591,10 @@ public class PageStore implements CacheWriter {
     private void openMetaIndex() {
         CreateTableData data = new CreateTableData();
         ArrayList<Column> cols = data.columns;
-        cols.add(new Column("ID", Value.INT));
-        cols.add(new Column("TYPE", Value.INT));
-        cols.add(new Column("PARENT", Value.INT));
-        cols.add(new Column("HEAD", Value.INT));
+        cols.add(new Column("ID", Value.INTEGER));
+        cols.add(new Column("TYPE", Value.INTEGER));
+        cols.add(new Column("PARENT", Value.INTEGER));
+        cols.add(new Column("HEAD", Value.INTEGER));
         cols.add(new Column("OPTIONS", Value.VARCHAR));
         cols.add(new Column("COLUMNS", Value.VARCHAR));
         metaSchema = new Schema(database, 0, "", null, true);
@@ -1676,7 +1676,7 @@ public class PageStore implements CacheWriter {
                 throw DbException.throwInternalError(row.toString());
             }
             for (int i = 0, len = columns.length; i < len; i++) {
-                Column col = new Column("C" + i, Value.INT);
+                Column col = new Column("C" + i, Value.INTEGER);
                 data.columns.add(col);
             }
             data.schema = metaSchema;

--- a/h2/src/main/org/h2/pagestore/db/PageStoreRow.java
+++ b/h2/src/main/org/h2/pagestore/db/PageStoreRow.java
@@ -10,7 +10,7 @@ import org.h2.message.DbException;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 
 /**
  * Page Store implementation of a row.
@@ -39,7 +39,7 @@ public final class PageStoreRow {
         @Override
         public Value getValue(int i) {
             if (i == ROWID_INDEX) {
-                return ValueLong.get(key);
+                return ValueBigint.get(key);
             }
             throw DbException.throwInternalError();
         }

--- a/h2/src/main/org/h2/result/DefaultRow.java
+++ b/h2/src/main/org/h2/result/DefaultRow.java
@@ -7,7 +7,7 @@ package org.h2.result;
 
 import org.h2.engine.Constants;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 
 /**
  * The default implementation of a row in a table.
@@ -37,7 +37,7 @@ public class DefaultRow extends Row
 
     @Override
     public Value getValue(int i) {
-        return i == ROWID_INDEX ? ValueLong.get(key) : data[i];
+        return i == ROWID_INDEX ? ValueBigint.get(key) : data[i];
     }
 
     @Override

--- a/h2/src/main/org/h2/result/ResultWithPaddedStrings.java
+++ b/h2/src/main/org/h2/result/ResultWithPaddedStrings.java
@@ -10,7 +10,7 @@ import org.h2.engine.SessionInterface;
 import org.h2.util.MathUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
-import org.h2.value.ValueString;
+import org.h2.value.ValueVarchar;
 
 /**
  * Result with padded fixed length strings.
@@ -71,7 +71,7 @@ public class ResultWithPaddedStrings implements ResultInterface {
                      * no difference between ValueStringFixed and ValueString
                      * for JDBC layer anyway.
                      */
-                    row[i] = ValueString.get(rightPadWithSpaces(s, MathUtils.convertLongToInt(precision)));
+                    row[i] = ValueVarchar.get(rightPadWithSpaces(s, MathUtils.convertLongToInt(precision)));
                 }
             }
         }

--- a/h2/src/main/org/h2/result/SimpleRowValue.java
+++ b/h2/src/main/org/h2/result/SimpleRowValue.java
@@ -7,7 +7,7 @@ package org.h2.result;
 
 import org.h2.engine.Constants;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueNull;
 
 /**
@@ -36,7 +36,7 @@ public class SimpleRowValue extends SearchRow {
     @Override
     public Value getValue(int idx) {
         if (idx == ROWID_INDEX) {
-            return ValueLong.get(getKey());
+            return ValueBigint.get(getKey());
         }
         return idx == index ? data : null;
     }

--- a/h2/src/main/org/h2/result/Sparse.java
+++ b/h2/src/main/org/h2/result/Sparse.java
@@ -6,7 +6,7 @@
 package org.h2.result;
 
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 
 /**
  * Class Sparse.
@@ -34,7 +34,7 @@ public final class Sparse extends DefaultRow {
     @Override
     public Value getValue(int i) {
         if (i == ROWID_INDEX) {
-            return ValueLong.get(getKey());
+            return ValueBigint.get(getKey());
         }
         int index = map[i];
         return index > 0 ? super.getValue(index - 1) : null;

--- a/h2/src/main/org/h2/schema/Sequence.java
+++ b/h2/src/main/org/h2/schema/Sequence.java
@@ -14,8 +14,8 @@ import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.table.Table;
 import org.h2.value.Value;
-import org.h2.value.ValueDecimal;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
+import org.h2.value.ValueNumeric;
 
 /**
  * A sequence is created using the statement
@@ -315,9 +315,9 @@ public class Sequence extends SchemaObjectBase {
         }
         Value result;
         if (database.getMode().decimalSequences) {
-            result = ValueDecimal.get(BigDecimal.valueOf(resultAsLong));
+            result = ValueNumeric.get(BigDecimal.valueOf(resultAsLong));
         } else {
-            result = ValueLong.get(resultAsLong);
+            result = ValueBigint.get(resultAsLong);
         }
         if (session != null) {
             session.setCurrentValueFor(this, result);

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -80,44 +80,44 @@ public class Data {
     public static final int LENGTH_LONG = 8;
 
     private static final byte NULL = 0;
-    private static final byte BYTE = 2;
-    private static final byte SHORT = 3;
-    private static final byte INT = 4;
-    private static final byte LONG = 5;
-    private static final byte DECIMAL = 6;
+    private static final byte TINYINT = 2;
+    private static final byte SMALLINT = 3;
+    private static final byte INTEGER = 4;
+    private static final byte BIGINT = 5;
+    private static final byte NUMERIC = 6;
     private static final byte DOUBLE = 7;
-    private static final byte FLOAT = 8;
+    private static final byte REAL = 8;
     private static final byte TIME = 9;
     private static final byte DATE = 10;
     private static final byte TIMESTAMP = 11;
-    private static final byte BYTES = 12;
-    private static final byte STRING = 13;
-    private static final byte STRING_IGNORECASE = 14;
+    private static final byte VARBINARY = 12;
+    private static final byte VARCHAR = 13;
+    private static final byte VARCHAR_IGNORECASE = 14;
     private static final byte BLOB = 15;
     private static final byte CLOB = 16;
     private static final byte ARRAY = 17;
     private static final byte RESULT_SET = 18;
     private static final byte JAVA_OBJECT = 19;
     private static final byte UUID = 20;
-    private static final byte STRING_FIXED = 21;
+    private static final byte CHAR = 21;
     private static final byte GEOMETRY = 22;
     private static final byte TIMESTAMP_TZ = 24;
     private static final byte ENUM = 25;
     private static final byte INTERVAL = 26;
     private static final byte ROW = 27;
     private static final byte INT_0_15 = 32;
-    private static final byte LONG_0_7 = 48;
-    private static final byte DECIMAL_0_1 = 56;
-    private static final byte DECIMAL_SMALL_0 = 58;
-    private static final byte DECIMAL_SMALL = 59;
+    private static final byte BIGINT_0_7 = 48;
+    private static final byte NUMERIC_0_1 = 56;
+    private static final byte NUMERIC_SMALL_0 = 58;
+    private static final byte NUMERIC_SMALL = 59;
     private static final byte DOUBLE_0_1 = 60;
-    private static final byte FLOAT_0_1 = 62;
+    private static final byte REAL_0_1 = 62;
     private static final byte BOOLEAN_FALSE = 64;
     private static final byte BOOLEAN_TRUE = 65;
     private static final byte INT_NEG = 66;
-    private static final byte LONG_NEG = 67;
-    private static final byte STRING_0_31 = 68;
-    private static final int BYTES_0_31 = 100;
+    private static final byte BIGINT_NEG = 67;
+    private static final byte VARCHAR_0_31 = 68;
+    private static final int VARBINARY_0_31 = 100;
     private static final int LOCAL_TIME = 132;
     private static final int LOCAL_DATE = 133;
     private static final int LOCAL_TIMESTAMP = 134;
@@ -467,15 +467,15 @@ public class Data {
             writeByte(v.getBoolean() ? BOOLEAN_TRUE : BOOLEAN_FALSE);
             break;
         case Value.TINYINT:
-            writeByte(BYTE);
+            writeByte(TINYINT);
             writeByte(v.getByte());
             break;
         case Value.SMALLINT:
-            writeByte(SHORT);
+            writeByte(SMALLINT);
             writeShortInt(v.getShort());
             break;
         case Value.ENUM:
-        case Value.INT: {
+        case Value.INTEGER: {
             int x = v.getInt();
             if (x < 0) {
                 writeByte(INT_NEG);
@@ -483,7 +483,7 @@ public class Data {
             } else if (x < 16) {
                 writeByte((byte) (INT_0_15 + x));
             } else {
-                writeByte(type == Value.INT ? INT : ENUM);
+                writeByte(type == Value.INTEGER ? INTEGER : ENUM);
                 writeVarInt(x);
             }
             break;
@@ -491,12 +491,12 @@ public class Data {
         case Value.BIGINT: {
             long x = v.getLong();
             if (x < 0) {
-                writeByte(LONG_NEG);
+                writeByte(BIGINT_NEG);
                 writeVarLong(-x);
             } else if (x < 8) {
-                writeByte((byte) (LONG_0_7 + x));
+                writeByte((byte) (BIGINT_0_7 + x));
             } else {
-                writeByte(LONG);
+                writeByte(BIGINT);
                 writeVarLong(x);
             }
             break;
@@ -504,24 +504,24 @@ public class Data {
         case Value.NUMERIC: {
             BigDecimal x = v.getBigDecimal();
             if (BigDecimal.ZERO.equals(x)) {
-                writeByte(DECIMAL_0_1);
+                writeByte(NUMERIC_0_1);
             } else if (BigDecimal.ONE.equals(x)) {
-                writeByte((byte) (DECIMAL_0_1 + 1));
+                writeByte((byte) (NUMERIC_0_1 + 1));
             } else {
                 int scale = x.scale();
                 BigInteger b = x.unscaledValue();
                 int bits = b.bitLength();
                 if (bits <= 63) {
                     if (scale == 0) {
-                        writeByte(DECIMAL_SMALL_0);
+                        writeByte(NUMERIC_SMALL_0);
                         writeVarLong(b.longValue());
                     } else {
-                        writeByte(DECIMAL_SMALL);
+                        writeByte(NUMERIC_SMALL);
                         writeVarInt(scale);
                         writeVarLong(b.longValue());
                     }
                 } else {
-                    writeByte(DECIMAL);
+                    writeByte(NUMERIC);
                     writeVarInt(scale);
                     byte[] bytes = b.toByteArray();
                     writeVarInt(bytes.length);
@@ -614,10 +614,10 @@ public class Data {
             byte[] b = v.getBytesNoCopy();
             int len = b.length;
             if (len < 32) {
-                writeByte((byte) (BYTES_0_31 + len));
+                writeByte((byte) (VARBINARY_0_31 + len));
                 write(b, 0, len);
             } else {
-                writeByte(BYTES);
+                writeByte(VARBINARY);
                 writeVarInt(len);
                 write(b, 0, len);
             }
@@ -634,20 +634,20 @@ public class Data {
             String s = v.getString();
             int len = s.length();
             if (len < 32) {
-                writeByte((byte) (STRING_0_31 + len));
+                writeByte((byte) (VARCHAR_0_31 + len));
                 writeStringWithoutLength(s, len);
             } else {
-                writeByte(STRING);
+                writeByte(VARCHAR);
                 writeString(s);
             }
             break;
         }
         case Value.VARCHAR_IGNORECASE:
-            writeByte(STRING_IGNORECASE);
+            writeByte(VARCHAR_IGNORECASE);
             writeString(v.getString());
             break;
         case Value.CHAR:
-            writeByte(STRING_FIXED);
+            writeByte(CHAR);
             writeString(v.getString());
             break;
         case Value.DOUBLE: {
@@ -668,13 +668,13 @@ public class Data {
         case Value.REAL: {
             float x = v.getFloat();
             if (x == 1.0f) {
-                writeByte((byte) (FLOAT_0_1 + 1));
+                writeByte((byte) (REAL_0_1 + 1));
             } else {
                 int f = Float.floatToIntBits(x);
                 if (f == ValueFloat.ZERO_BITS) {
-                    writeByte(FLOAT_0_1);
+                    writeByte(REAL_0_1);
                 } else {
-                    writeByte(FLOAT);
+                    writeByte(REAL);
                     writeVarInt(Integer.reverse(f));
                 }
             }
@@ -796,27 +796,27 @@ public class Data {
         case INT_NEG:
             return ValueInt.get(-readVarInt());
         case ENUM:
-        case INT:
+        case INTEGER:
             return ValueInt.get(readVarInt());
-        case LONG_NEG:
+        case BIGINT_NEG:
             return ValueLong.get(-readVarLong());
         case Value.BIGINT:
             return ValueLong.get(readVarLong());
-        case BYTE:
+        case TINYINT:
             return ValueByte.get(readByte());
-        case SHORT:
+        case SMALLINT:
             return ValueShort.get(readShortInt());
-        case DECIMAL_0_1:
+        case NUMERIC_0_1:
             return ValueDecimal.ZERO;
-        case DECIMAL_0_1 + 1:
+        case NUMERIC_0_1 + 1:
             return ValueDecimal.ONE;
-        case DECIMAL_SMALL_0:
+        case NUMERIC_SMALL_0:
             return ValueDecimal.get(BigDecimal.valueOf(readVarLong()));
-        case DECIMAL_SMALL: {
+        case NUMERIC_SMALL: {
             int scale = readVarInt();
             return ValueDecimal.get(BigDecimal.valueOf(readVarLong(), scale));
         }
-        case DECIMAL: {
+        case NUMERIC: {
             int scale = readVarInt();
             int len = readVarInt();
             byte[] buff = Utils.newBytes(len);
@@ -857,7 +857,7 @@ public class Data {
             int tz = readTimeZone();
             return ValueTimestampTimeZone.fromDateValueAndNanos(dateValue, nanos, tz);
         }
-        case BYTES: {
+        case VARBINARY: {
             int len = readVarInt();
             byte[] b = Utils.newBytes(len);
             read(b, 0, len);
@@ -877,15 +877,15 @@ public class Data {
         }
         case UUID:
             return ValueUuid.get(readLong(), readLong());
-        case STRING:
+        case VARCHAR:
             return ValueString.get(readString());
-        case STRING_IGNORECASE:
+        case VARCHAR_IGNORECASE:
             return ValueStringIgnoreCase.get(readString());
-        case STRING_FIXED:
+        case CHAR:
             return ValueStringFixed.get(readString());
-        case FLOAT_0_1:
+        case REAL_0_1:
             return ValueFloat.ZERO;
-        case FLOAT_0_1 + 1:
+        case REAL_0_1 + 1:
             return ValueFloat.ONE;
         case DOUBLE_0_1:
             return ValueDouble.ZERO;
@@ -893,7 +893,7 @@ public class Data {
             return ValueDouble.ONE;
         case DOUBLE:
             return ValueDouble.get(Double.longBitsToDouble(Long.reverse(readVarLong())));
-        case FLOAT:
+        case REAL:
             return ValueFloat.get(Float.intBitsToFloat(Integer.reverse(readVarInt())));
         case BLOB:
         case CLOB: {
@@ -955,15 +955,15 @@ public class Data {
         default:
             if (type >= INT_0_15 && type < INT_0_15 + 16) {
                 return ValueInt.get(type - INT_0_15);
-            } else if (type >= LONG_0_7 && type < LONG_0_7 + 8) {
-                return ValueLong.get(type - LONG_0_7);
-            } else if (type >= BYTES_0_31 && type < BYTES_0_31 + 32) {
-                int len = type - BYTES_0_31;
+            } else if (type >= BIGINT_0_7 && type < BIGINT_0_7 + 8) {
+                return ValueLong.get(type - BIGINT_0_7);
+            } else if (type >= VARBINARY_0_31 && type < VARBINARY_0_31 + 32) {
+                int len = type - VARBINARY_0_31;
                 byte[] b = Utils.newBytes(len);
                 read(b, 0, len);
                 return ValueBytes.getNoCopy(b);
-            } else if (type >= STRING_0_31 && type < STRING_0_31 + 32) {
-                return ValueString.get(readString(type - STRING_0_31));
+            } else if (type >= VARCHAR_0_31 && type < VARCHAR_0_31 + 32) {
+                return ValueString.get(readString(type - VARCHAR_0_31));
             }
             throw DbException.get(ErrorCode.FILE_CORRUPTED_1, "type: " + type);
         }
@@ -1013,7 +1013,7 @@ public class Data {
         case Value.SMALLINT:
             return 3;
         case Value.ENUM:
-        case Value.INT: {
+        case Value.INTEGER: {
             int x = v.getInt();
             if (x < 0) {
                 return 1 + getVarIntLen(-x);

--- a/h2/src/main/org/h2/store/Data.java
+++ b/h2/src/main/org/h2/store/Data.java
@@ -32,33 +32,33 @@ import org.h2.util.Utils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
-import org.h2.value.ValueByte;
-import org.h2.value.ValueBytes;
+import org.h2.value.ValueChar;
 import org.h2.value.ValueCollectionBase;
 import org.h2.value.ValueDate;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueFloat;
 import org.h2.value.ValueGeometry;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueJavaObject;
 import org.h2.value.ValueJson;
 import org.h2.value.ValueLob;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
 import org.h2.value.ValueResultSet;
 import org.h2.value.ValueRow;
-import org.h2.value.ValueShort;
-import org.h2.value.ValueString;
-import org.h2.value.ValueStringFixed;
-import org.h2.value.ValueStringIgnoreCase;
+import org.h2.value.ValueSmallint;
 import org.h2.value.ValueTime;
 import org.h2.value.ValueTimeTimeZone;
 import org.h2.value.ValueTimestamp;
 import org.h2.value.ValueTimestampTimeZone;
+import org.h2.value.ValueTinyint;
 import org.h2.value.ValueUuid;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
+import org.h2.value.ValueVarcharIgnoreCase;
 
 /**
  * This class represents a byte buffer that contains persistent data of a page.
@@ -671,7 +671,7 @@ public class Data {
                 writeByte((byte) (REAL_0_1 + 1));
             } else {
                 int f = Float.floatToIntBits(x);
-                if (f == ValueFloat.ZERO_BITS) {
+                if (f == ValueReal.ZERO_BITS) {
                     writeByte(REAL_0_1);
                 } else {
                     writeByte(REAL);
@@ -794,27 +794,27 @@ public class Data {
         case BOOLEAN_FALSE:
             return ValueBoolean.FALSE;
         case INT_NEG:
-            return ValueInt.get(-readVarInt());
+            return ValueInteger.get(-readVarInt());
         case ENUM:
         case INTEGER:
-            return ValueInt.get(readVarInt());
+            return ValueInteger.get(readVarInt());
         case BIGINT_NEG:
-            return ValueLong.get(-readVarLong());
+            return ValueBigint.get(-readVarLong());
         case Value.BIGINT:
-            return ValueLong.get(readVarLong());
+            return ValueBigint.get(readVarLong());
         case TINYINT:
-            return ValueByte.get(readByte());
+            return ValueTinyint.get(readByte());
         case SMALLINT:
-            return ValueShort.get(readShortInt());
+            return ValueSmallint.get(readShortInt());
         case NUMERIC_0_1:
-            return ValueDecimal.ZERO;
+            return ValueNumeric.ZERO;
         case NUMERIC_0_1 + 1:
-            return ValueDecimal.ONE;
+            return ValueNumeric.ONE;
         case NUMERIC_SMALL_0:
-            return ValueDecimal.get(BigDecimal.valueOf(readVarLong()));
+            return ValueNumeric.get(BigDecimal.valueOf(readVarLong()));
         case NUMERIC_SMALL: {
             int scale = readVarInt();
-            return ValueDecimal.get(BigDecimal.valueOf(readVarLong(), scale));
+            return ValueNumeric.get(BigDecimal.valueOf(readVarLong(), scale));
         }
         case NUMERIC: {
             int scale = readVarInt();
@@ -822,7 +822,7 @@ public class Data {
             byte[] buff = Utils.newBytes(len);
             read(buff, 0, len);
             BigInteger b = new BigInteger(buff);
-            return ValueDecimal.get(new BigDecimal(b, scale));
+            return ValueNumeric.get(new BigDecimal(b, scale));
         }
         case LOCAL_DATE:
             return ValueDate.fromDateValue(readVarLong());
@@ -861,7 +861,7 @@ public class Data {
             int len = readVarInt();
             byte[] b = Utils.newBytes(len);
             read(b, 0, len);
-            return ValueBytes.getNoCopy(b);
+            return ValueVarbinary.getNoCopy(b);
         }
         case GEOMETRY: {
             int len = readVarInt();
@@ -878,15 +878,15 @@ public class Data {
         case UUID:
             return ValueUuid.get(readLong(), readLong());
         case VARCHAR:
-            return ValueString.get(readString());
+            return ValueVarchar.get(readString());
         case VARCHAR_IGNORECASE:
-            return ValueStringIgnoreCase.get(readString());
+            return ValueVarcharIgnoreCase.get(readString());
         case CHAR:
-            return ValueStringFixed.get(readString());
+            return ValueChar.get(readString());
         case REAL_0_1:
-            return ValueFloat.ZERO;
+            return ValueReal.ZERO;
         case REAL_0_1 + 1:
-            return ValueFloat.ONE;
+            return ValueReal.ONE;
         case DOUBLE_0_1:
             return ValueDouble.ZERO;
         case DOUBLE_0_1 + 1:
@@ -894,7 +894,7 @@ public class Data {
         case DOUBLE:
             return ValueDouble.get(Double.longBitsToDouble(Long.reverse(readVarLong())));
         case REAL:
-            return ValueFloat.get(Float.intBitsToFloat(Integer.reverse(readVarInt())));
+            return ValueReal.get(Float.intBitsToFloat(Integer.reverse(readVarInt())));
         case BLOB:
         case CLOB: {
             int smallLen = readVarInt();
@@ -954,16 +954,16 @@ public class Data {
         }
         default:
             if (type >= INT_0_15 && type < INT_0_15 + 16) {
-                return ValueInt.get(type - INT_0_15);
+                return ValueInteger.get(type - INT_0_15);
             } else if (type >= BIGINT_0_7 && type < BIGINT_0_7 + 8) {
-                return ValueLong.get(type - BIGINT_0_7);
+                return ValueBigint.get(type - BIGINT_0_7);
             } else if (type >= VARBINARY_0_31 && type < VARBINARY_0_31 + 32) {
                 int len = type - VARBINARY_0_31;
                 byte[] b = Utils.newBytes(len);
                 read(b, 0, len);
-                return ValueBytes.getNoCopy(b);
+                return ValueVarbinary.getNoCopy(b);
             } else if (type >= VARCHAR_0_31 && type < VARCHAR_0_31 + 32) {
-                return ValueString.get(readString(type - VARCHAR_0_31));
+                return ValueVarchar.get(readString(type - VARCHAR_0_31));
             }
             throw DbException.get(ErrorCode.FILE_CORRUPTED_1, "type: " + type);
         }
@@ -1050,7 +1050,7 @@ public class Data {
                 return 1;
             }
             int f = Float.floatToIntBits(x);
-            if (f == ValueFloat.ZERO_BITS) {
+            if (f == ValueReal.ZERO_BITS) {
                 return 1;
             }
             return 1 + getVarIntLen(Integer.reverse(f));

--- a/h2/src/main/org/h2/table/Column.java
+++ b/h2/src/main/org/h2/table/Column.java
@@ -29,7 +29,7 @@ import org.h2.util.StringUtils;
 import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueUuid;
 
@@ -420,7 +420,7 @@ public class Column implements HasSQL {
             }
             if (update) {
                 sequence.modify(null, now + inc, null, null, null);
-                session.setLastIdentity(ValueLong.get(now));
+                session.setLastIdentity(ValueBigint.get(now));
                 sequence.flush(session);
             }
         }

--- a/h2/src/main/org/h2/table/GeneratedColumnResolver.java
+++ b/h2/src/main/org/h2/table/GeneratedColumnResolver.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 
 import org.h2.result.Row;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 
 /**
  * Column resolver for generated columns.
@@ -88,7 +88,7 @@ class GeneratedColumnResolver implements ColumnResolver {
     public Value getValue(Column column) {
         int columnId = column.getColumnId();
         if (columnId == -1) {
-            return ValueLong.get(current.getKey());
+            return ValueBigint.get(current.getKey());
         }
         return current.getValue(columnId);
     }

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -69,14 +69,14 @@ import org.h2.util.Utils;
 import org.h2.value.CompareMode;
 import org.h2.value.DataType;
 import org.h2.value.Value;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueInt;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
-import org.h2.value.ValueShort;
-import org.h2.value.ValueString;
-import org.h2.value.ValueStringIgnoreCase;
+import org.h2.value.ValueSmallint;
+import org.h2.value.ValueVarchar;
+import org.h2.value.ValueVarcharIgnoreCase;
 
 /**
  * This class is responsible to build the database meta data pseudo tables.
@@ -762,9 +762,9 @@ public class MetaTable extends Table {
         }
         Value v;
         if (database.getSettings().caseInsensitiveIdentifiers) {
-            v = ValueStringIgnoreCase.get(value);
+            v = ValueVarcharIgnoreCase.get(value);
         } else {
-            v = ValueString.get(value);
+            v = ValueVarchar.get(value);
         }
         if (indexFrom != null && session.compare(v, indexFrom) < 0) {
             return false;
@@ -853,14 +853,14 @@ public class MetaTable extends Table {
                         // REMARKS
                         replaceNullWithEmpty(table.getComment()),
                         // LAST_MODIFICATION
-                        ValueLong.get(table.getMaxDataModificationId()),
+                        ValueBigint.get(table.getMaxDataModificationId()),
                         // ID
-                        ValueInt.get(table.getId()),
+                        ValueInteger.get(table.getId()),
                         // TYPE_NAME
                         null,
                         // TABLE_CLASS
                         table.getClass().getName(), // ROW_COUNT_ESTIMATE
-                        ValueLong.get(table.getRowCountApproximation())
+                        ValueBigint.get(table.getRowCountApproximation())
                 );
             }
             break;
@@ -892,8 +892,8 @@ public class MetaTable extends Table {
                     Column c = cols[j];
                     Domain domain = c.getDomain();
                     DataType dataType = c.getDataType();
-                    ValueInt precision = ValueInt.get(c.getPrecisionAsInt());
-                    ValueInt scale = ValueInt.get(c.getType().getScale());
+                    ValueInteger precision = ValueInteger.get(c.getPrecisionAsInt());
+                    ValueInteger scale = ValueInteger.get(c.getType().getScale());
                     Sequence sequence = c.getSequence();
                     boolean hasDateTimePrecision;
                     int type = dataType.type;
@@ -926,13 +926,13 @@ public class MetaTable extends Table {
                             // COLUMN_NAME
                             c.getName(),
                             // ORDINAL_POSITION
-                            ValueInt.get(j + 1),
+                            ValueInteger.get(j + 1),
                             // COLUMN_DEFAULT
                             isGenerated ? null : c.getDefaultSQL(),
                             // IS_NULLABLE
                             c.isNullable() ? "YES" : "NO",
                             // DATA_TYPE
-                            ValueInt.get(dataType.sqlType),
+                            ValueInteger.get(dataType.sqlType),
                             // CHARACTER_MAXIMUM_LENGTH
                             precision,
                             // CHARACTER_OCTET_LENGTH
@@ -940,7 +940,7 @@ public class MetaTable extends Table {
                             // NUMERIC_PRECISION
                             precision,
                             // NUMERIC_PRECISION_RADIX
-                            ValueInt.get(10),
+                            ValueInteger.get(10),
                             // NUMERIC_SCALE
                             scale,
                             // DATETIME_PRECISION
@@ -966,12 +966,12 @@ public class MetaTable extends Table {
                             // TYPE_NAME
                             identifier(isInterval ? "INTERVAL" : dataType.name),
                             // NULLABLE
-                            ValueInt.get(c.isNullable()
+                            ValueInteger.get(c.isNullable()
                                     ? DatabaseMetaData.columnNullable : DatabaseMetaData.columnNoNulls),
                             // IS_COMPUTED
                             ValueBoolean.get(isGenerated),
                             // SELECTIVITY
-                            ValueInt.get(c.getSelectivity()),
+                            ValueInteger.get(c.getSelectivity()),
                             // SEQUENCE_NAME
                             sequence == null ? null : sequence.getName(),
                             // REMARKS
@@ -1048,11 +1048,11 @@ public class MetaTable extends Table {
                                 // INDEX_NAME
                                 index.getName(),
                                 // ORDINAL_POSITION
-                                ValueShort.get((short) (k + 1)),
+                                ValueSmallint.get((short) (k + 1)),
                                 // COLUMN_NAME
                                 column.getName(),
                                 // CARDINALITY
-                                ValueInt.get(0),
+                                ValueInteger.get(0),
                                 // PRIMARY_KEY
                                 ValueBoolean.get(index.getIndexType().isPrimaryKey()),
                                 // INDEX_TYPE_NAME
@@ -1060,11 +1060,11 @@ public class MetaTable extends Table {
                                 // IS_GENERATED
                                 ValueBoolean.get(index.getIndexType().getBelongsToConstraint()),
                                 // INDEX_TYPE
-                                ValueShort.get(DatabaseMetaData.tableIndexOther),
+                                ValueSmallint.get(DatabaseMetaData.tableIndexOther),
                                 // ASC_OR_DESC
                                 (idxCol.sortType & SortOrder.DESCENDING) != 0 ? "D" : "A",
                                 // PAGES
-                                ValueInt.get(0),
+                                ValueInteger.get(0),
                                 // FILTER_CONDITION
                                 "",
                                 // REMARKS
@@ -1072,9 +1072,9 @@ public class MetaTable extends Table {
                                 // SQL
                                 index.getCreateSQL(),
                                 // ID
-                                ValueInt.get(index.getId()),
+                                ValueInteger.get(index.getId()),
                                 // SORT_TYPE
-                                ValueInt.get(idxCol.sortType),
+                                ValueInteger.get(idxCol.sortType),
                                 // CONSTRAINT_NAME
                                 constraintName, // INDEX_CLASS
                                 indexClass
@@ -1102,9 +1102,9 @@ public class MetaTable extends Table {
                         // TYPE_NAME
                         t.name,
                         // DATA_TYPE
-                        ValueInt.get(t.sqlType),
+                        ValueInteger.get(t.sqlType),
                         // PRECISION
-                        ValueInt.get(MathUtils.convertLongToInt(t.maxPrecision)),
+                        ValueInteger.get(MathUtils.convertLongToInt(t.maxPrecision)),
                         // PREFIX
                         t.prefix,
                         // SUFFIX
@@ -1114,18 +1114,18 @@ public class MetaTable extends Table {
                         // AUTO_INCREMENT
                         ValueBoolean.get(t.autoIncrement),
                         // MINIMUM_SCALE
-                        ValueShort.get(MathUtils.convertIntToShort(t.minScale)),
+                        ValueSmallint.get(MathUtils.convertIntToShort(t.minScale)),
                         // MAXIMUM_SCALE
-                        ValueShort.get(MathUtils.convertIntToShort(t.maxScale)),
+                        ValueSmallint.get(MathUtils.convertIntToShort(t.maxScale)),
                         // RADIX
-                        t.decimal ? ValueInt.get(10) : null,
+                        t.decimal ? ValueInteger.get(10) : null,
                         // POS
-                        ValueInt.get(t.sqlTypePos),
+                        ValueInteger.get(t.sqlTypePos),
                         // CASE_SENSITIVE
                         ValueBoolean.get(t.caseSensitive),
                         // NULLABLE
-                        ValueShort.get((short) DatabaseMetaData.typeNullable), // SEARCHABLE
-                        ValueShort.get((short) DatabaseMetaData.typeSearchable)
+                        ValueSmallint.get((short) DatabaseMetaData.typeNullable), // SEARCHABLE
+                        ValueSmallint.get((short) DatabaseMetaData.typeSearchable)
                 );
             }
             break;
@@ -1255,7 +1255,7 @@ public class MetaTable extends Table {
                     add(session,
                         rows,
                         // ID
-                        ValueInt.get(i),
+                        ValueInteger.get(i),
                         // SECTION
                         rs.getString(1).trim(),
                         // TOPIC
@@ -1284,30 +1284,30 @@ public class MetaTable extends Table {
                         // DATA_TYPE
                         "BIGINT",
                         // NUMERIC_PRECISION
-                        ValueInt.get(ValueLong.PRECISION),
+                        ValueInteger.get(ValueBigint.PRECISION),
                         // NUMERIC_PRECISION_RADIX
-                        ValueInt.get(10),
+                        ValueInteger.get(10),
                         // NUMERIC_SCALE
-                        ValueInt.get(0),
+                        ValueInteger.get(0),
                         // START_VALUE
-                        ValueLong.get(s.getStartValue()),
+                        ValueBigint.get(s.getStartValue()),
                         // MINIMUM_VALUE
-                        ValueLong.get(s.getMinValue()),
+                        ValueBigint.get(s.getMinValue()),
                         // MAXIMUM_VALUE
-                        ValueLong.get(s.getMaxValue()),
+                        ValueBigint.get(s.getMaxValue()),
                         // INCREMENT
-                        ValueLong.get(s.getIncrement()),
+                        ValueBigint.get(s.getIncrement()),
                         // CYCLE_OPTION
                         s.getCycle() ? "YES" : "NO",
                         // CURRENT_VALUE
-                        ValueLong.get(s.getCurrentValue()),
+                        ValueBigint.get(s.getCurrentValue()),
                         // IS_GENERATED
                         ValueBoolean.get(s.getBelongsToTable()),
                         // REMARKS
                         replaceNullWithEmpty(s.getComment()),
                         // CACHE
-                        ValueLong.get(s.getCacheSize()), // ID
-                        ValueInt.get(s.getId())
+                        ValueBigint.get(s.getCacheSize()), // ID
+                        ValueInteger.get(s.getId())
                     );
             }
             break;
@@ -1323,7 +1323,7 @@ public class MetaTable extends Table {
                             String.valueOf(u.isAdmin()),
                             // REMARKS
                             replaceNullWithEmpty(u.getComment()), // ID
-                            ValueInt.get(u.getId())
+                            ValueInteger.get(u.getId())
                     );
                 }
             }
@@ -1338,7 +1338,7 @@ public class MetaTable extends Table {
                             identifier(r.getName()),
                             // REMARKS
                             replaceNullWithEmpty(r.getComment()), // ID
-                            ValueInt.get(r.getId())
+                            ValueInteger.get(r.getId())
                     );
                 }
             }
@@ -1381,7 +1381,7 @@ public class MetaTable extends Table {
                                 schemaName,
                                 // TABLE_NAME
                                 tableName, // ID
-                                ValueInt.get(r.getId())
+                                ValueInteger.get(r.getId())
                         );
                     } else {
                         add(session,
@@ -1398,7 +1398,7 @@ public class MetaTable extends Table {
                                 "",
                                 // TABLE_NAME
                                 "", // ID
-                                ValueInt.get(r.getId())
+                                ValueInteger.get(r.getId())
                         );
                     }
                 }
@@ -1429,19 +1429,19 @@ public class MetaTable extends Table {
                             // JAVA_METHOD
                             alias.getJavaMethodName(),
                             // DATA_TYPE
-                            ValueInt.get(DataType.convertTypeToSQLType(method.getDataType())),
+                            ValueInteger.get(DataType.convertTypeToSQLType(method.getDataType())),
                             // TYPE_NAME
                             DataType.getDataType(method.getDataType()).name,
                             // COLUMN_COUNT
-                            ValueInt.get(method.getParameterCount()),
+                            ValueInteger.get(method.getParameterCount()),
                             // RETURNS_RESULT
-                            ValueShort.get(method.getDataType() == Value.NULL
+                            ValueSmallint.get(method.getDataType() == Value.NULL
                                     ? (short) DatabaseMetaData.procedureNoResult
                                     : (short) DatabaseMetaData.procedureReturnsResult),
                             // REMARKS
                             replaceNullWithEmpty(alias.getComment()),
                             // ID
-                            ValueInt.get(alias.getId())
+                            ValueInteger.get(alias.getId())
 , // SOURCE
                             alias.getSource()
                             // when adding more columns, see also below
@@ -1462,17 +1462,17 @@ public class MetaTable extends Table {
                         // JAVA_METHOD
                         "",
                         // DATA_TYPE
-                        ValueInt.get(Types.NULL),
+                        ValueInteger.get(Types.NULL),
                         // TYPE_NAME
                         DataType.getDataType(Value.NULL).name,
                         // COLUMN_COUNT
-                        ValueInt.get(1),
+                        ValueInteger.get(1),
                         // RETURNS_RESULT
-                        ValueShort.get((short) DatabaseMetaData.procedureReturnsResult),
+                        ValueSmallint.get((short) DatabaseMetaData.procedureReturnsResult),
                         // REMARKS
                         replaceNullWithEmpty(agg.getComment()),
                         // ID
-                        ValueInt.get(agg.getId())
+                        ValueInteger.get(agg.getId())
 , // SOURCE
                         ""
                         // when adding more columns, see also below
@@ -1507,25 +1507,25 @@ public class MetaTable extends Table {
                                 // JAVA_METHOD
                                 alias.getJavaMethodName(),
                                 // COLUMN_COUNT
-                                ValueInt.get(method.getParameterCount()),
+                                ValueInteger.get(method.getParameterCount()),
                                 // POS
-                                ValueInt.get(0),
+                                ValueInteger.get(0),
                                 // COLUMN_NAME
                                 "P0",
                                 // DATA_TYPE
-                                ValueInt.get(DataType.convertTypeToSQLType(method.getDataType())),
+                                ValueInteger.get(DataType.convertTypeToSQLType(method.getDataType())),
                                 // TYPE_NAME
                                 dt.name,
                                 // PRECISION
-                                ValueInt.get(MathUtils.convertLongToInt(dt.defaultPrecision)),
+                                ValueInteger.get(MathUtils.convertLongToInt(dt.defaultPrecision)),
                                 // SCALE
-                                ValueShort.get(MathUtils.convertIntToShort(dt.defaultScale)),
+                                ValueSmallint.get(MathUtils.convertIntToShort(dt.defaultScale)),
                                 // RADIX
-                                ValueShort.get((short) 10),
+                                ValueSmallint.get((short) 10),
                                 // NULLABLE
-                                ValueShort.get((short) DatabaseMetaData.columnNullableUnknown),
+                                ValueSmallint.get((short) DatabaseMetaData.columnNullableUnknown),
                                 // COLUMN_TYPE
-                                ValueShort.get((short) DatabaseMetaData.procedureColumnReturn),
+                                ValueSmallint.get((short) DatabaseMetaData.procedureColumnReturn),
                                 // REMARKS
                                 "", // COLUMN_DEFAULT
                                 null
@@ -1552,27 +1552,27 @@ public class MetaTable extends Table {
                                 // JAVA_METHOD
                                 alias.getJavaMethodName(),
                                 // COLUMN_COUNT
-                                ValueInt.get(method.getParameterCount()),
+                                ValueInteger.get(method.getParameterCount()),
                                 // POS
-                                ValueInt.get(k + (method.hasConnectionParam() ? 0 : 1)),
+                                ValueInteger.get(k + (method.hasConnectionParam() ? 0 : 1)),
                                 // COLUMN_NAME
                                 "P" + (k + 1),
                                 // DATA_TYPE
-                                ValueInt.get(DataType.convertTypeToSQLType(dt.type)),
+                                ValueInteger.get(DataType.convertTypeToSQLType(dt.type)),
                                 // TYPE_NAME
                                 dt.name,
                                 // PRECISION
-                                ValueInt.get(MathUtils.convertLongToInt(dt.defaultPrecision)),
+                                ValueInteger.get(MathUtils.convertLongToInt(dt.defaultPrecision)),
                                 // SCALE
-                                ValueShort.get(MathUtils.convertIntToShort(dt.defaultScale)),
+                                ValueSmallint.get(MathUtils.convertIntToShort(dt.defaultScale)),
                                 // RADIX
-                                ValueShort.get((short) 10),
+                                ValueSmallint.get((short) 10),
                                 // NULLABLE
-                                ValueShort.get(clazz.isPrimitive()
+                                ValueSmallint.get(clazz.isPrimitive()
                                         ? (short) DatabaseMetaData.columnNoNulls
                                         : (short) DatabaseMetaData.columnNullable),
                                 // COLUMN_TYPE
-                                ValueShort.get((short) DatabaseMetaData.procedureColumnIn),
+                                ValueSmallint.get((short) DatabaseMetaData.procedureColumnIn),
                                 // REMARKS
                                 "", // COLUMN_DEFAULT
                                 null
@@ -1601,7 +1601,7 @@ public class MetaTable extends Table {
                         ValueBoolean.get(schema.getId() == Constants.MAIN_SCHEMA_ID),
                         // REMARKS
                         replaceNullWithEmpty(schema.getComment()), // ID
-                        ValueInt.get(schema.getId())
+                        ValueInteger.get(schema.getId())
                 );
             }
             break;
@@ -1685,7 +1685,7 @@ public class MetaTable extends Table {
                         view.isInvalid() ? "INVALID" : "VALID",
                         // REMARKS
                         replaceNullWithEmpty(view.getComment()), // ID
-                        ValueInt.get(view.getId())
+                        ValueInteger.get(view.getId())
                 );
             }
             break;
@@ -1720,8 +1720,8 @@ public class MetaTable extends Table {
                 if (!checkIndex(session, tableName, indexFrom, indexTo)) {
                     continue;
                 }
-                ValueShort update = ValueShort.get(getRefAction(ref.getUpdateAction()));
-                ValueShort delete = ValueShort.get(getRefAction(ref.getDeleteAction()));
+                ValueSmallint update = ValueSmallint.get(getRefAction(ref.getUpdateAction()));
+                ValueSmallint delete = ValueSmallint.get(getRefAction(ref.getDeleteAction()));
                 for (int j = 0; j < cols.length; j++) {
                     add(session,
                             rows,
@@ -1742,7 +1742,7 @@ public class MetaTable extends Table {
                             // FKCOLUMN_NAME
                             cols[j].column.getName(),
                             // ORDINAL_POSITION
-                            ValueShort.get((short) (j + 1)),
+                            ValueSmallint.get((short) (j + 1)),
                             // UPDATE_RULE
                             update,
                             // DELETE_RULE
@@ -1751,7 +1751,7 @@ public class MetaTable extends Table {
                             ref.getName(),
                             // PK_NAME
                             ref.getReferencedConstraint().getName(), // DEFERRABILITY
-                            ValueShort.get((short) DatabaseMetaData.importedKeyNotDeferrable)
+                            ValueSmallint.get((short) DatabaseMetaData.importedKeyNotDeferrable)
                     );
                 }
             }
@@ -1771,12 +1771,12 @@ public class MetaTable extends Table {
                         // CONSTANT_NAME
                         constant.getName(),
                         // DATA_TYPE
-                        ValueInt.get(DataType.convertTypeToSQLType(expr.getType().getValueType())),
+                        ValueInteger.get(DataType.convertTypeToSQLType(expr.getType().getValueType())),
                         // REMARKS
                         replaceNullWithEmpty(constant.getComment()),
                         // SQL
                         expr.getSQL(DEFAULT_SQL_FLAGS), // ID
-                        ValueInt.get(constant.getId())
+                        ValueInteger.get(constant.getId())
                     );
             }
             break;
@@ -1799,11 +1799,11 @@ public class MetaTable extends Table {
                         // DOMAIN_ON_UPDATE
                         col.getOnUpdateSQL(),
                         // DATA_TYPE
-                        ValueInt.get(col.getDataType().sqlType),
+                        ValueInteger.get(col.getDataType().sqlType),
                         // PRECISION
-                        ValueInt.get(col.getPrecisionAsInt()),
+                        ValueInteger.get(col.getPrecisionAsInt()),
                         // SCALE
-                        ValueInt.get(col.getType().getScale()),
+                        ValueInteger.get(col.getType().getScale()),
                         // TYPE_NAME
                         col.getDataType().name,
                         // PARENT_DOMAIN_CATALOG
@@ -1813,12 +1813,12 @@ public class MetaTable extends Table {
                         // PARENT_DOMAIN_NAME
                         parentDomain != null ? parentDomain.getName() : null,
                         // SELECTIVITY INT
-                        ValueInt.get(col.getSelectivity()),
+                        ValueInteger.get(col.getSelectivity()),
                         // REMARKS
                         replaceNullWithEmpty(domain.getComment()),
                         // SQL
                         domain.getCreateSQL(), // ID
-                        ValueInt.get(domain.getId())
+                        ValueInteger.get(domain.getId())
                 );
             }
             break;
@@ -1849,14 +1849,14 @@ public class MetaTable extends Table {
                         // JAVA_CLASS
                         trigger.getTriggerClassName(),
                         // QUEUE_SIZE
-                        ValueInt.get(trigger.getQueueSize()),
+                        ValueInteger.get(trigger.getQueueSize()),
                         // NO_WAIT
                         ValueBoolean.get(trigger.isNoWait()),
                         // REMARKS
                         replaceNullWithEmpty(trigger.getComment()),
                         // SQL
                         trigger.getCreateSQL(), // ID
-                        ValueInt.get(trigger.getId())
+                        ValueInteger.get(trigger.getId())
                 );
             }
             break;
@@ -1870,7 +1870,7 @@ public class MetaTable extends Table {
                     add(session,
                             rows,
                             // ID
-                            ValueInt.get(s.getId()),
+                            ValueInteger.get(s.getId()),
                             // USER_NAME
                             s.getUser().getName(),
                             // SERVER
@@ -1891,7 +1891,7 @@ public class MetaTable extends Table {
                             ValueBoolean.get(s.containsUncommitted()),
                             // STATE
                             String.valueOf(s.getState()), // BLOCKER_ID
-                            blockingSessionId == 0 ? null : ValueInt.get(blockingSessionId)
+                            blockingSessionId == 0 ? null : ValueInteger.get(blockingSessionId)
                     );
                 }
             }
@@ -1908,7 +1908,7 @@ public class MetaTable extends Table {
                                 // TABLE_NAME
                                 table.getName(),
                                 // SESSION_ID
-                                ValueInt.get(s.getId()), // LOCK_TYPE
+                                ValueInteger.get(s.getId()), // LOCK_TYPE
                                 table.isLockedExclusivelyBy(s) ? "WRITE" : "READ"
                         );
                     }
@@ -1981,7 +1981,7 @@ public class MetaTable extends Table {
                             // SQL_STATEMENT
                             entry.sqlStatement,
                             // EXECUTION_COUNT
-                            ValueInt.get(entry.count),
+                            ValueInteger.get(entry.count),
                             // MIN_EXECUTION_TIME
                             ValueDouble.get(entry.executionTimeMinNanos / 1_000_000d),
                             // MAX_EXECUTION_TIME
@@ -1993,11 +1993,11 @@ public class MetaTable extends Table {
                             // STD_DEV_EXECUTION_TIME
                             ValueDouble.get(entry.getExecutionTimeStandardDeviation() / 1_000_000d),
                             // MIN_ROW_COUNT
-                            ValueInt.get(entry.rowCountMin),
+                            ValueInteger.get(entry.rowCountMin),
                             // MAX_ROW_COUNT
-                            ValueInt.get(entry.rowCountMax),
+                            ValueInteger.get(entry.rowCountMax),
                             // CUMULATIVE_ROW_COUNT
-                            ValueLong.get(entry.rowCountCumulative),
+                            ValueBigint.get(entry.rowCountCumulative),
                             // AVERAGE_ROW_COUNT
                             ValueDouble.get(entry.rowCountMean), // STD_DEV_ROW_COUNT
                             ValueDouble.get(entry.getRowCountStandardDeviation())
@@ -2026,7 +2026,7 @@ public class MetaTable extends Table {
                         "VALID",
                         // REMARKS
                         replaceNullWithEmpty(synonym.getComment()), // ID
-                        ValueInt.get(synonym.getId())
+                        ValueInteger.get(synonym.getId())
                 );
             }
             break;
@@ -2070,7 +2070,7 @@ public class MetaTable extends Table {
                         replaceNullWithEmpty(constraint.getComment()),
                         // SQL
                         constraint.getCreateSQL(), // ID
-                        ValueInt.get(constraint.getId())
+                        ValueInteger.get(constraint.getId())
                 );
             }
             break;
@@ -2104,7 +2104,7 @@ public class MetaTable extends Table {
                         replaceNullWithEmpty(constraint.getComment()),
                         // SQL
                         constraint.getCreateSQL(), // ID
-                        ValueInt.get(constraint.getId())
+                        ValueInteger.get(constraint.getId())
                 );
             }
             break;
@@ -2139,14 +2139,14 @@ public class MetaTable extends Table {
                 Index index = constraint.getIndex();
                 for (int i = 0; i < indexColumns.length; i++) {
                     IndexColumn indexColumn = indexColumns[i];
-                    ValueInt ordinalPosition = ValueInt.get(i + 1);
-                    ValueInt positionInUniqueConstraint = null;
+                    ValueInteger ordinalPosition = ValueInteger.get(i + 1);
+                    ValueInteger positionInUniqueConstraint = null;
                     if (referenced != null) {
                         Column c = ((ConstraintReferential) constraint).getRefColumns()[i].column;
                         IndexColumn[] refColumns = referenced.getColumns();
                         for (int j = 0; j < refColumns.length; j++) {
                             if (refColumns[j].column.equals(c)) {
-                                positionInUniqueConstraint = ValueInt.get(j + 1);
+                                positionInUniqueConstraint = ValueInteger.get(j + 1);
                                 break;
                             }
                         }
@@ -2415,7 +2415,7 @@ public class MetaTable extends Table {
         Value[] values = new Value[stringsOrValues.length];
         for (int i = 0; i < stringsOrValues.length; i++) {
             Object s = stringsOrValues[i];
-            Value v = s == null ? ValueNull.INSTANCE : s instanceof String ? ValueString.get((String) s) : (Value) s;
+            Value v = s == null ? ValueNull.INSTANCE : s instanceof String ? ValueVarchar.get((String) s) : (Value) s;
             values[i] = columns[i].convert(session, v);
         }
         rows.add(Row.get(values, 1, rows.size()));

--- a/h2/src/main/org/h2/table/TableBase.java
+++ b/h2/src/main/org/h2/table/TableBase.java
@@ -53,7 +53,7 @@ public abstract class TableBase extends Table {
         switch (first.column.getType().getValueType()) {
         case Value.TINYINT:
         case Value.SMALLINT:
-        case Value.INT:
+        case Value.INTEGER:
         case Value.BIGINT:
             return first.column.getColumnId();
         default:

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -32,7 +32,7 @@ import org.h2.util.HasSQL;
 import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 import org.h2.value.Value;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueNull;
 
 /**
@@ -1037,7 +1037,7 @@ public class TableFilter implements ColumnResolver {
         }
         int columnId = column.getColumnId();
         if (columnId == -1) {
-            return ValueLong.get(currentSearchRow.getKey());
+            return ValueBigint.get(currentSearchRow.getKey());
         }
         if (current == null) {
             Value v = currentSearchRow.getValue(columnId);

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1016,7 +1016,7 @@ public class TableFilter implements ColumnResolver {
             return null;
         }
         Column[] sys = new Column[3];
-        sys[0] = new Column("oid", Value.INT);
+        sys[0] = new Column("oid", Value.INTEGER);
         sys[0].setTable(table, 0);
         sys[1] = new Column("ctid", Value.VARCHAR);
         sys[1].setTable(table, 0);

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -42,12 +42,12 @@ import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.MVStoreTool;
 import org.h2.mvstore.StreamStore;
-import org.h2.mvstore.type.MetaType;
 import org.h2.mvstore.db.LobStorageMap;
 import org.h2.mvstore.db.ValueDataType;
 import org.h2.mvstore.tx.TransactionMap;
 import org.h2.mvstore.tx.TransactionStore;
 import org.h2.mvstore.type.DataType;
+import org.h2.mvstore.type.MetaType;
 import org.h2.mvstore.type.StringDataType;
 import org.h2.pagestore.Page;
 import org.h2.pagestore.PageFreeList;
@@ -76,9 +76,9 @@ import org.h2.util.Tool;
 import org.h2.util.Utils;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueCollectionBase;
 import org.h2.value.ValueLob;
-import org.h2.value.ValueLong;
 
 /**
  * Helps recovering a corrupted database.
@@ -1230,7 +1230,7 @@ public class Recover extends Tool implements DataHandler {
             long key = s.readVarLong();
             Value data;
             if (positionOnly) {
-                data = ValueLong.get(key);
+                data = ValueBigint.get(key);
             } else {
                 try {
                     data = s.readValue();
@@ -1291,7 +1291,7 @@ public class Recover extends Tool implements DataHandler {
             long key = s.readVarLong();
             Value data;
             if (positionOnly) {
-                data = ValueLong.get(key);
+                data = ValueBigint.get(key);
             } else {
                 try {
                     data = s.readValue();

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -231,11 +231,11 @@ public class DataType {
                 createNumeric(ValueShort.PRECISION, 0, false),
                 new String[]{"SMALLINT", "YEAR", "INT2"}
         );
-        add(Value.INT, Types.INTEGER,
+        add(Value.INTEGER, Types.INTEGER,
                 createNumeric(ValueInt.PRECISION, 0, false),
                 new String[]{"INTEGER", "INT", "MEDIUMINT", "INT4", "SIGNED"}
         );
-        add(Value.INT, Types.INTEGER,
+        add(Value.INTEGER, Types.INTEGER,
                 createNumeric(ValueInt.PRECISION, 0, true),
                 new String[]{"SERIAL"}
         );
@@ -685,7 +685,7 @@ public class DataType {
                 v = rs.wasNull() ? ValueNull.INSTANCE : ValueFloat.get(value);
                 break;
             }
-            case Value.INT: {
+            case Value.INTEGER: {
                 int value = rs.getInt(columnIndex);
                 v = rs.wasNull() ? ValueNull.INSTANCE : ValueInt.get(value);
                 break;
@@ -874,7 +874,7 @@ public class DataType {
             }
             // "java.lang.Short";
             return Short.class.getName();
-        case Value.INT:
+        case Value.INTEGER:
             // "java.lang.Integer";
             return Integer.class.getName();
         case Value.BIGINT:
@@ -1095,7 +1095,7 @@ public class DataType {
         case Types.BOOLEAN:
             return Value.BOOLEAN;
         case Types.INTEGER:
-            return Value.INT;
+            return Value.INTEGER;
         case Types.SMALLINT:
             return Value.SMALLINT;
         case Types.TINYINT:
@@ -1180,7 +1180,7 @@ public class DataType {
         if (String.class == x) {
             return Value.VARCHAR;
         } else if (Integer.class == x) {
-            return Value.INT;
+            return Value.INTEGER;
         } else if (Long.class == x) {
             return Value.BIGINT;
         } else if (Boolean.class == x) {
@@ -1653,7 +1653,7 @@ public class DataType {
         case Value.BOOLEAN:
         case Value.TINYINT:
         case Value.SMALLINT:
-        case Value.INT:
+        case Value.INTEGER:
         case Value.BIGINT:
         // Negative zeroes and NaNs are normalized
         case Value.DOUBLE:
@@ -1699,7 +1699,7 @@ public class DataType {
         case Value.NUMERIC:
         case Value.DOUBLE:
         case Value.REAL:
-        case Value.INT:
+        case Value.INTEGER:
         case Value.BIGINT:
         case Value.SMALLINT:
         case Value.INTERVAL_YEAR:
@@ -1752,7 +1752,7 @@ public class DataType {
             return Value.BIGINT;
         case Value.REAL:
             return Value.DOUBLE;
-        case Value.INT:
+        case Value.INTEGER:
             return Value.BIGINT;
         case Value.BIGINT:
             return Value.NUMERIC;

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.UUID;
 
 import org.h2.api.ErrorCode;
+import org.h2.api.H2Type;
 import org.h2.api.Interval;
 import org.h2.api.IntervalQualifier;
 import org.h2.engine.Mode;
@@ -1064,7 +1065,9 @@ public class DataType {
      * @return the value type
      */
     public static int convertSQLTypeToValueType(SQLType sqlType) {
-        if (sqlType instanceof JDBCType) {
+        if (sqlType instanceof H2Type) {
+            return sqlType.getVendorTypeNumber();
+        } else if (sqlType instanceof JDBCType) {
             return convertSQLTypeToValueType(sqlType.getVendorTypeNumber());
         } else {
             throw DbException.get(ErrorCode.UNKNOWN_DATA_TYPE_1, sqlType == null ? "<null>"

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -224,27 +224,27 @@ public class DataType {
                 new String[]{"BOOLEAN", "BIT", "BOOL"}
         );
         add(Value.TINYINT, Types.TINYINT,
-                createNumeric(ValueByte.PRECISION, 0, false),
+                createNumeric(ValueTinyint.PRECISION, 0, false),
                 new String[]{"TINYINT"}
         );
         add(Value.SMALLINT, Types.SMALLINT,
-                createNumeric(ValueShort.PRECISION, 0, false),
+                createNumeric(ValueSmallint.PRECISION, 0, false),
                 new String[]{"SMALLINT", "YEAR", "INT2"}
         );
         add(Value.INTEGER, Types.INTEGER,
-                createNumeric(ValueInt.PRECISION, 0, false),
+                createNumeric(ValueInteger.PRECISION, 0, false),
                 new String[]{"INTEGER", "INT", "MEDIUMINT", "INT4", "SIGNED"}
         );
         add(Value.INTEGER, Types.INTEGER,
-                createNumeric(ValueInt.PRECISION, 0, true),
+                createNumeric(ValueInteger.PRECISION, 0, true),
                 new String[]{"SERIAL"}
         );
         add(Value.BIGINT, Types.BIGINT,
-                createNumeric(ValueLong.PRECISION, 0, false),
+                createNumeric(ValueBigint.PRECISION, 0, false),
                 new String[]{"BIGINT", "INT8", "LONG"}
         );
         add(Value.BIGINT, Types.BIGINT,
-                createNumeric(ValueLong.PRECISION, 0, true),
+                createNumeric(ValueBigint.PRECISION, 0, true),
                 new String[]{"IDENTITY", "BIGSERIAL"}
         );
         if (SysProperties.BIG_DECIMAL_IS_DECIMAL) {
@@ -255,7 +255,7 @@ public class DataType {
             addDecimal();
         }
         add(Value.REAL, Types.REAL,
-                createNumeric(ValueFloat.PRECISION, 0, false),
+                createNumeric(ValueReal.PRECISION, 0, false),
                 new String[] {"REAL", "FLOAT4"}
         );
         add(Value.DOUBLE, Types.DOUBLE,
@@ -464,10 +464,10 @@ public class DataType {
         DataType dataType = new DataType();
         dataType.minPrecision = 1;
         dataType.maxPrecision = Integer.MAX_VALUE;
-        dataType.defaultPrecision = ValueDecimal.DEFAULT_PRECISION;
-        dataType.defaultScale = ValueDecimal.DEFAULT_SCALE;
-        dataType.maxScale = ValueDecimal.MAXIMUM_SCALE;
-        dataType.minScale = ValueDecimal.MINIMUM_SCALE;
+        dataType.defaultPrecision = ValueNumeric.DEFAULT_PRECISION;
+        dataType.defaultScale = ValueNumeric.DEFAULT_SCALE;
+        dataType.maxScale = ValueNumeric.MAXIMUM_SCALE;
+        dataType.minScale = ValueNumeric.MINIMUM_SCALE;
         dataType.params = "PRECISION,SCALE";
         dataType.supportsPrecision = true;
         dataType.supportsScale = true;
@@ -571,7 +571,7 @@ public class DataType {
                  */
                 Object o = rs.getObject(columnIndex);
                 if (o instanceof byte[]) {
-                    v = ValueBytes.getNoCopy((byte[]) o);
+                    v = ValueVarbinary.getNoCopy((byte[]) o);
                 } else if (o != null) {
                     v = ValueUuid.get((UUID) o);
                 } else {
@@ -597,7 +597,7 @@ public class DataType {
             }
             case Value.TINYINT: {
                 byte value = rs.getByte(columnIndex);
-                v = rs.wasNull() ? ValueNull.INSTANCE : ValueByte.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueTinyint.get(value);
                 break;
             }
             case Value.DATE: {
@@ -672,7 +672,7 @@ public class DataType {
             }
             case Value.NUMERIC: {
                 BigDecimal value = rs.getBigDecimal(columnIndex);
-                v = value == null ? ValueNull.INSTANCE : ValueDecimal.get(value);
+                v = value == null ? ValueNull.INSTANCE : ValueNumeric.get(value);
                 break;
             }
             case Value.DOUBLE: {
@@ -682,37 +682,37 @@ public class DataType {
             }
             case Value.REAL: {
                 float value = rs.getFloat(columnIndex);
-                v = rs.wasNull() ? ValueNull.INSTANCE : ValueFloat.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueReal.get(value);
                 break;
             }
             case Value.INTEGER: {
                 int value = rs.getInt(columnIndex);
-                v = rs.wasNull() ? ValueNull.INSTANCE : ValueInt.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueInteger.get(value);
                 break;
             }
             case Value.BIGINT: {
                 long value = rs.getLong(columnIndex);
-                v = rs.wasNull() ? ValueNull.INSTANCE : ValueLong.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueBigint.get(value);
                 break;
             }
             case Value.SMALLINT: {
                 short value = rs.getShort(columnIndex);
-                v = rs.wasNull() ? ValueNull.INSTANCE : ValueShort.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueSmallint.get(value);
                 break;
             }
             case Value.VARCHAR_IGNORECASE: {
                 String s = rs.getString(columnIndex);
-                v = (s == null) ? ValueNull.INSTANCE : ValueStringIgnoreCase.get(s);
+                v = (s == null) ? ValueNull.INSTANCE : ValueVarcharIgnoreCase.get(s);
                 break;
             }
             case Value.CHAR: {
                 String s = rs.getString(columnIndex);
-                v = (s == null) ? ValueNull.INSTANCE : ValueStringFixed.get(s);
+                v = (s == null) ? ValueNull.INSTANCE : ValueChar.get(s);
                 break;
             }
             case Value.VARCHAR: {
                 String s = rs.getString(columnIndex);
-                v = (s == null) ? ValueNull.INSTANCE : ValueString.get(s);
+                v = (s == null) ? ValueNull.INSTANCE : ValueVarchar.get(s);
                 break;
             }
             case Value.CLOB: {
@@ -774,7 +774,7 @@ public class DataType {
             }
             case Value.ENUM: {
                 int value = rs.getInt(columnIndex);
-                v = rs.wasNull() ? ValueNull.INSTANCE : ValueInt.get(value);
+                v = rs.wasNull() ? ValueNull.INSTANCE : ValueInteger.get(value);
                 break;
             }
             case Value.ROW: {
@@ -1261,7 +1261,7 @@ public class DataType {
         } else if (type == Value.JAVA_OBJECT) {
             return ValueJavaObject.getNoCopy(x, null, session.getDataHandler());
         } else if (x instanceof String) {
-            return ValueString.get((String) x);
+            return ValueVarchar.get((String) x);
         } else if (x instanceof Value) {
             Value v = (Value) x;
             if (v instanceof ValueLob) {
@@ -1269,25 +1269,25 @@ public class DataType {
             }
             return v;
         } else if (x instanceof Long) {
-            return ValueLong.get((Long) x);
+            return ValueBigint.get((Long) x);
         } else if (x instanceof Integer) {
-            return ValueInt.get((Integer) x);
+            return ValueInteger.get((Integer) x);
         } else if (x instanceof BigInteger) {
-            return ValueDecimal.get((BigInteger) x);
+            return ValueNumeric.get((BigInteger) x);
         } else if (x instanceof BigDecimal) {
-            return ValueDecimal.get((BigDecimal) x);
+            return ValueNumeric.get((BigDecimal) x);
         } else if (x instanceof Boolean) {
             return ValueBoolean.get((Boolean) x);
         } else if (x instanceof Byte) {
-            return ValueByte.get((Byte) x);
+            return ValueTinyint.get((Byte) x);
         } else if (x instanceof Short) {
-            return ValueShort.get((Short) x);
+            return ValueSmallint.get((Short) x);
         } else if (x instanceof Float) {
-            return ValueFloat.get((Float) x);
+            return ValueReal.get((Float) x);
         } else if (x instanceof Double) {
             return ValueDouble.get((Double) x);
         } else if (x instanceof byte[]) {
-            return ValueBytes.get((byte[]) x);
+            return ValueVarbinary.get((byte[]) x);
         } else if (x instanceof Date) {
             return LegacyDateTimeUtils.fromDate(session, null, (Date) x);
         } else if (x instanceof Time) {
@@ -1320,7 +1320,7 @@ public class DataType {
             }
             return ValueArray.get(v);
         } else if (x instanceof Character) {
-            return ValueStringFixed.get(((Character) x).toString());
+            return ValueChar.get(((Character) x).toString());
         } else if (isGeometry(x)) {
             return ValueGeometry.getFromGeometry(x);
         } else if (clazz == LocalDate.class) {

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -44,26 +44,26 @@ public class Transfer {
 
     private static final int NULL = 0;
     private static final int BOOLEAN = 1;
-    private static final int BYTE = 2;
-    private static final int SHORT = 3;
-    private static final int INT = 4;
-    private static final int LONG = 5;
-    private static final int DECIMAL = 6;
+    private static final int TINYINT = 2;
+    private static final int SMALLINT = 3;
+    private static final int INTEGER = 4;
+    private static final int BIGINT = 5;
+    private static final int NUMERIC = 6;
     private static final int DOUBLE = 7;
-    private static final int FLOAT = 8;
+    private static final int REAL = 8;
     private static final int TIME = 9;
     private static final int DATE = 10;
     private static final int TIMESTAMP = 11;
-    private static final int BYTES = 12;
-    private static final int STRING = 13;
-    private static final int STRING_IGNORECASE = 14;
+    private static final int VARBINARY = 12;
+    private static final int VARCHAR = 13;
+    private static final int VARCHAR_IGNORECASE = 14;
     private static final int BLOB = 15;
     private static final int CLOB = 16;
     private static final int ARRAY = 17;
     private static final int RESULT_SET = 18;
     private static final int JAVA_OBJECT = 19;
     private static final int UUID = 20;
-    private static final int STRING_FIXED = 21;
+    private static final int CHAR = 21;
     private static final int GEOMETRY = 22;
     private static final int TIMESTAMP_TZ = 24;
     private static final int ENUM = 25;
@@ -374,7 +374,7 @@ public class Transfer {
             writeInt(NULL);
             break;
         case Value.VARBINARY:
-            writeInt(BYTES);
+            writeInt(VARBINARY);
             writeBytes(v.getBytesNoCopy());
             break;
         case Value.JAVA_OBJECT:
@@ -393,7 +393,7 @@ public class Transfer {
             writeBoolean(v.getBoolean());
             break;
         case Value.TINYINT:
-            writeInt(BYTE);
+            writeInt(TINYINT);
             writeByte(v.getByte());
             break;
         case Value.TIME:
@@ -443,7 +443,7 @@ public class Transfer {
             break;
         }
         case Value.NUMERIC:
-            writeInt(DECIMAL);
+            writeInt(NUMERIC);
             writeString(v.getString());
             break;
         case Value.DOUBLE:
@@ -451,31 +451,31 @@ public class Transfer {
             writeDouble(v.getDouble());
             break;
         case Value.REAL:
-            writeInt(FLOAT);
+            writeInt(REAL);
             writeFloat(v.getFloat());
             break;
-        case Value.INT:
-            writeInt(INT);
+        case Value.INTEGER:
+            writeInt(INTEGER);
             writeInt(v.getInt());
             break;
         case Value.BIGINT:
-            writeInt(LONG);
+            writeInt(BIGINT);
             writeLong(v.getLong());
             break;
         case Value.SMALLINT:
-            writeInt(SHORT);
+            writeInt(SMALLINT);
             writeInt(v.getShort());
             break;
         case Value.VARCHAR:
-            writeInt(STRING);
+            writeInt(VARCHAR);
             writeString(v.getString());
             break;
         case Value.VARCHAR_IGNORECASE:
-            writeInt(STRING_IGNORECASE);
+            writeInt(VARCHAR_IGNORECASE);
             writeString(v.getString());
             break;
         case Value.CHAR:
-            writeInt(STRING_FIXED);
+            writeInt(CHAR);
             writeString(v.getString());
             break;
         case Value.BLOB: {
@@ -604,7 +604,7 @@ public class Transfer {
                 writeByte((byte) ordinal);
                 writeLong(interval.getLeading());
             } else {
-                writeInt(STRING);
+                writeInt(VARCHAR);
                 writeString(v.getString());
             }
             break;
@@ -627,7 +627,7 @@ public class Transfer {
                 writeLong(interval.getLeading());
                 writeLong(interval.getRemaining());
             } else {
-                writeInt(STRING);
+                writeInt(VARCHAR);
                 writeString(v.getString());
             }
             break;
@@ -651,7 +651,7 @@ public class Transfer {
         switch (type) {
         case NULL:
             return ValueNull.INSTANCE;
-        case BYTES:
+        case VARBINARY:
             return ValueBytes.getNoCopy(readBytes());
         case UUID:
             return ValueUuid.get(readLong(), readLong());
@@ -659,7 +659,7 @@ public class Transfer {
             return ValueJavaObject.getNoCopy(null, readBytes(), session.getDataHandler());
         case BOOLEAN:
             return ValueBoolean.get(readBoolean());
-        case BYTE:
+        case TINYINT:
             return ValueByte.get(readByte());
         case DATE:
             return ValueDate.fromDateValue(readLong());
@@ -675,28 +675,28 @@ public class Transfer {
             return ValueTimestampTimeZone.fromDateValueAndNanos(dateValue, timeNanos,
                     version >= Constants.TCP_PROTOCOL_VERSION_19 ? timeZoneOffset : timeZoneOffset * 60);
         }
-        case DECIMAL:
+        case NUMERIC:
             return ValueDecimal.get(new BigDecimal(readString()));
         case DOUBLE:
             return ValueDouble.get(readDouble());
-        case FLOAT:
+        case REAL:
             return ValueFloat.get(readFloat());
         case ENUM: {
             final int ordinal = readInt();
             final String label = readString();
             return ValueEnumBase.get(label, ordinal);
         }
-        case INT:
+        case INTEGER:
             return ValueInt.get(readInt());
-        case LONG:
+        case BIGINT:
             return ValueLong.get(readLong());
-        case SHORT:
+        case SMALLINT:
             return ValueShort.get((short) readInt());
-        case STRING:
+        case VARCHAR:
             return ValueString.get(readString());
-        case STRING_IGNORECASE:
+        case VARCHAR_IGNORECASE:
             return ValueStringIgnoreCase.get(readString());
-        case STRING_FIXED:
+        case CHAR:
             return ValueStringFixed.get(readString());
         case BLOB: {
             long length = readLong();

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -652,7 +652,7 @@ public class Transfer {
         case NULL:
             return ValueNull.INSTANCE;
         case VARBINARY:
-            return ValueBytes.getNoCopy(readBytes());
+            return ValueVarbinary.getNoCopy(readBytes());
         case UUID:
             return ValueUuid.get(readLong(), readLong());
         case JAVA_OBJECT:
@@ -660,7 +660,7 @@ public class Transfer {
         case BOOLEAN:
             return ValueBoolean.get(readBoolean());
         case TINYINT:
-            return ValueByte.get(readByte());
+            return ValueTinyint.get(readByte());
         case DATE:
             return ValueDate.fromDateValue(readLong());
         case TIME:
@@ -676,28 +676,28 @@ public class Transfer {
                     version >= Constants.TCP_PROTOCOL_VERSION_19 ? timeZoneOffset : timeZoneOffset * 60);
         }
         case NUMERIC:
-            return ValueDecimal.get(new BigDecimal(readString()));
+            return ValueNumeric.get(new BigDecimal(readString()));
         case DOUBLE:
             return ValueDouble.get(readDouble());
         case REAL:
-            return ValueFloat.get(readFloat());
+            return ValueReal.get(readFloat());
         case ENUM: {
             final int ordinal = readInt();
             final String label = readString();
             return ValueEnumBase.get(label, ordinal);
         }
         case INTEGER:
-            return ValueInt.get(readInt());
+            return ValueInteger.get(readInt());
         case BIGINT:
-            return ValueLong.get(readLong());
+            return ValueBigint.get(readLong());
         case SMALLINT:
-            return ValueShort.get((short) readInt());
+            return ValueSmallint.get((short) readInt());
         case VARCHAR:
-            return ValueString.get(readString());
+            return ValueVarchar.get(readString());
         case VARCHAR_IGNORECASE:
-            return ValueStringIgnoreCase.get(readString());
+            return ValueVarcharIgnoreCase.get(readString());
         case CHAR:
-            return ValueStringFixed.get(readString());
+            return ValueChar.get(readString());
         case BLOB: {
             long length = readLong();
             if (length == -1) {

--- a/h2/src/main/org/h2/value/TypeInfo.java
+++ b/h2/src/main/org/h2/value/TypeInfo.java
@@ -194,22 +194,22 @@ public class TypeInfo {
         infos[Value.NULL] = TYPE_NULL = new TypeInfo(Value.NULL, ValueNull.PRECISION, 0, ValueNull.DISPLAY_SIZE, null);
         infos[Value.BOOLEAN] = TYPE_BOOLEAN = new TypeInfo(Value.BOOLEAN, ValueBoolean.PRECISION, 0,
                 ValueBoolean.DISPLAY_SIZE, null);
-        infos[Value.TINYINT] = TYPE_TINYINT = new TypeInfo(Value.TINYINT, ValueByte.PRECISION, 0,
-                ValueByte.DISPLAY_SIZE, null);
-        infos[Value.SMALLINT] = TYPE_SMALLINT = new TypeInfo(Value.SMALLINT, ValueShort.PRECISION, 0,
-                ValueShort.DISPLAY_SIZE, null);
-        infos[Value.INTEGER] = TYPE_INTEGER = new TypeInfo(Value.INTEGER, ValueInt.PRECISION, 0, ValueInt.DISPLAY_SIZE,
-                null);
-        infos[Value.BIGINT] = TYPE_BIGINT = new TypeInfo(Value.BIGINT, ValueLong.PRECISION, 0, ValueLong.DISPLAY_SIZE,
-                null);
+        infos[Value.TINYINT] = TYPE_TINYINT = new TypeInfo(Value.TINYINT, ValueTinyint.PRECISION, 0,
+                ValueTinyint.DISPLAY_SIZE, null);
+        infos[Value.SMALLINT] = TYPE_SMALLINT = new TypeInfo(Value.SMALLINT, ValueSmallint.PRECISION, 0,
+                ValueSmallint.DISPLAY_SIZE, null);
+        infos[Value.INTEGER] = TYPE_INTEGER = new TypeInfo(Value.INTEGER, ValueInteger.PRECISION, 0,
+                ValueInteger.DISPLAY_SIZE, null);
+        infos[Value.BIGINT] = TYPE_BIGINT = new TypeInfo(Value.BIGINT, ValueBigint.PRECISION, 0,
+        ValueBigint.DISPLAY_SIZE, null);
         infos[Value.NUMERIC] = TYPE_NUMERIC = new TypeInfo(Value.NUMERIC, Integer.MAX_VALUE, //
-                ValueDecimal.MAXIMUM_SCALE, Integer.MAX_VALUE, null);
-        TYPE_NUMERIC_BIGINT = new TypeInfo(Value.NUMERIC, ValueLong.PRECISION, 0, ValueLong.DISPLAY_SIZE, null);
-        TYPE_NUMERIC_FLOATING_POINT = new TypeInfo(Value.NUMERIC, ValueDecimal.DEFAULT_PRECISION,
-                ValueDecimal.DEFAULT_PRECISION / 2, ValueDecimal.DEFAULT_PRECISION + 2, null);
+                ValueNumeric.MAXIMUM_SCALE, Integer.MAX_VALUE, null);
+        TYPE_NUMERIC_BIGINT = new TypeInfo(Value.NUMERIC, ValueBigint.PRECISION, 0, ValueBigint.DISPLAY_SIZE, null);
+        TYPE_NUMERIC_FLOATING_POINT = new TypeInfo(Value.NUMERIC, ValueNumeric.DEFAULT_PRECISION,
+                ValueNumeric.DEFAULT_PRECISION / 2, ValueNumeric.DEFAULT_PRECISION + 2, null);
         infos[Value.DOUBLE] = TYPE_DOUBLE = new TypeInfo(Value.DOUBLE, ValueDouble.PRECISION, 0,
                 ValueDouble.DISPLAY_SIZE, null);
-        infos[Value.REAL] = TYPE_REAL = new TypeInfo(Value.REAL, ValueFloat.PRECISION, 0, ValueFloat.DISPLAY_SIZE,
+        infos[Value.REAL] = TYPE_REAL = new TypeInfo(Value.REAL, ValueReal.PRECISION, 0, ValueReal.DISPLAY_SIZE,
                 null);
         infos[Value.TIME] = TYPE_TIME = new TypeInfo(Value.TIME, ValueTime.MAXIMUM_PRECISION, ValueTime.MAXIMUM_SCALE,
                 ValueTime.MAXIMUM_PRECISION, null);
@@ -313,7 +313,7 @@ public class TypeInfo {
             return TYPE_UNKNOWN;
         case Value.NUMERIC:
             if (precision < 0) {
-                precision = ValueDecimal.DEFAULT_PRECISION;
+                precision = ValueNumeric.DEFAULT_PRECISION;
             } else if (precision > Integer.MAX_VALUE) {
                 precision = Integer.MAX_VALUE;
             }

--- a/h2/src/main/org/h2/value/TypeInfo.java
+++ b/h2/src/main/org/h2/value/TypeInfo.java
@@ -44,7 +44,7 @@ public class TypeInfo {
     /**
      * INTEGER type with parameters.
      */
-    public static final TypeInfo TYPE_INT;
+    public static final TypeInfo TYPE_INTEGER;
 
     /**
      * BIGINT type with parameters.
@@ -198,7 +198,8 @@ public class TypeInfo {
                 ValueByte.DISPLAY_SIZE, null);
         infos[Value.SMALLINT] = TYPE_SMALLINT = new TypeInfo(Value.SMALLINT, ValueShort.PRECISION, 0,
                 ValueShort.DISPLAY_SIZE, null);
-        infos[Value.INT] = TYPE_INT = new TypeInfo(Value.INT, ValueInt.PRECISION, 0, ValueInt.DISPLAY_SIZE, null);
+        infos[Value.INTEGER] = TYPE_INTEGER = new TypeInfo(Value.INTEGER, ValueInt.PRECISION, 0, ValueInt.DISPLAY_SIZE,
+                null);
         infos[Value.BIGINT] = TYPE_BIGINT = new TypeInfo(Value.BIGINT, ValueLong.PRECISION, 0, ValueLong.DISPLAY_SIZE,
                 null);
         infos[Value.NUMERIC] = TYPE_NUMERIC = new TypeInfo(Value.NUMERIC, Integer.MAX_VALUE, //
@@ -297,7 +298,7 @@ public class TypeInfo {
         case Value.BOOLEAN:
         case Value.TINYINT:
         case Value.SMALLINT:
-        case Value.INT:
+        case Value.INTEGER:
         case Value.BIGINT:
         case Value.DOUBLE:
         case Value.REAL:
@@ -611,7 +612,7 @@ public class TypeInfo {
         case Value.BOOLEAN:
         case Value.TINYINT:
         case Value.SMALLINT:
-        case Value.INT:
+        case Value.INTEGER:
             return getTypeInfo(Value.NUMERIC, precision, 0, null);
         case Value.BIGINT:
             return TYPE_NUMERIC_BIGINT;

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -72,7 +72,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
     /**
      * The value type for INTEGER values.
      */
-    public static final int INT = 4;
+    public static final int INTEGER = 4;
 
     /**
      * The value type for BIGINT values.
@@ -403,7 +403,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             return 21_000;
         case SMALLINT:
             return 22_000;
-        case INT:
+        case INTEGER:
             return 23_000;
         case BIGINT:
             return 24_000;
@@ -822,7 +822,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             return convertToTinyint(column);
         case SMALLINT:
             return convertToSmallint(column);
-        case INT:
+        case INTEGER:
             return convertToInt(column);
         case BIGINT:
             return convertToBigint(column);
@@ -902,7 +902,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             return (ValueBoolean) this;
         case TINYINT:
         case SMALLINT:
-        case INT:
+        case INTEGER:
         case BIGINT:
         case NUMERIC:
         case DOUBLE:
@@ -958,7 +958,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             return ValueByte.get(getBoolean() ? (byte) 1 : (byte) 0);
         case SMALLINT:
         case ENUM:
-        case INT:
+        case INTEGER:
             return ValueByte.get(convertToByte(getInt(), column));
         case BIGINT:
         case INTERVAL_YEAR:
@@ -1017,7 +1017,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case TINYINT:
             return ValueShort.get(getByte());
         case ENUM:
-        case INT:
+        case INTEGER:
             return ValueShort.get(convertToShort(getInt(), column));
         case BIGINT:
         case INTERVAL_YEAR:
@@ -1069,7 +1069,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
      */
     public final ValueInt convertToInt(Object column) {
         switch (getValueType()) {
-        case INT:
+        case INTEGER:
             return (ValueInt) this;
         case BOOLEAN:
             return ValueInt.get(getBoolean() ? 1 : 0);
@@ -1105,7 +1105,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         }
         //$FALL-THROUGH$
         case TIMESTAMP_TZ:
-            throw getDataConversionError(INT);
+            throw getDataConversionError(INTEGER);
         case NULL:
             throw DbException.throwInternalError();
         }
@@ -1134,7 +1134,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case TINYINT:
         case SMALLINT:
         case ENUM:
-        case INT:
+        case INTEGER:
         case INTERVAL_YEAR:
         case INTERVAL_MONTH:
         case INTERVAL_DAY:
@@ -1187,7 +1187,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case TINYINT:
         case SMALLINT:
         case ENUM:
-        case INT:
+        case INTEGER:
             v =  ValueDecimal.get(BigDecimal.valueOf(getInt()));
             break;
         case BIGINT:
@@ -1247,7 +1247,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             return getBoolean() ? ValueDouble.ONE : ValueDouble.ZERO;
         case TINYINT:
         case SMALLINT:
-        case INT:
+        case INTEGER:
             return ValueDouble.get(getInt());
         case BIGINT:
         case INTERVAL_YEAR:
@@ -1295,7 +1295,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             return getBoolean() ? ValueFloat.ONE : ValueFloat.ZERO;
         case TINYINT:
         case SMALLINT:
-        case INT:
+        case INTEGER:
             return ValueFloat.get(getInt());
         case BIGINT:
         case INTERVAL_YEAR:
@@ -1588,7 +1588,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             v = ValueBytes.getNoCopy(new byte[] { (byte) (x >> 8), (byte) x });
             break;
         }
-        case INT: {
+        case INTEGER: {
             byte[] b = new byte[4];
             Bits.writeInt(b, 0, getInt());
             v = ValueBytes.getNoCopy(b);
@@ -1692,7 +1692,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         }
         case TINYINT:
         case SMALLINT:
-        case INT:
+        case INTEGER:
         case BIGINT:
         case NUMERIC:
             return extTypeInfo.getValue(getInt());
@@ -1855,7 +1855,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         switch (getValueType()) {
         case TINYINT:
         case SMALLINT:
-        case INT:
+        case INTEGER:
             leading = getInt();
             break;
         case BIGINT:
@@ -1918,7 +1918,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         switch (getValueType()) {
         case TINYINT:
         case SMALLINT:
-        case INT:
+        case INTEGER:
             leading = getInt();
             break;
         case BIGINT:
@@ -2006,7 +2006,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             return ValueJson.get(getBoolean());
         case TINYINT:
         case SMALLINT:
-        case INT:
+        case INTEGER:
             return ValueJson.get(getInt());
         case BIGINT:
             return ValueJson.get(getLong());

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -845,9 +845,9 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case VARBINARY:
             return convertToVarbinary(targetType, conversionMode, column);
         case VARCHAR:
-            return ValueString.get(convertToVarchar(targetType, conversionMode, column));
+            return ValueVarchar.get(convertToVarchar(targetType, conversionMode, column));
         case VARCHAR_IGNORECASE:
-            return ValueStringIgnoreCase.get(convertToVarchar(targetType, conversionMode, column));
+            return ValueVarcharIgnoreCase.get(convertToVarchar(targetType, conversionMode, column));
         case CHAR:
             return convertToChar(targetType, conversionMode, column);
         case JAVA_OBJECT:
@@ -950,16 +950,16 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
      *            conversion fails
      * @return the TINYINT value
      */
-    public final ValueByte convertToTinyint(Object column) {
+    public final ValueTinyint convertToTinyint(Object column) {
         switch (getValueType()) {
         case TINYINT:
-            return (ValueByte) this;
+            return (ValueTinyint) this;
         case BOOLEAN:
-            return ValueByte.get(getBoolean() ? (byte) 1 : (byte) 0);
+            return ValueTinyint.get(getBoolean() ? (byte) 1 : (byte) 0);
         case SMALLINT:
         case ENUM:
         case INTEGER:
-            return ValueByte.get(convertToByte(getInt(), column));
+            return ValueTinyint.get(convertToByte(getInt(), column));
         case BIGINT:
         case INTERVAL_YEAR:
         case INTERVAL_MONTH:
@@ -974,16 +974,16 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case INTERVAL_HOUR_TO_MINUTE:
         case INTERVAL_HOUR_TO_SECOND:
         case INTERVAL_MINUTE_TO_SECOND:
-            return ValueByte.get(convertToByte(getLong(), column));
+            return ValueTinyint.get(convertToByte(getLong(), column));
         case NUMERIC:
-            return ValueByte.get(convertToByte(convertToLong(getBigDecimal(), column), column));
+            return ValueTinyint.get(convertToByte(convertToLong(getBigDecimal(), column), column));
         case REAL:
         case DOUBLE:
-            return ValueByte.get(convertToByte(convertToLong(getDouble(), column), column));
+            return ValueTinyint.get(convertToByte(convertToLong(getDouble(), column), column));
         case VARBINARY: {
             byte[] bytes = getBytesNoCopy();
             if (bytes.length == 1) {
-                return ValueByte.get(bytes[0]);
+                return ValueTinyint.get(bytes[0]);
             }
         }
         //$FALL-THROUGH$
@@ -994,7 +994,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         }
         String s = getString();
         try {
-            return ValueByte.get(Byte.parseByte(s.trim()));
+            return ValueTinyint.get(Byte.parseByte(s.trim()));
         } catch (NumberFormatException e) {
             throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, s);
         }
@@ -1008,17 +1008,17 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
      *            conversion fails
      * @return the SMALLINT value
      */
-    public final ValueShort convertToSmallint(Object column) {
+    public final ValueSmallint convertToSmallint(Object column) {
         switch (getValueType()) {
         case SMALLINT:
-            return (ValueShort) this;
+            return (ValueSmallint) this;
         case BOOLEAN:
-            return ValueShort.get(getBoolean() ? (short) 1 : (short) 0);
+            return ValueSmallint.get(getBoolean() ? (short) 1 : (short) 0);
         case TINYINT:
-            return ValueShort.get(getByte());
+            return ValueSmallint.get(getByte());
         case ENUM:
         case INTEGER:
-            return ValueShort.get(convertToShort(getInt(), column));
+            return ValueSmallint.get(convertToShort(getInt(), column));
         case BIGINT:
         case INTERVAL_YEAR:
         case INTERVAL_MONTH:
@@ -1033,16 +1033,16 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case INTERVAL_HOUR_TO_MINUTE:
         case INTERVAL_HOUR_TO_SECOND:
         case INTERVAL_MINUTE_TO_SECOND:
-            return ValueShort.get(convertToShort(getLong(), column));
+            return ValueSmallint.get(convertToShort(getLong(), column));
         case NUMERIC:
-            return ValueShort.get(convertToShort(convertToLong(getBigDecimal(), column), column));
+            return ValueSmallint.get(convertToShort(convertToLong(getBigDecimal(), column), column));
         case REAL:
         case DOUBLE:
-            return ValueShort.get(convertToShort(convertToLong(getDouble(), column), column));
+            return ValueSmallint.get(convertToShort(convertToLong(getDouble(), column), column));
         case VARBINARY: {
             byte[] bytes = getBytesNoCopy();
             if (bytes.length == 2) {
-                return ValueShort.get((short) ((bytes[0] << 8) + (bytes[1] & 0xff)));
+                return ValueSmallint.get((short) ((bytes[0] << 8) + (bytes[1] & 0xff)));
             }
         }
         //$FALL-THROUGH$
@@ -1053,7 +1053,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         }
         String s = getString();
         try {
-            return ValueShort.get(Short.parseShort(s.trim()));
+            return ValueSmallint.get(Short.parseShort(s.trim()));
         } catch (NumberFormatException e) {
             throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, s);
         }
@@ -1067,16 +1067,16 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
      *            conversion fails
      * @return the INT value
      */
-    public final ValueInt convertToInt(Object column) {
+    public final ValueInteger convertToInt(Object column) {
         switch (getValueType()) {
         case INTEGER:
-            return (ValueInt) this;
+            return (ValueInteger) this;
         case BOOLEAN:
-            return ValueInt.get(getBoolean() ? 1 : 0);
+            return ValueInteger.get(getBoolean() ? 1 : 0);
         case TINYINT:
         case ENUM:
         case SMALLINT:
-            return ValueInt.get(getInt());
+            return ValueInteger.get(getInt());
         case BIGINT:
         case INTERVAL_YEAR:
         case INTERVAL_MONTH:
@@ -1091,16 +1091,16 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case INTERVAL_HOUR_TO_MINUTE:
         case INTERVAL_HOUR_TO_SECOND:
         case INTERVAL_MINUTE_TO_SECOND:
-            return ValueInt.get(convertToInt(getLong(), column));
+            return ValueInteger.get(convertToInt(getLong(), column));
         case NUMERIC:
-            return ValueInt.get(convertToInt(convertToLong(getBigDecimal(), column), column));
+            return ValueInteger.get(convertToInt(convertToLong(getBigDecimal(), column), column));
         case REAL:
         case DOUBLE:
-            return ValueInt.get(convertToInt(convertToLong(getDouble(), column), column));
+            return ValueInteger.get(convertToInt(convertToLong(getDouble(), column), column));
         case VARBINARY: {
             byte[] bytes = getBytesNoCopy();
             if (bytes.length == 4) {
-                return ValueInt.get(Bits.readInt(bytes, 0));
+                return ValueInteger.get(Bits.readInt(bytes, 0));
             }
         }
         //$FALL-THROUGH$
@@ -1111,7 +1111,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         }
         String s = getString();
         try {
-            return ValueInt.get(Integer.parseInt(s.trim()));
+            return ValueInteger.get(Integer.parseInt(s.trim()));
         } catch (NumberFormatException e) {
             throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, s);
         }
@@ -1125,12 +1125,12 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
      *            conversion fails
      * @return the BIGINT value
      */
-    public final ValueLong convertToBigint(Object column) {
+    public final ValueBigint convertToBigint(Object column) {
         switch (getValueType()) {
         case BIGINT:
-            return (ValueLong) this;
+            return (ValueBigint) this;
         case BOOLEAN:
-            return ValueLong.get(getBoolean() ? 1 : 0);
+            return ValueBigint.get(getBoolean() ? 1 : 0);
         case TINYINT:
         case SMALLINT:
         case ENUM:
@@ -1148,16 +1148,16 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case INTERVAL_HOUR_TO_MINUTE:
         case INTERVAL_HOUR_TO_SECOND:
         case INTERVAL_MINUTE_TO_SECOND:
-            return ValueLong.get(getInt());
+            return ValueBigint.get(getInt());
         case NUMERIC:
-            return ValueLong.get(convertToLong(getBigDecimal(), column));
+            return ValueBigint.get(convertToLong(getBigDecimal(), column));
         case REAL:
         case DOUBLE:
-            return ValueLong.get(convertToLong(getDouble(), column));
+            return ValueBigint.get(convertToLong(getDouble(), column));
         case VARBINARY: {
             byte[] bytes = getBytesNoCopy();
             if (bytes.length == 8) {
-                return ValueLong.get(Bits.readLong(bytes, 0));
+                return ValueBigint.get(Bits.readLong(bytes, 0));
             }
         }
         //$FALL-THROUGH$
@@ -1168,30 +1168,30 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         }
         String s = getString();
         try {
-            return ValueLong.get(Long.parseLong(s.trim()));
+            return ValueBigint.get(Long.parseLong(s.trim()));
         } catch (NumberFormatException e) {
             throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, s);
         }
     }
 
-    private ValueDecimal convertToNumeric(TypeInfo targetType, CastDataProvider provider, int conversionMode,
+    private ValueNumeric convertToNumeric(TypeInfo targetType, CastDataProvider provider, int conversionMode,
             Object column) {
-        ValueDecimal v;
+        ValueNumeric v;
         switch (getValueType()) {
         case NUMERIC:
-            v = (ValueDecimal) this;
+            v = (ValueNumeric) this;
             break;
         case BOOLEAN:
-            v = getBoolean() ? ValueDecimal.ONE : ValueDecimal.ZERO;
+            v = getBoolean() ? ValueNumeric.ONE : ValueNumeric.ZERO;
             break;
         case TINYINT:
         case SMALLINT:
         case ENUM:
         case INTEGER:
-            v =  ValueDecimal.get(BigDecimal.valueOf(getInt()));
+            v =  ValueNumeric.get(BigDecimal.valueOf(getInt()));
             break;
         case BIGINT:
-            v = ValueDecimal.get(BigDecimal.valueOf(getLong()));
+            v = ValueNumeric.get(BigDecimal.valueOf(getLong()));
             break;
         case DOUBLE:
         case REAL:
@@ -1208,14 +1208,14 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case INTERVAL_HOUR_TO_MINUTE:
         case INTERVAL_HOUR_TO_SECOND:
         case INTERVAL_MINUTE_TO_SECOND:
-            v = ValueDecimal.get(getBigDecimal());
+            v = ValueNumeric.get(getBigDecimal());
             break;
         case TIMESTAMP_TZ:
             throw getDataConversionError(NUMERIC);
         default:
             String s = getString();
             try {
-                v = ValueDecimal.get(new BigDecimal(s.trim()));
+                v = ValueNumeric.get(new BigDecimal(s.trim()));
             } catch (NumberFormatException e) {
                 throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, s);
             }
@@ -1225,7 +1225,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             BigDecimal value = v.getBigDecimal();
             int scale = value.scale();
             if (scale != targetScale && (scale >= targetScale || !provider.getMode().convertOnlyToSmallerScale)) {
-                v = ValueDecimal.get(ValueDecimal.setScale(value, targetScale));
+                v = ValueNumeric.get(ValueNumeric.setScale(value, targetScale));
             }
             if (v.getBigDecimal().precision() > targetType.getPrecision()) {
                 throw v.getValueTooLongException(targetType, column);
@@ -1287,23 +1287,23 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
      *
      * @return the REAL value
      */
-    public final ValueFloat convertToReal() {
+    public final ValueReal convertToReal() {
         switch (getValueType()) {
         case REAL:
-            return (ValueFloat) this;
+            return (ValueReal) this;
         case BOOLEAN:
-            return getBoolean() ? ValueFloat.ONE : ValueFloat.ZERO;
+            return getBoolean() ? ValueReal.ONE : ValueReal.ZERO;
         case TINYINT:
         case SMALLINT:
         case INTEGER:
-            return ValueFloat.get(getInt());
+            return ValueReal.get(getInt());
         case BIGINT:
         case INTERVAL_YEAR:
         case INTERVAL_MONTH:
         case INTERVAL_DAY:
         case INTERVAL_HOUR:
         case INTERVAL_MINUTE:
-            return ValueFloat.get(getLong());
+            return ValueReal.get(getLong());
         case NUMERIC:
         case INTERVAL_SECOND:
         case INTERVAL_YEAR_TO_MONTH:
@@ -1313,9 +1313,9 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         case INTERVAL_HOUR_TO_MINUTE:
         case INTERVAL_HOUR_TO_SECOND:
         case INTERVAL_MINUTE_TO_SECOND:
-            return ValueFloat.get(getBigDecimal().floatValue());
+            return ValueReal.get(getBigDecimal().floatValue());
         case DOUBLE:
-            return ValueFloat.get((float) getDouble());
+            return ValueReal.get((float) getDouble());
         case ENUM:
         case TIMESTAMP_TZ:
             throw getDataConversionError(REAL);
@@ -1324,7 +1324,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         }
         String s = getString();
         try {
-            return ValueFloat.get(Float.parseFloat(s.trim()));
+            return ValueReal.get(Float.parseFloat(s.trim()));
         } catch (NumberFormatException e) {
             throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, s);
         }
@@ -1565,43 +1565,43 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         return v;
     }
 
-    private ValueBytes convertToVarbinary(TypeInfo targetType, int conversionMode, Object column) {
-        ValueBytes v;
+    private ValueVarbinary convertToVarbinary(TypeInfo targetType, int conversionMode, Object column) {
+        ValueVarbinary v;
         switch (getValueType()) {
         case VARBINARY:
-            v = (ValueBytes) this;
+            v = (ValueVarbinary) this;
             break;
         case JAVA_OBJECT:
         case BLOB:
         case GEOMETRY:
         case JSON:
-            v = ValueBytes.getNoCopy(getBytesNoCopy());
+            v = ValueVarbinary.getNoCopy(getBytesNoCopy());
             break;
         case UUID:
-            v = ValueBytes.getNoCopy(getBytes());
+            v = ValueVarbinary.getNoCopy(getBytes());
             break;
         case TINYINT:
-            v = ValueBytes.getNoCopy(new byte[] { getByte() });
+            v = ValueVarbinary.getNoCopy(new byte[] { getByte() });
             break;
         case SMALLINT: {
             int x = getShort();
-            v = ValueBytes.getNoCopy(new byte[] { (byte) (x >> 8), (byte) x });
+            v = ValueVarbinary.getNoCopy(new byte[] { (byte) (x >> 8), (byte) x });
             break;
         }
         case INTEGER: {
             byte[] b = new byte[4];
             Bits.writeInt(b, 0, getInt());
-            v = ValueBytes.getNoCopy(b);
+            v = ValueVarbinary.getNoCopy(b);
             break;
         }
         case BIGINT: {
             byte[] b = new byte[8];
             Bits.writeLong(b, 0, getLong());
-            v = ValueBytes.getNoCopy(b);
+            v = ValueVarbinary.getNoCopy(b);
             break;
         }
         default:
-            v = ValueBytes.getNoCopy(getString().getBytes(StandardCharsets.UTF_8));
+            v = ValueVarbinary.getNoCopy(getString().getBytes(StandardCharsets.UTF_8));
             break;
         case ENUM:
         case TIMESTAMP_TZ:
@@ -1613,7 +1613,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
             if (conversionMode == CAST_TO) {
                 int p = MathUtils.convertLongToInt(targetType.getPrecision());
                 if (length > p) {
-                    v = ValueBytes.getNoCopy(Arrays.copyOf(value, p));
+                    v = ValueVarbinary.getNoCopy(Arrays.copyOf(value, p));
                 }
             } else if (length > targetType.getPrecision()) {
                 throw v.getValueTooLongException(targetType, column);
@@ -1636,7 +1636,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         return s;
     }
 
-    private ValueStringFixed convertToChar(TypeInfo targetType, int conversionMode, Object column) {
+    private ValueChar convertToChar(TypeInfo targetType, int conversionMode, Object column) {
         String s = getString();
         int p = MathUtils.convertLongToInt(targetType.getPrecision()), l = s.length();
         if (conversionMode == CAST_TO && l > p) {
@@ -1648,7 +1648,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         if (conversionMode == ASSIGN_TO && l > p) {
             throw getValueTooLongException(targetType, column);
         }
-        return ValueStringFixed.get(s.substring(0, l));
+        return ValueChar.get(s.substring(0, l));
     }
 
     /**
@@ -2045,11 +2045,11 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
                 a = ((ValueRow) this).getList();
                 break;
             case BLOB:
-                a = new Value[] { ValueBytes.get(getBytesNoCopy()) };
+                a = new Value[] { ValueVarbinary.get(getBytesNoCopy()) };
                 break;
             case CLOB:
             case RESULT_SET:
-                a = new Value[] { ValueString.get(getString()) };
+                a = new Value[] { ValueVarchar.get(getString()) };
                 break;
             default:
                 a = new Value[] { this };

--- a/h2/src/main/org/h2/value/ValueBigint.java
+++ b/h2/src/main/org/h2/value/ValueBigint.java
@@ -16,17 +16,17 @@ import org.h2.message.DbException;
 /**
  * Implementation of the BIGINT data type.
  */
-public class ValueLong extends Value {
+public class ValueBigint extends Value {
 
     /**
      * The smallest {@code ValueLong} value.
      */
-    public static final ValueLong MIN = get(Long.MIN_VALUE);
+    public static final ValueBigint MIN = get(Long.MIN_VALUE);
 
     /**
      * The largest {@code ValueLong} value.
      */
-    public static final ValueLong MAX = get(Long.MAX_VALUE);
+    public static final ValueBigint MAX = get(Long.MAX_VALUE);
 
     /**
      * The largest Long value, as a BigInteger.
@@ -39,31 +39,31 @@ public class ValueLong extends Value {
     public static final int PRECISION = 19;
 
     /**
-     * The maximum display size of a long.
+     * The maximum display size of a BIGINT.
      * Example: 9223372036854775808
      */
     public static final int DISPLAY_SIZE = 20;
 
     private static final int STATIC_SIZE = 100;
-    private static final ValueLong[] STATIC_CACHE;
+    private static final ValueBigint[] STATIC_CACHE;
 
     private final long value;
 
     static {
-        STATIC_CACHE = new ValueLong[STATIC_SIZE];
+        STATIC_CACHE = new ValueBigint[STATIC_SIZE];
         for (int i = 0; i < STATIC_SIZE; i++) {
-            STATIC_CACHE[i] = new ValueLong(i);
+            STATIC_CACHE[i] = new ValueBigint(i);
         }
     }
 
-    private ValueLong(long value) {
+    private ValueBigint(long value) {
         this.value = value;
     }
 
     @Override
     public Value add(Value v) {
         long x = value;
-        long y = ((ValueLong) v).value;
+        long y = ((ValueBigint) v).value;
         long result = x + y;
         /*
          * If signs of both summands are different from the sign of the sum there is an
@@ -72,7 +72,7 @@ public class ValueLong extends Value {
         if (((x ^ result) & (y ^ result)) < 0) {
             throw getOverflow();
         }
-        return ValueLong.get(result);
+        return ValueBigint.get(result);
     }
 
     @Override
@@ -85,7 +85,7 @@ public class ValueLong extends Value {
         if (value == Long.MIN_VALUE) {
             throw getOverflow();
         }
-        return ValueLong.get(-value);
+        return ValueBigint.get(-value);
     }
 
     private DbException getOverflow() {
@@ -96,7 +96,7 @@ public class ValueLong extends Value {
     @Override
     public Value subtract(Value v) {
         long x = value;
-        long y = ((ValueLong) v).value;
+        long y = ((ValueBigint) v).value;
         long result = x - y;
         /*
          * If minuend and subtrahend have different signs and minuend and difference
@@ -105,13 +105,13 @@ public class ValueLong extends Value {
         if (((x ^ y) & (x ^ result)) < 0) {
             throw getOverflow();
         }
-        return ValueLong.get(result);
+        return ValueBigint.get(result);
     }
 
     @Override
     public Value multiply(Value v) {
         long x = value;
-        long y = ((ValueLong) v).value;
+        long y = ((ValueBigint) v).value;
         long result = x * y;
         // Check whether numbers are large enough to overflow and second value != 0
         if ((Math.abs(x) | Math.abs(y)) >>> 31 != 0 && y != 0
@@ -121,12 +121,12 @@ public class ValueLong extends Value {
                 || x == Long.MIN_VALUE && y == -1)) {
             throw getOverflow();
         }
-        return ValueLong.get(result);
+        return ValueBigint.get(result);
     }
 
     @Override
     public Value divide(Value v, long divisorPrecision) {
-        long y = ((ValueLong) v).value;
+        long y = ((ValueBigint) v).value;
         if (y == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
@@ -134,16 +134,16 @@ public class ValueLong extends Value {
         if (x == Long.MIN_VALUE && y == -1) {
             throw getOverflow();
         }
-        return ValueLong.get(x / y);
+        return ValueBigint.get(x / y);
     }
 
     @Override
     public Value modulus(Value v) {
-        ValueLong other = (ValueLong) v;
+        ValueBigint other = (ValueBigint) v;
         if (other.value == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
-        return ValueLong.get(this.value % other.value);
+        return ValueBigint.get(this.value % other.value);
     }
 
     @Override
@@ -168,7 +168,7 @@ public class ValueLong extends Value {
 
     @Override
     public int compareTypeSafe(Value o, CompareMode mode, CastDataProvider provider) {
-        return Long.compare(value, ((ValueLong) o).value);
+        return Long.compare(value, ((ValueBigint) o).value);
     }
 
     @Override
@@ -193,21 +193,21 @@ public class ValueLong extends Value {
     }
 
     /**
-     * Get or create a long value for the given long.
+     * Get or create a BIGINT value for the given long.
      *
      * @param i the long
      * @return the value
      */
-    public static ValueLong get(long i) {
+    public static ValueBigint get(long i) {
         if (i >= 0 && i < STATIC_SIZE) {
             return STATIC_CACHE[(int) i];
         }
-        return (ValueLong) Value.cache(new ValueLong(i));
+        return (ValueBigint) Value.cache(new ValueBigint(i));
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueLong && value == ((ValueLong) other).value;
+        return other instanceof ValueBigint && value == ((ValueBigint) other).value;
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueChar.java
+++ b/h2/src/main/org/h2/value/ValueChar.java
@@ -11,11 +11,11 @@ import org.h2.util.StringUtils;
 /**
  * Implementation of the CHAR data type.
  */
-public class ValueStringFixed extends ValueString {
+public class ValueChar extends ValueVarchar {
 
-    private static final ValueStringFixed EMPTY = new ValueStringFixed("");
+    private static final ValueChar EMPTY = new ValueChar("");
 
-    protected ValueStringFixed(String value) {
+    protected ValueChar(String value) {
         super(value);
     }
 
@@ -39,23 +39,23 @@ public class ValueStringFixed extends ValueString {
     }
 
     /**
-     * Get or create a fixed length string value for the given string.
+     * Get or create a CHAR value for the given string.
      * Spaces at the end of the string will be removed.
      *
      * @param s the string
      * @return the value
      */
-    public static ValueStringFixed get(String s) {
+    public static ValueChar get(String s) {
         s = trimRight(s);
         int length = s.length();
         if (length == 0) {
             return EMPTY;
         }
-        ValueStringFixed obj = new ValueStringFixed(StringUtils.cache(s));
+        ValueChar obj = new ValueChar(StringUtils.cache(s));
         if (length > SysProperties.OBJECT_CACHE_MAX_PER_ELEMENT_SIZE) {
             return obj;
         }
-        return (ValueStringFixed) Value.cache(obj);
+        return (ValueChar) Value.cache(obj);
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueDouble.java
+++ b/h2/src/main/org/h2/value/ValueDouble.java
@@ -24,7 +24,7 @@ public class ValueDouble extends Value {
     public static final int PRECISION = 17;
 
     /**
-     * The maximum display size of a double.
+     * The maximum display size of a DOUBLE.
      * Example: -3.3333333333333334E-100
      */
     public static final int DISPLAY_SIZE = 24;
@@ -168,7 +168,7 @@ public class ValueDouble extends Value {
     }
 
     /**
-     * Get or create double value for the given double.
+     * Get or create a DOUBLE value for the given double.
      *
      * @param d the double
      * @return the value

--- a/h2/src/main/org/h2/value/ValueEnumBase.java
+++ b/h2/src/main/org/h2/value/ValueEnumBase.java
@@ -29,7 +29,7 @@ public class ValueEnumBase extends Value {
 
     @Override
     public Value add(Value v) {
-        ValueInt iv = v.convertToInt(null);
+        ValueInteger iv = v.convertToInt(null);
         return convertToInt(null).add(iv);
     }
 
@@ -40,7 +40,7 @@ public class ValueEnumBase extends Value {
 
     @Override
     public Value divide(Value v, long divisorPrecision) {
-        ValueInt iv = v.convertToInt(null);
+        ValueInteger iv = v.convertToInt(null);
         return convertToInt(null).divide(iv, divisorPrecision);
     }
 
@@ -116,13 +116,13 @@ public class ValueEnumBase extends Value {
 
     @Override
     public Value modulus(Value v) {
-        ValueInt iv = v.convertToInt(null);
+        ValueInteger iv = v.convertToInt(null);
         return convertToInt(null).modulus(iv);
     }
 
     @Override
     public Value multiply(Value v) {
-        ValueInt iv = v.convertToInt(null);
+        ValueInteger iv = v.convertToInt(null);
         return convertToInt(null).multiply(iv);
     }
 
@@ -134,7 +134,7 @@ public class ValueEnumBase extends Value {
 
     @Override
     public Value subtract(Value v) {
-        ValueInt iv = v.convertToInt(null);
+        ValueInteger iv = v.convertToInt(null);
         return convertToInt(null).subtract(iv);
     }
 

--- a/h2/src/main/org/h2/value/ValueInt.java
+++ b/h2/src/main/org/h2/value/ValueInt.java
@@ -128,12 +128,12 @@ public class ValueInt extends Value {
 
     @Override
     public TypeInfo getType() {
-        return TypeInfo.TYPE_INT;
+        return TypeInfo.TYPE_INTEGER;
     }
 
     @Override
     public int getValueType() {
-        return INT;
+        return INTEGER;
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueInteger.java
+++ b/h2/src/main/org/h2/value/ValueInteger.java
@@ -13,9 +13,9 @@ import org.h2.engine.CastDataProvider;
 import org.h2.message.DbException;
 
 /**
- * Implementation of the INT data type.
+ * Implementation of the INTEGER data type.
  */
-public class ValueInt extends Value {
+public class ValueInteger extends Value {
 
     /**
      * The precision in digits.
@@ -23,7 +23,7 @@ public class ValueInt extends Value {
     public static final int PRECISION = 10;
 
     /**
-     * The maximum display size of an int.
+     * The maximum display size of an INT.
      * Example: -2147483648
      */
     public static final int DISPLAY_SIZE = 11;
@@ -31,34 +31,34 @@ public class ValueInt extends Value {
     private static final int STATIC_SIZE = 128;
     // must be a power of 2
     private static final int DYNAMIC_SIZE = 256;
-    private static final ValueInt[] STATIC_CACHE = new ValueInt[STATIC_SIZE];
-    private static final ValueInt[] DYNAMIC_CACHE = new ValueInt[DYNAMIC_SIZE];
+    private static final ValueInteger[] STATIC_CACHE = new ValueInteger[STATIC_SIZE];
+    private static final ValueInteger[] DYNAMIC_CACHE = new ValueInteger[DYNAMIC_SIZE];
 
     private final int value;
 
     static {
         for (int i = 0; i < STATIC_SIZE; i++) {
-            STATIC_CACHE[i] = new ValueInt(i);
+            STATIC_CACHE[i] = new ValueInteger(i);
         }
     }
 
-    private ValueInt(int value) {
+    private ValueInteger(int value) {
         this.value = value;
     }
 
     /**
-     * Get or create an int value for the given int.
+     * Get or create an INTEGER value for the given int.
      *
      * @param i the int
      * @return the value
      */
-    public static ValueInt get(int i) {
+    public static ValueInteger get(int i) {
         if (i >= 0 && i < STATIC_SIZE) {
             return STATIC_CACHE[i];
         }
-        ValueInt v = DYNAMIC_CACHE[i & (DYNAMIC_SIZE - 1)];
+        ValueInteger v = DYNAMIC_CACHE[i & (DYNAMIC_SIZE - 1)];
         if (v == null || v.value != i) {
-            v = new ValueInt(i);
+            v = new ValueInteger(i);
             DYNAMIC_CACHE[i & (DYNAMIC_SIZE - 1)] = v;
         }
         return v;
@@ -66,15 +66,15 @@ public class ValueInt extends Value {
 
     @Override
     public Value add(Value v) {
-        ValueInt other = (ValueInt) v;
+        ValueInteger other = (ValueInteger) v;
         return checkRange((long) value + (long) other.value);
     }
 
-    private static ValueInt checkRange(long x) {
+    private static ValueInteger checkRange(long x) {
         if ((int) x != x) {
             throw DbException.get(ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE_1, Long.toString(x));
         }
-        return ValueInt.get((int) x);
+        return ValueInteger.get((int) x);
     }
 
     @Override
@@ -89,19 +89,19 @@ public class ValueInt extends Value {
 
     @Override
     public Value subtract(Value v) {
-        ValueInt other = (ValueInt) v;
+        ValueInteger other = (ValueInteger) v;
         return checkRange((long) value - (long) other.value);
     }
 
     @Override
     public Value multiply(Value v) {
-        ValueInt other = (ValueInt) v;
+        ValueInteger other = (ValueInteger) v;
         return checkRange((long) value * (long) other.value);
     }
 
     @Override
     public Value divide(Value v, long divisorPrecision) {
-        int y = ((ValueInt) v).value;
+        int y = ((ValueInteger) v).value;
         if (y == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
@@ -109,16 +109,16 @@ public class ValueInt extends Value {
         if (x == Integer.MIN_VALUE && y == -1) {
             throw DbException.get(ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE_1, "2147483648");
         }
-        return ValueInt.get(x / y);
+        return ValueInteger.get(x / y);
     }
 
     @Override
     public Value modulus(Value v) {
-        ValueInt other = (ValueInt) v;
+        ValueInteger other = (ValueInteger) v;
         if (other.value == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
-        return ValueInt.get(value % other.value);
+        return ValueInteger.get(value % other.value);
     }
 
     @Override
@@ -148,7 +148,7 @@ public class ValueInt extends Value {
 
     @Override
     public int compareTypeSafe(Value o, CompareMode mode, CastDataProvider provider) {
-        return Integer.compare(value, ((ValueInt) o).value);
+        return Integer.compare(value, ((ValueInteger) o).value);
     }
 
     @Override
@@ -174,7 +174,7 @@ public class ValueInt extends Value {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueInt && value == ((ValueInt) other).value;
+        return other instanceof ValueInteger && value == ((ValueInteger) other).value;
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueJavaObject.java
+++ b/h2/src/main/org/h2/value/ValueJavaObject.java
@@ -19,7 +19,7 @@ import org.h2.util.Utils;
 /**
  * Implementation of the OBJECT data type.
  */
-public class ValueJavaObject extends ValueBytes {
+public class ValueJavaObject extends ValueVarbinary {
 
     private static final ValueJavaObject EMPTY =
             new ValueJavaObject(Utils.EMPTY_BYTES, null);

--- a/h2/src/main/org/h2/value/ValueNumeric.java
+++ b/h2/src/main/org/h2/value/ValueNumeric.java
@@ -17,32 +17,32 @@ import org.h2.message.DbException;
 import org.h2.util.MathUtils;
 
 /**
- * Implementation of the DECIMAL data type.
+ * Implementation of the NUMERIC data type.
  */
-public class ValueDecimal extends Value {
+public class ValueNumeric extends Value {
 
     /**
      * The value 'zero'.
      */
-    public static final ValueDecimal ZERO = new ValueDecimal(BigDecimal.ZERO);
+    public static final ValueNumeric ZERO = new ValueNumeric(BigDecimal.ZERO);
 
     /**
      * The value 'one'.
      */
-    public static final ValueDecimal ONE = new ValueDecimal(BigDecimal.ONE);
+    public static final ValueNumeric ONE = new ValueNumeric(BigDecimal.ONE);
 
     /**
-     * The default precision for a decimal value.
+     * The default precision for a NUMERIC value.
      */
     static final int DEFAULT_PRECISION = 65535;
 
     /**
-     * The default scale for a decimal value.
+     * The default scale for a NUMERIC value.
      */
     static final int DEFAULT_SCALE = 0;
 
     /**
-     * The default display size for a decimal value.
+     * The default display size for a NUMERIC value.
      */
     static final int DEFAULT_DISPLAY_SIZE = 65535;
 
@@ -59,7 +59,7 @@ public class ValueDecimal extends Value {
     private final BigDecimal value;
     private TypeInfo type;
 
-    private ValueDecimal(BigDecimal value) {
+    private ValueNumeric(BigDecimal value) {
         if (value == null) {
             throw new IllegalArgumentException("null");
         } else if (value.getClass() != BigDecimal.class) {
@@ -71,34 +71,34 @@ public class ValueDecimal extends Value {
 
     @Override
     public Value add(Value v) {
-        ValueDecimal dec = (ValueDecimal) v;
-        return ValueDecimal.get(value.add(dec.value));
+        ValueNumeric dec = (ValueNumeric) v;
+        return ValueNumeric.get(value.add(dec.value));
     }
 
     @Override
     public Value subtract(Value v) {
-        ValueDecimal dec = (ValueDecimal) v;
-        return ValueDecimal.get(value.subtract(dec.value));
+        ValueNumeric dec = (ValueNumeric) v;
+        return ValueNumeric.get(value.subtract(dec.value));
     }
 
     @Override
     public Value negate() {
-        return ValueDecimal.get(value.negate());
+        return ValueNumeric.get(value.negate());
     }
 
     @Override
     public Value multiply(Value v) {
-        ValueDecimal dec = (ValueDecimal) v;
-        return ValueDecimal.get(value.multiply(dec.value));
+        ValueNumeric dec = (ValueNumeric) v;
+        return ValueNumeric.get(value.multiply(dec.value));
     }
 
     @Override
     public Value divide(Value v, long divisorPrecision) {
-        BigDecimal divisor = ((ValueDecimal) v).value;
+        BigDecimal divisor = ((ValueNumeric) v).value;
         if (divisor.signum() == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
-        return ValueDecimal.get(value.divide(divisor,
+        return ValueNumeric.get(value.divide(divisor,
                 getQuotientScale(value.scale(), divisorPrecision, divisor.scale()), RoundingMode.HALF_DOWN));
     }
 
@@ -119,13 +119,13 @@ public class ValueDecimal extends Value {
     }
 
     @Override
-    public ValueDecimal modulus(Value v) {
-        ValueDecimal dec = (ValueDecimal) v;
+    public ValueNumeric modulus(Value v) {
+        ValueNumeric dec = (ValueNumeric) v;
         if (dec.value.signum() == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
         BigDecimal bd = value.remainder(dec.value);
-        return ValueDecimal.get(bd);
+        return ValueNumeric.get(bd);
     }
 
     @Override
@@ -152,7 +152,7 @@ public class ValueDecimal extends Value {
 
     @Override
     public int compareTypeSafe(Value o, CompareMode mode, CastDataProvider provider) {
-        return value.compareTo(((ValueDecimal) o).value);
+        return value.compareTo(((ValueNumeric) o).value);
     }
 
     @Override
@@ -187,33 +187,33 @@ public class ValueDecimal extends Value {
     }
 
     /**
-     * Get or create big decimal value for the given big decimal.
+     * Get or create a NUMERIC value for the given big decimal.
      *
      * @param dec the big decimal
      * @return the value
      */
-    public static ValueDecimal get(BigDecimal dec) {
+    public static ValueNumeric get(BigDecimal dec) {
         if (BigDecimal.ZERO.equals(dec)) {
             return ZERO;
         } else if (BigDecimal.ONE.equals(dec)) {
             return ONE;
         }
-        return (ValueDecimal) Value.cache(new ValueDecimal(dec));
+        return (ValueNumeric) Value.cache(new ValueNumeric(dec));
     }
 
     /**
-     * Get or create big decimal value for the given big integer.
+     * Get or create a NUMERIC value for the given big integer.
      *
      * @param bigInteger the big integer
      * @return the value
      */
-    public static ValueDecimal get(BigInteger bigInteger) {
+    public static ValueNumeric get(BigInteger bigInteger) {
         if (bigInteger.signum() == 0) {
             return ZERO;
         } else if (BigInteger.ONE.equals(bigInteger)) {
             return ONE;
         }
-        return (ValueDecimal) Value.cache(new ValueDecimal(new BigDecimal(bigInteger)));
+        return (ValueNumeric) Value.cache(new ValueNumeric(new BigDecimal(bigInteger)));
     }
 
     @Override
@@ -222,8 +222,8 @@ public class ValueDecimal extends Value {
         // value and scale (thus 2.0 is not equal to 2.00 when using equals;
         // however -0.0 and 0.0 are). Can not use compareTo because 2.0 and 2.00
         // have different hash codes
-        return other instanceof ValueDecimal &&
-                value.equals(((ValueDecimal) other).value);
+        return other instanceof ValueNumeric &&
+                value.equals(((ValueNumeric) other).value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueReal.java
+++ b/h2/src/main/org/h2/value/ValueReal.java
@@ -16,7 +16,7 @@ import org.h2.message.DbException;
 /**
  * Implementation of the REAL data type.
  */
-public class ValueFloat extends Value {
+public class ValueReal extends Value {
 
     /**
      * The precision in digits.
@@ -24,7 +24,7 @@ public class ValueFloat extends Value {
     static final int PRECISION = 7;
 
     /**
-     * The maximum display size of a float.
+     * The maximum display size of a REAL.
      * Example: -1.12345676E-20
      */
     static final int DISPLAY_SIZE = 15;
@@ -37,30 +37,30 @@ public class ValueFloat extends Value {
     /**
      * The value 0.
      */
-    public static final ValueFloat ZERO = new ValueFloat(0f);
+    public static final ValueReal ZERO = new ValueReal(0f);
 
     /**
      * The value 1.
      */
-    public static final ValueFloat ONE = new ValueFloat(1f);
+    public static final ValueReal ONE = new ValueReal(1f);
 
-    private static final ValueFloat NAN = new ValueFloat(Float.NaN);
+    private static final ValueReal NAN = new ValueReal(Float.NaN);
 
     private final float value;
 
-    private ValueFloat(float value) {
+    private ValueReal(float value) {
         this.value = value;
     }
 
     @Override
     public Value add(Value v) {
-        ValueFloat v2 = (ValueFloat) v;
+        ValueReal v2 = (ValueReal) v;
         return get(value + v2.value);
     }
 
     @Override
     public Value subtract(Value v) {
-        ValueFloat v2 = (ValueFloat) v;
+        ValueReal v2 = (ValueReal) v;
         return get(value - v2.value);
     }
 
@@ -71,13 +71,13 @@ public class ValueFloat extends Value {
 
     @Override
     public Value multiply(Value v) {
-        ValueFloat v2 = (ValueFloat) v;
+        ValueReal v2 = (ValueReal) v;
         return get(value * v2.value);
     }
 
     @Override
     public Value divide(Value v, long divisorPrecision) {
-        ValueFloat v2 = (ValueFloat) v;
+        ValueReal v2 = (ValueReal) v;
         if (v2.value == 0.0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
@@ -86,7 +86,7 @@ public class ValueFloat extends Value {
 
     @Override
     public Value modulus(Value v) {
-        ValueFloat other = (ValueFloat) v;
+        ValueReal other = (ValueReal) v;
         if (other.value == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
@@ -119,7 +119,7 @@ public class ValueFloat extends Value {
 
     @Override
     public int compareTypeSafe(Value o, CompareMode mode, CastDataProvider provider) {
-        return Float.compare(value, ((ValueFloat) o).value);
+        return Float.compare(value, ((ValueReal) o).value);
     }
 
     @Override
@@ -173,12 +173,12 @@ public class ValueFloat extends Value {
     }
 
     /**
-     * Get or create float value for the given float.
+     * Get or create a REAL value for the given float.
      *
      * @param d the float
      * @return the value
      */
-    public static ValueFloat get(float d) {
+    public static ValueReal get(float d) {
         if (d == 1.0F) {
             return ONE;
         } else if (d == 0.0F) {
@@ -187,15 +187,15 @@ public class ValueFloat extends Value {
         } else if (Float.isNaN(d)) {
             return NAN;
         }
-        return (ValueFloat) Value.cache(new ValueFloat(d));
+        return (ValueReal) Value.cache(new ValueReal(d));
     }
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ValueFloat)) {
+        if (!(other instanceof ValueReal)) {
             return false;
         }
-        return compareTypeSafe((ValueFloat) other, null, null) == 0;
+        return compareTypeSafe((ValueReal) other, null, null) == 0;
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueSmallint.java
+++ b/h2/src/main/org/h2/value/ValueSmallint.java
@@ -15,7 +15,7 @@ import org.h2.message.DbException;
 /**
  * Implementation of the SMALLINT data type.
  */
-public class ValueShort extends Value {
+public class ValueSmallint extends Value {
 
     /**
      * The precision in digits.
@@ -23,29 +23,29 @@ public class ValueShort extends Value {
     static final int PRECISION = 5;
 
     /**
-     * The maximum display size of a short.
+     * The maximum display size of a SMALLINT.
      * Example: -32768
      */
     static final int DISPLAY_SIZE = 6;
 
     private final short value;
 
-    private ValueShort(short value) {
+    private ValueSmallint(short value) {
         this.value = value;
     }
 
     @Override
     public Value add(Value v) {
-        ValueShort other = (ValueShort) v;
+        ValueSmallint other = (ValueSmallint) v;
         return checkRange(value + other.value);
     }
 
-    private static ValueShort checkRange(int x) {
+    private static ValueSmallint checkRange(int x) {
         if ((short) x != x) {
             throw DbException.get(ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE_1,
                     Integer.toString(x));
         }
-        return ValueShort.get((short) x);
+        return ValueSmallint.get((short) x);
     }
 
     @Override
@@ -60,19 +60,19 @@ public class ValueShort extends Value {
 
     @Override
     public Value subtract(Value v) {
-        ValueShort other = (ValueShort) v;
+        ValueSmallint other = (ValueSmallint) v;
         return checkRange(value - other.value);
     }
 
     @Override
     public Value multiply(Value v) {
-        ValueShort other = (ValueShort) v;
+        ValueSmallint other = (ValueSmallint) v;
         return checkRange(value * other.value);
     }
 
     @Override
     public Value divide(Value v, long divisorPrecision) {
-        ValueShort other = (ValueShort) v;
+        ValueSmallint other = (ValueSmallint) v;
         if (other.value == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
@@ -81,11 +81,11 @@ public class ValueShort extends Value {
 
     @Override
     public Value modulus(Value v) {
-        ValueShort other = (ValueShort) v;
+        ValueSmallint other = (ValueSmallint) v;
         if (other.value == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
-        return ValueShort.get((short) (value % other.value));
+        return ValueSmallint.get((short) (value % other.value));
     }
 
     @Override
@@ -115,7 +115,7 @@ public class ValueShort extends Value {
 
     @Override
     public int compareTypeSafe(Value o, CompareMode mode, CastDataProvider provider) {
-        return Integer.compare(value, ((ValueShort) o).value);
+        return Integer.compare(value, ((ValueSmallint) o).value);
     }
 
     @Override
@@ -140,18 +140,18 @@ public class ValueShort extends Value {
     }
 
     /**
-     * Get or create a short value for the given short.
+     * Get or create a SMALLINT value for the given short.
      *
      * @param i the short
      * @return the value
      */
-    public static ValueShort get(short i) {
-        return (ValueShort) Value.cache(new ValueShort(i));
+    public static ValueSmallint get(short i) {
+        return (ValueSmallint) Value.cache(new ValueSmallint(i));
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueShort && value == ((ValueShort) other).value;
+        return other instanceof ValueSmallint && value == ((ValueSmallint) other).value;
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueTinyint.java
+++ b/h2/src/main/org/h2/value/ValueTinyint.java
@@ -13,9 +13,9 @@ import org.h2.engine.CastDataProvider;
 import org.h2.message.DbException;
 
 /**
- * Implementation of the BYTE data type.
+ * Implementation of the TINYINT data type.
  */
-public class ValueByte extends Value {
+public class ValueTinyint extends Value {
 
     /**
      * The precision in digits.
@@ -23,29 +23,29 @@ public class ValueByte extends Value {
     static final int PRECISION = 3;
 
     /**
-     * The display size for a byte.
+     * The display size for a TINYINT.
      * Example: -127
      */
     static final int DISPLAY_SIZE = 4;
 
     private final byte value;
 
-    private ValueByte(byte value) {
+    private ValueTinyint(byte value) {
         this.value = value;
     }
 
     @Override
     public Value add(Value v) {
-        ValueByte other = (ValueByte) v;
+        ValueTinyint other = (ValueTinyint) v;
         return checkRange(value + other.value);
     }
 
-    private static ValueByte checkRange(int x) {
+    private static ValueTinyint checkRange(int x) {
         if ((byte) x != x) {
             throw DbException.get(ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE_1,
                     Integer.toString(x));
         }
-        return ValueByte.get((byte) x);
+        return ValueTinyint.get((byte) x);
     }
 
     @Override
@@ -60,19 +60,19 @@ public class ValueByte extends Value {
 
     @Override
     public Value subtract(Value v) {
-        ValueByte other = (ValueByte) v;
+        ValueTinyint other = (ValueTinyint) v;
         return checkRange(value - other.value);
     }
 
     @Override
     public Value multiply(Value v) {
-        ValueByte other = (ValueByte) v;
+        ValueTinyint other = (ValueTinyint) v;
         return checkRange(value * other.value);
     }
 
     @Override
     public Value divide(Value v, long divisorPrecision) {
-        ValueByte other = (ValueByte) v;
+        ValueTinyint other = (ValueTinyint) v;
         if (other.value == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
@@ -81,11 +81,11 @@ public class ValueByte extends Value {
 
     @Override
     public Value modulus(Value v) {
-        ValueByte other = (ValueByte) v;
+        ValueTinyint other = (ValueTinyint) v;
         if (other.value == 0) {
             throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
         }
-        return ValueByte.get((byte) (value % other.value));
+        return ValueTinyint.get((byte) (value % other.value));
     }
 
     @Override
@@ -115,7 +115,7 @@ public class ValueByte extends Value {
 
     @Override
     public int compareTypeSafe(Value o, CompareMode mode, CastDataProvider provider) {
-        return Integer.compare(value, ((ValueByte) o).value);
+        return Integer.compare(value, ((ValueTinyint) o).value);
     }
 
     @Override
@@ -140,18 +140,18 @@ public class ValueByte extends Value {
     }
 
     /**
-     * Get or create byte value for the given byte.
+     * Get or create a TINYINT value for the given byte.
      *
      * @param i the byte
      * @return the value
      */
-    public static ValueByte get(byte i) {
-        return (ValueByte) Value.cache(new ValueByte(i));
+    public static ValueTinyint get(byte i) {
+        return (ValueTinyint) Value.cache(new ValueTinyint(i));
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueByte && value == ((ValueByte) other).value;
+        return other instanceof ValueTinyint && value == ((ValueTinyint) other).value;
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueVarbinary.java
+++ b/h2/src/main/org/h2/value/ValueVarbinary.java
@@ -18,15 +18,15 @@ import org.h2.util.StringUtils;
 import org.h2.util.Utils;
 
 /**
- * Implementation of the BINARY data type.
+ * Implementation of the VARBINARY data type.
  * It is also the base class for ValueJavaObject.
  */
-public class ValueBytes extends Value {
+public class ValueVarbinary extends Value {
 
     /**
      * Empty value.
      */
-    public static final ValueBytes EMPTY = new ValueBytes(Utils.EMPTY_BYTES);
+    public static final ValueVarbinary EMPTY = new ValueVarbinary(Utils.EMPTY_BYTES);
 
     /**
      * The value.
@@ -43,18 +43,18 @@ public class ValueBytes extends Value {
      */
     protected int hash;
 
-    protected ValueBytes(byte[] v) {
+    protected ValueVarbinary(byte[] v) {
         this.value = v;
     }
 
     /**
-     * Get or create a bytes value for the given byte array.
+     * Get or create a VARBINARY value for the given byte array.
      * Clone the data.
      *
      * @param b the byte array
      * @return the value
      */
-    public static ValueBytes get(byte[] b) {
+    public static ValueVarbinary get(byte[] b) {
         if (b.length == 0) {
             return EMPTY;
         }
@@ -63,21 +63,21 @@ public class ValueBytes extends Value {
     }
 
     /**
-     * Get or create a bytes value for the given byte array.
+     * Get or create a VARBINARY value for the given byte array.
      * Do not clone the date.
      *
      * @param b the byte array
      * @return the value
      */
-    public static ValueBytes getNoCopy(byte[] b) {
+    public static ValueVarbinary getNoCopy(byte[] b) {
         if (b.length == 0) {
             return EMPTY;
         }
-        ValueBytes obj = new ValueBytes(b);
+        ValueVarbinary obj = new ValueVarbinary(b);
         if (b.length > SysProperties.OBJECT_CACHE_MAX_PER_ELEMENT_SIZE) {
             return obj;
         }
-        return (ValueBytes) Value.cache(obj);
+        return (ValueVarbinary) Value.cache(obj);
     }
 
     @Override
@@ -113,7 +113,7 @@ public class ValueBytes extends Value {
 
     @Override
     public int compareTypeSafe(Value v, CompareMode mode, CastDataProvider provider) {
-        byte[] v2 = ((ValueBytes) v).value;
+        byte[] v2 = ((ValueVarbinary) v).value;
         if (mode.isBinaryUnsigned()) {
             return Bits.compareNotNullUnsigned(value, v2);
         }
@@ -151,8 +151,8 @@ public class ValueBytes extends Value {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueBytes
-                && Arrays.equals(value, ((ValueBytes) other).value);
+        return other instanceof ValueVarbinary
+                && Arrays.equals(value, ((ValueVarbinary) other).value);
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueVarchar.java
+++ b/h2/src/main/org/h2/value/ValueVarchar.java
@@ -14,15 +14,15 @@ import org.h2.util.StringUtils;
 
 /**
  * Implementation of the VARCHAR data type.
- * It is also the base class for other ValueString* classes.
+ * It is also the base class for ValueVarcharIgnoreCase and ValueChar classes.
  */
-public class ValueString extends Value {
+public class ValueVarchar extends Value {
 
     /**
      * Empty string. Should not be used in places where empty string can be
      * treated as {@code NULL} depending on database mode.
      */
-    public static final ValueString EMPTY = new ValueString("");
+    public static final ValueVarchar EMPTY = new ValueVarchar("");
 
     /**
      * The string data.
@@ -31,7 +31,7 @@ public class ValueString extends Value {
 
     private TypeInfo type;
 
-    protected ValueString(String value) {
+    protected ValueVarchar(String value) {
         this.value = value;
     }
 
@@ -42,13 +42,13 @@ public class ValueString extends Value {
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueString
-                && value.equals(((ValueString) other).value);
+        return other instanceof ValueVarchar
+                && value.equals(((ValueVarchar) other).value);
     }
 
     @Override
     public int compareTypeSafe(Value o, CompareMode mode, CastDataProvider provider) {
-        return mode.compareString(value, ((ValueString) o).value, false);
+        return mode.compareString(value, ((ValueVarchar) o).value, false);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class ValueString extends Value {
     }
 
     /**
-     * Get or create a string value for the given string.
+     * Get or create a VARCHAR value for the given string.
      *
      * @param s the string
      * @return the value
@@ -135,7 +135,7 @@ public class ValueString extends Value {
     }
 
     /**
-     * Get or create a string value for the given string.
+     * Get or create a VARCHAR value for the given string.
      *
      * @param s the string
      * @param provider the cast information provider, or {@code null}
@@ -145,7 +145,7 @@ public class ValueString extends Value {
         if (s.isEmpty()) {
             return provider != null && provider.getMode().treatEmptyStringsAsNull ? ValueNull.INSTANCE : EMPTY;
         }
-        ValueString obj = new ValueString(StringUtils.cache(s));
+        ValueVarchar obj = new ValueVarchar(StringUtils.cache(s));
         if (s.length() > SysProperties.OBJECT_CACHE_MAX_PER_ELEMENT_SIZE) {
             return obj;
         }

--- a/h2/src/main/org/h2/value/ValueVarcharIgnoreCase.java
+++ b/h2/src/main/org/h2/value/ValueVarcharIgnoreCase.java
@@ -12,13 +12,13 @@ import org.h2.util.StringUtils;
 /**
  * Implementation of the VARCHAR_IGNORECASE data type.
  */
-public class ValueStringIgnoreCase extends ValueString {
+public class ValueVarcharIgnoreCase extends ValueVarchar {
 
-    private static final ValueStringIgnoreCase EMPTY =
-            new ValueStringIgnoreCase("");
+    private static final ValueVarcharIgnoreCase EMPTY =
+            new ValueVarcharIgnoreCase("");
     private int hash;
 
-    protected ValueStringIgnoreCase(String value) {
+    protected ValueVarcharIgnoreCase(String value) {
         super(value);
     }
 
@@ -29,13 +29,13 @@ public class ValueStringIgnoreCase extends ValueString {
 
     @Override
     public int compareTypeSafe(Value o, CompareMode mode, CastDataProvider provider) {
-        return mode.compareString(value, ((ValueStringIgnoreCase) o).value, true);
+        return mode.compareString(value, ((ValueVarcharIgnoreCase) o).value, true);
     }
 
     @Override
     public boolean equals(Object other) {
-        return other instanceof ValueString
-                && value.equalsIgnoreCase(((ValueString) other).value);
+        return other instanceof ValueVarchar
+                && value.equalsIgnoreCase(((ValueVarchar) other).value);
     }
 
     @Override
@@ -54,22 +54,22 @@ public class ValueStringIgnoreCase extends ValueString {
     }
 
     /**
-     * Get or create a case insensitive string value for the given string.
+     * Get or create a VARCHAR_IGNORECASE value for the given string.
      * The value will have the same case as the passed string.
      *
      * @param s the string
      * @return the value
      */
-    public static ValueStringIgnoreCase get(String s) {
+    public static ValueVarcharIgnoreCase get(String s) {
         int length = s.length();
         if (length == 0) {
             return EMPTY;
         }
-        ValueStringIgnoreCase obj = new ValueStringIgnoreCase(StringUtils.cache(s));
+        ValueVarcharIgnoreCase obj = new ValueVarcharIgnoreCase(StringUtils.cache(s));
         if (length > SysProperties.OBJECT_CACHE_MAX_PER_ELEMENT_SIZE) {
             return obj;
         }
-        ValueStringIgnoreCase cache = (ValueStringIgnoreCase) Value.cache(obj);
+        ValueVarcharIgnoreCase cache = (ValueVarcharIgnoreCase) Value.cache(obj);
         // the cached object could have the wrong case
         // (it would still be 'equal', but we don't like to store it)
         if (cache.value.equals(s)) {

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -60,7 +60,7 @@ import org.h2.util.IOUtils;
 import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
-import org.h2.value.ValueDecimal;
+import org.h2.value.ValueNumeric;
 import org.h2.value.ValueTimestamp;
 import org.h2.value.ValueTimestampTimeZone;
 
@@ -527,8 +527,8 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         stat.execute("create aggregate agg_sum for \""+getClass().getName()+"\"");
         rs = stat.executeQuery("select agg_sum(1), sum(1.6) from dual");
         rs.next();
-        assertEquals(ValueDecimal.MAXIMUM_SCALE, rs.getMetaData().getScale(2));
-        assertEquals(ValueDecimal.MAXIMUM_SCALE, rs.getMetaData().getScale(1));
+        assertEquals(ValueNumeric.MAXIMUM_SCALE, rs.getMetaData().getScale(2));
+        assertEquals(ValueNumeric.MAXIMUM_SCALE, rs.getMetaData().getScale(1));
         stat.executeQuery("select * from information_schema.function_aliases");
         conn.close();
     }

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -22,7 +22,7 @@ import org.h2.result.SortOrder;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.tools.SimpleResultSet;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 
 /**
  * Index tests.
@@ -735,8 +735,8 @@ public class TestIndex extends TestDb {
             }
         }
         SimpleResultSet rs = new SimpleResultSet();
-        rs.addColumn("ID", Types.INTEGER, ValueInt.PRECISION, 0);
-        rs.addColumn("VALUE", Types.INTEGER, ValueInt.PRECISION, 0);
+        rs.addColumn("ID", Types.INTEGER, ValueInteger.PRECISION, 0);
+        rs.addColumn("VALUE", Types.INTEGER, ValueInteger.PRECISION, 0);
         rs.addRow(1, 10);
         rs.addRow(2, 20);
         rs.addRow(3, 30);

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -40,7 +40,7 @@ import org.h2.table.TableType;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.value.Value;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueNull;
 
 /**
@@ -731,7 +731,7 @@ public class TestTableEngines extends TestDb {
 
             EndlessTable(CreateTableData data) {
                 super(data);
-                row = Row.get(new Value[] { ValueInt.get(1), ValueNull.INSTANCE }, 0);
+                row = Row.get(new Value[] { ValueInteger.get(1), ValueNull.INSTANCE }, 0);
                 scanIndex = new Auto(this);
             }
 

--- a/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
+++ b/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
@@ -21,7 +21,7 @@ import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.tools.TriggerAdapter;
 import org.h2.util.Task;
-import org.h2.value.ValueLong;
+import org.h2.value.ValueBigint;
 
 /**
  * Tests for trigger and constraints.
@@ -350,7 +350,7 @@ public class TestTriggersConstraints extends TestDb implements Trigger {
                 if (rs.next()) {
                     JdbcConnection jconn = (JdbcConnection) conn;
                     Session session = (Session) jconn.getSession();
-                    session.setLastTriggerIdentity(ValueLong.get(rs.getLong(1)));
+                    session.setLastTriggerIdentity(ValueBigint.get(rs.getLong(1)));
                 }
             }
         }

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -39,6 +39,7 @@ import java.util.TimeZone;
 import java.util.UUID;
 
 import org.h2.api.ErrorCode;
+import org.h2.api.H2Type;
 import org.h2.api.Interval;
 import org.h2.api.IntervalQualifier;
 import org.h2.api.Trigger;
@@ -643,7 +644,7 @@ public class TestPreparedStatement extends TestDb {
 
     private void testSetObject2(Connection conn) throws SQLException {
         try (PreparedStatement prep = conn.prepareStatement("VALUES (?1, ?1 IS OF(INTEGER), ?1 IS OF(BIGINT))")) {
-            for (int i = 1; i <= 5; i++) {
+            for (int i = 1; i <= 6; i++) {
                 testSetObject2SetObjectType(prep, i, (long) i);
                 try (ResultSet rs = prep.executeQuery()) {
                     rs.next();
@@ -685,6 +686,9 @@ public class TestPreparedStatement extends TestDb {
             break;
         case 5:
             prep.setObject(1, value, JDBCType.INTEGER, 0);
+            break;
+        case 6:
+            prep.setObject(1, value, H2Type.INTEGER, 0);
         }
     }
 

--- a/h2/src/test/org/h2/test/jdbc/TestUpdatableResultSet.java
+++ b/h2/src/test/org/h2/test/jdbc/TestUpdatableResultSet.java
@@ -27,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 import org.h2.api.ErrorCode;
+import org.h2.api.H2Type;
 import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
@@ -740,14 +741,14 @@ public class TestUpdatableResultSet extends TestDb {
         Statement stat = conn.createStatement();
         stat.execute("CREATE TABLE TEST(ID INT PRIMARY KEY, V INT)");
         PreparedStatement prep = conn.prepareStatement("INSERT INTO TEST VALUES (?1, ?1)");
-        for (int i = 1; i <= 8; i++) {
+        for (int i = 1; i <= 12; i++) {
             prep.setInt(1, i);
             prep.executeUpdate();
         }
         prep = conn.prepareStatement("TABLE TEST ORDER BY ID", ResultSet.TYPE_FORWARD_ONLY,
                 ResultSet.CONCUR_UPDATABLE);
         try (ResultSet rs = prep.executeQuery()) {
-            for (int i = 1; i <= 8; i++) {
+            for (int i = 1; i <= 12; i++) {
             rs.next();
                 assertEquals(i, rs.getInt(1));
                 assertEquals(i, rs.getInt(2));
@@ -757,7 +758,7 @@ public class TestUpdatableResultSet extends TestDb {
             assertFalse(rs.next());
         }
         try (ResultSet rs = prep.executeQuery()) {
-            for (int i = 1; i <= 8; i++) {
+            for (int i = 1; i <= 12; i++) {
                 assertTrue(rs.next());
                 assertEquals(i, rs.getInt(1));
                 assertEquals(i * 10, rs.getInt(2));
@@ -767,7 +768,7 @@ public class TestUpdatableResultSet extends TestDb {
             assertFalse(rs.next());
         }
         try (ResultSet rs = prep.executeQuery()) {
-            for (int i = 1; i <= 8; i++) {
+            for (int i = 1; i <= 12; i++) {
                 assertTrue(rs.next());
                 assertEquals(i, rs.getInt(1));
                 assertNull(rs.getObject(2));
@@ -792,16 +793,28 @@ public class TestUpdatableResultSet extends TestDb {
             rs.updateObject(2, value, JDBCType.INTEGER);
             break;
         case 5:
-            rs.updateObject("V", value, 0);
+            rs.updateObject(2, value, H2Type.INTEGER);
             break;
         case 6:
-            rs.updateObject("V", value, JDBCType.INTEGER);
+            rs.updateObject("V", value, 0);
             break;
         case 7:
-            rs.updateObject(2, value, JDBCType.INTEGER, 0);
+            rs.updateObject("V", value, JDBCType.INTEGER);
             break;
         case 8:
+            rs.updateObject("V", value, H2Type.INTEGER);
+            break;
+        case 9:
+            rs.updateObject(2, value, JDBCType.INTEGER, 0);
+            break;
+        case 10:
+            rs.updateObject(2, value, H2Type.INTEGER, 0);
+            break;
+        case 11:
             rs.updateObject("V", value, JDBCType.INTEGER, 0);
+            break;
+        case 12:
+            rs.updateObject("V", value, H2Type.INTEGER, 0);
         }
     }
 

--- a/h2/src/test/org/h2/test/unit/TestDataPage.java
+++ b/h2/src/test/org/h2/test/unit/TestDataPage.java
@@ -23,23 +23,23 @@ import org.h2.util.TempFileDeleter;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
-import org.h2.value.ValueByte;
-import org.h2.value.ValueBytes;
-import org.h2.value.ValueDecimal;
+import org.h2.value.ValueChar;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueFloat;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueJavaObject;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
 import org.h2.value.ValueResultSet;
-import org.h2.value.ValueShort;
-import org.h2.value.ValueString;
-import org.h2.value.ValueStringFixed;
-import org.h2.value.ValueStringIgnoreCase;
+import org.h2.value.ValueSmallint;
 import org.h2.value.ValueTimestampTimeZone;
+import org.h2.value.ValueTinyint;
 import org.h2.value.ValueUuid;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
+import org.h2.value.ValueVarcharIgnoreCase;
 
 /**
  * Data page tests.
@@ -126,42 +126,42 @@ public class TestDataPage extends TestBase implements DataHandler {
         testValue(ValueBoolean.FALSE);
         testValue(ValueBoolean.TRUE);
         for (int i = 0; i < 256; i++) {
-            testValue(ValueByte.get((byte) i));
+            testValue(ValueTinyint.get((byte) i));
         }
         for (int i = 0; i < 256 * 256; i += 10) {
-            testValue(ValueShort.get((short) i));
+            testValue(ValueSmallint.get((short) i));
         }
         for (int i = 0; i < 256 * 256; i += 10) {
-            testValue(ValueInt.get(i));
-            testValue(ValueInt.get(-i));
-            testValue(ValueLong.get(i));
-            testValue(ValueLong.get(-i));
+            testValue(ValueInteger.get(i));
+            testValue(ValueInteger.get(-i));
+            testValue(ValueBigint.get(i));
+            testValue(ValueBigint.get(-i));
         }
-        testValue(ValueInt.get(Integer.MAX_VALUE));
-        testValue(ValueInt.get(Integer.MIN_VALUE));
+        testValue(ValueInteger.get(Integer.MAX_VALUE));
+        testValue(ValueInteger.get(Integer.MIN_VALUE));
         for (long i = 0; i < Integer.MAX_VALUE; i += 10 + i / 4) {
-            testValue(ValueInt.get((int) i));
-            testValue(ValueInt.get((int) -i));
+            testValue(ValueInteger.get((int) i));
+            testValue(ValueInteger.get((int) -i));
         }
-        testValue(ValueLong.get(Long.MAX_VALUE));
-        testValue(ValueLong.get(Long.MIN_VALUE));
+        testValue(ValueBigint.get(Long.MAX_VALUE));
+        testValue(ValueBigint.get(Long.MIN_VALUE));
         for (long i = 0; i >= 0; i += 10 + i / 4) {
-            testValue(ValueLong.get(i));
-            testValue(ValueLong.get(-i));
+            testValue(ValueBigint.get(i));
+            testValue(ValueBigint.get(-i));
         }
-        testValue(ValueDecimal.get(BigDecimal.ZERO));
-        testValue(ValueDecimal.get(BigDecimal.ONE));
-        testValue(ValueDecimal.get(BigDecimal.TEN));
-        testValue(ValueDecimal.get(BigDecimal.ONE.negate()));
-        testValue(ValueDecimal.get(BigDecimal.TEN.negate()));
+        testValue(ValueNumeric.get(BigDecimal.ZERO));
+        testValue(ValueNumeric.get(BigDecimal.ONE));
+        testValue(ValueNumeric.get(BigDecimal.TEN));
+        testValue(ValueNumeric.get(BigDecimal.ONE.negate()));
+        testValue(ValueNumeric.get(BigDecimal.TEN.negate()));
         for (long i = 0; i >= 0; i += 10 + i / 4) {
-            testValue(ValueDecimal.get(new BigDecimal(i)));
-            testValue(ValueDecimal.get(new BigDecimal(-i)));
+            testValue(ValueNumeric.get(new BigDecimal(i)));
+            testValue(ValueNumeric.get(new BigDecimal(-i)));
             for (int j = 0; j < 200; j += 50) {
-                testValue(ValueDecimal.get(new BigDecimal(i).setScale(j)));
-                testValue(ValueDecimal.get(new BigDecimal(i * i).setScale(j)));
+                testValue(ValueNumeric.get(new BigDecimal(i).setScale(j)));
+                testValue(ValueNumeric.get(new BigDecimal(i * i).setScale(j)));
             }
-            testValue(ValueDecimal.get(new BigDecimal(i * i)));
+            testValue(ValueNumeric.get(new BigDecimal(i * i)));
         }
         testValue(LegacyDateTimeUtils.fromDate(null, null, new Date(System.currentTimeMillis())));
         testValue(LegacyDateTimeUtils.fromDate(null, null, new Date(0)));
@@ -173,43 +173,43 @@ public class TestDataPage extends TestBase implements DataHandler {
         testValue(ValueJavaObject.getNoCopy(null, new byte[0], this));
         testValue(ValueJavaObject.getNoCopy(null, new byte[100], this));
         for (int i = 0; i < 300; i++) {
-            testValue(ValueBytes.getNoCopy(new byte[i]));
+            testValue(ValueVarbinary.getNoCopy(new byte[i]));
         }
         for (int i = 0; i < 65000; i += 10 + i) {
-            testValue(ValueBytes.getNoCopy(new byte[i]));
+            testValue(ValueVarbinary.getNoCopy(new byte[i]));
         }
         testValue(ValueUuid.getNewRandom());
         for (int i = 0; i < 100; i++) {
-            testValue(ValueString.get(new String(new char[i])));
+            testValue(ValueVarchar.get(new String(new char[i])));
         }
         for (int i = 0; i < 65000; i += 10 + i) {
-            testValue(ValueString.get(new String(new char[i])));
-            testValue(ValueStringFixed.get(new String(new char[i])));
-            testValue(ValueStringIgnoreCase.get(new String(new char[i])));
+            testValue(ValueVarchar.get(new String(new char[i])));
+            testValue(ValueChar.get(new String(new char[i])));
+            testValue(ValueVarcharIgnoreCase.get(new String(new char[i])));
         }
-        testValue(ValueFloat.get(0f));
-        testValue(ValueFloat.get(1f));
-        testValue(ValueFloat.get(-1f));
+        testValue(ValueReal.get(0f));
+        testValue(ValueReal.get(1f));
+        testValue(ValueReal.get(-1f));
         testValue(ValueDouble.get(0));
         testValue(ValueDouble.get(1));
         testValue(ValueDouble.get(-1));
         for (int i = 0; i < 65000; i += 10 + i) {
             for (double j = 0.1; j < 65000; j += 10 + j) {
-                testValue(ValueFloat.get((float) (i / j)));
+                testValue(ValueReal.get((float) (i / j)));
                 testValue(ValueDouble.get(i / j));
-                testValue(ValueFloat.get((float) -(i / j)));
+                testValue(ValueReal.get((float) -(i / j)));
                 testValue(ValueDouble.get(-(i / j)));
             }
         }
         testValue(ValueArray.get(new Value[0]));
-        testValue(ValueArray.get(new Value[] { ValueInt.get(-20), ValueInt.get(10) }));
+        testValue(ValueArray.get(new Value[] { ValueInteger.get(-20), ValueInteger.get(10) }));
 
         SimpleResult rs = new SimpleResult();
         rs.addColumn("ID", "ID", Value.INTEGER, 0, 0);
         rs.addColumn("NAME", "NAME", Value.VARCHAR, 255, 0);
-        rs.addRow(ValueInt.get(1), ValueString.get("Hello"));
-        rs.addRow(ValueInt.get(2), ValueString.get("World"));
-        rs.addRow(ValueInt.get(3), ValueString.get("Peace"));
+        rs.addRow(ValueInteger.get(1), ValueVarchar.get("Hello"));
+        rs.addRow(ValueInteger.get(2), ValueVarchar.get("World"));
+        rs.addRow(ValueInteger.get(3), ValueVarchar.get("Peace"));
         testValue(ValueResultSet.get(rs));
     }
 
@@ -253,9 +253,9 @@ public class TestDataPage extends TestBase implements DataHandler {
 
         page.writeString("H\u1111!");
         page.writeString("John\tBrack's \"how are you\" M\u1111ller");
-        page.writeValue(ValueInt.get(10));
-        page.writeValue(ValueString.get("test"));
-        page.writeValue(ValueFloat.get(-2.25f));
+        page.writeValue(ValueInteger.get(10));
+        page.writeValue(ValueVarchar.get("test"));
+        page.writeValue(ValueReal.get(-2.25f));
         page.writeValue(ValueDouble.get(10.40));
         page.writeValue(ValueNull.INSTANCE);
         trace(new String(page.getBytes()));

--- a/h2/src/test/org/h2/test/unit/TestDataPage.java
+++ b/h2/src/test/org/h2/test/unit/TestDataPage.java
@@ -205,7 +205,7 @@ public class TestDataPage extends TestBase implements DataHandler {
         testValue(ValueArray.get(new Value[] { ValueInt.get(-20), ValueInt.get(10) }));
 
         SimpleResult rs = new SimpleResult();
-        rs.addColumn("ID", "ID", Value.INT, 0, 0);
+        rs.addColumn("ID", "ID", Value.INTEGER, 0, 0);
         rs.addColumn("NAME", "NAME", Value.VARCHAR, 255, 0);
         rs.addRow(ValueInt.get(1), ValueString.get("Hello"));
         rs.addRow(ValueInt.get(2), ValueString.get("World"));

--- a/h2/src/test/org/h2/test/unit/TestOverflow.java
+++ b/h2/src/test/org/h2/test/unit/TestOverflow.java
@@ -11,7 +11,7 @@ import java.util.Random;
 
 import org.h2.test.TestBase;
 import org.h2.value.Value;
-import org.h2.value.ValueString;
+import org.h2.value.ValueVarchar;
 
 /**
  * Tests numeric overflow on various data types.
@@ -124,7 +124,7 @@ public class TestOverflow extends TestBase {
     }
 
     private void add(long l) {
-        values.add(ValueString.get("" + l).convertTo(dataType));
+        values.add(ValueVarchar.get("" + l).convertTo(dataType));
     }
 
 }

--- a/h2/src/test/org/h2/test/unit/TestOverflow.java
+++ b/h2/src/test/org/h2/test/unit/TestOverflow.java
@@ -36,7 +36,7 @@ public class TestOverflow extends TestBase {
     @Override
     public void test() {
         test(Value.TINYINT, Byte.MIN_VALUE, Byte.MAX_VALUE);
-        test(Value.INT, Integer.MIN_VALUE, Integer.MAX_VALUE);
+        test(Value.INTEGER, Integer.MIN_VALUE, Integer.MAX_VALUE);
         test(Value.BIGINT, Long.MIN_VALUE, Long.MAX_VALUE);
         test(Value.SMALLINT, Short.MIN_VALUE, Short.MAX_VALUE);
     }

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -223,7 +223,7 @@ public class TestValue extends TestDb {
         testValueResultSetTest(ValueResultSet.get(null, rs, 2), 2, true);
 
         SimpleResult result = new SimpleResult();
-        result.addColumn("ID", "ID", Value.INT, 0, 0);
+        result.addColumn("ID", "ID", Value.INTEGER, 0, 0);
         result.addColumn("NAME", "NAME", Value.VARCHAR, 255, 0);
         result.addRow(ValueInt.get(1), ValueString.get("Hello"));
         result.addRow(ValueInt.get(2), ValueString.get("World"));
@@ -242,7 +242,7 @@ public class TestValue extends TestDb {
         assertEquals("ID", res.getAlias(0));
         assertEquals("ID", res.getColumnName(0));
         TypeInfo type = res.getColumnType(0);
-        assertEquals(Value.INT, type.getValueType());
+        assertEquals(Value.INTEGER, type.getValueType());
         assertEquals(ValueInt.PRECISION, type.getPrecision());
         assertEquals(0, type.getScale());
         assertEquals(ValueInt.DISPLAY_SIZE, type.getDisplaySize());
@@ -274,7 +274,7 @@ public class TestValue extends TestDb {
         testDataType(Value.NULL, void.class);
         testDataType(Value.ARRAY, String[].class);
         testDataType(Value.VARCHAR, String.class);
-        testDataType(Value.INT, Integer.class);
+        testDataType(Value.INTEGER, Integer.class);
         testDataType(Value.BIGINT, Long.class);
         testDataType(Value.BOOLEAN, Boolean.class);
         testDataType(Value.DOUBLE, Double.class);
@@ -502,7 +502,7 @@ public class TestValue extends TestDb {
 
         testTypeInfoCheck(Value.TINYINT, 3, 0, 4, TypeInfo.TYPE_TINYINT, TypeInfo.getTypeInfo(Value.TINYINT));
         testTypeInfoCheck(Value.SMALLINT, 5, 0, 6, TypeInfo.TYPE_SMALLINT, TypeInfo.getTypeInfo(Value.SMALLINT));
-        testTypeInfoCheck(Value.INT, 10, 0, 11, TypeInfo.TYPE_INT, TypeInfo.getTypeInfo(Value.INT));
+        testTypeInfoCheck(Value.INTEGER, 10, 0, 11, TypeInfo.TYPE_INTEGER, TypeInfo.getTypeInfo(Value.INTEGER));
         testTypeInfoCheck(Value.BIGINT, 19, 0, 20, TypeInfo.TYPE_BIGINT, TypeInfo.getTypeInfo(Value.BIGINT));
 
         testTypeInfoCheck(Value.REAL, 7, 0, 15, TypeInfo.TYPE_REAL, TypeInfo.getTypeInfo(Value.REAL));

--- a/h2/src/test/org/h2/test/unit/TestValue.java
+++ b/h2/src/test/org/h2/test/unit/TestValue.java
@@ -41,19 +41,19 @@ import org.h2.value.DataType;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
-import org.h2.value.ValueBytes;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueFloat;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueJavaObject;
 import org.h2.value.ValueLob;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
 import org.h2.value.ValueResultSet;
-import org.h2.value.ValueString;
 import org.h2.value.ValueTimestamp;
 import org.h2.value.ValueUuid;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
 
 /**
  * Tests features of values.
@@ -168,15 +168,15 @@ public class TestValue extends TestDb {
         Value v;
         String spaces = new String(new char[100]).replace((char) 0, ' ');
 
-        v = ValueArray.get(new Value[] { ValueString.get("hello"), ValueString.get("world") });
+        v = ValueArray.get(new Value[] { ValueVarchar.get("hello"), ValueVarchar.get("world") });
         TypeInfo typeInfo = TypeInfo.getTypeInfo(Value.ARRAY, 1L, 0, null);
         assertEquals(2, v.getType().getPrecision());
         assertEquals(1, v.castTo(typeInfo, null).getType().getPrecision());
-        v = ValueArray.get(new Value[]{ValueString.get(""), ValueString.get("")});
+        v = ValueArray.get(new Value[]{ValueVarchar.get(""), ValueVarchar.get("")});
         assertEquals(2, v.getType().getPrecision());
         assertEquals("ARRAY ['']", v.castTo(typeInfo, null).toString());
 
-        v = ValueBytes.get(spaces.getBytes());
+        v = ValueVarbinary.get(spaces.getBytes());
         typeInfo = TypeInfo.getTypeInfo(Value.VARBINARY, 10L, 0, null);
         assertEquals(100, v.getType().getPrecision());
         assertEquals(10, v.castTo(typeInfo, null).getType().getPrecision());
@@ -200,7 +200,7 @@ public class TestValue extends TestDb {
         assertEquals(32, v.castTo(typeInfo, null).getBytes()[9]);
         assertEquals(10, v.castTo(typeInfo, null).getType().getPrecision());
 
-        v = ValueString.get(spaces);
+        v = ValueVarchar.get(spaces);
         typeInfo = TypeInfo.getTypeInfo(Value.VARCHAR, 10L, 0, null);
         assertEquals(100, v.getType().getPrecision());
         assertEquals(10, v.castTo(typeInfo, null).getType().getPrecision());
@@ -225,9 +225,9 @@ public class TestValue extends TestDb {
         SimpleResult result = new SimpleResult();
         result.addColumn("ID", "ID", Value.INTEGER, 0, 0);
         result.addColumn("NAME", "NAME", Value.VARCHAR, 255, 0);
-        result.addRow(ValueInt.get(1), ValueString.get("Hello"));
-        result.addRow(ValueInt.get(2), ValueString.get("World"));
-        result.addRow(ValueInt.get(3), ValueString.get("Peace"));
+        result.addRow(ValueInteger.get(1), ValueVarchar.get("Hello"));
+        result.addRow(ValueInteger.get(2), ValueVarchar.get("World"));
+        result.addRow(ValueInteger.get(3), ValueVarchar.get("Peace"));
 
         ValueResultSet v = ValueResultSet.get(result);
         testValueResultSetTest(v, Integer.MAX_VALUE, false);
@@ -243,9 +243,9 @@ public class TestValue extends TestDb {
         assertEquals("ID", res.getColumnName(0));
         TypeInfo type = res.getColumnType(0);
         assertEquals(Value.INTEGER, type.getValueType());
-        assertEquals(ValueInt.PRECISION, type.getPrecision());
+        assertEquals(ValueInteger.PRECISION, type.getPrecision());
         assertEquals(0, type.getScale());
-        assertEquals(ValueInt.DISPLAY_SIZE, type.getDisplaySize());
+        assertEquals(ValueInteger.DISPLAY_SIZE, type.getDisplaySize());
         assertEquals("NAME", res.getAlias(1));
         assertEquals("NAME", res.getColumnName(1));
         type = res.getColumnType(1);
@@ -255,13 +255,13 @@ public class TestValue extends TestDb {
         assertEquals(255, type.getDisplaySize());
         if (count >= 1) {
             assertTrue(res.next());
-            assertEquals(new Value[] {ValueInt.get(1), ValueString.get("Hello")}, res.currentRow());
+            assertEquals(new Value[] {ValueInteger.get(1), ValueVarchar.get("Hello")}, res.currentRow());
             if (count >= 2) {
                 assertTrue(res.next());
-                assertEquals(new Value[] {ValueInt.get(2), ValueString.get("World")}, res.currentRow());
+                assertEquals(new Value[] {ValueInteger.get(2), ValueVarchar.get("World")}, res.currentRow());
                 if (count >= 3) {
                     assertTrue(res.next());
-                    assertEquals(new Value[] {ValueInt.get(3), ValueString.get("Peace")}, res.currentRow());
+                    assertEquals(new Value[] {ValueInteger.get(3), ValueVarchar.get("Peace")}, res.currentRow());
                 }
             }
         }
@@ -316,7 +316,7 @@ public class TestValue extends TestDb {
         };
         Value[] values = new Value[d.length];
         for (int i = 0; i < d.length; i++) {
-            Value v = useFloat ? (Value) ValueFloat.get((float) d[i])
+            Value v = useFloat ? (Value) ValueReal.get((float) d[i])
                     : (Value) ValueDouble.get(d[i]);
             values[i] = v;
             assertTrue(values[i].compareTypeSafe(values[i], null, null) == 0);
@@ -360,11 +360,11 @@ public class TestValue extends TestDb {
 
     private void testArray() {
         ValueArray src = ValueArray.get(
-                new Value[] {ValueString.get("1"), ValueString.get("22"), ValueString.get("333")});
+                new Value[] {ValueVarchar.get("1"), ValueVarchar.get("22"), ValueVarchar.get("333")});
         assertEquals(3, src.getType().getPrecision());
         assertSame(src, src.castTo(TypeInfo.getTypeInfo(Value.ARRAY, 3L, 0, null), null));
         ValueArray exp = ValueArray.get(
-                new Value[] {ValueString.get("1"), ValueString.get("22")});
+                new Value[] {ValueVarchar.get("1"), ValueVarchar.get("22")});
         Value got = src.castTo(TypeInfo.getTypeInfo(Value.ARRAY, 2L, 0, null), null);
         assertEquals(exp, got);
         assertEquals(Value.VARCHAR, ((ValueArray) got).getComponentType().getValueType());
@@ -418,13 +418,13 @@ public class TestValue extends TestDb {
     }
 
     private void testModulusDecimal() {
-        final ValueDecimal vd1 = ValueDecimal.get(new BigDecimal(12));
+        final ValueNumeric vd1 = ValueNumeric.get(new BigDecimal(12));
         new AssertThrows(ErrorCode.DIVISION_BY_ZERO_1) { @Override
         public void test() {
-            vd1.modulus(ValueDecimal.get(new BigDecimal(0)));
+            vd1.modulus(ValueNumeric.get(new BigDecimal(0)));
         }};
-        ValueDecimal vd2 = ValueDecimal.get(new BigDecimal(10));
-        ValueDecimal vd3 = vd1.modulus(vd2);
+        ValueNumeric vd2 = ValueNumeric.get(new BigDecimal(10));
+        ValueNumeric vd3 = vd1.modulus(vd2);
         assertEquals(2, vd3.getDouble());
     }
 
@@ -507,7 +507,7 @@ public class TestValue extends TestDb {
 
         testTypeInfoCheck(Value.REAL, 7, 0, 15, TypeInfo.TYPE_REAL, TypeInfo.getTypeInfo(Value.REAL));
         testTypeInfoCheck(Value.DOUBLE, 17, 0, 24, TypeInfo.TYPE_DOUBLE, TypeInfo.getTypeInfo(Value.DOUBLE));
-        testTypeInfoCheck(Value.NUMERIC, Integer.MAX_VALUE, ValueDecimal.MAXIMUM_SCALE, Integer.MAX_VALUE,
+        testTypeInfoCheck(Value.NUMERIC, Integer.MAX_VALUE, ValueNumeric.MAXIMUM_SCALE, Integer.MAX_VALUE,
                 TypeInfo.TYPE_NUMERIC, TypeInfo.getTypeInfo(Value.NUMERIC));
         testTypeInfoCheck(Value.NUMERIC, 65_535, 32_767, 65_537, TypeInfo.TYPE_NUMERIC_FLOATING_POINT);
 

--- a/h2/src/test/org/h2/test/unit/TestValueMemory.java
+++ b/h2/src/test/org/h2/test/unit/TestValueMemory.java
@@ -174,7 +174,7 @@ public class TestValueMemory extends TestBase implements DataHandler {
             return ValueByte.get((byte) random.nextInt());
         case Value.SMALLINT:
             return ValueShort.get((short) random.nextInt());
-        case Value.INT:
+        case Value.INTEGER:
             return ValueInt.get(random.nextInt());
         case Value.BIGINT:
             return ValueLong.get(random.nextLong());

--- a/h2/src/test/org/h2/test/unit/TestValueMemory.java
+++ b/h2/src/test/org/h2/test/unit/TestValueMemory.java
@@ -29,31 +29,31 @@ import org.h2.util.Utils;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
 import org.h2.value.ValueArray;
+import org.h2.value.ValueBigint;
 import org.h2.value.ValueBoolean;
-import org.h2.value.ValueByte;
-import org.h2.value.ValueBytes;
+import org.h2.value.ValueChar;
 import org.h2.value.ValueDate;
-import org.h2.value.ValueDecimal;
 import org.h2.value.ValueDouble;
-import org.h2.value.ValueFloat;
 import org.h2.value.ValueGeometry;
-import org.h2.value.ValueInt;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueJavaObject;
 import org.h2.value.ValueJson;
-import org.h2.value.ValueLong;
 import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
 import org.h2.value.ValueResultSet;
 import org.h2.value.ValueRow;
-import org.h2.value.ValueShort;
-import org.h2.value.ValueString;
-import org.h2.value.ValueStringFixed;
-import org.h2.value.ValueStringIgnoreCase;
+import org.h2.value.ValueSmallint;
 import org.h2.value.ValueTime;
 import org.h2.value.ValueTimeTimeZone;
 import org.h2.value.ValueTimestamp;
 import org.h2.value.ValueTimestampTimeZone;
+import org.h2.value.ValueTinyint;
 import org.h2.value.ValueUuid;
+import org.h2.value.ValueVarbinary;
+import org.h2.value.ValueVarchar;
+import org.h2.value.ValueVarcharIgnoreCase;
 
 /**
  * Tests the memory consumption of values. Values can estimate how much memory
@@ -123,8 +123,8 @@ public class TestValueMemory extends TestBase implements DataHandler {
     }
 
     private void testCompare() {
-        ValueDecimal a = ValueDecimal.get(new BigDecimal("0.0"));
-        ValueDecimal b = ValueDecimal.get(new BigDecimal("-0.00"));
+        ValueNumeric a = ValueNumeric.get(new BigDecimal("0.0"));
+        ValueNumeric b = ValueNumeric.get(new BigDecimal("-0.00"));
         assertTrue(a.hashCode() != b.hashCode());
         assertFalse(a.equals(b));
     }
@@ -171,20 +171,20 @@ public class TestValueMemory extends TestBase implements DataHandler {
         case Value.BOOLEAN:
             return ValueBoolean.FALSE;
         case Value.TINYINT:
-            return ValueByte.get((byte) random.nextInt());
+            return ValueTinyint.get((byte) random.nextInt());
         case Value.SMALLINT:
-            return ValueShort.get((short) random.nextInt());
+            return ValueSmallint.get((short) random.nextInt());
         case Value.INTEGER:
-            return ValueInt.get(random.nextInt());
+            return ValueInteger.get(random.nextInt());
         case Value.BIGINT:
-            return ValueLong.get(random.nextLong());
+            return ValueBigint.get(random.nextLong());
         case Value.NUMERIC:
-            return ValueDecimal.get(new BigDecimal(random.nextInt()));
+            return ValueNumeric.get(new BigDecimal(random.nextInt()));
             // + "12123344563456345634565234523451312312"
         case Value.DOUBLE:
             return ValueDouble.get(random.nextDouble());
         case Value.REAL:
-            return ValueFloat.get(random.nextFloat());
+            return ValueReal.get(random.nextFloat());
         case Value.TIME:
             return ValueTime.fromNanos(randomTimeNanos());
         case Value.TIME_TZ:
@@ -197,11 +197,11 @@ public class TestValueMemory extends TestBase implements DataHandler {
             return ValueTimestampTimeZone.fromDateValueAndNanos(
                     randomDateValue(), randomTimeNanos(), randomZoneOffset());
         case Value.VARBINARY:
-            return ValueBytes.get(randomBytes(random.nextInt(1000)));
+            return ValueVarbinary.get(randomBytes(random.nextInt(1000)));
         case Value.VARCHAR:
-            return ValueString.get(randomString(random.nextInt(100)));
+            return ValueVarchar.get(randomString(random.nextInt(100)));
         case Value.VARCHAR_IGNORECASE:
-            return ValueStringIgnoreCase.get(randomString(random.nextInt(100)));
+            return ValueVarcharIgnoreCase.get(randomString(random.nextInt(100)));
         case Value.BLOB: {
             int len = (int) Math.abs(random.nextGaussian() * 10);
             byte[] data = randomBytes(len);
@@ -223,7 +223,7 @@ public class TestValueMemory extends TestBase implements DataHandler {
         case Value.UUID:
             return ValueUuid.get(random.nextLong(), random.nextLong());
         case Value.CHAR:
-            return ValueStringFixed.get(randomString(random.nextInt(100)));
+            return ValueChar.get(randomString(random.nextInt(100)));
         case Value.GEOMETRY:
             return ValueGeometry.get("POINT (" + random.nextInt(100) + ' ' + random.nextInt(100) + ')');
         case Value.INTERVAL_YEAR:

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -824,4 +824,4 @@ umcfo iapi autoloaded derbyshared darkred coral mistyrose lightseagreen unmodifi
 quotient niomem niomapped obtaining rare occasions oversynchronizing disallows opponent adversarial broader decent tmv
 prize secured stateful generification bracketed permissible opaque aside indexable daytime uncomparable reevaluates
 pct sliding deliberately sampling grabs saw video keyed carries estimator restrain remainer magnitude placeholder
-expandable jira meaningless
+expandable jira meaningless iterated


### PR DESCRIPTION
Closes #2194.

I didn't allocate any LTS numbers for `getVendorTypeNumber()` here. Even the SQL Standard and JDBC have strange deviations in many numbers. Right now this method simply returns internal type numbers and its javadoc says that they are valid only for the current version.

This PR also contains some internal changes in names of constants and value implementations, not visible from our official API. `Value.BYTES` and `ValueBytes` are renamed to `Value.VARBINARY` and `ValueVarbinary`, for example. This class is going to be separated into `VARBINARY` and `BINARY` implementations, so it's better to have precise names of constants instead of `BYTES`. `Value.FLOAT` is renamed to `Value.REAL`, because the `FLOAT` is a different thing in SQL and such name only creates a confusion. And so on.