### PR TITLE
Document possible deserialization in linked tables

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3661,15 +3661,22 @@ BINARY(1000)
 This type allows storing serialized Java objects. Internally, a byte array is used.
 The maximum size of serialized form is 2 GB, but the whole array is kept in memory when using this data type.
 The precision is a size constraint; only the actual data is persisted.
-Serialization and deserialization is done on the client side only.
+Serialization and deserialization is done on the client side only with one exclusion described below.
 Deserialization is only done when ""getObject"" is called.
 Java operations cannot be executed inside the database engine for security reasons.
 Use ""PreparedStatement.setObject"" with ""Types.JAVA_OBJECT"" or ""H2Type.JAVA_OBJECT""
 as a third argument to store values.
 
+If a [linked table](https://h2database.com/html/advanced.html#linked_tables) has a column with ""Types.JAVA_OBJECT""
+JDBC data type and its database is not an another H2, Java objects need to be serialized and deserialized during
+interaction between H2 and database that owns the table on the server side of H2.
+
+This data type needs special attention in secure environments.
+
 Mapped to ""java.lang.Object"" (or any subclass).
 ","
-OTHER
+JAVA_OBJECT
+JAVA_OBJECT(10000)
 "
 
 "Data Types","VARCHAR Type","

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2378: JAVA_OBJECT and TableLink
+</li>
 <li>Issue #2417: Casts between binary strings and non-string data types
 </li>
 <li>Issue #2416: OTHER and JAVA_OBJECT

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -35,7 +35,6 @@ import org.h2.message.DbException;
 import org.h2.util.Utils.ClassFactory;
 import org.h2.value.DataType;
 import org.h2.value.Value;
-import org.h2.value.ValueJavaObject;
 import org.h2.value.ValueLob;
 import org.h2.value.ValueUuid;
 
@@ -553,9 +552,7 @@ public class JdbcUtils {
             break;
         case Value.JAVA_OBJECT:
             prep.setObject(parameterIndex,
-                    value.getClass() == ValueJavaObject.class
-                            ? JdbcUtils.deserialize(value.getBytesNoCopy(), provider.getJavaObjectSerializer())
-                            : /* ValueJavaObject.NotSerialized */ value.getObject(),
+                    JdbcUtils.deserialize(value.getBytesNoCopy(), provider.getJavaObjectSerializer()),
                     Types.JAVA_OBJECT);
             break;
         case Value.UUID:

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -1814,7 +1814,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL {
         //$FALL-THROUGH$
         default:
             v = ValueLob.createSmallLob(CLOB, getString().getBytes(StandardCharsets.UTF_8));
-        } 
+        }
         if (conversionMode != CONVERT_TO) {
             if (conversionMode == CAST_TO) {
                 v = v.convertPrecision(targetType.getPrecision());

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -824,4 +824,4 @@ umcfo iapi autoloaded derbyshared darkred coral mistyrose lightseagreen unmodifi
 quotient niomem niomapped obtaining rare occasions oversynchronizing disallows opponent adversarial broader decent tmv
 prize secured stateful generification bracketed permissible opaque aside indexable daytime uncomparable reevaluates
 pct sliding deliberately sampling grabs saw video keyed carries estimator restrain remainer magnitude placeholder
-expandable jira meaningless iterated maliciously crafted cdef
+expandable jira meaningless iterated maliciously crafted cdef attention deserialized


### PR DESCRIPTION
In previous pull requests different undocumented places where deserialization was possible were removed. Linked tables, however, may still need it. Deserialization was removed for linked tables from another H2, but it is needed for non-H2 databases anyway. This case is documented here.

Closes #2378.