### PR TITLE
add `pg_type.typelem` and `pg_type.typdelim`

### DIFF
--- a/h2/src/main/org/h2/mode/PgCatalogTable.java
+++ b/h2/src/main/org/h2/mode/PgCatalogTable.java
@@ -302,7 +302,9 @@ public class PgCatalogTable extends MetaTable {
                     "TYPNAMESPACE INTEGER", //
                     "TYPLEN INTEGER", //
                     "TYPTYPE VARCHAR", //
+                    "TYPDELIM VARCHAR", //
                     "TYPRELID INTEGER", //
+                    "TYPELEM INTEGER", //
                     "TYPBASETYPE INTEGER", //
                     "TYPTYPMOD INTEGER", //
                     "TYPNOTNULL BOOLEAN", //
@@ -547,19 +549,34 @@ public class PgCatalogTable extends MetaTable {
                 if (pgType == PgServer.PG_TYPE_UNKNOWN || !types.add(pgType)) {
                     continue;
                 }
+                String name;
+                int elemId;
+                switch (pgType) {
+                case PgServer.PG_TYPE_VARCHAR_ARRAY:
+                    name = "_varchar";
+                    elemId = PgServer.PG_TYPE_VARCHAR;
+                    break;
+                default:
+                    name = t.name;
+                    elemId = 0;
+                }
                 add(session, rows,
                         // OID
                         ValueInteger.get(pgType),
                         // TYPNAME
-                        t.name,
+                        name,
                         // TYPNAMESPACE
                         ValueInteger.get(Constants.PG_CATALOG_SCHEMA_ID),
                         // TYPLEN
                         ValueInteger.get(-1),
                         // TYPTYPE
-                        "c",
+                        "b",
+                        // TYPDELIM
+                        ",",
                         // TYPRELID
                         ValueInteger.get(0),
+                        // TYPELEM
+                        ValueInteger.get(elemId),
                         // TYPBASETYPE
                         ValueInteger.get(0),
                         // TYPTYPMOD
@@ -569,8 +586,12 @@ public class PgCatalogTable extends MetaTable {
                         // TYPINPUT
                         null);
             }
-            for (Object[] pgType : new Object[][] { { 19, "name", -1, "c" }, { 0, "null", -1, "c" },
-                    { 22, "int2vector", -1, "c" }, { 2205, "regproc", 4, "b" } }) {
+            for (Object[] pgType : new Object[][] {
+                    { 18, "char", 1, 0 },
+                    { 19, "name", 64, 18 },
+                    { 22, "int2vector", -1, 21 },
+                    { 2205, "regproc", 4, 0 },
+            }) {
                 add(session, rows,
                         // OID
                         ValueInteger.get((int) pgType[0]),
@@ -581,9 +602,13 @@ public class PgCatalogTable extends MetaTable {
                         // TYPLEN
                         ValueInteger.get((int) pgType[2]),
                         // TYPTYPE
-                        pgType[3],
+                        "b",
+                        // TYPDELIM
+                        ",",
                         // TYPRELID
                         ValueInteger.get(0),
+                        // TYPELEM
+                        ValueInteger.get((int) pgType[3]),
                         // TYPBASETYPE
                         ValueInteger.get(0),
                         // TYPTYPMOD

--- a/h2/src/main/org/h2/mode/PgCatalogTable.java
+++ b/h2/src/main/org/h2/mode/PgCatalogTable.java
@@ -590,7 +590,8 @@ public class PgCatalogTable extends MetaTable {
                     { 18, "char", 1, 0 },
                     { 19, "name", 64, 18 },
                     { 22, "int2vector", -1, 21 },
-                    { 2205, "regproc", 4, 0 },
+                    { 24, "regproc", 4, 0 },
+                    { 2205, "regclass", 4, 0 },
             }) {
                 add(session, rows,
                         // OID

--- a/h2/src/main/org/h2/server/pg/PgServer.java
+++ b/h2/src/main/org/h2/server/pg/PgServer.java
@@ -313,6 +313,8 @@ public class PgServer implements Service {
         case PG_TYPE_BYTEA:
             valueType = Value.VARBINARY;
             break;
+        case 18:
+            return "char";
         case 19:
             return "name";
         case PG_TYPE_INT8:

--- a/h2/src/main/org/h2/server/pg/PgServer.java
+++ b/h2/src/main/org/h2/server/pg/PgServer.java
@@ -328,6 +328,8 @@ public class PgServer implements Service {
         case PG_TYPE_INT4:
             valueType = Value.INTEGER;
             break;
+        case 24:
+            return "regproc";
         case PG_TYPE_TEXT:
             valueType = Value.CLOB;
             break;
@@ -364,7 +366,7 @@ public class PgServer implements Service {
             valueType = Value.NUMERIC;
             break;
         case 2205:
-            return "regproc";
+            return "regclass";
         default:
             return "???";
         }

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.h2.api.ErrorCode;
+import org.h2.server.pg.PgServer;
 import org.h2.store.Data;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
@@ -335,6 +336,13 @@ public class TestPgServer extends TestDb {
         rs = stat.executeQuery("select pg_get_indexdef("+indexId+", 2, false)");
         rs.next();
         assertEquals("id", rs.getString(1));
+
+        rs = stat.executeQuery("select * from pg_type where oid = " + PgServer.PG_TYPE_VARCHAR_ARRAY);
+        rs.next();
+        assertEquals("_varchar", rs.getString("typname"));
+        assertEquals("b", rs.getString("typtype"));
+        assertEquals(",", rs.getString("typdelim"));
+        assertEquals(PgServer.PG_TYPE_VARCHAR, rs.getInt("typelem"));
 
         conn.close();
     }


### PR DESCRIPTION
for some pg clients' compatibility:
`typtype` for basic types changed to 'b';
`typname` for VARCHAR ARRAY (1015) changed to '_varchar'.