### PR TITLE
Fix issue #2430: pgjdbc can read `bytea` data without `forceBinary`

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -522,10 +522,8 @@ public class PgServerThread implements Runnable {
         for (int i = 1; i <= columns; i++) {
             int pgType = PgServer.convertType(metaData.getColumnType(i));
             boolean text = formatAsText(pgType);
-            if (formatCodes != null) {
-                if (formatCodes.length == 0) {
-                    text = true;
-                } else if (formatCodes.length == 1) {
+            if (text && formatCodes != null && formatCodes.length > 0) {
+                if (formatCodes.length == 1) {
                     text = formatCodes[0] == 0;
                 } else if (i - 1 < formatCodes.length) {
                     text = formatCodes[i - 1] == 0;
@@ -813,7 +811,7 @@ public class PgServerThread implements Runnable {
     /**
      * Check whether the given type should be formatted as text.
      *
-     * @return true for binary
+     * @return true for text
      */
     private static boolean formatAsText(int pgType) {
         switch (pgType) {

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -394,6 +394,11 @@ public class TestPgServer extends TestDb {
     }
 
     private void testBinaryTypes() throws SQLException {
+        testBinaryTypes(false);
+        testBinaryTypes(true);
+    }
+
+    private void testBinaryTypes(boolean forceBinary) throws SQLException {
         if (!getPgJdbcDriver()) {
             return;
         }
@@ -404,8 +409,9 @@ public class TestPgServer extends TestDb {
             Properties props = new Properties();
             props.setProperty("user", "sa");
             props.setProperty("password", "sa");
-            // force binary
-            props.setProperty("prepareThreshold", "-1");
+            if (forceBinary) {
+                props.setProperty("prepareThreshold", "-1");
+            }
 
             Connection conn = DriverManager.getConnection(
                     "jdbc:postgresql://localhost:5535/pgserver", props);
@@ -487,8 +493,8 @@ public class TestPgServer extends TestDb {
                 Properties props = new Properties();
                 props.setProperty("user", "sa");
                 props.setProperty("password", "sa");
-                // force binary
-                props.setProperty("prepareThreshold", "-1");
+                // no need to force binary for date/time types
+                // props.setProperty("prepareThreshold", "-1");
 
                 Connection conn = DriverManager.getConnection(
                         "jdbc:postgresql://localhost:5535/pgserver", props);


### PR DESCRIPTION
Fix issue #2430: pgjdbc can read `bytea` data without `forceBinary`