### PR TITLE
Assorted minor changes

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTableEngine.java
@@ -185,38 +185,34 @@ public class MVTableEngine implements TableEngine {
          * @return the database exception
          */
         DbException convertMVStoreException(MVStoreException e) {
-            int errorCode = e.getErrorCode();
-            if (errorCode == DataUtils.ERROR_CLOSED) {
-                throw DbException.get(
-                        ErrorCode.DATABASE_IS_CLOSED,
-                        e, fileName);
-            } else if (errorCode == DataUtils.ERROR_FILE_CORRUPT) {
-                if (encrypted) {
+            switch (e.getErrorCode()) {
+                case DataUtils.ERROR_CLOSED:
                     throw DbException.get(
-                            ErrorCode.FILE_ENCRYPTION_ERROR_1,
+                            ErrorCode.DATABASE_IS_CLOSED,
                             e, fileName);
-                }
-            } else if (errorCode == DataUtils.ERROR_FILE_LOCKED) {
-                throw DbException.get(
-                        ErrorCode.DATABASE_ALREADY_OPEN_1,
-                        e, fileName);
-            } else if (errorCode == DataUtils.ERROR_READING_FAILED) {
-                throw DbException.get(
-                        ErrorCode.IO_EXCEPTION_1,
-                        e, fileName);
-            } else if (errorCode == DataUtils.ERROR_TRANSACTION_ILLEGAL_STATE) {
-                throw DbException.get(
-                        ErrorCode.GENERAL_ERROR_1,
-                        e, e.getMessage());
-            } else if (errorCode == DataUtils.ERROR_INTERNAL) {
-                throw DbException.get(
-                        ErrorCode.GENERAL_ERROR_1,
-                        e, fileName);
+                case DataUtils.ERROR_FILE_CORRUPT:
+                    if (encrypted) {
+                        throw DbException.get(
+                                ErrorCode.FILE_ENCRYPTION_ERROR_1,
+                                e, fileName);
+                    }
+                    throw DbException.get(
+                            ErrorCode.FILE_CORRUPTED_1,
+                            e, fileName);
+                case DataUtils.ERROR_FILE_LOCKED:
+                    throw DbException.get(
+                            ErrorCode.DATABASE_ALREADY_OPEN_1,
+                            e, fileName);
+                case DataUtils.ERROR_READING_FAILED:
+                case DataUtils.ERROR_WRITING_FAILED:
+                    throw DbException.get(
+                            ErrorCode.IO_EXCEPTION_1,
+                            e, fileName);
+                default:
+                    throw DbException.get(
+                            ErrorCode.GENERAL_ERROR_1,
+                            e, e.getMessage());
             }
-            throw DbException.get(
-                    ErrorCode.FILE_CORRUPTED_1,
-                    e, fileName);
-
         }
 
         public MVStore getMvStore() {

--- a/h2/src/test/org/h2/test/unit/TestConcurrentJdbc.java
+++ b/h2/src/test/org/h2/test/unit/TestConcurrentJdbc.java
@@ -10,6 +10,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.CountDownLatch;
 
 import org.h2.api.ErrorCode;
 import org.h2.test.TestBase;
@@ -48,10 +49,12 @@ public class TestConcurrentJdbc extends TestBase {
                 break;
             }
             final PreparedStatement prep = conn.prepareStatement(sql);
+            final CountDownLatch executedUpdate = new CountDownLatch(1);
             Task t = new Task() {
                 @Override
                 public void call() throws SQLException {
                     while (!conn.isClosed()) {
+                        executedUpdate.countDown();
                         switch (x % 6) {
                         case 0:
                             prep.executeQuery();
@@ -76,16 +79,21 @@ public class TestConcurrentJdbc extends TestBase {
                 }
             };
             t.execute();
-            Thread.sleep(100);
+            //Wait until the concurrent task has started
+            try {
+                executedUpdate.await();
+            } catch (InterruptedException e) {
+                // ignore
+            }
             conn.close();
             SQLException e = (SQLException) t.getException();
             if (e != null) {
                 if (ErrorCode.OBJECT_CLOSED != e.getErrorCode() &&
-                        ErrorCode.STATEMENT_WAS_CANCELED != e.getErrorCode()) {
+                        ErrorCode.STATEMENT_WAS_CANCELED != e.getErrorCode() &&
+                        ErrorCode.DATABASE_CALLED_AT_SHUTDOWN != e.getErrorCode()) {
                     throw e;
                 }
             }
         }
     }
-
 }


### PR DESCRIPTION
1. Replace wait() with CountdownLatch, since 100ms was way too long and test was useless. In the event of unlucky thread scheduling test was  failing with ``org.h2.jdbc.JdbcSQLNonTransientConnectionException: Database is already closed (to disable automatic closing at VM shutdown, add ";DB_CLOSE_ON_EXIT=FALSE" to the db URL) [90121-201]``
This should be expected exception.

2. Fix MVStore -> SQL (database) error code translation to default to ErrorCode.GENERAL_ERROR_1 instead of ErrorCode.FILE_CORRUPTED_1