### PR TITLE
fix issue #2455

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -561,7 +561,7 @@ public class PgServerThread implements Runnable {
                     byte b = bytes[i];
                     if (b < 32 || b > 126) {
                         data[j++] = '\\';
-                        data[j++] = (byte) (((b >>> 6) & 7) + '0');
+                        data[j++] = (byte) (((b >>> 6) & 3) + '0');
                         data[j++] = (byte) (((b >>> 3) & 7) + '0');
                         data[j++] = (byte) ((b & 7) + '0');
                     } else if (b == 92) {


### PR DESCRIPTION
escape string for `{ 'a', (byte) 0xfe, '\127', 0, 127, '\\' }` should be
`a\376W\000\177\\` but not `a\776W\000\177\\`