### PR TITLE
Fix JSON_OBJECT grammar in documentation

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -5878,7 +5878,7 @@ H2VERSION()
 
 "Functions (JSON)","JSON_OBJECT","
 JSON_OBJECT(
-[{[KEY] string VALUE expression} [,...] | {string : expression} [,...]]
+[{{[KEY] string VALUE expression} | {string : expression}} [,...] ]
 [ { NULL | ABSENT } ON NULL ]
 [ { WITH | WITHOUT } UNIQUE KEYS ]
 )

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -5878,7 +5878,7 @@ H2VERSION()
 
 "Functions (JSON)","JSON_OBJECT","
 JSON_OBJECT(
-[{[KEY] string VALUE expression} | {string : expression} [,...]]
+[{[KEY] string VALUE expression} [,...] | {string : expression} [,...]]
 [ { NULL | ABSENT } ON NULL ]
 [ { WITH | WITHOUT } UNIQUE KEYS ]
 )


### PR DESCRIPTION
The `JSON_OBJECT()` function allows repetitions also with the `KEY` .. `VALUE` .. syntax