### PR TITLE
Use full TypeInfo for conversions between PG and H2 data types

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcParameterMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcParameterMetaData.java
@@ -255,4 +255,11 @@ public class JdbcParameterMetaData extends TraceObject implements
         return getTraceObjectName() + ": parameterCount=" + paramCount;
     }
 
+    /**
+     * INTERNAL
+     */
+    public TypeInfo getParameterInternalType(int param) {
+        return getParameter(param).getType();
+    }
+
 }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSetMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSetMetaData.java
@@ -13,6 +13,7 @@ import org.h2.message.TraceObject;
 import org.h2.result.ResultInterface;
 import org.h2.util.MathUtils;
 import org.h2.value.DataType;
+import org.h2.value.TypeInfo;
 import org.h2.value.ValueToObjectConverter;
 
 /**
@@ -485,6 +486,13 @@ public class JdbcResultSetMetaData extends TraceObject implements
     @Override
     public String toString() {
         return getTraceObjectName() + ": columns=" + columnCount;
+    }
+
+    /**
+     * INTERNAL
+     */
+    public TypeInfo getColumnInternalType(int column) {
+        return result.getColumnType(--column);
     }
 
 }

--- a/h2/src/main/org/h2/mode/PgCatalogTable.java
+++ b/h2/src/main/org/h2/mode/PgCatalogTable.java
@@ -540,7 +540,10 @@ public class PgCatalogTable extends MetaTable {
                 if (t.hidden || t.sqlType == Value.NULL) {
                     continue;
                 }
-                int pgType = PgServer.convertType(t.sqlType);
+                int valueType = t.type;
+                // Only VARCHAR ARRAY is currently supported
+                int pgType = PgServer.convertType(valueType == Value.ARRAY ? TypeInfo.getTypeInfo(Value.ARRAY,
+                        Integer.MAX_VALUE, 0, TypeInfo.TYPE_VARCHAR) : TypeInfo.getTypeInfo(valueType));
                 if (pgType == PgServer.PG_TYPE_UNKNOWN || !types.add(pgType)) {
                     continue;
                 }
@@ -627,7 +630,7 @@ public class PgCatalogTable extends MetaTable {
                 // ATTNAME
                 column.getName(),
                 // ATTTYPID
-                ValueInteger.get(PgServer.convertType(DataType.convertTypeToSQLType(column.getType().getValueType()))),
+                ValueInteger.get(PgServer.convertType(column.getType())),
                 // ATTLEN
                 ValueInteger.get(precision > 255 ? -1 : (int) precision),
                 // ATTNUM


### PR DESCRIPTION
Small refactoring of conversions between types of H2 and PostgreSQL. It is needed to improve support of arrays in the future.

Type codes of H2 don't include information about type of array elements, only `TypeInfo` has it.