### PR TITLE
Fix nested comments in ScriptReader

### DIFF
--- a/h2/src/main/org/h2/util/ScriptReader.java
+++ b/h2/src/main/org/h2/util/ScriptReader.java
@@ -168,6 +168,7 @@ public class ScriptReader implements Closeable {
                 if (c == '*') {
                     // block comment
                     startRemark(true);
+                    int level = 1;
                     while (true) {
                         c = read();
                         if (c < 0) {
@@ -180,8 +181,19 @@ public class ScriptReader implements Closeable {
                                 break;
                             }
                             if (c == '/') {
-                                endRemark();
+                                if (--level == 0) {
+                                    endRemark();
+                                    break;
+                                }
+                            }
+                        } else if (c == '/') {
+                            c = read();
+                            if (c < 0) {
+                                clearRemark();
                                 break;
+                            }
+                            if (c == '*') {
+                                level++;
                             }
                         }
                     }


### PR DESCRIPTION
Handling of nested comments was fixed in H2 earlier, but H2 Console wasn't able to process them correctly in many cases. This issue is fixed here.