### PR TITLE
fix: quoted VALUE in documentation

### DIFF
--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -415,7 +415,7 @@ and re-run the <code>CreateCluster</code> tool.
 To find out which cluster nodes are currently running, execute the following SQL statement:
 </p>
 <pre>
-SELECT VALUE FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME='CLUSTER'
+SELECT `VALUE` FROM INFORMATION_SCHEMA.SETTINGS WHERE NAME='CLUSTER'
 </pre>
 <p>
 If the result is <code>''</code> (two single quotes), then the cluster mode is disabled. Otherwise, the list of


### PR DESCRIPTION
Hello,

this adds quotes around `VALUE` in the advanced documentation. It is a keyword since 4c40a20aece767dde1ef8a41c5a7c764bc1d20a8

I have also found an [invalid query inside a test](https://github.com/h2database/h2database/blob/master/h2/src/test/org/h2/test/store/TestMVTableEngine.java#L675).
```java
            ResultSet rs = stat.executeQuery(
                    "select value from information_schema.settings " +
                    "where name='RETENTION_TIME'");
```

But it is dead code. So I was not sure if it should be replaced or removed. It is [called inside a block of commented out code](https://github.com/h2database/h2database/blob/master/h2/src/test/org/h2/test/store/TestMVTableEngine.java#L86).

