### PR TITLE
Add MD5 and all SHA-1, SHA-2, and SHA-3 digests to the HASH() function

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -2673,7 +2673,7 @@ Boolean value or condition.
 ""UNIQUE"" predicate tests absence of duplicate rows in the specified subquery and returns ""TRUE"" or ""FALSE"".
 Rows with ""NULL"" value in any column are ignored.
 
-""INTERSECTS"" checks whether 2D bounding boxes of specified geometries intersects with each other
+""INTERSECTS"" checks whether 2D bounding boxes of specified geometries intersect with each other
 and returns ""TRUE"" or ""FALSE"".
 ","
 ID<>2

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4492,10 +4492,21 @@ CALL TRIM(CHAR(0) FROM UTF8TOSTRING(
 @h2@ HASH(algorithmString, expression [, iterationInt])
 ","
 Calculate the hash value using an algorithm, and repeat this process for a number of iterations.
-Currently, the only algorithm supported is SHA256.
+
+This function supports MD5, SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA3-224, SHA3-256, SHA3-384, and SHA3-512
+algorithms.
+SHA-224, SHA-384, and SHA-512 may be unavailable in some JREs.
+
+MD5 and SHA-1 algorithms should not be considered as secure.
+
+If this function is used to encrypt a password, a random salt should be concatenated with a password and this salt and
+result of the function should be stored to prevent a rainbow table attack and number of iterations should be large
+enough to slow down a dictionary or a brute force attack.
+
 This method returns bytes.
 ","
-CALL HASH('SHA256', STRINGTOUTF8('Password'), 1000)
+CALL HASH('SHA-256', 'Text', 1000)
+CALL HASH('SHA3-256', X'0102')
 "
 
 "Functions (Numeric)","TRUNCATE","

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #2426: Add MD5 and all SHA-1, SHA-2, and SHA-3 digests to the HASH() function
+</li>
 <li>Issue #2424: 0 should not be accepted as a length of data type
 </li>
 <li>Issue #2378: JAVA_OBJECT and TableLink

--- a/h2/src/main/org/h2/security/SHA3.java
+++ b/h2/src/main/org/h2/security/SHA3.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.security;
+
+import java.security.MessageDigest;
+import java.util.Arrays;
+
+import org.h2.util.Bits;
+
+/**
+ * SHA-3 message digest family.
+ */
+public final class SHA3 extends MessageDigest {
+
+    private static final long[] ROUND_CONSTANTS;
+
+    static {
+        long[] rc = new long[24];
+        byte l = 1;
+        for (int i = 0; i < 24; i++) {
+            rc[i] = 0;
+            for (int j = 0; j < 7; j++) {
+                byte t = l;
+                l = (byte) (t < 0 ? t << 1 ^ 0x71 : t << 1);
+                if ((t & 1) != 0) {
+                    rc[i] ^= 1L << (1 << j) - 1;
+                }
+            }
+        }
+        ROUND_CONSTANTS = rc;
+    }
+
+    /**
+     * Returns a new instance of SHA3-224 message digest.
+     *
+     * @return SHA3-224 message digest
+     */
+    public static SHA3 getSha3_224() {
+        return new SHA3("SHA3-224", 28);
+    }
+
+    /**
+     * Returns a new instance of SHA3-256 message digest.
+     *
+     * @return SHA3-256 message digest
+     */
+    public static SHA3 getSha3_256() {
+        return new SHA3("SHA3-256", 32);
+    }
+
+    /**
+     * Returns a new instance of SHA3-384 message digest.
+     *
+     * @return SHA3-384 message digest
+     */
+    public static SHA3 getSha3_384() {
+        return new SHA3("SHA3-384", 48);
+    }
+
+    /**
+     * Returns a new instance of SHA3-512 message digest.
+     *
+     * @return SHA3-512 message digest
+     */
+    public static SHA3 getSha3_512() {
+        return new SHA3("SHA3-512", 64);
+    }
+
+    private final int digestLength;
+
+    private final int rate;
+
+    private long state00, state01, state02, state03, state04, state05, state06, state07, state08, state09, //
+            state10, state11, state12, state13, state14, state15, state16, state17, state18, state19, //
+            state20, state21, state22, state23, state24;
+
+    private final byte[] buf;
+
+    private int bufcnt;
+
+    private SHA3(String algorithm, int digestLength) {
+        super(algorithm);
+        this.digestLength = digestLength;
+        buf = new byte[this.rate = 200 - digestLength * 2];
+    }
+
+    @Override
+    protected byte[] engineDigest() {
+        buf[bufcnt] = 0b110;
+        Arrays.fill(buf, bufcnt + 1, rate, (byte) 0);
+        buf[rate - 1] |= 0x80;
+        absorbQueue();
+        byte[] r = new byte[digestLength];
+        switch (digestLength) {
+        case 64:
+            Bits.writeLongLE(r, 56, state07);
+            Bits.writeLongLE(r, 48, state06);
+            //$FALL-THROUGH$
+        case 48:
+            Bits.writeLongLE(r, 40, state05);
+            Bits.writeLongLE(r, 32, state04);
+            //$FALL-THROUGH$
+        case 32:
+            Bits.writeLongLE(r, 24, state03);
+            break;
+        case 28:
+            Bits.writeIntLE(r, 24, (int) state03);
+        }
+        Bits.writeLongLE(r, 16, state02);
+        Bits.writeLongLE(r, 8, state01);
+        Bits.writeLongLE(r, 0, state00);
+        engineReset();
+        return r;
+    }
+
+    @Override
+    protected int engineGetDigestLength() {
+        return digestLength;
+    }
+
+    @Override
+    protected void engineReset() {
+        state24 = state23 = state22 = state21 = state20 //
+                = state19 = state18 = state17 = state16 = state15 //
+                = state14 = state13 = state12 = state11 = state10 //
+                = state09 = state08 = state07 = state06 = state05 //
+                = state04 = state03 = state02 = state01 = state00 = 0L;
+        Arrays.fill(buf, (byte) 0);
+        bufcnt = 0;
+    }
+
+    @Override
+    protected void engineUpdate(byte input) {
+        buf[bufcnt++] = input;
+        if (bufcnt == rate) {
+            absorbQueue();
+        }
+    }
+
+    @Override
+    protected void engineUpdate(byte[] input, int offset, int len) {
+        while (len > 0) {
+            if (bufcnt == 0 && len >= rate) {
+                do {
+                    absorb(input, offset);
+                    offset += rate;
+                    len -= rate;
+                } while (len >= rate);
+            } else {
+                int partialBlock = Math.min(len, rate - bufcnt);
+                System.arraycopy(input, offset, buf, bufcnt, partialBlock);
+                bufcnt += partialBlock;
+                offset += partialBlock;
+                len -= partialBlock;
+                if (bufcnt == rate) {
+                    absorbQueue();
+                }
+            }
+        }
+    }
+
+    private void absorbQueue() {
+        absorb(buf, 0);
+        bufcnt = 0;
+    }
+
+    private void absorb(byte[] data, int offset) {
+        /*
+         * There is no need to copy 25 state* fields into local variables,
+         * because so large number of local variables only hurts performance.
+         */
+        switch (digestLength) {
+        case 28:
+            state17 ^= Bits.readLongLE(data, offset + 136);
+            //$FALL-THROUGH$
+        case 32:
+            state13 ^= Bits.readLongLE(data, offset + 104);
+            state14 ^= Bits.readLongLE(data, offset + 112);
+            state15 ^= Bits.readLongLE(data, offset + 120);
+            state16 ^= Bits.readLongLE(data, offset + 128);
+            //$FALL-THROUGH$
+        case 48:
+            state09 ^= Bits.readLongLE(data, offset + 72);
+            state10 ^= Bits.readLongLE(data, offset + 80);
+            state11 ^= Bits.readLongLE(data, offset + 88);
+            state12 ^= Bits.readLongLE(data, offset + 96);
+        }
+        state00 ^= Bits.readLongLE(data, offset);
+        state01 ^= Bits.readLongLE(data, offset + 8);
+        state02 ^= Bits.readLongLE(data, offset + 16);
+        state03 ^= Bits.readLongLE(data, offset + 24);
+        state04 ^= Bits.readLongLE(data, offset + 32);
+        state05 ^= Bits.readLongLE(data, offset + 40);
+        state06 ^= Bits.readLongLE(data, offset + 48);
+        state07 ^= Bits.readLongLE(data, offset + 56);
+        state08 ^= Bits.readLongLE(data, offset + 64);
+        for (int i = 0; i < 24; i++) {
+            long c0 = state00 ^ state05 ^ state10 ^ state15 ^ state20;
+            long c1 = state01 ^ state06 ^ state11 ^ state16 ^ state21;
+            long c2 = state02 ^ state07 ^ state12 ^ state17 ^ state22;
+            long c3 = state03 ^ state08 ^ state13 ^ state18 ^ state23;
+            long c4 = state04 ^ state09 ^ state14 ^ state19 ^ state24;
+            long dX = (c1 << 1 | c1 >>> 63) ^ c4;
+            state00 ^= dX;
+            state05 ^= dX;
+            state10 ^= dX;
+            state15 ^= dX;
+            state20 ^= dX;
+            dX = (c2 << 1 | c2 >>> 63) ^ c0;
+            state01 ^= dX;
+            state06 ^= dX;
+            state11 ^= dX;
+            state16 ^= dX;
+            state21 ^= dX;
+            dX = (c3 << 1 | c3 >>> 63) ^ c1;
+            state02 ^= dX;
+            state07 ^= dX;
+            state12 ^= dX;
+            state17 ^= dX;
+            state22 ^= dX;
+            dX = (c4 << 1 | c4 >>> 63) ^ c2;
+            state03 ^= dX;
+            state08 ^= dX;
+            state13 ^= dX;
+            state18 ^= dX;
+            state23 ^= dX;
+            dX = (c0 << 1 | c0 >>> 63) ^ c3;
+            state04 ^= dX;
+            state09 ^= dX;
+            state14 ^= dX;
+            state19 ^= dX;
+            state24 ^= dX;
+            long s00 = state00;
+            long s01 = state06 << 44 | state06 >>> 20;
+            long s02 = state12 << 43 | state12 >>> 21;
+            long s03 = state18 << 21 | state18 >>> 43;
+            long s04 = state24 << 14 | state24 >>> 50;
+            long s05 = state03 << 28 | state03 >>> 36;
+            long s06 = state09 << 20 | state09 >>> 44;
+            long s07 = state10 << 3 | state10 >>> 61;
+            long s08 = state16 << 45 | state16 >>> 19;
+            long s09 = state22 << 61 | state22 >>> 3;
+            long s10 = state01 << 1 | state01 >>> 63;
+            long s11 = state07 << 6 | state07 >>> 58;
+            long s12 = state13 << 25 | state13 >>> 39;
+            long s13 = state19 << 8 | state19 >>> 56;
+            long s14 = state20 << 18 | state20 >>> 46;
+            long s15 = state04 << 27 | state04 >>> 37;
+            long s16 = state05 << 36 | state05 >>> 28;
+            long s17 = state11 << 10 | state11 >>> 54;
+            long s18 = state17 << 15 | state17 >>> 49;
+            long s19 = state23 << 56 | state23 >>> 8;
+            long s20 = state02 << 62 | state02 >>> 2;
+            long s21 = state08 << 55 | state08 >>> 9;
+            long s22 = state14 << 39 | state14 >>> 25;
+            long s23 = state15 << 41 | state15 >>> 23;
+            long s24 = state21 << 2 | state21 >>> 62;
+            state00 = s00 ^ ~s01 & s02 ^ ROUND_CONSTANTS[i];
+            state01 = s01 ^ ~s02 & s03;
+            state02 = s02 ^ ~s03 & s04;
+            state03 = s03 ^ ~s04 & s00;
+            state04 = s04 ^ ~s00 & s01;
+            state05 = s05 ^ ~s06 & s07;
+            state06 = s06 ^ ~s07 & s08;
+            state07 = s07 ^ ~s08 & s09;
+            state08 = s08 ^ ~s09 & s05;
+            state09 = s09 ^ ~s05 & s06;
+            state10 = s10 ^ ~s11 & s12;
+            state11 = s11 ^ ~s12 & s13;
+            state12 = s12 ^ ~s13 & s14;
+            state13 = s13 ^ ~s14 & s10;
+            state14 = s14 ^ ~s10 & s11;
+            state15 = s15 ^ ~s16 & s17;
+            state16 = s16 ^ ~s17 & s18;
+            state17 = s17 ^ ~s18 & s19;
+            state18 = s18 ^ ~s19 & s15;
+            state19 = s19 ^ ~s15 & s16;
+            state20 = s20 ^ ~s21 & s22;
+            state21 = s21 ^ ~s22 & s23;
+            state22 = s22 ^ ~s23 & s24;
+            state23 = s23 ^ ~s24 & s20;
+            state24 = s24 ^ ~s20 & s21;
+        }
+    }
+
+}

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/hash.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/hash.sql
@@ -23,3 +23,63 @@ CALL HASH('SHA256', STRINGTOUTF8('Password'), 1000);
 
 call hash('unknown', 'Hello', 1);
 > exception INVALID_VALUE_2
+
+CALL HASH('MD5', '****** Message digest test ******', 1);
+>> X'ccd7ee53b52575b5b04fcadf1637fd30'
+
+CALL HASH('MD5', '****** Message digest test ******', 10);
+>> X'b9e4b74ee3c41f646ee0ba42335efe20'
+
+CALL HASH('SHA-1', '****** Message digest test ******', 1);
+>> X'b9f28134b8c9aef59e1257eca89e3e5101234694'
+
+CALL HASH('SHA-1', '****** Message digest test ******', 10);
+>> X'e69a31beb996b59700aed3e6fbf9c29791efbc15'
+
+CALL HASH('SHA-224', '****** Message digest test ******', 1);
+>> X'7bd9bf319961cfdb7fc9351debbcc8a80143d5d0909e8cbccd8b5f0f'
+
+CALL HASH('SHA-224', '****** Message digest test ******', 10);
+>> X'6685a394158763e754332f0adec3ed43866dd0ba8f47624d0521fd1e'
+
+CALL HASH('SHA-256', '****** Message digest test ******', 1);
+>> X'4e732bc9788b0958022403dbe42b4b79bfa270f05fbe914b4ecca074635f3f5c'
+
+CALL HASH('SHA-256', '****** Message digest test ******', 10);
+>> X'93731025337904f6bc117ca5d3adc960ee2070c7a9666a5499af28546520da85'
+
+CALL HASH('SHA-384', '****** Message digest test ******', 1);
+>> X'a37baa07c0cd5bc8dbb510b3fc3fa6f5ca539c847d8ee382d1d045b405a3d43dc4a898fcc31930cf7a80e2a79af82d4e'
+
+CALL HASH('SHA-384', '****** Message digest test ******', 10);
+>> X'03cc3a769871ab13a64c387c44853efafe016180ab6ea70565924ccabe62c8884b2f2e1a53c1a79db184c112c9082bc2'
+
+CALL HASH('SHA-512', '****** Message digest test ******', 1);
+>> X'88eb2488557eaf7e4da394b6f4ba08d4c781b9f2b9c9d150195ac7f7fbee7819923476b5139abc98f252b07649ade2471be46e2625b8003d0af5a8a50ca2915f'
+
+CALL HASH('SHA-512', '****** Message digest test ******', 10);
+>> X'ab3bb7d9447f87a07379e9219c79da2e05122ff87bf25a5e553a7e44af7ac724ed91fb1fe5730d4bb584c367fc2232680f5c45b3863c6550fcf27b4473d05695'
+
+CALL HASH('SHA3-224', '****** Message digest test ******', 1);
+>> X'cb91fec022d97ed63622d382e36e336b65a806888416a549fb4db390'
+
+CALL HASH('SHA3-224', '****** Message digest test ******', 10);
+>> X'0d4dd581ed9b188341ec413988cb7c6bf15d178b151b543c91031ae6'
+
+CALL HASH('SHA3-256', '****** Message digest test ******', 1);
+>> X'91db71f65f3c5b19370e0d9fd947da52695b28c9b440a1324d11e8076643c21f'
+
+CALL HASH('SHA3-256', '****** Message digest test ******', 10);
+>> X'ed62484d8ac54550292241698dd5480de061fc23ab12e3e941a96ec7d3afd70f'
+
+CALL HASH('SHA3-384', '****** Message digest test ******', 1);
+>> X'c2d5e516ea10a82a3d3a8c5fe8838ca77d402490f33ef813be9af168fd2cdf8f6daa7e9cf79565f3987f897d4087ce26'
+
+CALL HASH('SHA3-384', '****** Message digest test ******', 10);
+>> X'9f5ac0eae232746826ea59196b455267e3aaa492047d5a2616c4a8aa325216f706dc7203fcbe71ee7e3357e0f3d93ee3'
+
+CALL HASH('SHA3-512', '****** Message digest test ******', 1);
+>> X'08811cf7409957b59bb5ba090edbef9a35c3b7a4db5d5760f15f2b14453f9cacba30b9744d4248c742aa47f3d9943cf99e7d78d1700d4ccf5bc88b394bc00603'
+
+CALL HASH('SHA3-512', '****** Message digest test ******', 10);
+>> X'37f2a9dbc6cd7a5122cc84383843566dd7195ed8d868b1c10aca2b706667c7bb0b4f00eab81d9e87b6f355e3afe0bccd57ba04aa121d0ef0c0bdea2ff8f95513'

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -824,4 +824,4 @@ umcfo iapi autoloaded derbyshared darkred coral mistyrose lightseagreen unmodifi
 quotient niomem niomapped obtaining rare occasions oversynchronizing disallows opponent adversarial broader decent tmv
 prize secured stateful generification bracketed permissible opaque aside indexable daytime uncomparable reevaluates
 pct sliding deliberately sampling grabs saw video keyed carries estimator restrain remainer magnitude placeholder
-expandable jira meaningless iterated maliciously crafted cdef attention deserialized
+expandable jira meaningless iterated maliciously crafted cdef attention deserialized hurts absorb bufcnt


### PR DESCRIPTION
The `HASH` function is extended to support more common message digests. Only `SHA-256` was supported earlier.

A custom implementation of SHA-3 algorithms is used, because they aren't available on older JREs and on Android. This custom implementation is also faster than implementation from recent JREs at least on my system, therefore it is used unconditionally.