### PR TITLE
Assorted changes in MVStore

### DIFF
--- a/h2/src/main/org/h2/mvstore/CursorPos.java
+++ b/h2/src/main/org/h2/mvstore/CursorPos.java
@@ -47,7 +47,7 @@ public final class CursorPos<K,V>
      * @param key       the key to search for
      * @return head of the CursorPos chain (insertion point)
      */
-    public static <K,V> CursorPos<K,V> traverseDown(Page<K,V> page, K key) {
+    static <K,V> CursorPos<K,V> traverseDown(Page<K,V> page, K key) {
         CursorPos<K,V> cursorPos = null;
         while (!page.isLeaf()) {
             int index = page.binarySearch(key) + 1;

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2846,7 +2846,7 @@ public class MVStore implements AutoCloseable
      * @return the name, or null if not found
      */
     public String getMapName(int id) {
-        checkOpen();
+//        checkOpen();
         String m = meta.get(MVMap.getMapKey(id));
         return m == null ? null : DataUtils.getMapName(m);
     }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1401,26 +1401,7 @@ public class MVStore implements AutoCloseable
         c.next = Long.MAX_VALUE;
         c.occupancy = new BitSet();
         chunks.put(c.id, c);
-        ArrayList<Page<?,?>> changed = new ArrayList<>();
-        for (Iterator<MVMap<?, ?>> iter = maps.values().iterator(); iter.hasNext(); ) {
-            MVMap<?,?> map = iter.next();
-            RootReference<?,?> rootReference = map.setWriteVersion(version);
-            if (rootReference == null) {
-                iter.remove();
-            } else if (map.getCreateVersion() <= storeVersion && // if map was created after storing started, skip it
-                    !map.isVolatile() &&
-                    map.hasChangesSince(lastStoredVersion)) {
-                assert rootReference.version <= version : rootReference.version + " > " + version;
-                Page<?,?> rootPage = rootReference.root;
-                if (!rootPage.isSaved() ||
-                        // after deletion previously saved leaf
-                        // may pop up as a root, but we still need
-                        // to save new root pos in meta
-                        rootPage.isLeaf()) {
-                    changed.add(rootPage);
-                }
-            }
-        }
+        ArrayList<Page<?,?>> changed = collectChangedMapRoots(storeVersion, version);
         List<Long> toc = new ArrayList<>();
         WriteBuffer buff = getWriteBuffer();
         // need to patch the header later
@@ -1517,19 +1498,11 @@ public class MVStore implements AutoCloseable
                     // we write after at least every 20 versions
                     writeStoreHeader = true;
                 } else {
-                    int chunkId = DataUtils.readHexInt(storeHeader, HDR_CHUNK, 0);
-                    while (true) {
-                        Chunk old = chunks.get(chunkId);
-                        if (old == null) {
-                            // one of the chunks in between
-                            // was removed
-                            writeStoreHeader = true;
-                            break;
-                        }
-                        if (chunkId == lastChunk.id) {
-                            break;
-                        }
-                        chunkId++;
+                    for (int chunkId = DataUtils.readHexInt(storeHeader, HDR_CHUNK, 0);
+                         !writeStoreHeader && chunkId <= lastChunk.id; ++chunkId) {
+                        // one of the chunks in between
+                        // was removed
+                        writeStoreHeader = !chunks.containsKey(chunkId);
                     }
                 }
             }
@@ -1557,6 +1530,31 @@ public class MVStore implements AutoCloseable
         saveNeeded = false;
         unsavedMemory = Math.max(0, unsavedMemory - currentUnsavedPageCount);
         lastStoredVersion = storeVersion;
+    }
+
+    private ArrayList<Page<?,?>> collectChangedMapRoots(long storeVersion, long version) {
+        assert storeVersion + 1 == version;
+        ArrayList<Page<?,?>> changed = new ArrayList<>();
+        for (Iterator<MVMap<?, ?>> iter = maps.values().iterator(); iter.hasNext(); ) {
+            MVMap<?, ?> map = iter.next();
+            RootReference<?,?> rootReference = map.setWriteVersion(version);
+            if (rootReference == null) {
+                iter.remove();
+            } else if (map.getCreateVersion() <= storeVersion && // if map was created after storing started, skip it
+                    !map.isVolatile() &&
+                    map.hasChangesSince(lastStoredVersion)) {
+                assert rootReference.version <= version : rootReference.version + " > " + version;
+                Page<?,?> rootPage = rootReference.root;
+                if (!rootPage.isSaved() ||
+                        // after deletion previously saved leaf
+                        // may pop up as a root, but we still need
+                        // to save new root pos in meta
+                        rootPage.isLeaf()) {
+                    changed.add(rootPage);
+                }
+            }
+        }
+        return changed;
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -791,17 +791,6 @@ public abstract class Page<K,V> implements Cloneable
 
     public abstract int getRawChildPageCount();
 
-    @SuppressWarnings("rawtypes")
-    @Override
-    public final boolean equals(Object other) {
-        return other == this || other instanceof Page && isSaved() && ((Page) other).pos == pos;
-    }
-
-    @Override
-    public final int hashCode() {
-        return isSaved() ? (int) (pos | (pos >>> 32)) : super.hashCode();
-    }
-
     protected final boolean isPersistent() {
         return memory != IN_MEMORY;
     }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -201,28 +201,6 @@ public class Transaction {
         return getStatus(statusAndLogId.get());
     }
 
-    /**
-     * Create a snapshot for the given map id.
-     *
-     * @param mapId the map id
-     * @return the root reference
-     */
-    <K,V> Snapshot<K,VersionedValue<V>> createSnapshot(int mapId) {
-        // The purpose of the following loop is to get a coherent picture
-        // of a state of two independent volatile / atomic variables,
-        // which they had at some recent moment in time.
-        // In order to get such a "snapshot", we wait for a moment of silence,
-        // when neither of the variables concurrently changes it's value.
-        BitSet committingTransactions;
-        RootReference<K,VersionedValue<V>> root;
-        do {
-            committingTransactions = store.committingTransactions.get();
-            MVMap<K,VersionedValue<V>> map = store.getMap(mapId);
-            root = map.flushAndGetRoot();
-        } while (committingTransactions != store.committingTransactions.get());
-        return new Snapshot<>(root, committingTransactions);
-    }
-
     RootReference<Long,Record<?,?>>[] getUndoLogRootReferences() {
         return undoLogRootReferences;
     }

--- a/h2/src/main/org/h2/value/ValueCollectionBase.java
+++ b/h2/src/main/org/h2/value/ValueCollectionBase.java
@@ -104,9 +104,9 @@ public abstract class ValueCollectionBase extends Value {
 
     @Override
     public int getMemory() {
-        int memory = 72;
+        int memory = 72 + values.length * Constants.MEMORY_POINTER;
         for (Value v : values) {
-            memory += v.getMemory() + Constants.MEMORY_POINTER;
+            memory += v.getMemory();
         }
         return memory;
     }


### PR DESCRIPTION
1. Fix for potential race condition in TransactionMap.getImmediate(), when uncommitted value may become visible to another transaction, instead of a just committed one, because used map root and bitmask of committing transactions may be incoherent. De-duplicate related logic by merging with getFromSnapshot()
2. Re-use instances of TxDecisionMaker (and subclasses) within TransactionMap instance, because it is only suppose to be used by one thread at a time.
3. De-dup refactoring in RootReference
4. Fix some minor generics issue still in MVMap.
