### PR TITLE
Add partial support for the mysql COLLATE and CHARACTER syntax

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #2466: Add partial support for MySQL COLLATE and CHARACTER statements
+</li>
 <li>Issue #2461: Support for binary_float and binary_double type aliases
 </li>
 <li>Issue #2460: Exception when accessing empty arrays

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6001,6 +6001,15 @@ public class Parser {
             int value = readNonNegativeInt();
             column.setSelectivity(value);
         }
+        if (database.getMode().getEnum() == ModeEnum.MySQL) {
+            if (readIf("CHARACTER")) {
+                readIf(SET);
+                readMySQLCharset();
+            }
+            if (readIf("COLLATE")) {
+                readMySQLCharset();
+            }
+        }
         String comment = readCommentIf();
         if (comment != null) {
             column.setComment(comment);
@@ -9078,11 +9087,14 @@ public class Parser {
                 if (readIf("CHARACTER")) {
                     read(SET);
                 } else {
-                    read("CHARSET");
+                    readIf("CHARSET");
+                    readIf("COLLATE");
                 }
                 readMySQLCharset();
             } else if (readIf("CHARACTER")) {
                 read(SET);
+                readMySQLCharset();
+            } else if (readIf("COLLATE")) {
                 readMySQLCharset();
             } else if (readIf("CHARSET")) {
                 readMySQLCharset();
@@ -9106,9 +9118,7 @@ public class Parser {
 
     private void readMySQLCharset() {
         readIf(EQUAL);
-        if (!readIf("UTF8")) {
-            read("UTF8MB4");
-        }
+        readUniqueIdentifier();
     }
 
     /**

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -420,6 +420,11 @@ public class TestCompatibility extends TestDb {
                 "(ID INT, KEY TEST_7_IDX(ID) USING BTREE)");
         stat.execute("CREATE TABLE TEST_10" +
                 "(ID INT, UNIQUE KEY TEST_10_IDX(ID) USING BTREE)");
+        stat.execute("CREATE TABLE TEST_11(ID INT) COLLATE UTF8");
+        stat.execute("CREATE TABLE TEST_12(ID INT) DEFAULT COLLATE UTF8");
+        stat.execute("CREATE TABLE TEST_13(a VARCHAR(10) COLLATE UTF8MB4)");
+        stat.execute("CREATE TABLE TEST_14(a VARCHAR(10) NULL CHARACTER SET UTF8MB4 COLLATE UTF8MB4_BIN)");
+        stat.execute("ALTER TABLE TEST_14 MODIFY a VARCHAR(10) NOT NULL CHARACTER SET UTF8MB4 COLLATE UTF8");
         assertThrows(ErrorCode.SYNTAX_ERROR_2, stat).execute("CREATE TABLE TEST_99" +
                 "(ID INT PRIMARY KEY) CHARSET UTF8,");
         assertThrows(ErrorCode.COLUMN_NOT_FOUND_1, stat).execute("CREATE TABLE TEST_99" +


### PR DESCRIPTION
Add support to parse the mysql COLLATE and CHARACTER keywords during
table creation, column definition or table alteration. Also add the
support for UTF8MB4_BIN mysqlcharset.

This PR doesn't add support for column collation, but merely make it
possible to use mysql scripts that uses those keyword without giving an
error.