### PR TITLE
Performance fix for PageStore under concurrent load

### DIFF
--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -1028,6 +1028,13 @@ public class Session extends SessionWithState implements TransactionStore.Rollba
             }
             locks.clear();
         }
+        if (!database.isMVStore() && database.getLockMode() == Constants.LOCK_MODE_READ_COMMITTED) {
+            // PageStoreTable.doLock2() doesn't register a table lock in this setup
+            // but waiting threads still need to be awoken from their sleep
+            synchronized (database) {
+                database.notifyAll();
+            }
+        }
         database.unlockMetaDebug(this);
         savepoints = null;
         sessionStateChanged = true;


### PR DESCRIPTION
After updating from H2 1.3.174 to 1.4.196+ we noticed a significant reduction of query throughput under concurrent load when using the PageStore with the default lock mode "read committed".

The reproduce case below runs in less than 1 sec on H2 1.3.174 but takes more than 4 mins here on H2 1.4.196+, i.e. newer H2 versions are orders of magnitude slower in this scenario.

AFAIU, this is triggered by the following chain of events:

* H2 1.4.196+ as database using the PageStore engine (MV_STORE=FALSE) and lock mode "read committed" (LOCK_MODE=3, default)
* thread A disables auto-commit on its JDBC connection to start a transaction and executes an UPDATE against table T thereby acquiring an exclusive lock on the table
  * directly after thread A has completed `org.h2.command.Command.executeUpdate()`, it holds that thread A no longer owns the monitor for the database but the `org.h2.table.RegularTable` object for table T still has `lockExclusiveSession != null` (which remains until the transaction is committed and `PageStoreTable.unlock()` is called).
* thread B executes a SELECT against table T, acquiring the monitor for the database and getting as far as `PageStoreTable.doLock2()` where it finds `lockExclusiveSession != null` and returns false, causing `doLock1()` to reach `database.wait(sleep)`
  * at this point, thread B has released the monitor on the database
* thread C executes a SELECT statement against table T, acquiring the monitor for the database and getting into `PageStoreTable.doLock1()` where it finds `waitingSessions.getFirst() != session` (thread B is first) and reaches `database.wait(sleep)`
* thread D...Z do just like thread C, all ending up waiting on the database
* thread A resumes execution and commits its transaction, setting `lockExclusiveSession = null` for the `RegularTable` T
* thread B resumes execution and during `PageStoreTable.doLock2()` returns true
  * notably, thread B does not call `session.registerTableAsLocked()` because `lockMode == Constants.LOCK_MODE_READ_COMMITTED`
* thread B completes its query, calling `Session.commit()` which in turns calls `endTransaction()` which in turn calls `unlockAll()`
  * because thread B previously didn't call `Session.registerTableAsLocked()`, `session.locks` is empty and consequently `Table.unlock()` is not called, but without `PageStoreTable.unlock()`, nothing calls `database.notifyAll()` to awake the waiting threads
* threads C...Z keep waiting until the > 100 ms wait time expires instead of one of them immediately resuming execution
* when thread C eventually resumes execution, thread D...Z find `waitingSessions.getFirst() != session` again during `doLock1()` and enter another wait cycle
and so on.


`````
package org.h2.test;

import java.sql.Connection;
import java.sql.DriverManager;
import java.sql.PreparedStatement;
import java.sql.ResultSet;
import java.sql.Statement;
import java.util.concurrent.CountDownLatch;

public class H2ConcurrencyTest
{
  private static final String JDBC_URL =
      "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;LOCK_MODE=3;LOCK_TIMEOUT=10000;MV_STORE=FALSE";

  public static void main(String[] args) throws Exception {
    try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
      stmt.executeUpdate("CREATE TABLE test (row_id varchar(100), CONSTRAINT table_pk PRIMARY KEY (row_id))");
    }

    CountDownLatch latch = new CountDownLatch(1);
    Thread workers[] = new Thread[20];
    for (int i = 0; i < workers.length; i++) {
      workers[i] = new Thread("Worker-" + i)
      {
        @Override
        public void run() {
          try {
            try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
              conn.setAutoCommit(false); // important to trigger slowness
              latch.await();
              try (PreparedStatement stmt = conn.prepareStatement("INSERT INTO test (row_id) VALUES (?)")) {
                stmt.setString(1, getName());
                stmt.executeUpdate();
                conn.commit();
              }
              conn.setAutoCommit(true);
              try (PreparedStatement stmt = conn.prepareStatement("SELECT * FROM test WHERE row_id = ?")) {
                stmt.setString(1, getName());
                for (int i = 0; i < 200; i++) {
                  stmt.setQueryTimeout(0); // important to trigger slowness
                  try (ResultSet results = stmt.executeQuery()) {
                  }
                }
              }
            }
          }
          catch (Exception e) {
            e.printStackTrace();
          }
        }
      };
    }
    for (Thread worker : workers) {
      worker.start();
    }
    long start = System.currentTimeMillis();
    latch.countDown();
    for (Thread worker : workers) {
      worker.join();
    }
    long duration = System.currentTimeMillis() - start;
    System.out.println("DONE after " + duration + " ms");
    if (duration > 10_000) {
      throw new Exception("execution took too long");
    }
  }
}
