### PR TITLE
SHUTDOWN IMMEDIATELY should be a normal shut down

### DIFF
--- a/h2/src/main/org/h2/command/dml/TransactionCommand.java
+++ b/h2/src/main/org/h2/command/dml/TransactionCommand.java
@@ -73,24 +73,18 @@ public class TransactionCommand extends Prepared {
             session.getUser().checkAdmin();
             session.setPreparedTransaction(transactionName, false);
             break;
-        case CommandInterface.SHUTDOWN_IMMEDIATELY:
-            session.getUser().checkAdmin();
-            session.getDatabase().shutdownImmediately();
-            break;
         case CommandInterface.SHUTDOWN:
         case CommandInterface.SHUTDOWN_COMPACT:
-        case CommandInterface.SHUTDOWN_DEFRAG: {
-            session.getUser().checkAdmin();
+        case CommandInterface.SHUTDOWN_DEFRAG:
             session.commit(false);
+        case CommandInterface.SHUTDOWN_IMMEDIATELY: {
+            session.getUser().checkAdmin();
             // throttle, to allow testing concurrent
             // execution of shutdown and query
             session.throttle();
             Database db = session.getDatabase();
             if (db.setExclusiveSession(session, true)) {
-                if (type == CommandInterface.SHUTDOWN_COMPACT ||
-                        type == CommandInterface.SHUTDOWN_DEFRAG) {
-                    db.setCompactMode(type);
-                }
+                db.setCompactMode(type);
                 // close the database, but don't update the persistent setting
                 db.setCloseDelay(0);
                 session.close();

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -396,9 +396,9 @@ public class JdbcConnection extends TraceObject implements Connection, JdbcConne
                                 try {
                                     rollbackInternal();
                                 } catch (DbException e) {
-                                    // ignore if the connection is broken
-                                    // right now
-                                    if (e.getErrorCode() != ErrorCode.CONNECTION_BROKEN_1) {
+                                    // ignore if the connection is broken or database shut down
+                                    if (e.getErrorCode() != ErrorCode.CONNECTION_BROKEN_1 &&
+                                            e.getErrorCode() != ErrorCode.DATABASE_IS_CLOSED) {
                                         throw e;
                                     }
                                 }

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2201,9 +2201,9 @@ public class MVStore implements AutoCloseable
     private int compactRewrite(Set<Integer> set) {
         assert storeLock.isHeldByCurrentThread();
         assert currentStoreVersion < 0; // we should be able to do tryCommit() -> store()
-        acceptChunkOccupancyChanges(getTimeSinceCreation(), currentVersion + 1);
+        acceptChunkOccupancyChanges(getTimeSinceCreation(), currentVersion);
         int rewrittenPageCount = rewriteChunks(set, false);
-        acceptChunkOccupancyChanges(getTimeSinceCreation(), currentVersion + 1);
+        acceptChunkOccupancyChanges(getTimeSinceCreation(), currentVersion);
         rewrittenPageCount += rewriteChunks(set, true);
         return rewrittenPageCount;
     }

--- a/h2/src/main/org/h2/pagestore/PageStore.java
+++ b/h2/src/main/org/h2/pagestore/PageStore.java
@@ -476,9 +476,8 @@ public class PageStore implements CacheWriter {
         if (!database.getSettings().pageStoreTrim) {
             return;
         }
-        if (SysProperties.MODIFY_ON_WRITE && readMode &&
-                compactMode == 0 ||
-                 compactMode == CommandInterface.SHUTDOWN_IMMEDIATELY) {
+        if (SysProperties.MODIFY_ON_WRITE && readMode && compactMode == 0 ||
+                compactMode == CommandInterface.SHUTDOWN_IMMEDIATELY) {
             return;
         }
         openForWriting();

--- a/h2/src/main/org/h2/pagestore/PageStore.java
+++ b/h2/src/main/org/h2/pagestore/PageStore.java
@@ -477,7 +477,8 @@ public class PageStore implements CacheWriter {
             return;
         }
         if (SysProperties.MODIFY_ON_WRITE && readMode &&
-                compactMode == 0) {
+                compactMode == 0 ||
+                 compactMode == CommandInterface.SHUTDOWN_IMMEDIATELY) {
             return;
         }
         openForWriting();

--- a/h2/src/test/org/h2/test/db/TestEncryptedDb.java
+++ b/h2/src/test/org/h2/test/db/TestEncryptedDb.java
@@ -39,26 +39,26 @@ public class TestEncryptedDb extends TestDb {
     @Override
     public void test() throws SQLException {
         deleteDb("encrypted");
-        Connection conn = getConnection("encrypted;CIPHER=AES", "sa", "123 123");
-        Statement stat = conn.createStatement();
-        stat.execute("CREATE TABLE TEST(ID INT)");
-        stat.execute("CHECKPOINT");
-        stat.execute("SET WRITE_DELAY 0");
-        stat.execute("INSERT INTO TEST VALUES(1)");
-        stat.execute("SHUTDOWN IMMEDIATELY");
-        assertThrows(ErrorCode.DATABASE_IS_CLOSED, conn).close();
+        try (Connection conn = getConnection("encrypted;CIPHER=AES", "sa", "123 123")) {
+            Statement stat = conn.createStatement();
+            stat.execute("CREATE TABLE TEST(ID INT)");
+            stat.execute("CHECKPOINT");
+            stat.execute("SET WRITE_DELAY 0");
+            stat.execute("INSERT INTO TEST VALUES(1)");
+            stat.execute("SHUTDOWN IMMEDIATELY");
+        }
 
         assertThrows(ErrorCode.FILE_ENCRYPTION_ERROR_1, this).
                 getConnection("encrypted;CIPHER=AES", "sa", "1234 1234");
 
-        conn = getConnection("encrypted;CIPHER=AES", "sa", "123 123");
-        stat = conn.createStatement();
-        ResultSet rs = stat.executeQuery("SELECT * FROM TEST");
-        assertTrue(rs.next());
-        assertEquals(1, rs.getInt(1));
-        assertFalse(rs.next());
-
-        conn.close();
+        try (Connection conn = getConnection("encrypted;CIPHER=AES", "sa", "123 123")) {
+            Statement stat = conn.createStatement();
+            ResultSet rs = stat.executeQuery("SELECT * FROM TEST");
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertFalse(rs.next());
+        }
+//        conn.close();
         deleteDb("encrypted");
     }
 

--- a/h2/src/test/org/h2/test/jdbcx/TestConnectionPool.java
+++ b/h2/src/test/org/h2/test/jdbcx/TestConnectionPool.java
@@ -61,7 +61,7 @@ public class TestConnectionPool extends TestDb {
         conn1.close();
         conn2.createStatement().execute("shutdown immediately");
         cp.dispose();
-        assertTrue(w.toString().length() > 0);
+        assertTrue(w.toString().length() == 0);
         cp.dispose();
     }
 

--- a/h2/src/test/org/h2/test/server/TestAutoServer.java
+++ b/h2/src/test/org/h2/test/server/TestAutoServer.java
@@ -72,7 +72,7 @@ public class TestAutoServer extends TestDb {
             url += ";AUTO_SERVER_PORT=11111";
         }
         String user = getUser(), password = getPassword();
-        Connection connServer = getConnection(url + ";OPEN_NEW=TRUE", user, password);
+        try (Connection connServer = getConnection(url + ";OPEN_NEW=TRUE", user, password)) {
             int i = ITERATIONS;
             for (; i > 0; i--) {
                 Thread.sleep(100);
@@ -106,7 +106,7 @@ public class TestAutoServer extends TestDb {
                     }
                 }
             }
-        connServer.close();
+        }
         deleteDb("autoServer");
     }
 

--- a/h2/src/test/org/h2/test/server/TestAutoServer.java
+++ b/h2/src/test/org/h2/test/server/TestAutoServer.java
@@ -156,7 +156,15 @@ public class TestAutoServer extends TestDb {
             }
             conn.close();
         } finally {
-            connServer.createStatement().execute("SHUTDOWN");
+            try {
+                connServer.createStatement().execute("SHUTDOWN");
+                if (config.big) {
+                    fail("server should be dowmn already");
+                }
+            } catch (SQLException e) {
+                assertTrue(config.big);
+                assertKnownException(e);
+            }
             try {
                 connServer.close();
             } catch (SQLException ignore) {}


### PR DESCRIPTION
Fix for #2507 
This PR unifies code path and behaviour of different flavours of SHUTDOWN command.

SHUTDOWN IMMEDIATELY corrected implementation follows the same path as other flavours of SHUTDOWN command. 
Old code path involved Database.shutdownImmediately() call, but it is the same call that is used in emergencies, like OOME or if underlying MVStore found to be closed. This code path also did MVStore.closeImmediately(), and that can leave database without latest changes, even corrupted.

This new common code path has some changes too.
If any session has prepared, but not committed transaction, then such transaction is left alone (neither committed, nor rolled back) and will show up is "in doubt" upon next start. This was the behaviour of SHUTDOWN IMMEDIATELY, but regular one use to roll back such transactions, and only commit it's own.
Another change - behaviour of Connection.close() when database has been shutdown already by this or another connection. There is no exception is thrown any more, where it used to be DATABASE_IS_CLOSED (90098), if it's after "SHUTDOWN IMMEDIATELY", but after regular shutdown Connection.close() did not throw any exception.
