### PR TITLE
Reduce I/O during database presence check and restrict some compatibility settings to their modes

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -7839,10 +7839,6 @@ public class Parser {
             // Derby compatibility (CREATE=TRUE in the database URL)
             read();
             return new NoOperation(session);
-        } else if (readIf("HSQLDB.DEFAULT_TABLE_TYPE")) {
-            readIfEqualOrTo();
-            read();
-            return new NoOperation(session);
         } else if (readIf("PAGE_STORE")) {
             readIfEqualOrTo();
             read();

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -454,33 +454,6 @@ public class Database implements DataHandler, CastDataProvider {
     }
 
     /**
-     * Check if a database with the given name exists.
-     *
-     * @param name the name of the database (including path)
-     * @return true if one exists
-     */
-    static boolean exists(String name) {
-        if (FileUtils.exists(name + Constants.SUFFIX_PAGE_FILE)) {
-            return true;
-        }
-        return FileUtils.exists(name + Constants.SUFFIX_MV_FILE);
-    }
-
-    /**
-     * Check if a database with the given name exists.
-     *
-     * @param name
-     *            the name of the database (including path)
-     * @param mvStore
-     *            {@code true} to check MVStore file only, {@code false} to
-     *            check PageStore file only
-     * @return true if one exists
-     */
-    static boolean exists(String name, boolean mvStore) {
-        return FileUtils.exists(name + (mvStore ? Constants.SUFFIX_MV_FILE : Constants.SUFFIX_PAGE_FILE));
-    }
-
-    /**
      * Get the trace object for the given module id.
      *
      * @param moduleId the module id
@@ -547,24 +520,6 @@ public class Database implements DataHandler, CastDataProvider {
 
     private synchronized void open(int traceLevelFile, int traceLevelSystemOut) {
         if (persistent) {
-            String dataFileName = databaseName + Constants.SUFFIX_OLD_DATABASE_FILE;
-            boolean existsData = FileUtils.exists(dataFileName);
-            String pageFileName = databaseName + Constants.SUFFIX_PAGE_FILE;
-            String mvFileName = databaseName + Constants.SUFFIX_MV_FILE;
-            boolean existsPage = FileUtils.exists(pageFileName);
-            boolean existsMv = FileUtils.exists(mvFileName);
-            if (existsData && (!existsPage && !existsMv)) {
-                throw DbException.getFileVersionError(dataFileName);
-            }
-            if (existsPage && !FileUtils.canWrite(pageFileName)) {
-                readOnly = true;
-            }
-            if (existsMv && !FileUtils.canWrite(mvFileName)) {
-                readOnly = true;
-            }
-            if (existsPage && !existsMv) {
-                dbSettings.setMvStore(false);
-            }
             if (readOnly) {
                 if (traceLevelFile >= TraceSystem.DEBUG) {
                     String traceFile = Utils.getProperty("java.io.tmpdir", ".") +

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2364,8 +2364,12 @@ public class Database implements DataHandler, CastDataProvider {
         switch (lockMode) {
         case Constants.LOCK_MODE_OFF:
         case Constants.LOCK_MODE_READ_COMMITTED:
+            break;
         case Constants.LOCK_MODE_TABLE:
         case Constants.LOCK_MODE_TABLE_GC:
+            if (isMVStore()) {
+                lockMode = Constants.LOCK_MODE_READ_COMMITTED;
+            }
             break;
         default:
             throw DbException.getInvalidValueException("lock mode", lockMode);

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 
 import org.h2.api.ErrorCode;
 import org.h2.message.DbException;
-import org.h2.util.Utils;
 
 /**
  * This class contains various database-level settings. To override the
@@ -347,9 +346,6 @@ public class DbSettings extends SettingsBase {
 
     private DbSettings(HashMap<String, String> s) {
         super(s);
-        if (s.get("NESTED_JOINS") != null || Utils.getProperty("h2.nestedJoins", null) != null) {
-            throw DbException.getUnsupportedException("NESTED_JOINS setting is not available since 1.4.197");
-        }
         boolean lower = get("DATABASE_TO_LOWER", false);
         boolean upperSet = containsKey("DATABASE_TO_UPPER");
         boolean upper = get("DATABASE_TO_UPPER", true);

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -328,7 +328,7 @@ public class DbSettings extends SettingsBase {
      * (default: true).<br />
      * Use the MVStore storage engine.
      */
-    public boolean mvStore = get("MV_STORE", true);
+    public final boolean mvStore = get("MV_STORE", true);
 
     /**
      * Database setting <code>COMPRESS</code>
@@ -365,17 +365,6 @@ public class DbSettings extends SettingsBase {
         HashMap<String, String> settings = getSettings();
         settings.put("DATABASE_TO_LOWER", Boolean.toString(lower));
         settings.put("DATABASE_TO_UPPER", Boolean.toString(upper));
-    }
-
-    /**
-     * Sets the database engine setting.
-     *
-     * @param mvStore
-     *            true for MVStore engine, false for PageStore engine
-     */
-    void setMvStore(boolean mvStore) {
-        this.mvStore = mvStore;
-        set("MV_STORE", mvStore);
     }
 
     /**

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -69,7 +69,7 @@ public class Engine implements SessionFactory {
                         if (!FileUtils.exists(fileName)) {
                             fileName = name + Constants.SUFFIX_PAGE_FILE;
                             if (FileUtils.exists(fileName)) {
-                                ci.setProperty("MV_STORE", "FALSE");
+                                ci.setProperty("MV_STORE", "false");
                             } else {
                                 throwNotFound(ifExists, forbidCreation, name);
                                 fileName = name + Constants.SUFFIX_OLD_DATABASE_FILE;

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -208,16 +208,6 @@ public class MVTable extends RegularTable {
             }
             try {
                 traceLock(session, exclusive, TraceLockEvent.TRACE_LOCK_WAITING_FOR, NO_EXTRA_INFO);
-                if (database.getLockMode() == Constants.LOCK_MODE_TABLE_GC) {
-                    for (int i = 0; i < 20; i++) {
-                        long free = Runtime.getRuntime().freeMemory();
-                        System.gc();
-                        long free2 = Runtime.getRuntime().freeMemory();
-                        if (free == free2) {
-                            break;
-                        }
-                    }
-                }
                 // don't wait too long so that deadlocks are detected early
                 long sleep = Math.min(Constants.DEADLOCK_CHECK,
                         TimeUnit.NANOSECONDS.toMillis(max - now));

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -304,7 +304,7 @@ public class TestCompatibility extends TestDb {
         conn.close();
         deleteDb("compatibility");
         // `stat.getQueryTimeout()` caches the result, so create another connection
-        conn = getConnection("compatibility");
+        conn = getConnection("compatibility;MODE=PostgreSQL");
         stat = conn.createStatement();
         // `STATEMENT_TIMEOUT` uses milliseconds
         stat.execute("SET STATEMENT_TIMEOUT TO 30000");

--- a/h2/src/test/org/h2/test/rowlock/TestRowLocks.java
+++ b/h2/src/test/org/h2/test/rowlock/TestRowLocks.java
@@ -38,22 +38,10 @@ public class TestRowLocks extends TestDb {
 
     @Override
     public void test() throws Exception {
-        testSetMode();
         if (config.mvStore) {
             testCases();
         }
         deleteDb(getTestName());
-    }
-
-    private void testSetMode() throws SQLException {
-        deleteDb(getTestName());
-        c1 = getConnection(getTestName());
-        Statement stat = c1.createStatement();
-        stat.execute("SET LOCK_MODE 2");
-        ResultSet rs = stat.executeQuery("call lock_mode()");
-        rs.next();
-        assertEquals("2", rs.getString(1));
-        c1.close();
     }
 
     private void testCases() throws Exception {

--- a/h2/src/test/org/h2/test/scripts/other/set.sql
+++ b/h2/src/test/org/h2/test/scripts/other/set.sql
@@ -115,4 +115,30 @@ DROP TABLE TEST;
 SET VARIABLE_BINARY FALSE;
 > ok
 
+SET LOCK_MODE 0;
+> ok
+
+CALL LOCK_MODE();
+>> 0
+
+SET LOCK_MODE 1;
+> ok
+
+CALL LOCK_MODE();
+#+mvStore#>> 3
+#-mvStore#>> 1
+
+SET LOCK_MODE 2;
+> ok
+
+CALL LOCK_MODE();
+#+mvStore#>> 3
+#-mvStore#>> 2
+
+SET LOCK_MODE 3;
+> ok
+
+CALL LOCK_MODE();
+>> 3
+
 @reconnect on

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -1562,7 +1562,7 @@ drop table test;
 set autocommit off;
 > ok
 
-set search_path = public, information_schema;
+set schema_search_path = public, information_schema;
 > ok
 
 select table_name from tables where 1=0;
@@ -1570,7 +1570,7 @@ select table_name from tables where 1=0;
 > ----------
 > rows: 0
 
-set search_path = public;
+set schema_search_path = public;
 > ok
 
 set autocommit on;


### PR DESCRIPTION
1. Presence of database files is not checked so many times in different places anymore during pre-initialization. It slightly improves performance on file systems with slow metadata lookups and makes code cleaner.

2. Different compatibility settings `SET something` are restricted to their compatibility modes. `SET HSQLDB.DEFAULT_TABLE_TYPE` didn't work (`Parser` can't read `HSQLDB.DEFAULT_TABLE_TYPE` as a single token) and was simply removed.

3. Unneeded `LOCK_MODE_TABLE_GC` code is removed from `MVTable`. It looks like it was accidentally copied from PageStore engine. Attempts to choose `LOCK_MODE_TABLE*` values with MVStore engine now set the `LOCK_MODE` to default value to return the real used value from `LOCK_MODE()` function.

4. Custom error message for `NESTED_JOINS` setting is removed. 4 latest releases don't have this setting, I think we don't need the special message for it anymore, generic one is enough.