### PR TITLE
Extract some groups of functions from Function class

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -263,6 +263,7 @@ import org.h2.expression.condition.IsJsonPredicate;
 import org.h2.expression.condition.NullPredicate;
 import org.h2.expression.condition.TypePredicate;
 import org.h2.expression.condition.UniquePredicate;
+import org.h2.expression.function.BitFunction;
 import org.h2.expression.function.CastSpecification;
 import org.h2.expression.function.CompatibilityIdentityFunction;
 import org.h2.expression.function.CompatibilitySequenceValueFunction;
@@ -4294,6 +4295,23 @@ public class Parser {
             return readMathFunction1(MathFunction1.DEGREES);
         case "RADIANS":
             return readMathFunction1(MathFunction1.RADIANS);
+        case "BITAND":
+            return readBitFunction(BitFunction.BITAND);
+        case "BITOR":
+            return readBitFunction(BitFunction.BITOR);
+        case "BITXOR":
+            return readBitFunction(BitFunction.BITXOR);
+        case "BITNOT": {
+            Expression arg = readExpression();
+            read(CLOSE_PAREN);
+            return new BitFunction(arg, null, BitFunction.BITNOT);
+        }
+        case "BITGET":
+            return readBitFunction(BitFunction.BITGET);
+        case "LSHIFT":
+            return readBitFunction(BitFunction.LSHIFT);
+        case "RSHIFT":
+            return readBitFunction(BitFunction.RSHIFT);
         }
         Function function = Function.getFunction(database, upperName);
         return function != null ? readFunctionParameters(function) : null;
@@ -4313,9 +4331,17 @@ public class Parser {
         return new MathFunction2(arg1, arg2, function);
     }
 
+    private Expression readBitFunction(int function) {
+        Expression arg1 = readExpression();
+        read(COMMA);
+        Expression arg2 = readExpression();
+        read(CLOSE_PAREN);
+        return new BitFunction(arg1, arg2, function);
+    }
+
     private boolean isBuiltinFunction(String upperName) {
         return Function.getFunction(database, upperName) != null || MathFunction1.exists(upperName)
-                || MathFunction2.exists(upperName);
+                || MathFunction2.exists(upperName) || BitFunction.exists(upperName);
     }
 
     private Function readFunctionParameters(Function function) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -5073,7 +5073,7 @@ public class Parser {
                     r = new TimeZoneOperation(r, readExpression());
                     continue;
                 } else if (readIf("LOCAL")) {
-                    r = new TimeZoneOperation(r);
+                    r = new TimeZoneOperation(r, null);
                     continue;
                 } else {
                     reread(index);

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -264,6 +264,7 @@ import org.h2.expression.condition.NullPredicate;
 import org.h2.expression.condition.TypePredicate;
 import org.h2.expression.condition.UniquePredicate;
 import org.h2.expression.function.CastSpecification;
+import org.h2.expression.function.CompatibilitySequenceValueFunction;
 import org.h2.expression.function.CurrentDateTimeValueFunction;
 import org.h2.expression.function.CurrentGeneralValueSpecification;
 import org.h2.expression.function.DateTimeFunctions;
@@ -4189,6 +4190,11 @@ public class Parser {
         case "UCASE":
             function = Function.getFunction(Function.UPPER);
             break;
+        // Sequence value
+        case "CURRVAL":
+            return readCompatibilitySequenceValueFunction(true);
+        case "NEXTVAL":
+            return readCompatibilitySequenceValueFunction(false);
         default:
             return null;
         }
@@ -4216,6 +4222,12 @@ public class Parser {
         Expression elseExpression = readExpression();
         read(CLOSE_PAREN);
         return new SearchedCase(new Expression[] { when, then, elseExpression });
+    }
+
+    private Expression readCompatibilitySequenceValueFunction(boolean current) {
+        Expression arg1 = readExpression(), arg2 = readIf(COMMA) ? readExpression() : null;
+        read(CLOSE_PAREN);
+        return new CompatibilitySequenceValueFunction(arg1, arg2, current);
     }
 
     private Function readFunctionParameters(Function function) {

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -264,6 +264,7 @@ import org.h2.expression.condition.NullPredicate;
 import org.h2.expression.condition.TypePredicate;
 import org.h2.expression.condition.UniquePredicate;
 import org.h2.expression.function.CastSpecification;
+import org.h2.expression.function.CompatibilityIdentityFunction;
 import org.h2.expression.function.CompatibilitySequenceValueFunction;
 import org.h2.expression.function.CurrentDateTimeValueFunction;
 import org.h2.expression.function.CurrentGeneralValueSpecification;
@@ -4195,6 +4196,17 @@ public class Parser {
             return readCompatibilitySequenceValueFunction(true);
         case "NEXTVAL":
             return readCompatibilitySequenceValueFunction(false);
+        case "LASTVAL":
+            if (database.getMode().getEnum() != ModeEnum.PostgreSQL) {
+                return null;
+            }
+            //$FALL-THROUGH$
+        case "IDENTITY":
+            read(CLOSE_PAREN);
+            return new CompatibilityIdentityFunction(false);
+        case "SCOPE_IDENTITY":
+            read(CLOSE_PAREN);
+            return new CompatibilityIdentityFunction(true);
         default:
             return null;
         }

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4087,11 +4087,6 @@ public class Parser {
             function = Function.getFunction(Function.COALESCE);
             break;
         // CURRENT_CATALOG
-        case "CURRENT_DATABASE":
-            if (database.getMode().getEnum() != ModeEnum.PostgreSQL) {
-                return null;
-            }
-            //$FALL-THROUGH$
         case "DATABASE":
             read(CLOSE_PAREN);
             return new CurrentGeneralValueSpecification(CurrentGeneralValueSpecification.CURRENT_CATALOG);
@@ -4199,11 +4194,6 @@ public class Parser {
             return readCompatibilitySequenceValueFunction(true);
         case "NEXTVAL":
             return readCompatibilitySequenceValueFunction(false);
-        case "LASTVAL":
-            if (database.getMode().getEnum() != ModeEnum.PostgreSQL) {
-                return null;
-            }
-            //$FALL-THROUGH$
         case "IDENTITY":
             read(CLOSE_PAREN);
             return new CompatibilityIdentityFunction(false);

--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -5,7 +5,6 @@
  */
 package org.h2.command.dml;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map.Entry;
@@ -38,7 +37,6 @@ import org.h2.table.DataChangeDeltaTable.ResultOption;
 import org.h2.table.Table;
 import org.h2.util.HasSQL;
 import org.h2.value.Value;
-import org.h2.value.ValueNull;
 
 /**
  * This class represents the statement
@@ -57,6 +55,8 @@ public class Insert extends CommandWithValues implements ResultTarget, DataChang
      * For MySQL-style INSERT ... ON DUPLICATE KEY UPDATE ....
      */
     private HashMap<Column, Expression> duplicateKeyAssignmentMap;
+
+    private Value[] onDuplicateKeyRow;
 
     /**
      * For MySQL-style INSERT IGNORE and PostgreSQL-style ON CONFLICT DO
@@ -384,13 +384,10 @@ public class Insert extends CommandWithValues implements ResultTarget, DataChang
         }
 
         int columnCount = columns.length;
-        ArrayList<String> variableNames = new ArrayList<>(columnCount);
         Expression[] row = (currentRow == null) ? valuesExpressionList.get((int) getCurrentRowNumber() - 1)
                 : new Expression[columnCount];
+        onDuplicateKeyRow = new Value[table.getColumns().length];
         for (int i = 0; i < columnCount; i++) {
-            StringBuilder builder = table.getSQL(new StringBuilder(), HasSQL.DEFAULT_SQL_FLAGS).append('.');
-            String key = columns[i].getSQL(builder, HasSQL.DEFAULT_SQL_FLAGS).toString();
-            variableNames.add(key);
             Value value;
             if (currentRow != null) {
                 value = currentRow[i];
@@ -398,7 +395,7 @@ public class Insert extends CommandWithValues implements ResultTarget, DataChang
             } else {
                 value = row[i].getValue(session);
             }
-            session.setVariable(key, value);
+            onDuplicateKeyRow[columns[i].getColumnId()] = value;
         }
 
         StringBuilder builder = new StringBuilder("UPDATE ");
@@ -421,15 +418,13 @@ public class Insert extends CommandWithValues implements ResultTarget, DataChang
         prepareUpdateCondition(foundIndex, row).getSQL(builder, HasSQL.DEFAULT_SQL_FLAGS);
         String sql = builder.toString();
         Update command = (Update) session.prepare(sql);
-        command.setUpdateToCurrentValuesReturnsZero(true);
+        command.setOnDuplicateKeyInsert(this);
         for (Parameter param : command.getParameters()) {
             Parameter insertParam = parameters.get(param.getIndex());
             param.setValue(insertParam.getValue(session));
         }
         boolean result = command.update() > 0;
-        for (String variableName : variableNames) {
-            session.setVariable(variableName, ValueNull.INSTANCE);
-        }
+        onDuplicateKeyRow = null;
         return result;
     }
 
@@ -473,6 +468,10 @@ public class Insert extends CommandWithValues implements ResultTarget, DataChang
             }
         }
         return condition;
+    }
+
+    public Value getOnDuplicateKeyValue(int columnIndex) {
+        return onDuplicateKeyRow[columnIndex];
     }
 
     @Override

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -39,13 +39,13 @@ public class Update extends Prepared implements DataChangeStatement {
     /** The limit expression as specified in the LIMIT clause. */
     private Expression limitExpr;
 
-    private boolean updateToCurrentValuesReturnsZero;
-
     private SetClauseList setClauseList;
 
     private ResultTarget deltaChangeCollector;
 
     private ResultOption deltaChangeCollectionMode;
+
+    private Insert onDuplicateKeyInsert;
 
     public Update(Session session) {
         super(session);
@@ -118,7 +118,7 @@ public class Update extends Prepared implements DataChangeStatement {
                         }
                     }
                     if (setClauseList.prepareUpdate(table, session, deltaChangeCollector, deltaChangeCollectionMode,
-                            rows, oldRow, updateToCurrentValuesReturnsZero)) {
+                            rows, oldRow, onDuplicateKeyInsert != null)) {
                         count++;
                     }
                 }
@@ -209,16 +209,6 @@ public class Update extends Prepared implements DataChangeStatement {
         return true;
     }
 
-    /**
-     * Sets expected update count for update to current values case.
-     *
-     * @param updateToCurrentValuesReturnsZero if zero should be returned as update
-     *        count if update set row to current values
-     */
-    public void setUpdateToCurrentValuesReturnsZero(boolean updateToCurrentValuesReturnsZero) {
-        this.updateToCurrentValuesReturnsZero = updateToCurrentValuesReturnsZero;
-    }
-
     @Override
     public void collectDependencies(HashSet<DbObject> dependencies) {
         ExpressionVisitor visitor = ExpressionVisitor.getDependenciesVisitor(dependencies);
@@ -227,4 +217,13 @@ public class Update extends Prepared implements DataChangeStatement {
         }
         setClauseList.isEverything(visitor);
     }
+
+    public Insert getOnDuplicateKeyInsert() {
+        return onDuplicateKeyInsert;
+    }
+
+    void setOnDuplicateKeyInsert(Insert onDuplicateKeyInsert) {
+        this.onDuplicateKeyInsert = onDuplicateKeyInsert;
+    }
+
 }

--- a/h2/src/main/org/h2/expression/Operation1_2.java
+++ b/h2/src/main/org/h2/expression/Operation1_2.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression;
+
+import org.h2.engine.Session;
+import org.h2.table.ColumnResolver;
+import org.h2.table.TableFilter;
+import org.h2.value.TypeInfo;
+
+/**
+ * Operation with one or two arguments.
+ */
+public abstract class Operation1_2 extends Expression {
+
+    protected Expression left, right;
+
+    protected TypeInfo type;
+
+    protected Operation1_2(Expression left, Expression right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public TypeInfo getType() {
+        return type;
+    }
+
+    @Override
+    public void mapColumns(ColumnResolver resolver, int level, int state) {
+        left.mapColumns(resolver, level, state);
+        if (right != null) {
+            right.mapColumns(resolver, level, state);
+        }
+    }
+
+    @Override
+    public void setEvaluatable(TableFilter tableFilter, boolean value) {
+        left.setEvaluatable(tableFilter, value);
+        if (right != null) {
+            right.setEvaluatable(tableFilter, value);
+        }
+    }
+
+    @Override
+    public void updateAggregate(Session session, int stage) {
+        left.updateAggregate(session, stage);
+        if (right != null) {
+            right.updateAggregate(session, stage);
+        }
+    }
+
+    @Override
+    public boolean isEverything(ExpressionVisitor visitor) {
+        return left.isEverything(visitor) && (right == null || right.isEverything(visitor));
+    }
+
+    @Override
+    public int getCost() {
+        int cost = left.getCost() + 1;
+        if (right != null) {
+            cost += right.getCost();
+        }
+        return cost;
+    }
+
+    @Override
+    public int getSubexpressionCount() {
+        return right != null ? 2 : 1;
+    }
+
+    @Override
+    public Expression getSubexpression(int index) {
+        if (index == 0) {
+            return left;
+        }
+        if (index == 1 && right != null) {
+            return right;
+        }
+        throw new IndexOutOfBoundsException();
+    }
+
+}

--- a/h2/src/main/org/h2/expression/Operation2.java
+++ b/h2/src/main/org/h2/expression/Operation2.java
@@ -13,11 +13,11 @@ import org.h2.value.TypeInfo;
 /**
  * Operation with two arguments.
  */
-abstract class Operation2 extends Expression {
+public abstract class Operation2 extends Expression {
 
-    Expression left, right;
+    protected Expression left, right;
 
-    TypeInfo type;
+    protected TypeInfo type;
 
     protected Operation2(Expression left, Expression right) {
         this.left = left;

--- a/h2/src/main/org/h2/expression/function/BitFunction.java
+++ b/h2/src/main/org/h2/expression/function/BitFunction.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+import org.h2.engine.Mode.ExpressionNames;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.Operation1_2;
+import org.h2.expression.TypedValueExpression;
+import org.h2.message.DbException;
+import org.h2.util.StringUtils;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+import org.h2.value.ValueBigint;
+import org.h2.value.ValueBoolean;
+import org.h2.value.ValueNull;
+
+/**
+ * A bitwise function.
+ */
+public class BitFunction extends Operation1_2 {
+
+    /**
+     * BITAND() (non-standard).
+     */
+    public static final int BITAND = 0;
+
+    /**
+     * BITOR() (non-standard).
+     */
+    public static final int BITOR = BITAND + 1;
+
+    /**
+     * BITXOR() (non-standard).
+     */
+    public static final int BITXOR = BITOR + 1;
+
+    /**
+     * BITNOT() (non-standard).
+     */
+    public static final int BITNOT = BITXOR + 1;
+
+    /**
+     * BITGET() (non-standard).
+     */
+    public static final int BITGET = BITNOT + 1;
+
+    /**
+     * LSHIFT() (non-standard).
+     */
+    public static final int LSHIFT = BITGET + 1;
+
+    /**
+     * RSHIFT() (non-standard).
+     */
+    public static final int RSHIFT = LSHIFT + 1;
+
+    private static final String[] NAMES = { //
+            "BITAND", "BITOR", "BITXOR", "BITNOT", "BITGET", "LSHIFT", "RSHIFT" //
+    };
+
+    /**
+     * Returns whether specified function is known by this class.
+     *
+     * @param upperName
+     *            the name of the function in upper case
+     * @return {@code true} if it exists
+     */
+    public static boolean exists(String upperName) {
+        for (String n : NAMES) {
+            if (n.equals(upperName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private final int function;
+
+    public BitFunction(Expression arg1, Expression arg2, int function) {
+        super(arg1, arg2);
+        this.function = function;
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        Value v1 = left.getValue(session);
+        if (v1 == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        if (function == BITNOT) {
+            return ValueBigint.get(~v1.getLong());
+        }
+        Value v2 = right.getValue(session);
+        if (v2 == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        long l1 = v1.getLong();
+        switch (function) {
+        case BITAND:
+            l1 &= v2.getLong();
+            break;
+        case BITOR:
+            l1 |= v2.getLong();
+            break;
+        case BITXOR:
+            l1 ^= v2.getLong();
+            break;
+        case BITGET:
+            return ValueBoolean.get((l1 & (1L << v2.getInt())) != 0);
+        case LSHIFT:
+            l1 <<= v2.getInt();
+            break;
+        case RSHIFT:
+            l1 >>= v2.getInt();
+            break;
+        default:
+            throw DbException.throwInternalError("function=" + function);
+        }
+        return ValueBigint.get(l1);
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        left = left.optimize(session);
+        if (right != null) {
+            right = right.optimize(session);
+        }
+        type = function == BITGET ? TypeInfo.TYPE_BOOLEAN : TypeInfo.TYPE_BIGINT;
+        if (left.isConstant() && (right == null || right.isConstant())) {
+            return TypedValueExpression.getTypedIfNull(getValue(session), type);
+        }
+        return this;
+    }
+
+    @Override
+    public String getAlias(Session session, int columnIndex) {
+        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
+            return StringUtils.toLowerEnglish(NAMES[function]);
+        }
+        return super.getAlias(session, columnIndex);
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        left.getSQL(builder.append(NAMES[function]).append('('), sqlFlags);
+        if (right != null) {
+            right.getSQL(builder.append(", "), sqlFlags);
+        }
+        return builder.append(')');
+    }
+
+}

--- a/h2/src/main/org/h2/expression/function/CompatibilityIdentityFunction.java
+++ b/h2/src/main/org/h2/expression/function/CompatibilityIdentityFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionVisitor;
+import org.h2.expression.Operation0;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+
+/**
+ * IDENTITY() or SCOPE_IDENTITY() compatibility functions.
+ */
+public final class CompatibilityIdentityFunction extends Operation0 {
+
+    private final boolean scope;
+
+    private TypeInfo type;
+
+    public CompatibilityIdentityFunction(boolean scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        return scope ? session.getLastScopeIdentity() : session.getLastIdentity();
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        return builder.append(scope ? "SCOPE_IDENTITY()" : "IDENTITY()");
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        type = session.getMode().decimalSequences ? TypeInfo.TYPE_NUMERIC_BIGINT : TypeInfo.TYPE_BIGINT;
+        return this;
+    }
+
+    @Override
+    public boolean isEverything(ExpressionVisitor visitor) {
+        switch (visitor.getType()) {
+        case ExpressionVisitor.DETERMINISTIC:
+        case ExpressionVisitor.INDEPENDENT:
+        case ExpressionVisitor.QUERY_COMPARABLE:
+            return false;
+        default:
+            return true;
+        }
+    }
+
+    @Override
+    public TypeInfo getType() {
+        return type;
+    }
+
+    @Override
+    public int getCost() {
+        return 1;
+    }
+
+}

--- a/h2/src/main/org/h2/expression/function/CompatibilitySequenceValueFunction.java
+++ b/h2/src/main/org/h2/expression/function/CompatibilitySequenceValueFunction.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+import org.h2.command.Parser;
+import org.h2.engine.Database;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionColumn;
+import org.h2.expression.ExpressionVisitor;
+import org.h2.expression.Operation1_2;
+import org.h2.message.DbException;
+import org.h2.schema.Schema;
+import org.h2.schema.Sequence;
+import org.h2.util.StringUtils;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+
+/**
+ * NEXTVAL() and CURRVAL() compatibility functions.
+ */
+public class CompatibilitySequenceValueFunction extends Operation1_2 {
+
+    private final boolean current;
+
+    public CompatibilitySequenceValueFunction(Expression left, Expression right, boolean current) {
+        super(left, right);
+        this.current = current;
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        left.getSQL(builder.append(current ? "CURRVAL(" : "NEXTVAL("), sqlFlags);
+        if (right != null) {
+            right.getSQL(builder.append(", "), sqlFlags);
+        }
+        return builder.append(')');
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        Value v0 = left.getValue(session);
+        String schemaName, sequenceName;
+        if (right == null) {
+            Parser p = new Parser(session);
+            String sql = v0.getString();
+            Expression expr = p.parseExpression(sql);
+            if (expr instanceof ExpressionColumn) {
+                ExpressionColumn seq = (ExpressionColumn) expr;
+                schemaName = seq.getOriginalTableAliasName();
+                if (schemaName == null) {
+                    schemaName = session.getCurrentSchemaName();
+                    sequenceName = sql;
+                } else {
+                    sequenceName = seq.getColumnName(session, -1);
+                }
+            } else {
+                throw DbException.getSyntaxError(sql, 1);
+            }
+        } else {
+            schemaName = v0.getString();
+            sequenceName = right.getValue(session).getString();
+        }
+        Database database = session.getDatabase();
+        Schema s = database.findSchema(schemaName);
+        if (s == null) {
+            schemaName = StringUtils.toUpperEnglish(schemaName);
+            s = database.getSchema(schemaName);
+        }
+        Sequence seq = s.findSequence(sequenceName);
+        if (seq == null) {
+            sequenceName = StringUtils.toUpperEnglish(sequenceName);
+            seq = s.getSequence(sequenceName);
+        }
+        return current ? session.getCurrentValueFor(seq) : session.getNextValueFor(seq, null);
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        left = left.optimize(session);
+        if (right != null) {
+            right = right.optimize(session);
+        }
+        type = session.getMode().decimalSequences ? TypeInfo.TYPE_NUMERIC_BIGINT : TypeInfo.TYPE_BIGINT;
+        return this;
+    }
+
+    @Override
+    public boolean isEverything(ExpressionVisitor visitor) {
+        switch (visitor.getType()) {
+        case ExpressionVisitor.INDEPENDENT:
+        case ExpressionVisitor.DETERMINISTIC:
+        case ExpressionVisitor.QUERY_COMPARABLE:
+            return false;
+        case ExpressionVisitor.READONLY:
+            if (!current) {
+                return false;
+            }
+            //$FALL-THROUGH$
+        case ExpressionVisitor.OPTIMIZABLE_AGGREGATE:
+        case ExpressionVisitor.EVALUATABLE:
+        case ExpressionVisitor.SET_MAX_DATA_MODIFICATION_ID:
+        case ExpressionVisitor.NOT_FROM_RESOLVER:
+        case ExpressionVisitor.GET_DEPENDENCIES:
+        case ExpressionVisitor.GET_COLUMNS1:
+        case ExpressionVisitor.GET_COLUMNS2:
+            return super.isEverything(visitor);
+        default:
+            throw DbException.throwInternalError("type=" + visitor.getType());
+        }
+    }
+
+}

--- a/h2/src/main/org/h2/expression/function/CompatibilitySequenceValueFunction.java
+++ b/h2/src/main/org/h2/expression/function/CompatibilitySequenceValueFunction.java
@@ -8,6 +8,7 @@ package org.h2.expression.function;
 import org.h2.command.Parser;
 import org.h2.engine.Database;
 import org.h2.engine.Session;
+import org.h2.engine.Mode.ExpressionNames;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.expression.ExpressionVisitor;
@@ -29,6 +30,14 @@ public class CompatibilitySequenceValueFunction extends Operation1_2 {
     public CompatibilitySequenceValueFunction(Expression left, Expression right, boolean current) {
         super(left, right);
         this.current = current;
+    }
+
+    @Override
+    public String getAlias(Session session, int columnIndex) {
+        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
+            return current ? "currval" : "nextval";
+        }
+        return super.getAlias(session, columnIndex);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/function/CurrentDateTimeValueFunction.java
+++ b/h2/src/main/org/h2/expression/function/CurrentDateTimeValueFunction.java
@@ -5,9 +5,11 @@
  */
 package org.h2.expression.function;
 
+import org.h2.engine.Mode.ExpressionNames;
 import org.h2.engine.Session;
 import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.Operation0;
+import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueTime;
@@ -74,6 +76,14 @@ public final class CurrentDateTimeValueFunction extends Operation0 {
     @Override
     public Value getValue(Session session) {
         return session.currentTimestamp().castTo(type, session);
+    }
+
+    @Override
+    public String getAlias(Session session, int columnIndex) {
+        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
+            return StringUtils.toLowerEnglish(NAMES[function]);
+        }
+        return super.getAlias(session, columnIndex);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/function/CurrentGeneralValueSpecification.java
+++ b/h2/src/main/org/h2/expression/function/CurrentGeneralValueSpecification.java
@@ -6,11 +6,13 @@
 package org.h2.expression.function;
 
 import org.h2.command.Parser;
+import org.h2.engine.Mode.ExpressionNames;
 import org.h2.engine.Session;
 import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.Operation0;
 import org.h2.message.DbException;
 import org.h2.util.HasSQL;
+import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueNull;
@@ -114,6 +116,14 @@ public final class CurrentGeneralValueSpecification extends Operation0 {
             throw DbException.throwInternalError("specification=" + specification);
         }
         return s != null ? ValueVarchar.get(s, session) : ValueNull.INSTANCE;
+    }
+
+    @Override
+    public String getAlias(Session session, int columnIndex) {
+        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
+            return StringUtils.toLowerEnglish(NAMES[specification]);
+        }
+        return super.getAlias(session, columnIndex);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -154,11 +154,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
     public static final int REGEXP_LIKE = 240;
     public static final int REGEXP_SUBSTR = 241;
 
-    /**
-     * Used in MySQL-style INSERT ... ON DUPLICATE KEY UPDATE ... VALUES
-     */
-    public static final int VALUES = 250;
-
     public static final int JSON_OBJECT = 251, JSON_ARRAY = 252;
 
     /**
@@ -387,9 +382,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         addFunctionWithNull("TABLE", TABLE, VAR_ARGS, Value.RESULT_SET);
         addFunctionWithNull("TABLE_DISTINCT", TABLE_DISTINCT, VAR_ARGS, Value.RESULT_SET);
         addFunctionWithNull("UNNEST", UNNEST, VAR_ARGS, Value.RESULT_SET);
-
-        // ON DUPLICATE KEY VALUES function
-        addFunctionWithNull("VALUES", VALUES, 1, Value.NULL);
 
         addFunction("JSON_ARRAY", JSON_ARRAY, VAR_ARGS, Value.JSON, false, true, true);
         addFunction("JSON_OBJECT", JSON_OBJECT, VAR_ARGS, Value.JSON, false, true, true);
@@ -1493,15 +1485,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         }
         case REGEXP_SUBSTR: {
             result = regexpSubstr(v0, v1, v2, v3, v4, v5, session);
-            break;
-        }
-        case VALUES: {
-            Expression a0 = args[0];
-            StringBuilder builder = new StringBuilder();
-            Parser.quoteIdentifier(builder, a0.getSchemaName(), DEFAULT_SQL_FLAGS).append('.');
-            Parser.quoteIdentifier(builder, a0.getTableName(), DEFAULT_SQL_FLAGS).append('.');
-            Parser.quoteIdentifier(builder, a0.getColumnName(session, /* TODO */ 0), DEFAULT_SQL_FLAGS);
-            result = session.getVariable(builder.toString());
             break;
         }
         case SIGNAL: {

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -130,7 +130,7 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
             DATE_TRUNC = 125;
 
     public static final int
-            IDENTITY = 153, SCOPE_IDENTITY = 154, AUTOCOMMIT = 155,
+            AUTOCOMMIT = 155,
             READONLY = 156, DATABASE_PATH = 157, LOCK_TIMEOUT = 158,
             DISK_SPACE_USED = 159, SIGNAL = 160, ESTIMATED_ENVELOPE = 161;
 
@@ -320,10 +320,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         addFunctionWithNull("PARSEDATETIME", PARSEDATETIME, VAR_ARGS, Value.TIMESTAMP);
         addFunction("DATE_TRUNC", DATE_TRUNC, 2, Value.NULL);
         // system
-        addFunctionNotDeterministic("IDENTITY", IDENTITY,
-                0, Value.BIGINT);
-        addFunctionNotDeterministic("SCOPE_IDENTITY", SCOPE_IDENTITY,
-                0, Value.BIGINT);
         addFunctionNotDeterministic("AUTOCOMMIT", AUTOCOMMIT,
                 0, Value.BOOLEAN);
         addFunctionNotDeterministic("READONLY", READONLY,
@@ -754,12 +750,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
             result = ValueVarchar.get(DateTimeFunctions.getMonthsAndWeeks(0)[month - 1], session);
             break;
         }
-        case IDENTITY:
-            result = session.getLastIdentity();
-            break;
-        case SCOPE_IDENTITY:
-            result = session.getLastScopeIdentity();
-            break;
         case AUTOCOMMIT:
             result = ValueBoolean.get(session.getAutoCommit());
             break;

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -100,14 +100,14 @@ import org.h2.value.ValueVarchar;
  * This class implements most built-in functions of this database.
  */
 public class Function extends OperationN implements FunctionCall, ExpressionWithFlags {
-    public static final int ABS = 0, ACOS = 1, ASIN = 2, ATAN = 3, ATAN2 = 4,
-            BITAND = 5, BITOR = 6, BITXOR = 7, CEILING = 8, COS = 9, COT = 10,
-            DEGREES = 11, EXP = 12, FLOOR = 13, LOG = 14, LOG10 = 15, MOD = 16,
-            PI = 17, POWER = 18, RADIANS = 19, RAND = 20, ROUND = 21,
-            ROUNDMAGIC = 22, SIGN = 23, SIN = 24, SQRT = 25, TAN = 26,
+    public static final int ABS = 0,
+            BITAND = 5, BITOR = 6, BITXOR = 7, CEILING = 8,
+            FLOOR = 13, MOD = 16,
+            PI = 17, RAND = 20, ROUND = 21,
+            ROUNDMAGIC = 22, SIGN = 23,
             TRUNCATE = 27, SECURE_RAND = 28, HASH = 29, ENCRYPT = 30,
             DECRYPT = 31, COMPRESS = 32, EXPAND = 33, ZERO = 34,
-            RANDOM_UUID = 35, COSH = 36, SINH = 37, TANH = 38, LN = 39,
+            RANDOM_UUID = 35,
             BITGET = 40, ORA_HASH = 41, BITNOT = 42, LSHIFT = 43, RSHIFT = 44;
 
     public static final int ASCII = 50, BIT_LENGTH = 51, CHAR = 52,
@@ -206,10 +206,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
 
         // FUNCTIONS
         addFunction("ABS", ABS, 1, Value.NULL);
-        addFunction("ACOS", ACOS, 1, Value.DOUBLE);
-        addFunction("ASIN", ASIN, 1, Value.DOUBLE);
-        addFunction("ATAN", ATAN, 1, Value.DOUBLE);
-        addFunction("ATAN2", ATAN2, 2, Value.DOUBLE);
         addFunction("BITAND", BITAND, 2, Value.BIGINT);
         addFunction("BITGET", BITGET, 2, Value.BOOLEAN);
         addFunction("BITNOT", BITNOT, 1, Value.BIGINT);
@@ -217,20 +213,10 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         addFunction("BITXOR", BITXOR, 2, Value.BIGINT);
         addFunction("CEILING", CEILING, 1, Value.NULL);
         addFunction("CEIL", CEILING, 1, Value.NULL);
-        addFunction("COS", COS, 1, Value.DOUBLE);
-        addFunction("COSH", COSH, 1, Value.DOUBLE);
-        addFunction("COT", COT, 1, Value.DOUBLE);
-        addFunction("DEGREES", DEGREES, 1, Value.DOUBLE);
-        addFunction("EXP", EXP, 1, Value.DOUBLE);
         addFunction("FLOOR", FLOOR, 1, Value.NULL);
-        addFunction("LOG", LOG, 2, Value.DOUBLE);
-        addFunction("LN", LN, 1, Value.DOUBLE);
-        addFunction("LOG10", LOG10, 1, Value.DOUBLE);
         addFunction("LSHIFT", LSHIFT, 2, Value.BIGINT);
         addFunction("MOD", MOD, 2, Value.BIGINT);
         addFunction("PI", PI, 0, Value.DOUBLE);
-        addFunction("POWER", POWER, 2, Value.DOUBLE);
-        addFunction("RADIANS", RADIANS, 1, Value.DOUBLE);
         // RAND without argument: get the next value
         // RAND with one argument: seed the random generator
         addFunctionNotDeterministic("RAND", RAND, VAR_ARGS, Value.DOUBLE);
@@ -239,11 +225,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         addFunction("ROUNDMAGIC", ROUNDMAGIC, 1, Value.DOUBLE);
         addFunction("RSHIFT", RSHIFT, 2, Value.BIGINT);
         addFunction("SIGN", SIGN, 1, Value.INTEGER);
-        addFunction("SIN", SIN, 1, Value.DOUBLE);
-        addFunction("SINH", SINH, 1, Value.DOUBLE);
-        addFunction("SQRT", SQRT, 1, Value.DOUBLE);
-        addFunction("TAN", TAN, 1, Value.DOUBLE);
-        addFunction("TANH", TANH, 1, Value.DOUBLE);
         addFunction("TRUNCATE", TRUNCATE, VAR_ARGS, Value.NULL);
         // same as TRUNCATE
         addFunction("TRUNC", TRUNCATE, VAR_ARGS, Value.NULL);
@@ -533,65 +514,14 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         case ABS:
             result = v0.getSignum() >= 0 ? v0 : v0.negate();
             break;
-        case ACOS:
-            result = ValueDouble.get(Math.acos(v0.getDouble()));
-            break;
-        case ASIN:
-            result = ValueDouble.get(Math.asin(v0.getDouble()));
-            break;
-        case ATAN:
-            result = ValueDouble.get(Math.atan(v0.getDouble()));
-            break;
         case CEILING:
             result = getCeilOrFloor(v0, false);
-            break;
-        case COS:
-            result = ValueDouble.get(Math.cos(v0.getDouble()));
-            break;
-        case COSH:
-            result = ValueDouble.get(Math.cosh(v0.getDouble()));
-            break;
-        case COT: {
-            double d = Math.tan(v0.getDouble());
-            if (d == 0.0) {
-                throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
-            }
-            result = ValueDouble.get(1. / d);
-            break;
-        }
-        case DEGREES:
-            result = ValueDouble.get(Math.toDegrees(v0.getDouble()));
-            break;
-        case EXP:
-            result = ValueDouble.get(Math.exp(v0.getDouble()));
             break;
         case FLOOR:
             result = getCeilOrFloor(v0, true);
             break;
-        case LN: {
-            double arg = v0.getDouble();
-            if (arg <= 0) {
-                throw DbException.getInvalidValueException("LN() argument", arg);
-            }
-            result = ValueDouble.get(Math.log(arg));
-            break;
-        }
-        case LOG:
-            result = log(session, v0, getNullOrValue(session, args, values, 1));
-            break;
-        case LOG10: {
-            double arg = v0.getDouble();
-            if (arg <= 0) {
-                throw DbException.getInvalidValueException("LOG10() argument", arg);
-            }
-            result = ValueDouble.get(Math.log10(arg));
-            break;
-        }
         case PI:
             result = ValueDouble.get(Math.PI);
-            break;
-        case RADIANS:
-            result = ValueDouble.get(Math.toRadians(v0.getDouble()));
             break;
         case RAND: {
             if (v0 != null) {
@@ -605,21 +535,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
             break;
         case SIGN:
             result = ValueInteger.get(v0.getSignum());
-            break;
-        case SIN:
-            result = ValueDouble.get(Math.sin(v0.getDouble()));
-            break;
-        case SINH:
-            result = ValueDouble.get(Math.sinh(v0.getDouble()));
-            break;
-        case SQRT:
-            result = ValueDouble.get(Math.sqrt(v0.getDouble()));
-            break;
-        case TAN:
-            result = ValueDouble.get(Math.tan(v0.getDouble()));
-            break;
-        case TANH:
-            result = ValueDouble.get(Math.tanh(v0.getDouble()));
             break;
         case SECURE_RAND:
             result = ValueVarbinary.getNoCopy(
@@ -1007,10 +922,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         Value v5 = getNullOrValue(session, args, values, 5);
         Value result;
         switch (info.type) {
-        case ATAN2:
-            result = ValueDouble.get(
-                    Math.atan2(v0.getDouble(), v1.getDouble()));
-            break;
         case BITAND:
             result = ValueBigint.get(v0.getLong() & v1.getLong());
             break;
@@ -1040,10 +951,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
             result = ValueBigint.get(v0.getLong() % x);
             break;
         }
-        case POWER:
-            result = ValueDouble.get(Math.pow(
-                    v0.getDouble(), v1.getDouble()));
-            break;
         case ROUND:
             result = round(v0, v1);
             break;
@@ -1649,31 +1556,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         default:
             return v.getString().length();
         }
-    }
-
-    private static Value log(Session session, Value v0, Value v1) {
-        double base = v0.getDouble();
-        double arg = v1.getDouble();
-        if (session.getMode().swapLogFunctionParameters) {
-            double t = arg;
-            arg = base;
-            base = t;
-        }
-        if (arg <= 0) {
-            throw DbException.getInvalidValueException("LOG() argument", arg);
-        }
-        if (base <= 0 || base == 1) {
-            throw DbException.getInvalidValueException("LOG() base", base);
-        }
-        double r;
-        if (base == Math.E) {
-            r = Math.log(arg);
-        } else if (base == 10d) {
-            r = Math.log10(arg);
-        } else {
-            r = Math.log(arg) / Math.log(base);
-        }
-        return ValueDouble.get(r);
     }
 
     private static byte[] getPaddedArrayCopy(byte[] data, int blockSize) {

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -101,14 +101,14 @@ import org.h2.value.ValueVarchar;
  */
 public class Function extends OperationN implements FunctionCall, ExpressionWithFlags {
     public static final int ABS = 0,
-            BITAND = 5, BITOR = 6, BITXOR = 7, CEILING = 8,
+            CEILING = 8,
             FLOOR = 13, MOD = 16,
             PI = 17, RAND = 20, ROUND = 21,
             ROUNDMAGIC = 22, SIGN = 23,
             TRUNCATE = 27, SECURE_RAND = 28, HASH = 29, ENCRYPT = 30,
             DECRYPT = 31, COMPRESS = 32, EXPAND = 33, ZERO = 34,
             RANDOM_UUID = 35,
-            BITGET = 40, ORA_HASH = 41, BITNOT = 42, LSHIFT = 43, RSHIFT = 44;
+            ORA_HASH = 41;
 
     public static final int ASCII = 50, BIT_LENGTH = 51, CHAR = 52,
             CHAR_LENGTH = 53, CONCAT = 54, DIFFERENCE = 55, HEXTORAW = 56,
@@ -206,15 +206,9 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
 
         // FUNCTIONS
         addFunction("ABS", ABS, 1, Value.NULL);
-        addFunction("BITAND", BITAND, 2, Value.BIGINT);
-        addFunction("BITGET", BITGET, 2, Value.BOOLEAN);
-        addFunction("BITNOT", BITNOT, 1, Value.BIGINT);
-        addFunction("BITOR", BITOR, 2, Value.BIGINT);
-        addFunction("BITXOR", BITXOR, 2, Value.BIGINT);
         addFunction("CEILING", CEILING, 1, Value.NULL);
         addFunction("CEIL", CEILING, 1, Value.NULL);
         addFunction("FLOOR", FLOOR, 1, Value.NULL);
-        addFunction("LSHIFT", LSHIFT, 2, Value.BIGINT);
         addFunction("MOD", MOD, 2, Value.BIGINT);
         addFunction("PI", PI, 0, Value.DOUBLE);
         // RAND without argument: get the next value
@@ -223,7 +217,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         addFunctionNotDeterministic("RANDOM", RAND, VAR_ARGS, Value.DOUBLE);
         addFunction("ROUND", ROUND, VAR_ARGS, Value.NULL);
         addFunction("ROUNDMAGIC", ROUNDMAGIC, 1, Value.DOUBLE);
-        addFunction("RSHIFT", RSHIFT, 2, Value.BIGINT);
         addFunction("SIGN", SIGN, 1, Value.INTEGER);
         addFunction("TRUNCATE", TRUNCATE, VAR_ARGS, Value.NULL);
         // same as TRUNCATE
@@ -922,27 +915,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         Value v5 = getNullOrValue(session, args, values, 5);
         Value result;
         switch (info.type) {
-        case BITAND:
-            result = ValueBigint.get(v0.getLong() & v1.getLong());
-            break;
-        case BITGET:
-            result = ValueBoolean.get((v0.getLong() & (1L << v1.getInt())) != 0);
-            break;
-        case BITNOT:
-            result = ValueBigint.get(~v0.getLong());
-            break;
-        case BITOR:
-            result = ValueBigint.get(v0.getLong() | v1.getLong());
-            break;
-        case BITXOR:
-            result = ValueBigint.get(v0.getLong() ^ v1.getLong());
-            break;
-        case LSHIFT:
-            result = ValueBigint.get(v0.getLong() << v1.getInt());
-            break;
-        case RSHIFT:
-            result = ValueBigint.get(v0.getLong() >> v1.getInt());
-            break;
         case MOD: {
             long x = v1.getLong();
             if (x == 0) {

--- a/h2/src/main/org/h2/expression/function/FunctionInfo.java
+++ b/h2/src/main/org/h2/expression/function/FunctionInfo.java
@@ -41,11 +41,6 @@ public final class FunctionInfo {
     public final boolean deterministic;
 
     /**
-     * Should the no-arg function require parentheses.
-     */
-    final boolean requireParentheses;
-
-    /**
      * If arguments cannot be evaluated in normal way with
      * {@link org.h2.expression.Expression#getValue(org.h2.engine.Session)}.
      */
@@ -68,21 +63,18 @@ public final class FunctionInfo {
      * @param deterministic
      *            if this function always returns the same value for the same
      *            parameters
-     * @param requireParentheses
-     *            should the no-arg function require parentheses
      * @param specialArguments
      *            if arguments cannot be evaluated in normal way with
      *            {@link org.h2.expression.Expression#getValue(org.h2.engine.Session)}.
      */
     public FunctionInfo(String name, int type, int parameterCount, int returnDataType, boolean nullIfParameterIsNull,
-            boolean deterministic, boolean requireParentheses, boolean specialArguments) {
+            boolean deterministic, boolean specialArguments) {
         this.name = name;
         this.type = type;
         this.parameterCount = parameterCount;
         this.returnDataType = returnDataType;
         this.nullIfParameterIsNull = nullIfParameterIsNull;
         this.deterministic = deterministic;
-        this.requireParentheses = requireParentheses;
         this.specialArguments = specialArguments;
     }
 
@@ -102,7 +94,6 @@ public final class FunctionInfo {
         parameterCount = source.parameterCount;
         nullIfParameterIsNull = source.nullIfParameterIsNull;
         deterministic = source.deterministic;
-        requireParentheses = true;
         specialArguments = source.specialArguments;
     }
 

--- a/h2/src/main/org/h2/expression/function/MathFunction1.java
+++ b/h2/src/main/org/h2/expression/function/MathFunction1.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+import org.h2.engine.Mode.ExpressionNames;
+import org.h2.api.ErrorCode;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.Operation1;
+import org.h2.expression.TypedValueExpression;
+import org.h2.message.DbException;
+import org.h2.util.StringUtils;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+import org.h2.value.ValueDouble;
+import org.h2.value.ValueNull;
+
+/**
+ * A math function with one argument and DOUBLE PRECISION result.
+ */
+public class MathFunction1 extends Operation1 {
+
+    // Trigonometric functions
+
+    /**
+     * SIN().
+     */
+    public static final int SIN = 0;
+
+    /**
+     * COS().
+     */
+    public static final int COS = SIN + 1;
+
+    /**
+     * TAN().
+     */
+    public static final int TAN = COS + 1;
+
+    /**
+     * COT() (non-standard).
+     */
+    public static final int COT = TAN + 1;
+
+    /**
+     * SINH().
+     */
+    public static final int SINH = COT + 1;
+
+    /**
+     * COSH().
+     */
+    public static final int COSH = SINH + 1;
+
+    /**
+     * TANH().
+     */
+    public static final int TANH = COSH + 1;
+
+    /**
+     * ASIN().
+     */
+    public static final int ASIN = TANH + 1;
+
+    /**
+     * ACOS().
+     */
+    public static final int ACOS = ASIN + 1;
+
+    /**
+     * ATAN().
+     */
+    public static final int ATAN = ACOS + 1;
+
+    // Logarithm functions
+
+    /**
+     * LOG10().
+     */
+    public static final int LOG10 = ATAN + 1;
+
+    /**
+     * LN().
+     */
+    public static final int LN = LOG10 + 1;
+
+    // Exponential function
+
+    /**
+     * EXP().
+     */
+    public static final int EXP = LN + 1;
+
+    // Square root
+
+    /**
+     * SQRT().
+     */
+    public static final int SQRT = EXP + 1;
+
+    // Other non-standard
+
+    /**
+     * DEGREES() (non-standard).
+     */
+    public static final int DEGREES = SQRT + 1;
+
+    /**
+     * RADIANS() (non-standard).
+     */
+    public static final int RADIANS = DEGREES + 1;
+
+    private static final String[] NAMES = { //
+            "SIN", "COS", "TAN", "COT", "SINH", "COSH", "TANH", "ASIN", "ACOS", "ATAN", //
+            "LOG10", "LN", "EXP", "SQRT", "DEGREES", "RADIANS" //
+    };
+
+    /**
+     * Returns whether specified function is known by this class.
+     *
+     * @param upperName
+     *            the name of the function in upper case
+     * @return {@code true} if it exists
+     */
+    public static boolean exists(String upperName) {
+        for (String n : NAMES) {
+            if (n.equals(upperName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private final int function;
+
+    public MathFunction1(Expression arg, int function) {
+        super(arg);
+        this.function = function;
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        Value v = arg.getValue(session);
+        if (v == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        double d = v.getDouble();
+        switch (function) {
+        case SIN:
+            d = Math.sin(d);
+            break;
+        case COS:
+            d = Math.cos(d);
+            break;
+        case TAN:
+            d = Math.tan(d);
+            break;
+        case COT:
+            d = Math.tan(d);
+            if (d == 0.0) {
+                throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
+            }
+            d = 1d / d;
+            break;
+        case SINH:
+            d = Math.sinh(d);
+            break;
+        case COSH:
+            d = Math.cosh(d);
+            break;
+        case TANH:
+            d = Math.tanh(d);
+            break;
+        case ASIN:
+            d = Math.asin(d);
+            break;
+        case ACOS:
+            d = Math.acos(d);
+            break;
+        case ATAN:
+            d = Math.atan(d);
+            break;
+        case LOG10:
+            if (d <= 0) {
+                throw DbException.getInvalidValueException("LOG10() argument", d);
+            }
+            d = Math.log10(d);
+            break;
+        case LN:
+            if (d <= 0) {
+                throw DbException.getInvalidValueException("LN() argument", d);
+            }
+            d = Math.log(d);
+            break;
+        case EXP:
+            d = Math.exp(d);
+            break;
+        case SQRT:
+            d = Math.sqrt(d);
+            break;
+        case DEGREES:
+            d = Math.toDegrees(d);
+            break;
+        case RADIANS:
+            d = Math.toRadians(d);
+            break;
+        default:
+            throw DbException.throwInternalError("function=" + function);
+        }
+        return ValueDouble.get(d);
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        arg = arg.optimize(session);
+        type = TypeInfo.TYPE_DOUBLE;
+        if (arg.isConstant()) {
+            return TypedValueExpression.getTypedIfNull(getValue(session), type);
+        }
+        return this;
+    }
+
+    @Override
+    public String getAlias(Session session, int columnIndex) {
+        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
+            return StringUtils.toLowerEnglish(NAMES[function]);
+        }
+        return super.getAlias(session, columnIndex);
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        return arg.getSQL(builder.append(NAMES[function]).append('('), sqlFlags).append(')');
+    }
+
+}

--- a/h2/src/main/org/h2/expression/function/MathFunction2.java
+++ b/h2/src/main/org/h2/expression/function/MathFunction2.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+import org.h2.engine.Mode.ExpressionNames;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.Operation2;
+import org.h2.expression.TypedValueExpression;
+import org.h2.message.DbException;
+import org.h2.util.StringUtils;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+import org.h2.value.ValueDouble;
+import org.h2.value.ValueNull;
+
+/**
+ * A math function with two arguments and DOUBLE PRECISION result.
+ */
+public class MathFunction2 extends Operation2 {
+
+    /**
+     * ATAN2() (non-standard).
+     */
+    public static final int ATAN2 = 0;
+
+    /**
+     * LOG().
+     */
+    public static final int LOG = ATAN2 + 1;
+
+    /**
+     * POWER().
+     */
+    public static final int POWER = LOG + 1;
+
+    private static final String[] NAMES = { //
+            "LOG", "POWER", //
+    };
+
+    /**
+     * Returns whether specified function is known by this class.
+     *
+     * @param upperName
+     *            the name of the function in upper case
+     * @return {@code true} if it exists
+     */
+    public static boolean exists(String upperName) {
+        for (String n : NAMES) {
+            if (n.equals(upperName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private final int function;
+
+    public MathFunction2(Expression arg1, Expression arg2, int function) {
+        super(arg1, arg2);
+        this.function = function;
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        Value v1 = left.getValue(session);
+        if (v1 == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        Value v2 = right.getValue(session);
+        if (v2 == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        double d1 = v1.getDouble(), d2 = v2.getDouble();
+        switch (function) {
+        case ATAN2:
+            d1 = Math.atan2(d1, d2);
+            break;
+        case LOG: {
+            if (session.getMode().swapLogFunctionParameters) {
+                double t = d2;
+                d2 = d1;
+                d1 = t;
+            }
+            if (d2 <= 0) {
+                throw DbException.getInvalidValueException("LOG() argument", d2);
+            }
+            if (d1 <= 0 || d1 == 1) {
+                throw DbException.getInvalidValueException("LOG() base", d1);
+            }
+            if (d1 == Math.E) {
+                d1 = Math.log(d2);
+            } else if (d1 == 10d) {
+                d1 = Math.log10(d2);
+            } else {
+                d1 = Math.log(d2) / Math.log(d1);
+            }
+            break;
+        }
+        case POWER:
+            d1 = Math.pow(d1, d2);
+            break;
+        default:
+            throw DbException.throwInternalError("function=" + function);
+        }
+        return ValueDouble.get(d1);
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        left = left.optimize(session);
+        right = right.optimize(session);
+        type = TypeInfo.TYPE_DOUBLE;
+        if (left.isConstant() && right.isConstant()) {
+            return TypedValueExpression.getTypedIfNull(getValue(session), type);
+        }
+        return this;
+    }
+
+    @Override
+    public String getAlias(Session session, int columnIndex) {
+        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
+            return StringUtils.toLowerEnglish(NAMES[function]);
+        }
+        return super.getAlias(session, columnIndex);
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        builder.append(NAMES[function]).append('(');
+        left.getSQL(builder, sqlFlags).append(", ");
+        return right.getSQL(builder, sqlFlags).append(')');
+    }
+
+}

--- a/h2/src/main/org/h2/mode/FunctionsDB2Derby.java
+++ b/h2/src/main/org/h2/mode/FunctionsDB2Derby.java
@@ -7,8 +7,13 @@ package org.h2.mode;
 
 import java.util.HashMap;
 
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.function.CompatibilityIdentityFunction;
 import org.h2.expression.function.Function;
 import org.h2.expression.function.FunctionInfo;
+import org.h2.message.DbException;
+import org.h2.value.Value;
 
 /**
  * Functions for {@link org.h2.engine.Mode.ModeEnum#DB2} and
@@ -16,10 +21,13 @@ import org.h2.expression.function.FunctionInfo;
  */
 public final class FunctionsDB2Derby extends FunctionsBase {
 
+    private static final int IDENTITY_VAL_LOCAL = 5001;
+
     private static final HashMap<String, FunctionInfo> FUNCTIONS = new HashMap<>();
 
     static {
-        copyFunction(FUNCTIONS, "IDENTITY", "IDENTITY_VAL_LOCAL");
+        FUNCTIONS.put("IDENTITY_VAL_LOCAL",
+                new FunctionInfo("IDENTITY_VAL_LOCAL", IDENTITY_VAL_LOCAL, 0, Value.BIGINT, true, false, false));
     }
 
     /**
@@ -31,11 +39,21 @@ public final class FunctionsDB2Derby extends FunctionsBase {
      */
     public static Function getFunction(String upperName) {
         FunctionInfo info = FUNCTIONS.get(upperName);
-        return info != null ? new Function(info) : null;
+        return info != null ? new FunctionsDB2Derby(info) : null;
     }
 
     private FunctionsDB2Derby(FunctionInfo info) {
         super(info);
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        switch (info.type) {
+        case IDENTITY_VAL_LOCAL:
+            return new CompatibilityIdentityFunction(false).optimize(session);
+        default:
+            throw DbException.throwInternalError("type=" + info.type);
+        }
     }
 
 }

--- a/h2/src/main/org/h2/mode/FunctionsMSSQLServer.java
+++ b/h2/src/main/org/h2/mode/FunctionsMSSQLServer.java
@@ -27,9 +27,9 @@ public final class FunctionsMSSQLServer extends FunctionsBase {
 
     static {
         copyFunction(FUNCTIONS, "LOCATE", "CHARINDEX");
-        FUNCTIONS.put("GETDATE", new FunctionInfo("GETDATE", GETDATE, 0, Value.TIMESTAMP, false, true, true, false));
+        FUNCTIONS.put("GETDATE", new FunctionInfo("GETDATE", GETDATE, 0, Value.TIMESTAMP, false, true, false));
         FUNCTIONS.put("ISNULL", new FunctionInfo("ISNULL", Function.COALESCE,
-                2, Value.NULL, false, true, true, false));
+                2, Value.NULL, false, true, false));
         copyFunction(FUNCTIONS, "LENGTH", "LEN");
         copyFunction(FUNCTIONS, "RANDOM_UUID", "NEWID");
     }

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -42,13 +42,13 @@ public class FunctionsMySQL extends FunctionsBase {
 
     static {
         FUNCTIONS.put("UNIX_TIMESTAMP", new FunctionInfo("UNIX_TIMESTAMP", UNIX_TIMESTAMP,
-                VAR_ARGS, Value.INTEGER, false, false, true, false));
+                VAR_ARGS, Value.INTEGER, false, false, false));
         FUNCTIONS.put("FROM_UNIXTIME", new FunctionInfo("FROM_UNIXTIME", FROM_UNIXTIME,
-                VAR_ARGS, Value.VARCHAR, false, true, true, false));
+                VAR_ARGS, Value.VARCHAR, false, true, false));
         FUNCTIONS.put("DATE", new FunctionInfo("DATE", DATE,
-                1, Value.DATE, false, true, true, false));
+                1, Value.DATE, false, true, false));
         FUNCTIONS.put("LAST_INSERT_ID", new FunctionInfo("LAST_INSERT_ID", LAST_INSERT_ID,
-                VAR_ARGS, Value.BIGINT, false, false, true, false));
+                VAR_ARGS, Value.BIGINT, false, false, false));
 
     }
 

--- a/h2/src/main/org/h2/mode/FunctionsOracle.java
+++ b/h2/src/main/org/h2/mode/FunctionsOracle.java
@@ -39,15 +39,15 @@ public final class FunctionsOracle extends FunctionsBase {
 
     static {
         FUNCTIONS.put("ADD_MONTHS",
-                new FunctionInfo("ADD_MONTHS", ADD_MONTHS, 2, Value.TIMESTAMP, true, true, true, false));
+                new FunctionInfo("ADD_MONTHS", ADD_MONTHS, 2, Value.TIMESTAMP, true, true, false));
         FUNCTIONS.put("SYS_GUID",
-                new FunctionInfo("SYS_GUID", SYS_GUID, 0, Value.VARBINARY, false, false, true, false));
+                new FunctionInfo("SYS_GUID", SYS_GUID, 0, Value.VARBINARY, false, false, false));
         FUNCTIONS.put("TO_DATE",
-                new FunctionInfo("TO_DATE", TO_DATE, VAR_ARGS, Value.TIMESTAMP, true, true, true, false));
+                new FunctionInfo("TO_DATE", TO_DATE, VAR_ARGS, Value.TIMESTAMP, true, true, false));
         FUNCTIONS.put("TO_TIMESTAMP",
-                new FunctionInfo("TO_TIMESTAMP", TO_TIMESTAMP, VAR_ARGS, Value.TIMESTAMP, true, true, true, false));
+                new FunctionInfo("TO_TIMESTAMP", TO_TIMESTAMP, VAR_ARGS, Value.TIMESTAMP, true, true, false));
         FUNCTIONS.put("TO_TIMESTAMP_TZ", new FunctionInfo("TO_TIMESTAMP_TZ", TO_TIMESTAMP_TZ, VAR_ARGS,
-                Value.TIMESTAMP_TZ, true, true, true, false));
+                Value.TIMESTAMP_TZ, true, true, false));
     }
 
     /**

--- a/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
@@ -77,39 +77,39 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
 
     static {
         copyFunction(FUNCTIONS, "IDENTITY", "LASTVAL");
-        FUNCTIONS.put("CURRTID2", new FunctionInfo("CURRTID2", CURRTID2, 2, Value.INTEGER, true, false, true, false));
+        FUNCTIONS.put("CURRTID2", new FunctionInfo("CURRTID2", CURRTID2, 2, Value.INTEGER, true, false, false));
         FUNCTIONS.put("FORMAT_TYPE",
-                new FunctionInfo("FORMAT_TYPE", FORMAT_TYPE, 2, Value.VARCHAR, false, true, true, false));
+                new FunctionInfo("FORMAT_TYPE", FORMAT_TYPE, 2, Value.VARCHAR, false, true, false));
         FUNCTIONS.put("HAS_DATABASE_PRIVILEGE", new FunctionInfo("HAS_DATABASE_PRIVILEGE", HAS_DATABASE_PRIVILEGE,
-                VAR_ARGS, Value.BOOLEAN, true, false, true, false));
+                VAR_ARGS, Value.BOOLEAN, true, false, false));
         FUNCTIONS.put("HAS_SCHEMA_PRIVILEGE", new FunctionInfo("HAS_SCHEMA_PRIVILEGE", HAS_SCHEMA_PRIVILEGE,
-                VAR_ARGS, Value.BOOLEAN, true, false, true, false));
+                VAR_ARGS, Value.BOOLEAN, true, false, false));
         FUNCTIONS.put("HAS_TABLE_PRIVILEGE", new FunctionInfo("HAS_TABLE_PRIVILEGE", HAS_TABLE_PRIVILEGE,
-                VAR_ARGS, Value.BOOLEAN, true, false, true, false));
-        FUNCTIONS.put("VERSION", new FunctionInfo("VERSION", VERSION, 0, Value.VARCHAR, true, false, true, false));
+                VAR_ARGS, Value.BOOLEAN, true, false, false));
+        FUNCTIONS.put("VERSION", new FunctionInfo("VERSION", VERSION, 0, Value.VARCHAR, true, false, false));
         FUNCTIONS.put("OBJ_DESCRIPTION", new FunctionInfo("OBJ_DESCRIPTION", OBJ_DESCRIPTION, VAR_ARGS, Value.VARCHAR,
-                true, false, true, false));
+                true, false, false));
         FUNCTIONS.put("PG_ENCODING_TO_CHAR", new FunctionInfo("PG_ENCODING_TO_CHAR", PG_ENCODING_TO_CHAR, 1,
-                Value.VARCHAR, true, true, true, false));
+                Value.VARCHAR, true, true, false));
         FUNCTIONS.put("PG_GET_EXPR",
-                new FunctionInfo("PG_GET_EXPR", PG_GET_EXPR, VAR_ARGS, Value.VARCHAR, true, true, true, false));
+                new FunctionInfo("PG_GET_EXPR", PG_GET_EXPR, VAR_ARGS, Value.VARCHAR, true, true, false));
         FUNCTIONS.put("PG_GET_INDEXDEF", //
                 new FunctionInfo("PG_GET_INDEXDEF", PG_GET_INDEXDEF, VAR_ARGS, Value.VARCHAR, //
-                        true, false, true, false));
+                        true, false, false));
         FUNCTIONS.put("PG_GET_USERBYID",
-                new FunctionInfo("PG_GET_USERBYID", PG_GET_USERBYID, 1, Value.VARCHAR, true, false, true, false));
+                new FunctionInfo("PG_GET_USERBYID", PG_GET_USERBYID, 1, Value.VARCHAR, true, false, false));
         FUNCTIONS.put("PG_POSTMASTER_START_TIME", new FunctionInfo("PG_POSTMASTER_START_TIME", //
-                PG_POSTMASTER_START_TIME, 0, Value.TIMESTAMP_TZ, true, false, true, false));
+                PG_POSTMASTER_START_TIME, 0, Value.TIMESTAMP_TZ, true, false, false));
         FUNCTIONS.put("PG_RELATION_SIZE", new FunctionInfo("PG_RELATION_SIZE", //
-                PG_RELATION_SIZE, VAR_ARGS, Value.BIGINT, true, false, true, false));
+                PG_RELATION_SIZE, VAR_ARGS, Value.BIGINT, true, false, false));
         FUNCTIONS.put("PG_TABLE_IS_VISIBLE", new FunctionInfo("PG_TABLE_IS_VISIBLE", //
-                PG_TABLE_IS_VISIBLE, 1, Value.BOOLEAN, true, false, true, false));
+                PG_TABLE_IS_VISIBLE, 1, Value.BOOLEAN, true, false, false));
         FUNCTIONS.put("SET_CONFIG", new FunctionInfo("SET_CONFIG", //
-                SET_CONFIG, 3, Value.VARCHAR, true, false, true, false));
+                SET_CONFIG, 3, Value.VARCHAR, true, false, false));
         FUNCTIONS.put("ARRAY_TO_STRING", new FunctionInfo("ARRAY_TO_STRING", //
-                ARRAY_TO_STRING, VAR_ARGS, Value.VARCHAR, false, true, true, false));
+                ARRAY_TO_STRING, VAR_ARGS, Value.VARCHAR, false, true, false));
         FUNCTIONS.put("PG_STAT_GET_NUMSCANS", new FunctionInfo("PG_STAT_GET_NUMSCANS", //
-                PG_STAT_GET_NUMSCANS, 1, Value.INTEGER, true, true, true, false));
+                PG_STAT_GET_NUMSCANS, 1, Value.INTEGER, true, true, false));
     }
 
     /**

--- a/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
@@ -76,7 +76,6 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
     private static final HashMap<String, FunctionInfo> FUNCTIONS = new HashMap<>();
 
     static {
-        copyFunction(FUNCTIONS, "IDENTITY", "LASTVAL");
         FUNCTIONS.put("CURRTID2", new FunctionInfo("CURRTID2", CURRTID2, 2, Value.INTEGER, true, false, false));
         FUNCTIONS.put("FORMAT_TYPE",
                 new FunctionInfo("FORMAT_TYPE", FORMAT_TYPE, 2, Value.VARCHAR, false, true, false));

--- a/h2/src/main/org/h2/mode/OnDuplicateKeyValues.java
+++ b/h2/src/main/org/h2/mode/OnDuplicateKeyValues.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.mode;
+
+import org.h2.command.dml.Update;
+import org.h2.engine.Session;
+import org.h2.expression.ExpressionVisitor;
+import org.h2.expression.Operation0;
+import org.h2.message.DbException;
+import org.h2.table.Column;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+
+/**
+ * VALUES(column) function for ON DUPLICATE KEY UPDATE clause.
+ */
+public final class OnDuplicateKeyValues extends Operation0 {
+
+    private final Column column;
+
+    private final Update update;
+
+    public OnDuplicateKeyValues(Column column, Update update) {
+        this.column = column;
+        this.update = update;
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        Value v = update.getOnDuplicateKeyInsert().getOnDuplicateKeyValue(column.getColumnId());
+        if (v == null) {
+            throw DbException.getUnsupportedException(getTraceSQL());
+        }
+        return v;
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        return column.getSQL(builder.append("VALUES("), sqlFlags).append(')');
+    }
+
+    @Override
+    public boolean isEverything(ExpressionVisitor visitor) {
+        switch (visitor.getType()) {
+        case ExpressionVisitor.DETERMINISTIC:
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public TypeInfo getType() {
+        return column.getType();
+    }
+
+    @Override
+    public int getCost() {
+        return 1;
+    }
+
+}

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -180,9 +180,9 @@ public class TestScript extends TestDb {
         for (String s : new String[] { "abs", "acos", "asin", "atan", "atan2",
                 "bitand", "bitget", "bitnot", "bitor", "bitxor", "ceil", "compress",
                 "cos", "cosh", "cot", "decrypt", "degrees", "encrypt", "exp",
-                "expand", "floor", "hash", "length", "log", "mod", "ora-hash", "pi",
+                "expand", "floor", "hash", "length", "log", "lshift", "mod", "ora-hash", "pi",
                 "power", "radians", "rand", "random-uuid", "round",
-                "roundmagic", "secure-rand", "sign", "sin", "sinh", "sqrt",
+                "roundmagic", "rshift", "secure-rand", "sign", "sin", "sinh", "sqrt",
                 "tan", "tanh", "truncate", "zero" }) {
             testScript("functions/numeric/" + s + ".sql");
         }

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/log.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/log.sql
@@ -3,10 +3,16 @@
 -- Initial Developer: H2 Group
 --
 
-SELECT LN(NULL), LOG(NULL, NULL), LOG(NULL, 2), LOG(2, NULL), LOG10(NULL), LOG(NULL);
-> NULL NULL NULL NULL NULL NULL
-> ---- ---- ---- ---- ---- ----
-> null null null null null null
+SELECT LN(NULL), LOG(NULL, NULL), LOG(NULL, 2);
+> CAST(NULL AS DOUBLE PRECISION) CAST(NULL AS DOUBLE PRECISION) CAST(NULL AS DOUBLE PRECISION)
+> ------------------------------ ------------------------------ ------------------------------
+> null                           null                           null
+> rows: 1
+
+SELECT LOG(2, NULL), LOG10(NULL), LOG(NULL);
+> CAST(NULL AS DOUBLE PRECISION) CAST(NULL AS DOUBLE PRECISION) CAST(NULL AS DOUBLE PRECISION)
+> ------------------------------ ------------------------------ ------------------------------
+> null                           null                           null
 > rows: 1
 
 SELECT LN(0);

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -712,23 +712,26 @@ public class TestPgServer extends TestDb {
                 rs.next();
                 oid = rs.getInt("oid");
             }
-            try (ResultSet rs = stat.executeQuery("SELECT i.*,i.indkey as keys,c.relname,c.relnamespace,c.relam,c.reltablespace," +
-                    "tc.relname as tabrelname,dsc.description,pg_catalog.pg_get_expr(i.indpred, i.indrelid) as pred_expr," +
-                    "pg_catalog.pg_get_expr(i.indexprs, i.indrelid, true) as expr,pg_catalog.pg_relation_size(i.indexrelid) as index_rel_size," +
-                    "pg_catalog.pg_stat_get_numscans(i.indexrelid) as index_num_scans " + 
-                    "FROM pg_catalog.pg_index i " + 
-                    "INNER JOIN pg_catalog.pg_class c ON c.oid=i.indexrelid " + 
-                    "INNER JOIN pg_catalog.pg_class tc ON tc.oid=i.indrelid " + 
-                    "LEFT OUTER JOIN pg_catalog.pg_description dsc ON i.indexrelid=dsc.objoid " + 
+            try (ResultSet rs = stat.executeQuery("SELECT i.*,i.indkey as keys," +
+                    "c.relname,c.relnamespace,c.relam,c.reltablespace," +
+                    "tc.relname as tabrelname,dsc.description," +
+                    "pg_catalog.pg_get_expr(i.indpred, i.indrelid) as pred_expr," +
+                    "pg_catalog.pg_get_expr(i.indexprs, i.indrelid, true) as expr," +
+                    "pg_catalog.pg_relation_size(i.indexrelid) as index_rel_size," +
+                    "pg_catalog.pg_stat_get_numscans(i.indexrelid) as index_num_scans " +
+                    "FROM pg_catalog.pg_index i " +
+                    "INNER JOIN pg_catalog.pg_class c ON c.oid=i.indexrelid " +
+                    "INNER JOIN pg_catalog.pg_class tc ON tc.oid=i.indrelid " +
+                    "LEFT OUTER JOIN pg_catalog.pg_description dsc ON i.indexrelid=dsc.objoid " +
                     "WHERE i.indrelid=" + oid + " ORDER BY c.relname")) {
                 // pg_index is empty
                 assertFalse(rs.next());
             }
             try (ResultSet rs = stat.executeQuery("SELECT c.oid,c.*," +
-                    "t.relname as tabrelname,rt.relnamespace as refnamespace,d.description " + 
-                    "FROM pg_catalog.pg_constraint c " + 
-                    "INNER JOIN pg_catalog.pg_class t ON t.oid=c.conrelid " + 
-                    "LEFT OUTER JOIN pg_catalog.pg_class rt ON rt.oid=c.confrelid " + 
+                    "t.relname as tabrelname,rt.relnamespace as refnamespace,d.description " +
+                    "FROM pg_catalog.pg_constraint c " +
+                    "INNER JOIN pg_catalog.pg_class t ON t.oid=c.conrelid " +
+                    "LEFT OUTER JOIN pg_catalog.pg_class rt ON rt.oid=c.confrelid " +
                     "LEFT OUTER JOIN pg_catalog.pg_description d ON d.objoid=c.oid " +
                     "AND d.objsubid=0 AND d.classoid='pg_constraint'::regclass WHERE c.conrelid=" + oid)) {
                 assertTrue(rs.next());

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -837,3 +837,4 @@ indpred tgfoid indisprimary adsrc spcowner tgnargs typtype typinput rolcatupdate
 usesuper tgdeferrable rolpassword relam relpages tginitdeferred rolsuper autovacuum typnotnull spclocation cancreate
 nsp pgagent pga awoken serverencoding untyped ambiguities tons lhs letting rhs opportunities specifications
 usefully pipelining fetches reenable joiner visits dcl avxaaa german
+conrelid conkey tabrelname refnamespace dsc pred typrelid conname contype confrelid numscans beaver


### PR DESCRIPTION
1. Many functions are moved from `Function` to new classes `MathFunction1`, `MathFunction2`, `BitFunction`, `CompatibilityIdentityFunction`, `CompatibilitySequenceValueFunction`, and `OnDuplicateKeyValues`.

2. `ON DUPLICATE KEY UPDATE` doesn't use session variables any more.

3. `FunctionInfo.requireParentheses` is removed, it isn't needed after changes from previous PRs.

4. Existing test scripts for `LSHIFT` and `RSHIFT` are included into `TestScript`.