### PR TITLE
Feature: allow @ meta commands from Console

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -213,6 +213,13 @@
     </testResources>
     <plugins>
       <plugin>
+	<artifactId>maven-compiler-plugin</artifactId>
+	<version>3.6.0</version>
+	<configuration>
+	  <useIncrementalCompilation>false</useIncrementalCompilation>
+	</configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.1.2</version>

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -213,13 +213,6 @@
     </testResources>
     <plugins>
       <plugin>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>3.6.0</version>
-	<configuration>
-	  <useIncrementalCompilation>false</useIncrementalCompilation>
-	</configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.1.2</version>

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -1291,7 +1291,7 @@ public class WebApp {
                         .append(": serializable");
             }
             if (sql.startsWith("@")) {
-                rs = JdbcUtils.getMetaResultSet(conn, sql);
+                rs = JdbcUtils.getMetaResultSet(conn, sql, profiler);
                 if (rs == null) {
                     buff.append("?: ").append(sql);
                     return buff.toString();

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -1262,7 +1262,16 @@ public class WebApp {
                 profiler = new Profiler();
                 profiler.startCollecting();
                 return "Ok";
-            } else if (isBuiltIn(sql, "@sleep")) {
+            } else if (isBuiltIn(sql, "@prof_stop")) {
+		if (profiler != null) {
+		    profiler.stopCollecting();
+		    SimpleResultSet srs = new SimpleResultSet();
+		    srs.addColumn("Top Stack Trace(s)", Types.VARCHAR, 0, 0);
+		    srs.addRow(profiler.getTop(3));
+		    rs = srs;
+		    profiler = null;
+		}
+	    } else if (isBuiltIn(sql, "@sleep")) {
                 String s = StringUtils.trimSubstring(sql, "@sleep".length());
                 int sleep = 1;
                 if (s.length() > 0) {
@@ -1291,7 +1300,7 @@ public class WebApp {
                         .append(": serializable");
             }
             if (sql.startsWith("@")) {
-                rs = JdbcUtils.getMetaResultSet(conn, sql, profiler);
+                rs = JdbcUtils.getMetaResultSet(conn, sql);
                 if (rs == null) {
                     buff.append("?: ").append(sql);
                     return buff.toString();

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -1262,16 +1262,7 @@ public class WebApp {
                 profiler = new Profiler();
                 profiler.startCollecting();
                 return "Ok";
-            } else if (isBuiltIn(sql, "@prof_stop")) {
-		if (profiler != null) {
-		    profiler.stopCollecting();
-		    SimpleResultSet srs = new SimpleResultSet();
-		    srs.addColumn("Top Stack Trace(s)", Types.VARCHAR, 0, 0);
-		    srs.addRow(profiler.getTop(3));
-		    rs = srs;
-		    profiler = null;
-		}
-	    } else if (isBuiltIn(sql, "@sleep")) {
+            } else if (isBuiltIn(sql, "@sleep")) {
                 String s = StringUtils.trimSubstring(sql, "@sleep".length());
                 int sleep = 1;
                 if (s.length() > 0) {
@@ -1301,6 +1292,16 @@ public class WebApp {
             }
             if (sql.startsWith("@")) {
                 rs = JdbcUtils.getMetaResultSet(conn, sql);
+		if (isBuiltIn(sql, "@prof_stop")) {
+		    if (profiler != null) {
+			profiler.stopCollecting();
+			SimpleResultSet srs = new SimpleResultSet();
+			srs.addColumn("Top Stack Trace(s)", Types.VARCHAR, 0, 0);
+			srs.addRow(profiler.getTop(3));
+			rs = srs;
+			profiler = null;
+		    }
+		}
                 if (rs == null) {
                     buff.append("?: ").append(sql);
                     return buff.toString();

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -1187,13 +1187,13 @@ public class WebApp {
             Object generatedKeys = null;
             boolean edit = false;
             boolean list = false;
-            if (isBuiltIn(sql, "@autocommit_true")) {
+            if (JdbcUtils.isBuiltIn(sql, "@autocommit_true")) {
                 conn.setAutoCommit(true);
                 return "${text.result.autoCommitOn}";
-            } else if (isBuiltIn(sql, "@autocommit_false")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@autocommit_false")) {
                 conn.setAutoCommit(false);
                 return "${text.result.autoCommitOff}";
-            } else if (isBuiltIn(sql, "@cancel")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@cancel")) {
                 stat = session.executingStatement;
                 if (stat != null) {
                     stat.cancel();
@@ -1202,20 +1202,20 @@ public class WebApp {
                     buff.append("${text.result.noRunningStatement}");
                 }
                 return buff.toString();
-            } else if (isBuiltIn(sql, "@edit")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@edit")) {
                 edit = true;
                 sql = StringUtils.trimSubstring(sql, "@edit".length());
                 session.put("resultSetSQL", sql);
             }
-            if (isBuiltIn(sql, "@list")) {
+            if (JdbcUtils.isBuiltIn(sql, "@list")) {
                 list = true;
                 sql = StringUtils.trimSubstring(sql, "@list".length());
             }
-            if (isBuiltIn(sql, "@meta")) {
+            if (JdbcUtils.isBuiltIn(sql, "@meta")) {
                 metadata = true;
                 sql = StringUtils.trimSubstring(sql, "@meta".length());
             }
-            if (isBuiltIn(sql, "@generated")) {
+            if (JdbcUtils.isBuiltIn(sql, "@generated")) {
                 generatedKeys = true;
                 int offset = "@generated".length();
                 int length = sql.length();
@@ -1232,37 +1232,37 @@ public class WebApp {
                     }
                 }
                 sql = StringUtils.trimSubstring(sql, offset);
-            } else if (isBuiltIn(sql, "@history")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@history")) {
                 buff.append(getCommandHistoryString());
                 return buff.toString();
-            } else if (isBuiltIn(sql, "@loop")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@loop")) {
                 sql = StringUtils.trimSubstring(sql, "@loop".length());
                 int idx = sql.indexOf(' ');
                 int count = Integer.decode(sql.substring(0, idx));
                 sql = StringUtils.trimSubstring(sql, idx);
                 return executeLoop(conn, count, sql);
-            } else if (isBuiltIn(sql, "@maxrows")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@maxrows")) {
                 int maxrows = (int) Double.parseDouble(StringUtils.trimSubstring(sql, "@maxrows".length()));
                 session.put("maxrows", Integer.toString(maxrows));
                 return "${text.result.maxrowsSet}";
-            } else if (isBuiltIn(sql, "@parameter_meta")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@parameter_meta")) {
                 sql = StringUtils.trimSubstring(sql, "@parameter_meta".length());
                 PreparedStatement prep = conn.prepareStatement(sql);
                 buff.append(getParameterResultSet(prep.getParameterMetaData()));
                 return buff.toString();
-            } else if (isBuiltIn(sql, "@password_hash")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@password_hash")) {
                 sql = StringUtils.trimSubstring(sql, "@password_hash".length());
                 String[] p = JdbcUtils.split(sql);
                 return StringUtils.convertBytesToHex(
                         SHA256.getKeyPasswordHash(p[0], p[1].toCharArray()));
-            } else if (isBuiltIn(sql, "@prof_start")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@prof_start")) {
                 if (profiler != null) {
                     profiler.stopCollecting();
                 }
                 profiler = new Profiler();
                 profiler.startCollecting();
                 return "Ok";
-            } else if (isBuiltIn(sql, "@sleep")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@sleep")) {
                 String s = StringUtils.trimSubstring(sql, "@sleep".length());
                 int sleep = 1;
                 if (s.length() > 0) {
@@ -1270,7 +1270,7 @@ public class WebApp {
                 }
                 Thread.sleep(sleep * 1000);
                 return "Ok";
-            } else if (isBuiltIn(sql, "@transaction_isolation")) {
+            } else if (JdbcUtils.isBuiltIn(sql, "@transaction_isolation")) {
                 String s = StringUtils.trimSubstring(sql, "@transaction_isolation".length());
                 if (s.length() > 0) {
                     int level = Integer.parseInt(s);
@@ -1292,7 +1292,7 @@ public class WebApp {
             }
             if (sql.startsWith("@")) {
                 rs = JdbcUtils.getMetaResultSet(conn, sql);
-		if (isBuiltIn(sql, "@prof_stop")) {
+		if (JdbcUtils.isBuiltIn(sql, "@prof_stop")) {
 		    if (profiler != null) {
 			profiler.stopCollecting();
 			SimpleResultSet srs = new SimpleResultSet();
@@ -1356,10 +1356,6 @@ public class WebApp {
         }
     }
 
-    private static boolean isBuiltIn(String sql, String builtIn) {
-        return sql.regionMatches(true, 0, builtIn, 0, builtIn.length());
-    }
-
     private String executeLoop(Connection conn, int count, String sql)
             throws SQLException {
         ArrayList<Integer> params = new ArrayList<>();
@@ -1369,7 +1365,7 @@ public class WebApp {
             if (idx < 0) {
                 break;
             }
-            if (isBuiltIn(sql.substring(idx), "?/*rnd*/")) {
+            if (JdbcUtils.isBuiltIn(sql.substring(idx), "?/*rnd*/")) {
                 params.add(1);
                 sql = sql.substring(0, idx) + "?" + sql.substring(idx + "/*rnd*/".length() + 1);
             } else {
@@ -1380,7 +1376,7 @@ public class WebApp {
         boolean prepared;
         Random random = new Random(1);
         long time = System.currentTimeMillis();
-        if (isBuiltIn(sql, "@statement")) {
+        if (JdbcUtils.isBuiltIn(sql, "@statement")) {
             sql = StringUtils.trimSubstring(sql, "@statement".length());
             prepared = false;
             Statement stat = conn.createStatement();

--- a/h2/src/main/org/h2/tools/Shell.java
+++ b/h2/src/main/org/h2/tools/Shell.java
@@ -144,7 +144,7 @@ public class Shell extends Tool implements Runnable {
             }
         }
         if (url != null) {
-            org.h2.Driver.load();
+            JdbcUtils.load(url);
             conn = DriverManager.getConnection(url, user, password);
             stat = conn.createStatement();
         }

--- a/h2/src/main/org/h2/tools/Shell.java
+++ b/h2/src/main/org/h2/tools/Shell.java
@@ -144,7 +144,6 @@ public class Shell extends Tool implements Runnable {
             }
         }
         if (url != null) {
-            JdbcUtils.load(url);
             conn = DriverManager.getConnection(url, user, password);
             stat = conn.createStatement();
         }
@@ -467,7 +466,10 @@ public class Shell extends Tool implements Runnable {
         try {
             ResultSet rs = null;
             try {
-                if (stat.execute(sql)) {
+		 if (sql.startsWith("@")) {
+		     rs = JdbcUtils.getMetaResultSet(conn, sql);
+		     int rowCount = printResult(rs, listMode);
+		 } else if (stat.execute(sql)) {
                     rs = stat.getResultSet();
                     int rowCount = printResult(rs, listMode);
                     time = System.nanoTime() - time;

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -11,8 +11,11 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -32,6 +35,8 @@ import org.h2.engine.SysProperties;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.jdbc.JdbcPreparedStatement;
 import org.h2.message.DbException;
+import org.h2.tools.SimpleResultSet;
+import org.h2.util.Profiler;
 import org.h2.util.Utils.ClassFactory;
 import org.h2.value.DataType;
 import org.h2.value.Value;
@@ -56,7 +61,7 @@ public class JdbcUtils {
         "db2:", "com.ibm.db2.jcc.DB2Driver",
         "derby:net:", "org.apache.derby.client.ClientAutoloadedDriver",
         "derby://", "org.apache.derby.client.ClientAutoloadedDriver",
-        "derby:", "org.apache.derby.jdbc.AutoloadedDriver",
+        "derby:", "org.apache.derby.iapi.jdbc.AutoloadedDriver",
         "FrontBase:", "com.frontbase.jdbc.FBJDriver",
         "firebirdsql:", "org.firebirdsql.jdbc.FBDriver",
         "hsqldb:", "org.hsqldb.jdbcDriver",
@@ -83,6 +88,7 @@ public class JdbcUtils {
 
     private static boolean allowAllClasses;
     private static HashSet<String> allowedClassNames;
+    private static Profiler profiler;
 
     /**
      *  In order to manage more than one class loader
@@ -600,4 +606,156 @@ public class JdbcUtils {
         }
     }
 
+    public static ResultSet getMetaResultSet(Connection conn, String sql)
+            throws SQLException {
+        DatabaseMetaData meta = conn.getMetaData();
+        if (isBuiltIn(sql, "@best_row_identifier")) {
+            String[] p = split(sql);
+            int scale = p[4] == null ? 0 : Integer.parseInt(p[4]);
+            boolean nullable = Boolean.parseBoolean(p[5]);
+            return meta.getBestRowIdentifier(p[1], p[2], p[3], scale, nullable);
+        } else if (isBuiltIn(sql, "@catalogs")) {
+            return meta.getCatalogs();
+        } else if (isBuiltIn(sql, "@columns")) {
+            String[] p = split(sql);
+            return meta.getColumns(p[1], p[2], p[3], p[4]);
+        } else if (isBuiltIn(sql, "@column_privileges")) {
+            String[] p = split(sql);
+            return meta.getColumnPrivileges(p[1], p[2], p[3], p[4]);
+        } else if (isBuiltIn(sql, "@cross_references")) {
+            String[] p = split(sql);
+            return meta.getCrossReference(p[1], p[2], p[3], p[4], p[5], p[6]);
+        } else if (isBuiltIn(sql, "@exported_keys")) {
+            String[] p = split(sql);
+            return meta.getExportedKeys(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@imported_keys")) {
+            String[] p = split(sql);
+            return meta.getImportedKeys(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@index_info")) {
+            String[] p = split(sql);
+            boolean unique = Boolean.parseBoolean(p[4]);
+            boolean approx = Boolean.parseBoolean(p[5]);
+            return meta.getIndexInfo(p[1], p[2], p[3], unique, approx);
+        } else if (isBuiltIn(sql, "@primary_keys")) {
+            String[] p = split(sql);
+            return meta.getPrimaryKeys(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@procedures")) {
+            String[] p = split(sql);
+            return meta.getProcedures(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@procedure_columns")) {
+            String[] p = split(sql);
+            return meta.getProcedureColumns(p[1], p[2], p[3], p[4]);
+        } else if (isBuiltIn(sql, "@schemas")) {
+            return meta.getSchemas();
+        } else if (isBuiltIn(sql, "@tables")) {
+            String[] p = split(sql);
+            String[] types = p[4] == null ? null : StringUtils.arraySplit(p[4], ',', false);
+            return meta.getTables(p[1], p[2], p[3], types);
+        } else if (isBuiltIn(sql, "@table_privileges")) {
+            String[] p = split(sql);
+            return meta.getTablePrivileges(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@table_types")) {
+            return meta.getTableTypes();
+        } else if (isBuiltIn(sql, "@type_info")) {
+            return meta.getTypeInfo();
+        } else if (isBuiltIn(sql, "@udts")) {
+            String[] p = split(sql);
+            int[] types;
+            if (p[4] == null) {
+                types = null;
+            } else {
+                String[] t = StringUtils.arraySplit(p[4], ',', false);
+                types = new int[t.length];
+                for (int i = 0; i < t.length; i++) {
+                    types[i] = Integer.parseInt(t[i]);
+                }
+            }
+            return meta.getUDTs(p[1], p[2], p[3], types);
+        } else if (isBuiltIn(sql, "@version_columns")) {
+            String[] p = split(sql);
+            return meta.getVersionColumns(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@memory")) {
+            SimpleResultSet rs = new SimpleResultSet();
+            rs.addColumn("Type", Types.VARCHAR, 0, 0);
+            rs.addColumn("KB", Types.VARCHAR, 0, 0);
+            rs.addRow("Used Memory", Integer.toString(Utils.getMemoryUsed()));
+            rs.addRow("Free Memory", Integer.toString(Utils.getMemoryFree()));
+            return rs;
+        } else if (isBuiltIn(sql, "@info")) {
+            SimpleResultSet rs = new SimpleResultSet();
+            rs.addColumn("KEY", Types.VARCHAR, 0, 0);
+            rs.addColumn("VALUE", Types.VARCHAR, 0, 0);
+            rs.addRow("conn.getCatalog", conn.getCatalog());
+            rs.addRow("conn.getAutoCommit", Boolean.toString(conn.getAutoCommit()));
+            rs.addRow("conn.storesUpperCaseIdentifiers", Boolean.toString(meta.storesUpperCaseIdentifiers()));
+            rs.addRow("conn.storesLowerCaseIdentifiers", Boolean.toString(meta.storesLowerCaseIdentifiers()));
+            rs.addRow("conn.storesMixedCaseIdentifiers", Boolean.toString(meta.storesMixedCaseIdentifiers()));
+            rs.addRow("conn.getTransactionIsolation", Integer.toString(conn.getTransactionIsolation()));
+            rs.addRow("conn.getWarnings", String.valueOf(conn.getWarnings()));
+            String map;
+            try {
+                map = String.valueOf(conn.getTypeMap());
+            } catch (SQLException e) {
+                map = e.toString();
+            }
+            rs.addRow("conn.getTypeMap", map);
+            rs.addRow("conn.isReadOnly", Boolean.toString(conn.isReadOnly()));
+            rs.addRow("conn.getHoldability", Integer.toString(conn.getHoldability()));
+            addDatabaseMetaData(rs, meta);
+            return rs;
+        } else if (isBuiltIn(sql, "@attributes")) {
+            String[] p = split(sql);
+            return meta.getAttributes(p[1], p[2], p[3], p[4]);
+        } else if (isBuiltIn(sql, "@super_tables")) {
+            String[] p = split(sql);
+            return meta.getSuperTables(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@super_types")) {
+            String[] p = split(sql);
+            return meta.getSuperTypes(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@prof_stop")) {
+            if (profiler != null) {
+                profiler.stopCollecting();
+                SimpleResultSet rs = new SimpleResultSet();
+                rs.addColumn("Top Stack Trace(s)", Types.VARCHAR, 0, 0);
+                rs.addRow(profiler.getTop(3));
+                profiler = null;
+                return rs;
+            }
+        }
+        return null;
+    }
+
+    private static void addDatabaseMetaData(SimpleResultSet rs,
+            DatabaseMetaData meta) {
+        Method[] methods = DatabaseMetaData.class.getDeclaredMethods();
+        //Arrays.sort(methods, Comparator.comparing(Method::toString));
+        for (Method m : methods) {
+            if (m.getParameterTypes().length == 0) {
+                try {
+                    Object o = m.invoke(meta);
+                    rs.addRow("meta." + m.getName(), String.valueOf(o));
+                } catch (InvocationTargetException e) {
+                    rs.addRow("meta." + m.getName(), e.getTargetException().toString());
+                } catch (Exception e) {
+                    rs.addRow("meta." + m.getName(), e.toString());
+                }
+            }
+        }
+    }
+
+    private static boolean isBuiltIn(String sql, String builtIn) {
+        return sql.regionMatches(true, 0, builtIn, 0, builtIn.length());
+    }
+
+    private static String[] split(String s) {
+        String[] list = new String[10];
+        String[] t = StringUtils.arraySplit(s, ' ', true);
+        System.arraycopy(t, 0, list, 0, t.length);
+        for (int i = 0; i < list.length; i++) {
+            if ("null".equals(list[i])) {
+                list[i] = null;
+            }
+        }
+        return list;
+    }
 }

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -723,7 +723,7 @@ public class JdbcUtils {
     private static void addDatabaseMetaData(SimpleResultSet rs,
             DatabaseMetaData meta) {
         Method[] methods = DatabaseMetaData.class.getDeclaredMethods();
-        //Arrays.sort(methods, Comparator.comparing(Method::toString));
+        Arrays.sort(methods, Comparator.comparing(Method::toString));
         for (Method m : methods) {
             if (m.getParameterTypes().length == 0) {
                 try {

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -88,7 +88,6 @@ public class JdbcUtils {
 
     private static boolean allowAllClasses;
     private static HashSet<String> allowedClassNames;
-    private static Profiler profiler;
 
     /**
      *  In order to manage more than one class loader
@@ -606,7 +605,7 @@ public class JdbcUtils {
         }
     }
 
-    public static ResultSet getMetaResultSet(Connection conn, String sql)
+    public static ResultSet getMetaResultSet(Connection conn, String sql, Profiler profiler)
             throws SQLException {
         DatabaseMetaData meta = conn.getMetaData();
         if (isBuiltIn(sql, "@best_row_identifier")) {
@@ -687,9 +686,6 @@ public class JdbcUtils {
             rs.addColumn("VALUE", Types.VARCHAR, 0, 0);
             rs.addRow("conn.getCatalog", conn.getCatalog());
             rs.addRow("conn.getAutoCommit", Boolean.toString(conn.getAutoCommit()));
-            rs.addRow("conn.storesUpperCaseIdentifiers", Boolean.toString(meta.storesUpperCaseIdentifiers()));
-            rs.addRow("conn.storesLowerCaseIdentifiers", Boolean.toString(meta.storesLowerCaseIdentifiers()));
-            rs.addRow("conn.storesMixedCaseIdentifiers", Boolean.toString(meta.storesMixedCaseIdentifiers()));
             rs.addRow("conn.getTransactionIsolation", Integer.toString(conn.getTransactionIsolation()));
             rs.addRow("conn.getWarnings", String.valueOf(conn.getWarnings()));
             String map;
@@ -718,7 +714,6 @@ public class JdbcUtils {
                 SimpleResultSet rs = new SimpleResultSet();
                 rs.addColumn("Top Stack Trace(s)", Types.VARCHAR, 0, 0);
                 rs.addRow(profiler.getTop(3));
-                profiler = null;
                 return rs;
             }
         }

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -747,7 +747,7 @@ public class JdbcUtils {
         return sql.regionMatches(true, 0, builtIn, 0, builtIn.length());
     }
 
-    private static String[] split(String s) {
+    public static String[] split(String s) {
         String[] list = new String[10];
         String[] t = StringUtils.arraySplit(s, ' ', true);
         System.arraycopy(t, 0, list, 0, t.length);

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -56,7 +56,7 @@ public class JdbcUtils {
         "db2:", "com.ibm.db2.jcc.DB2Driver",
         "derby:net:", "org.apache.derby.client.ClientAutoloadedDriver",
         "derby://", "org.apache.derby.client.ClientAutoloadedDriver",
-        "derby:", "org.apache.derby.iapi.jdbc.AutoloadedDriver",
+        "derby:", "org.apache.derby.jdbc.AutoloadedDriver",
         "FrontBase:", "com.frontbase.jdbc.FBJDriver",
         "firebirdsql:", "org.firebirdsql.jdbc.FBDriver",
         "hsqldb:", "org.hsqldb.jdbcDriver",

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Properties;
 import javax.naming.Context;

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -36,7 +36,6 @@ import org.h2.jdbc.JdbcConnection;
 import org.h2.jdbc.JdbcPreparedStatement;
 import org.h2.message.DbException;
 import org.h2.tools.SimpleResultSet;
-import org.h2.util.Profiler;
 import org.h2.util.Utils.ClassFactory;
 import org.h2.value.DataType;
 import org.h2.value.Value;
@@ -605,7 +604,7 @@ public class JdbcUtils {
         }
     }
 
-    public static ResultSet getMetaResultSet(Connection conn, String sql, Profiler profiler)
+    public static ResultSet getMetaResultSet(Connection conn, String sql)
             throws SQLException {
         DatabaseMetaData meta = conn.getMetaData();
         if (isBuiltIn(sql, "@best_row_identifier")) {
@@ -708,14 +707,6 @@ public class JdbcUtils {
         } else if (isBuiltIn(sql, "@super_types")) {
             String[] p = split(sql);
             return meta.getSuperTypes(p[1], p[2], p[3]);
-        } else if (isBuiltIn(sql, "@prof_stop")) {
-            if (profiler != null) {
-                profiler.stopCollecting();
-                SimpleResultSet rs = new SimpleResultSet();
-                rs.addColumn("Top Stack Trace(s)", Types.VARCHAR, 0, 0);
-                rs.addRow(profiler.getTop(3));
-                return rs;
-            }
         }
         return null;
     }

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -731,7 +731,7 @@ public class JdbcUtils {
         }
     }
 
-    private static boolean isBuiltIn(String sql, String builtIn) {
+    public static boolean isBuiltIn(String sql, String builtIn) {
         return sql.regionMatches(true, 0, builtIn, 0, builtIn.length());
     }
 

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Properties;


### PR DESCRIPTION
I've moved getMetaResultSet() and split() to JdbcUtils so that it can be easily called from both WebApp and Console. This will allow @ meta commands to be executed from Console too making it useful as pure JDBC CLI. I'm using this for Emacs JDBC connection https://youtu.be/dUbqdY0KU0U . Let me know if this adds value.  