### PR TITLE
Do not use unsafe and unnecessary FROM DUAL internally

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1556,7 +1556,8 @@ public class Parser {
             // for PostgreSQL compatibility
             read("ISOLATION");
             read("LEVEL");
-            buff.append("'read committed' TRANSACTION_ISOLATION");
+            buff.append("LOWER(ISOLATION_LEVEL) TRANSACTION_ISOLATION FROM INFORMATION_SCHEMA.SESSIONS "
+                    + "WHERE ID = SESSION_ID()");
         } else if (readIf("DATESTYLE")) {
             // for PostgreSQL compatibility
             buff.append("'ISO' DATESTYLE");

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1548,26 +1548,24 @@ public class Parser {
         StringBuilder buff = new StringBuilder("SELECT ");
         if (readIf("CLIENT_ENCODING")) {
             // for PostgreSQL compatibility
-            buff.append("'UNICODE' AS CLIENT_ENCODING FROM DUAL");
+            buff.append("'UNICODE' CLIENT_ENCODING");
         } else if (readIf("DEFAULT_TRANSACTION_ISOLATION")) {
             // for PostgreSQL compatibility
-            buff.append("'read committed' AS DEFAULT_TRANSACTION_ISOLATION " +
-                    "FROM DUAL");
+            buff.append("'read committed' DEFAULT_TRANSACTION_ISOLATION");
         } else if (readIf("TRANSACTION")) {
             // for PostgreSQL compatibility
             read("ISOLATION");
             read("LEVEL");
-            buff.append("'read committed' AS TRANSACTION_ISOLATION " +
-                    "FROM DUAL");
+            buff.append("'read committed' TRANSACTION_ISOLATION");
         } else if (readIf("DATESTYLE")) {
             // for PostgreSQL compatibility
-            buff.append("'ISO' AS DATESTYLE FROM DUAL");
+            buff.append("'ISO' DATESTYLE");
         } else if (readIf("SERVER_VERSION")) {
             // for PostgreSQL compatibility
-            buff.append("'" + Constants.PG_VERSION + "' AS SERVER_VERSION FROM DUAL");
+            buff.append("'" + Constants.PG_VERSION + "' SERVER_VERSION");
         } else if (readIf("SERVER_ENCODING")) {
             // for PostgreSQL compatibility
-            buff.append("'UTF8' AS SERVER_ENCODING FROM DUAL");
+            buff.append("'UTF8' SERVER_ENCODING");
         } else if (readIf("TABLES")) {
             // for MySQL compatibility
             String schema = database.getMainSchema().getName();

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -1435,7 +1435,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
                     + "CAST(NULL AS SMALLINT) DATA_TYPE, "
                     + "CAST(NULL AS VARCHAR) REMARKS, "
                     + "CAST(NULL AS SMALLINT) BASE_TYPE "
-                    + "FROM DUAL WHERE FALSE");
+                    + "WHERE FALSE");
             return prep.executeQuery();
         } catch (Exception e) {
             throw logAndConvert(e);


### PR DESCRIPTION
H2 doesn't need the `FROM` clause in the `SELECT` command and H2, just like Oracle, allow `DUAL` as a name of a normal table. In result, if such table exists, it is used instead of dummy single-row table. H2 should never use this table in the main code.