### PR TITLE
Add field SLEEP_SINCE to session and INFORMATION_SCHEMA.SESSIONS table

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #2601: Add field SLEEP_SINCE to INFORMATION_SCHEMA.SESSIONS table
+</li>
 <li>Issue #1973: Standard MERGE statement doesn't work with views
 </li>
 <li>Issue #2552: MERGE statement should process each row only once

--- a/h2/src/main/org/h2/jmx/DatabaseInfo.java
+++ b/h2/src/main/org/h2/jmx/DatabaseInfo.java
@@ -262,7 +262,7 @@ public class DatabaseInfo implements DatabaseInfoMBean {
                         .append(command)
                         .append('\n')
                         .append("started: ")
-                        .append(session.getCurrentCommandStart().getString())
+                        .append(session.getCommandStartOrEnd().getString())
                         .append('\n');
             }
             for (Table table : session.getLocks()) {

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -1791,7 +1791,7 @@ public final class InformationSchemaTable extends MetaTable {
                             // STATEMENT
                             command == null ? null : command.toString(),
                             // STATEMENT_START
-                            command == null ? null : s.getCurrentCommandStart(),
+                            command == null ? null : s.getCommandStartOrEnd(),
                             // CONTAINS_UNCOMMITTED
                             ValueBoolean.get(s.containsUncommitted()),
                             // STATE
@@ -1799,7 +1799,7 @@ public final class InformationSchemaTable extends MetaTable {
                             // BLOCKER_ID
                             blockingSessionId == 0 ? null : ValueInteger.get(blockingSessionId),
                             // SLEEP_SINCE
-                            s.getState() == State.SLEEP ? s.getCurrentCommandStart() : null
+                            s.getState() == State.SLEEP ? s.getCommandStartOrEnd() : null
                     );
                 }
             }

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -1799,7 +1799,7 @@ public final class InformationSchemaTable extends MetaTable {
                             // BLOCKER_ID
                             blockingSessionId == 0 ? null : ValueInteger.get(blockingSessionId),
                             // SLEEP_SINCE
-                            s.getState() == State.SLEEP ? s.getSleepStateSince() : null
+                            s.getState() == State.SLEEP ? s.getCurrentCommandStart() : null
                     );
                 }
             }

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -36,6 +36,7 @@ import org.h2.engine.QueryStatisticsData;
 import org.h2.engine.Right;
 import org.h2.engine.Role;
 import org.h2.engine.Session;
+import org.h2.engine.Session.State;
 import org.h2.engine.Setting;
 import org.h2.engine.User;
 import org.h2.engine.UserAggregate;
@@ -516,7 +517,8 @@ public final class InformationSchemaTable extends MetaTable {
                     "STATEMENT_START TIMESTAMP WITH TIME ZONE",
                     "CONTAINS_UNCOMMITTED BIT",
                     "STATE",
-                    "BLOCKER_ID INT"
+                    "BLOCKER_ID INT",
+                    "SLEEP_SINCE TIMESTAMP WITH TIME ZONE"
             );
             break;
         }
@@ -1793,8 +1795,11 @@ public final class InformationSchemaTable extends MetaTable {
                             // CONTAINS_UNCOMMITTED
                             ValueBoolean.get(s.containsUncommitted()),
                             // STATE
-                            String.valueOf(s.getState()), // BLOCKER_ID
-                            blockingSessionId == 0 ? null : ValueInteger.get(blockingSessionId)
+                            String.valueOf(s.getState()),
+                            // BLOCKER_ID
+                            blockingSessionId == 0 ? null : ValueInteger.get(blockingSessionId),
+                            // SLEEP_SINCE
+                            s.getState() == State.SLEEP ? s.getSleepStateSince() : null
                     );
                 }
             }


### PR DESCRIPTION
This PR adds a new feature that allows to monitor and detect idle sessions.
Whenever a statement completes this timestamp  is set to the current time.
In combination with a heartbeat implemented on the connection, stale clients can be detected and removed using the abort_session() function implemented in PR #2195.
