### PR TITLE
fix issue #2464: node-postgres compatibility

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -191,6 +191,12 @@ public class PgServerThread implements Runnable {
                     } else if ("database".equals(param)) {
                         this.databaseName = server.checkKeyAndGetDatabaseName(value);
                     } else if ("client_encoding".equals(param)) {
+                        // node-postgres will send "'utf-8'"
+                        int length = value.length();
+                        if (length >= 2 && value.charAt(0) == '\''
+                                && value.charAt(length - 1) == '\'') {
+                            value = value.substring(1, length - 1);
+                        }
                         // UTF8
                         clientEncoding = value;
                     } else if ("DateStyle".equals(param)) {


### PR DESCRIPTION
To test the fix, set a breakpoint after first `ps.execute()` in `TestPgServer.testTextualAndBinaryTypes()` (Line 461) and run node.js:

```
const { Client } = require('pg');

const connectionString = 'postgres://sa:sa@localhost:5535/pgserver';
const client = new Client({
    connectionString: connectionString
});
client.connect();
client.query('SELECT x1, x10 FROM test LIMIT 1', [], function (err, result) {
  if (err) {
    console.log(err);
    return;
  }
  console.log(result.rows[0]);
  client.end();
});
```
Expected:
`{ x1: 'test', x10: <Buffer 61 fe 57 00 7f 5c> }`