### PR TITLE
Use JdbcUtils.load() for loading appropriate drivers

### DIFF
--- a/h2/src/main/org/h2/tools/Shell.java
+++ b/h2/src/main/org/h2/tools/Shell.java
@@ -144,7 +144,7 @@ public class Shell extends Tool implements Runnable {
             }
         }
         if (url != null) {
-            org.h2.Driver.load();
+            JdbcUtils.load(url);
             conn = DriverManager.getConnection(url, user, password);
             stat = conn.createStatement();
         }

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -56,7 +56,7 @@ public class JdbcUtils {
         "db2:", "com.ibm.db2.jcc.DB2Driver",
         "derby:net:", "org.apache.derby.client.ClientAutoloadedDriver",
         "derby://", "org.apache.derby.client.ClientAutoloadedDriver",
-        "derby:", "org.apache.derby.iapi.jdbc.AutoloadedDriver",
+        "derby:", "org.apache.derby.jdbc.AutoloadedDriver",
         "FrontBase:", "com.frontbase.jdbc.FBJDriver",
         "firebirdsql:", "org.firebirdsql.jdbc.FBDriver",
         "hsqldb:", "org.hsqldb.jdbcDriver",


### PR DESCRIPTION
Usually -driver option is redundant.