### PR TITLE
Recognize absolute path on Windows without drive letter

### DIFF
--- a/h2/src/main/org/h2/store/fs/FileUtils.java
+++ b/h2/src/main/org/h2/store/fs/FileUtils.java
@@ -139,7 +139,7 @@ public class FileUtils {
         return FilePath.get(fileName).isAbsolute()
                 // Allows Windows to recognize "/path" as absolute.
                 // Makes the same configuration work on all platforms.
-                || fileName.startsWith(File.pathSeparator)
+                || fileName.startsWith(File.separator)
                 // Just in case of non-normalized path on Windows
                 || fileName.startsWith("/");
     }

--- a/h2/src/test/org/h2/test/unit/TestFileSystem.java
+++ b/h2/src/test/org/h2/test/unit/TestFileSystem.java
@@ -201,7 +201,9 @@ public class TestFileSystem extends TestBase {
 
     private void testAbsoluteRelative() {
         assertFalse(FileUtils.isAbsolute("test/abc"));
+        assertFalse(FileUtils.isAbsolute("./test/abc"));
         assertTrue(FileUtils.isAbsolute("~/test/abc"));
+        assertTrue(FileUtils.isAbsolute("/test/abc"));
     }
 
     private void testMemFsDir() throws IOException {


### PR DESCRIPTION
As in #535 an absolute Windows path without drive letter should be recognized as absolute. See also #1797 and 7d4cb88.

If the path is like `jdbc:h2:file:/tmp/myproj/config.h2db` the method `FileUtils.isAbsolute` will check against the normalized path `\tmp\myproj\config.h2db` on Windows.
This is not recognized as absolute because the used constant `File.pathSeparator` is not what someone might assume from its name. It is the character used to separate entries in the PATH environment variable which is `;` for Windows.

Fortunately for me the path check in `ConnectionInfo.getName` is to lenient and can be tricked. If the example path is changed to `jdbc:h2:file:/tmp/./myproj/config.h2db` it will result in the same location but will not trigger the implicit relative path error due to the `!name.contains(".\\")` check.