### PR TITLE
Issue fix for issue_number_2407

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -355,6 +355,11 @@ public class Database implements DataHandler, CastDataProvider {
         return rowFactory;
     }
 
+    //getter method to fetch the database URL
+    public String getDatabaseURL(){
+        return databaseURL;
+    }
+
     public void setRowFactory(RowFactory rowFactory) {
         this.rowFactory = rowFactory;
     }

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -856,6 +856,7 @@ public abstract class Table extends SchemaObjectBase {
      * @param row the row
      */
     public void validateConvertUpdateSequence(Session session, Row row) {
+        session.getDatabase();
         for (int i = 0; i < columns.length; i++) {
             Value value = row.getValue(i);
             Column column = columns[i];

--- a/h2/src/main/org/h2/value/ValueChar.java
+++ b/h2/src/main/org/h2/value/ValueChar.java
@@ -33,6 +33,25 @@ public final class ValueChar extends ValueStringBase {
         return s;
     }
 
+    /**
+     * Get or create a CHAR value for the given string.
+     * Spaces at the end of the string will not be removed.
+     *
+     * @param s the string
+     * @return the value
+     */
+    public static ValueChar getWithoutRightTrim(String s) {
+        int length = s.length();
+        if (length == 0) {
+            return EMPTY;
+        }
+        ValueChar obj = new ValueChar(StringUtils.cache(s));
+        if (length > SysProperties.OBJECT_CACHE_MAX_PER_ELEMENT_SIZE) {
+            return obj;
+        }
+        return (ValueChar) Value.cache(obj);
+    }
+
     @Override
     public int getValueType() {
         return CHAR;


### PR DESCRIPTION
Fix for whitespaces issue #2407 

Created a new method getWithoutRightTrim in ValueChar.java to account for proper handling of right trailing whitespaces when using H2.

Right trailing whitespaces are removed only for MYSQL and PostgreSQL modes as mentioned.