### PR TITLE
Add some PostgreSQL compatibility features in #2450

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1572,6 +1572,9 @@ public class Parser {
         } else if (readIf("DATESTYLE")) {
             // for PostgreSQL compatibility
             buff.append("'ISO' DATESTYLE");
+        } else if (readIf("SEARCH_PATH")) {
+            // for PostgreSQL compatibility
+            buff.append('\'').append(String.join(", ", session.getSchemaSearchPath())).append('\'');
         } else if (readIf("SERVER_VERSION")) {
             // for PostgreSQL compatibility
             buff.append("'" + Constants.PG_VERSION + "' SERVER_VERSION");

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1574,7 +1574,18 @@ public class Parser {
             buff.append("'ISO' DATESTYLE");
         } else if (readIf("SEARCH_PATH")) {
             // for PostgreSQL compatibility
-            buff.append('\'').append(String.join(", ", session.getSchemaSearchPath())).append('\'');
+            String[] searchPath = session.getSchemaSearchPath();
+            StringBuilder searchPathBuff = new StringBuilder();
+            if (searchPath != null) {
+                for (int i = 0; i < searchPath.length; i ++) {
+                    if (i > 0) {
+                        searchPathBuff.append(", ");
+                    }
+                    quoteIdentifier(searchPathBuff, searchPath[i], HasSQL.QUOTE_ONLY_WHEN_REQUIRED);
+                }
+            }
+            StringUtils.quoteStringSQL(buff, searchPathBuff.toString());
+            buff.append(" SEARCH_PATH");
         } else if (readIf("SERVER_VERSION")) {
             // for PostgreSQL compatibility
             buff.append("'" + Constants.PG_VERSION + "' SERVER_VERSION");

--- a/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
@@ -71,6 +71,8 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
 
     private static final int ARRAY_TO_STRING = SET_CONFIG + 1;
 
+    private static final int PG_STAT_GET_NUMSCANS = ARRAY_TO_STRING + 1;
+
     private static final HashMap<String, FunctionInfo> FUNCTIONS = new HashMap<>();
 
     static {
@@ -91,7 +93,7 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
         FUNCTIONS.put("PG_ENCODING_TO_CHAR", new FunctionInfo("PG_ENCODING_TO_CHAR", PG_ENCODING_TO_CHAR, 1,
                 Value.VARCHAR, true, true, true, false));
         FUNCTIONS.put("PG_GET_EXPR",
-                new FunctionInfo("PG_GET_EXPR", PG_GET_EXPR, 2, Value.VARCHAR, true, true, true, false));
+                new FunctionInfo("PG_GET_EXPR", PG_GET_EXPR, VAR_ARGS, Value.VARCHAR, true, true, true, false));
         FUNCTIONS.put("PG_GET_INDEXDEF", //
                 new FunctionInfo("PG_GET_INDEXDEF", PG_GET_INDEXDEF, VAR_ARGS, Value.VARCHAR, //
                         true, false, true, false));
@@ -107,6 +109,8 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
                 SET_CONFIG, 3, Value.VARCHAR, true, false, true, false));
         FUNCTIONS.put("ARRAY_TO_STRING", new FunctionInfo("ARRAY_TO_STRING", //
                 ARRAY_TO_STRING, VAR_ARGS, Value.VARCHAR, false, true, true, false));
+        FUNCTIONS.put("PG_STAT_GET_NUMSCANS", new FunctionInfo("PG_STAT_GET_NUMSCANS", //
+                PG_STAT_GET_NUMSCANS, 1, Value.INTEGER, true, true, true, false));
     }
 
     /**
@@ -151,6 +155,7 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
                 throw DbException.get(ErrorCode.INVALID_PARAMETER_COUNT_2, info.name, "1, 3");
             }
             return;
+        case PG_GET_EXPR:
         case ARRAY_TO_STRING:
             min = 2;
             max = 3;
@@ -252,6 +257,10 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
                 }
             }
             result = ValueVarchar.get(joiner.toString());
+            break;
+        case PG_STAT_GET_NUMSCANS:
+            // Not implemented
+            result = ValueInteger.get(0);
             break;
         default:
             throw DbException.throwInternalError("type=" + info.type);

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -697,9 +697,15 @@ public class TestPgServer extends TestDb {
                     "LEFT OUTER JOIN pg_class c ON c.oid=t.typrelid WHERE typnamespace=-1000")) {
                 // just no exception
             }
+            stat.execute("SET search_path TO 'ab', 'c\"d', 'e''f'");
             try (ResultSet rs = stat.executeQuery("SHOW search_path")) {
                 assertTrue(rs.next());
-                assertEquals("pg_catalog, public", rs.getString(1));
+                assertEquals("pg_catalog, ab, \"c\"\"d\", \"e'f\"", rs.getString("search_path"));
+            }
+            stat.execute("SET search_path TO ab, \"c\"\"d\", \"e'f\"");
+            try (ResultSet rs = stat.executeQuery("SHOW search_path")) {
+                assertTrue(rs.next());
+                assertEquals("pg_catalog, ab, \"c\"\"d\", \"e'f\"", rs.getString("search_path"));
             }
             int oid;
             try (ResultSet rs = stat.executeQuery("SELECT oid FROM pg_class WHERE relname = 'test'")) {

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -672,7 +672,7 @@ public class TestPgServer extends TestDb {
             try (ResultSet rs = stat.executeQuery("SELECT \"p\".\"proname\", \"p\".\"proargtypes\" " +
                     "FROM \"pg_catalog\".\"pg_namespace\" AS \"n\" " +
                     "JOIN \"pg_catalog\".\"pg_proc\" AS \"p\" ON \"p\".\"pronamespace\" = \"n\".\"oid\" " +
-                    "WHERE \"n\".\"nspname\"='public';")) {
+                    "WHERE \"n\".\"nspname\"='public'")) {
                 assertFalse(rs.next()); // "pg_proc" always empty
             }
             try (ResultSet rs = stat.executeQuery("SELECT DISTINCT a.attname AS column_name, " +
@@ -690,6 +690,45 @@ public class TestPgServer extends TestDb {
                 assertTrue(rs.next());
                 assertEquals("x1", rs.getString("column_name"));
                 assertFalse(rs.next());
+            }
+
+            // DBeaver
+            try (ResultSet rs = stat.executeQuery("SELECT t.oid,t.*,c.relkind FROM pg_catalog.pg_type t " +
+                    "LEFT OUTER JOIN pg_class c ON c.oid=t.typrelid WHERE typnamespace=-1000")) {
+                // just no exception
+            }
+            try (ResultSet rs = stat.executeQuery("SHOW search_path")) {
+                assertTrue(rs.next());
+                assertEquals("pg_catalog, public", rs.getString(1));
+            }
+            int oid;
+            try (ResultSet rs = stat.executeQuery("SELECT oid FROM pg_class WHERE relname = 'test'")) {
+                rs.next();
+                oid = rs.getInt("oid");
+            }
+            try (ResultSet rs = stat.executeQuery("SELECT i.*,i.indkey as keys,c.relname,c.relnamespace,c.relam,c.reltablespace," +
+                    "tc.relname as tabrelname,dsc.description,pg_catalog.pg_get_expr(i.indpred, i.indrelid) as pred_expr," +
+                    "pg_catalog.pg_get_expr(i.indexprs, i.indrelid, true) as expr,pg_catalog.pg_relation_size(i.indexrelid) as index_rel_size," +
+                    "pg_catalog.pg_stat_get_numscans(i.indexrelid) as index_num_scans " + 
+                    "FROM pg_catalog.pg_index i " + 
+                    "INNER JOIN pg_catalog.pg_class c ON c.oid=i.indexrelid " + 
+                    "INNER JOIN pg_catalog.pg_class tc ON tc.oid=i.indrelid " + 
+                    "LEFT OUTER JOIN pg_catalog.pg_description dsc ON i.indexrelid=dsc.objoid " + 
+                    "WHERE i.indrelid=" + oid + " ORDER BY c.relname")) {
+                // pg_index is empty
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stat.executeQuery("SELECT c.oid,c.*," +
+                    "t.relname as tabrelname,rt.relnamespace as refnamespace,d.description " + 
+                    "FROM pg_catalog.pg_constraint c " + 
+                    "INNER JOIN pg_catalog.pg_class t ON t.oid=c.conrelid " + 
+                    "LEFT OUTER JOIN pg_catalog.pg_class rt ON rt.oid=c.confrelid " + 
+                    "LEFT OUTER JOIN pg_catalog.pg_description d ON d.objoid=c.oid " +
+                    "AND d.objsubid=0 AND d.classoid='pg_constraint'::regclass WHERE c.conrelid=" + oid)) {
+                assertTrue(rs.next());
+                assertEquals("test", rs.getString("tabrelname"));
+                assertEquals("p", rs.getString("contype"));
+                assertEquals("1", ((Object[]) rs.getArray("conkey").getArray())[0]);
             }
         } finally {
             server.stop();


### PR DESCRIPTION
Added these objects to prevent error from DBeaver:

- ~function `session_user`~
- column `pg_type.typrelid`
- function `pg_get_expr`, allow 3rd optional arg
- `SHOW search_path`
- function `pg_stat_get_numscans`
- table `pg_constraint`

`pg_constraint.conkey` is implemented but DBeaver still require to choose a unique key when change a row during view table. Probably because `conkey`'s type not correct, should be `_int2` but now `_text`.