### PR TITLE
Move out JSON, cardinality, ABS, MOD, FLOOR, and CEIL functions from the Function class

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3124,7 +3124,7 @@ ID=1 OR NAME='Hi'
 "
 
 "Other Grammar","Factor","
-term [ { { * | / | @h2@ { % } } term } [...] ]
+term [ { { * | / | @c@ { % } } term } [...] ]
 ","
 A value or a numeric factor.
 ","
@@ -4557,20 +4557,25 @@ RSHIFT(A, B)
 "
 
 "Functions (Numeric)","MOD","
-MOD(long, long)
+MOD(dividendNumeric, divisorNumeric)
 ","
-The modulo operation.
-This method returns a long.
-See also Java operator %.
+The modulus expression.
+
+Result has the same type as divisor.
+Result is NULL if either of arguments is NULL.
+If divisor is 0, an exception is raised.
+Result has the same sign as dividend or is equal to 0.
+
+Usually arguments should have scale 0, but it isn't required by H2.
 ","
 MOD(A, B)
 "
 
-"Functions (Numeric)","CEILING","
-{ CEILING | CEIL } (numeric)
+"Functions (Numeric)","CEIL","
+{ CEIL | CEILING } (numeric)
 ","
 Returns the smallest integer value that is greater than or equal to the argument.
-This method returns a double, float, or numeric value depending on type of the argument.
+This method returns value of the same type as argument, but with scale set to 0, if applicable.
 ","
 CEIL(A)
 "
@@ -4597,7 +4602,7 @@ EXP(A)
 FLOOR(numeric)
 ","
 Returns the largest integer value that is less than or equal to the argument.
-This method returns a double, float, or numeric value depending on type of the argument.
+This method returns value of the same type as argument, but with scale set to 0, if applicable.
 ","
 FLOOR(A)
 "

--- a/h2/src/main/org/h2/expression/BinaryOperation.java
+++ b/h2/src/main/org/h2/expression/BinaryOperation.java
@@ -41,12 +41,7 @@ public class BinaryOperation extends Operation2 {
         /**
          * This operation represents a division as in 4 * 2.
          */
-        DIVIDE,
-
-        /**
-         * This operation represents a modulus as in 5 % 2.
-         */
-        MODULUS
+        DIVIDE
     }
 
     private OpType opType;
@@ -89,8 +84,6 @@ public class BinaryOperation extends Operation2 {
             return "*";
         case DIVIDE:
             return "/";
-        case MODULUS:
-            return "%";
         default:
             throw DbException.throwInternalError("opType=" + opType);
         }
@@ -124,11 +117,6 @@ public class BinaryOperation extends Operation2 {
                 return ValueNull.INSTANCE;
             }
             return l.divide(r, right.getType().getPrecision());
-        case MODULUS:
-            if (l == ValueNull.INSTANCE || r == ValueNull.INSTANCE) {
-                return ValueNull.INSTANCE;
-            }
-            return l.modulus(r);
         default:
             throw DbException.throwInternalError("type=" + opType);
         }
@@ -214,11 +202,6 @@ public class BinaryOperation extends Operation2 {
             // 10^rightScale, so add rightScale to its precision and adjust the
             // result to the changes in scale.
             precision = leftPrecision + rightScale - leftScale + scale;
-            break;
-        case MODULUS:
-            // Non-standard operation.
-            precision = rightPrecision;
-            scale = rightScale;
             break;
         default:
             throw DbException.throwInternalError("type=" + opType);

--- a/h2/src/main/org/h2/expression/Expression.java
+++ b/h2/src/main/org/h2/expression/Expression.java
@@ -10,12 +10,14 @@ import java.util.List;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Database;
 import org.h2.engine.Session;
+import org.h2.expression.function.NamedExpression;
 import org.h2.message.DbException;
 import org.h2.result.ResultInterface;
 import org.h2.table.Column;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
 import org.h2.util.HasSQL;
+import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueRow;
@@ -348,6 +350,9 @@ public abstract class Expression implements HasSQL {
         case C_NUMBER:
             return "C" + (columnIndex + 1);
         case POSTGRESQL_STYLE:
+            if (this instanceof NamedExpression) {
+                return StringUtils.toLowerEnglish(((NamedExpression) this).getName());
+            }
             return "?column?";
         }
     }

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -28,7 +28,7 @@ import org.h2.expression.ExpressionWithFlags;
 import org.h2.expression.Subquery;
 import org.h2.expression.ValueExpression;
 import org.h2.expression.analysis.Window;
-import org.h2.expression.function.Function;
+import org.h2.expression.function.JsonConstructorFunction;
 import org.h2.index.Cursor;
 import org.h2.index.Index;
 import org.h2.message.DbException;
@@ -245,7 +245,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
         case JSON_ARRAYAGG:
             if (v != ValueNull.INSTANCE) {
                 v = updateCollecting(session, v, remembered);
-            } else if ((flags & Function.JSON_ABSENT_ON_NULL) == 0) {
+            } else if ((flags & JsonConstructorFunction.JSON_ABSENT_ON_NULL) == 0) {
                 v = updateCollecting(session, ValueJson.NULL, remembered);
             } else {
                 return;
@@ -259,7 +259,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
             }
             if (value != ValueNull.INSTANCE) {
                 v = ValueRow.get(new Value[] { key, value });
-            } else if ((flags & Function.JSON_ABSENT_ON_NULL) == 0) {
+            } else if ((flags & JsonConstructorFunction.JSON_ABSENT_ON_NULL) == 0) {
                 v = ValueRow.get(new Value[] { key, ValueJson.NULL });
             } else {
                 return;
@@ -496,7 +496,7 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
                 if (orderByList != null) {
                     v = ((ValueRow) v).getList()[0];
                 }
-                Function.jsonArrayAppend(baos, v, flags);
+                JsonConstructorFunction.jsonArrayAppend(baos, v, flags);
             }
             baos.write(']');
             return ValueJson.getInternal(baos.toByteArray());
@@ -514,9 +514,9 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
                 if (key == null) {
                     throw DbException.getInvalidValueException("JSON_OBJECTAGG key", "NULL");
                 }
-                Function.jsonObjectAppend(baos, key, row[1]);
+                JsonConstructorFunction.jsonObjectAppend(baos, key, row[1]);
             }
-            return Function.jsonObjectFinish(baos, flags);
+            return JsonConstructorFunction.jsonObjectFinish(baos, flags);
         }
         default:
             // Avoid compiler warning
@@ -972,15 +972,14 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
         builder.append("JSON_OBJECTAGG(");
         args[0].getSQL(builder, sqlFlags).append(": ");
         args[1].getSQL(builder, sqlFlags);
-        Function.getJsonFunctionFlagsSQL(builder, flags, false);
-        builder.append(')');
+        JsonConstructorFunction.getJsonFunctionFlagsSQL(builder, flags, false).append(')');
         return appendTailConditions(builder, sqlFlags, false);
     }
 
     private StringBuilder getSQLJsonArrayAggregate(StringBuilder builder, int sqlFlags) {
         builder.append("JSON_ARRAYAGG(");
         args[0].getSQL(builder, sqlFlags);
-        Function.getJsonFunctionFlagsSQL(builder, flags, true);
+        JsonConstructorFunction.getJsonFunctionFlagsSQL(builder, flags, true);
         Window.appendOrderBy(builder, orderByList, sqlFlags, false);
         builder.append(')');
         return appendTailConditions(builder, sqlFlags, false);

--- a/h2/src/main/org/h2/expression/function/BitFunction.java
+++ b/h2/src/main/org/h2/expression/function/BitFunction.java
@@ -5,13 +5,11 @@
  */
 package org.h2.expression.function;
 
-import org.h2.engine.Mode.ExpressionNames;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.expression.Operation1_2;
 import org.h2.expression.TypedValueExpression;
 import org.h2.message.DbException;
-import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueBigint;
@@ -21,7 +19,7 @@ import org.h2.value.ValueNull;
 /**
  * A bitwise function.
  */
-public class BitFunction extends Operation1_2 {
+public class BitFunction extends Operation1_2 implements NamedExpression {
 
     /**
      * BITAND() (non-standard).
@@ -137,20 +135,17 @@ public class BitFunction extends Operation1_2 {
     }
 
     @Override
-    public String getAlias(Session session, int columnIndex) {
-        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
-            return StringUtils.toLowerEnglish(NAMES[function]);
-        }
-        return super.getAlias(session, columnIndex);
-    }
-
-    @Override
     public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
-        left.getSQL(builder.append(NAMES[function]).append('('), sqlFlags);
+        left.getSQL(builder.append(getName()).append('('), sqlFlags);
         if (right != null) {
             right.getSQL(builder.append(", "), sqlFlags);
         }
         return builder.append(')');
+    }
+
+    @Override
+    public String getName() {
+        return NAMES[function];
     }
 
 }

--- a/h2/src/main/org/h2/expression/function/CompatibilitySequenceValueFunction.java
+++ b/h2/src/main/org/h2/expression/function/CompatibilitySequenceValueFunction.java
@@ -8,7 +8,6 @@ package org.h2.expression.function;
 import org.h2.command.Parser;
 import org.h2.engine.Database;
 import org.h2.engine.Session;
-import org.h2.engine.Mode.ExpressionNames;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
 import org.h2.expression.ExpressionVisitor;
@@ -23,7 +22,7 @@ import org.h2.value.Value;
 /**
  * NEXTVAL() and CURRVAL() compatibility functions.
  */
-public class CompatibilitySequenceValueFunction extends Operation1_2 {
+public class CompatibilitySequenceValueFunction extends Operation1_2 implements NamedExpression {
 
     private final boolean current;
 
@@ -33,16 +32,8 @@ public class CompatibilitySequenceValueFunction extends Operation1_2 {
     }
 
     @Override
-    public String getAlias(Session session, int columnIndex) {
-        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
-            return current ? "currval" : "nextval";
-        }
-        return super.getAlias(session, columnIndex);
-    }
-
-    @Override
     public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
-        left.getSQL(builder.append(current ? "CURRVAL(" : "NEXTVAL("), sqlFlags);
+        left.getSQL(builder.append(getName()).append('('), sqlFlags);
         if (right != null) {
             right.getSQL(builder.append(", "), sqlFlags);
         }
@@ -120,6 +111,11 @@ public class CompatibilitySequenceValueFunction extends Operation1_2 {
         default:
             throw DbException.throwInternalError("type=" + visitor.getType());
         }
+    }
+
+    @Override
+    public String getName() {
+        return current ? "CURRVAL" : "NEXTVAL";
     }
 
 }

--- a/h2/src/main/org/h2/expression/function/CurrentDateTimeValueFunction.java
+++ b/h2/src/main/org/h2/expression/function/CurrentDateTimeValueFunction.java
@@ -5,11 +5,9 @@
  */
 package org.h2.expression.function;
 
-import org.h2.engine.Mode.ExpressionNames;
 import org.h2.engine.Session;
 import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.Operation0;
-import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueTime;
@@ -18,7 +16,7 @@ import org.h2.value.ValueTimestamp;
 /**
  * Current datetime value function.
  */
-public final class CurrentDateTimeValueFunction extends Operation0 {
+public final class CurrentDateTimeValueFunction extends Operation0 implements NamedExpression {
 
     /**
      * The function "CURRENT_DATE"
@@ -79,16 +77,8 @@ public final class CurrentDateTimeValueFunction extends Operation0 {
     }
 
     @Override
-    public String getAlias(Session session, int columnIndex) {
-        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
-            return StringUtils.toLowerEnglish(NAMES[function]);
-        }
-        return super.getAlias(session, columnIndex);
-    }
-
-    @Override
     public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
-        builder.append(NAMES[function]);
+        builder.append(getName());
         if (scale >= 0) {
             builder.append('(').append(scale).append(')');
         }
@@ -112,6 +102,11 @@ public final class CurrentDateTimeValueFunction extends Operation0 {
     @Override
     public int getCost() {
         return 1;
+    }
+
+    @Override
+    public String getName() {
+        return NAMES[function];
     }
 
 }

--- a/h2/src/main/org/h2/expression/function/CurrentGeneralValueSpecification.java
+++ b/h2/src/main/org/h2/expression/function/CurrentGeneralValueSpecification.java
@@ -61,17 +61,6 @@ public final class CurrentGeneralValueSpecification extends Operation0 {
     private static final String[] NAMES = { "CURRENT_CATALOG", "CURRENT_PATH", "CURRENT_ROLE", "CURRENT_SCHEMA",
             "CURRENT_USER", "SESSION_USER", "SYSTEM_USER" };
 
-    /**
-     * Get the name for this specification id.
-     *
-     * @param specification
-     *            the specification id
-     * @return the name
-     */
-    public static String getName(int specification) {
-        return NAMES[specification];
-    }
-
     private final int specification;
 
     public CurrentGeneralValueSpecification(int specification) {

--- a/h2/src/main/org/h2/expression/function/CurrentGeneralValueSpecification.java
+++ b/h2/src/main/org/h2/expression/function/CurrentGeneralValueSpecification.java
@@ -6,13 +6,11 @@
 package org.h2.expression.function;
 
 import org.h2.command.Parser;
-import org.h2.engine.Mode.ExpressionNames;
 import org.h2.engine.Session;
 import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.Operation0;
 import org.h2.message.DbException;
 import org.h2.util.HasSQL;
-import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueNull;
@@ -21,7 +19,7 @@ import org.h2.value.ValueVarchar;
 /**
  * Simple general value specifications.
  */
-public final class CurrentGeneralValueSpecification extends Operation0 {
+public final class CurrentGeneralValueSpecification extends Operation0 implements NamedExpression {
 
     /**
      * The "CURRENT_CATALOG" general value specification.
@@ -108,16 +106,8 @@ public final class CurrentGeneralValueSpecification extends Operation0 {
     }
 
     @Override
-    public String getAlias(Session session, int columnIndex) {
-        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
-            return StringUtils.toLowerEnglish(NAMES[specification]);
-        }
-        return super.getAlias(session, columnIndex);
-    }
-
-    @Override
     public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
-        return builder.append(NAMES[specification]);
+        return builder.append(getName());
     }
 
     @Override
@@ -137,6 +127,11 @@ public final class CurrentGeneralValueSpecification extends Operation0 {
     @Override
     public int getCost() {
         return 1;
+    }
+
+    @Override
+    public String getName() {
+        return NAMES[specification];
     }
 
 }

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -33,7 +33,6 @@ import org.h2.command.Parser;
 import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.engine.Mode;
-import org.h2.engine.Mode.ExpressionNames;
 import org.h2.engine.Mode.ModeEnum;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
@@ -2285,14 +2284,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
             }
         }
         return TypeInfo.getTypeInfo(Value.NUMERIC, Integer.MAX_VALUE, scale, null);
-    }
-
-    @Override
-    public String getAlias(Session session, int columnIndex) {
-        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
-            return StringUtils.toLowerEnglish(getName());
-        }
-        return super.getAlias(session, columnIndex);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -289,8 +289,8 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         addFunctionWithNull("ARRAY_CONTAINS", ARRAY_CONTAINS, 2, Value.BOOLEAN);
         addFunctionWithNull("TRIM_ARRAY", TRIM_ARRAY, 2, Value.ARRAY);
         addFunction("ARRAY_SLICE", ARRAY_SLICE, 3, Value.ARRAY);
-        addFunction("CSVREAD", CSVREAD, VAR_ARGS, Value.RESULT_SET, false, false, false);
-        addFunction("CSVWRITE", CSVWRITE, VAR_ARGS, Value.INTEGER, false, false, false);
+        addFunction("CSVREAD", CSVREAD, VAR_ARGS, Value.RESULT_SET, false, false);
+        addFunction("CSVWRITE", CSVWRITE, VAR_ARGS, Value.INTEGER, false, false);
         addFunctionNotDeterministic("MEMORY_FREE", MEMORY_FREE,
                 0, Value.INTEGER);
         addFunctionNotDeterministic("MEMORY_USED", MEMORY_USED,
@@ -309,9 +309,9 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
                 1, Value.BOOLEAN);
         addFunctionNotDeterministic("ABORT_SESSION", ABORT_SESSION,
                 1, Value.BOOLEAN);
-        addFunction("SET", SET, 2, Value.NULL, false, false, false);
-        addFunction("FILE_READ", FILE_READ, VAR_ARGS, Value.NULL, false, false, false);
-        addFunction("FILE_WRITE", FILE_WRITE, 2, Value.BIGINT, false, false, false);
+        addFunction("SET", SET, 2, Value.NULL, false, false);
+        addFunction("FILE_READ", FILE_READ, VAR_ARGS, Value.NULL, false, false);
+        addFunction("FILE_WRITE", FILE_WRITE, 2, Value.BIGINT, false, false);
         addFunctionNotDeterministic("TRANSACTION_ID", TRANSACTION_ID,
                 0, Value.VARCHAR);
         addFunctionNotDeterministic("DISK_SPACE_USED", DISK_SPACE_USED,
@@ -327,9 +327,9 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
     }
 
     private static void addFunction(String name, int type, int parameterCount,
-            int returnDataType, boolean nullIfParameterIsNull, boolean deterministic, boolean specialArguments) {
+            int returnDataType, boolean nullIfParameterIsNull, boolean deterministic) {
         FunctionInfo info = new FunctionInfo(name, type, parameterCount, returnDataType, nullIfParameterIsNull,
-                deterministic, specialArguments);
+                deterministic);
         if (FUNCTIONS_BY_ID[type] == null) {
             FUNCTIONS_BY_ID[type] = info;
         }
@@ -338,17 +338,17 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
 
     private static void addFunctionNotDeterministic(String name, int type,
             int parameterCount, int returnDataType) {
-        addFunction(name, type, parameterCount, returnDataType, true, false, false);
+        addFunction(name, type, parameterCount, returnDataType, true, false);
     }
 
     private static void addFunction(String name, int type, int parameterCount,
             int returnDataType) {
-        addFunction(name, type, parameterCount, returnDataType, true, true, false);
+        addFunction(name, type, parameterCount, returnDataType, true, true);
     }
 
     private static void addFunctionWithNull(String name, int type,
             int parameterCount, int returnDataType) {
-        addFunction(name, type, parameterCount, returnDataType, false, true, false);
+        addFunction(name, type, parameterCount, returnDataType, false, true);
     }
 
     /**
@@ -852,7 +852,7 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         if (values == null) {
             return ValueNull.INSTANCE;
         }
-        Value v0 = info.specialArguments ? null : getNullOrValue(session, args, values, 0);
+        Value v0 = getNullOrValue(session, args, values, 0);
         Value resultSimple = getSimpleValue(session, v0, args, values);
         if (resultSimple != null) {
             return resultSimple;

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -132,11 +132,11 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
             CSVREAD = 210, CSVWRITE = 211,
             MEMORY_FREE = 212, MEMORY_USED = 213,
             LOCK_MODE = 214, SESSION_ID = 216,
-            CARDINALITY = 217, LINK_SCHEMA = 218, GREATEST = 219, LEAST = 220,
+            LINK_SCHEMA = 218, GREATEST = 219, LEAST = 220,
             CANCEL_SESSION = 221, SET = 222, TABLE = 223, TABLE_DISTINCT = 224,
             FILE_READ = 225, TRANSACTION_ID = 226, TRUNCATE_VALUE = 227,
             ARRAY_CONTAINS = 230, FILE_WRITE = 232,
-            UNNEST = 233, ARRAY_MAX_CARDINALITY = 234, TRIM_ARRAY = 235, ARRAY_SLICE = 236,
+            UNNEST = 233, TRIM_ARRAY = 235, ARRAY_SLICE = 236,
             ABORT_SESSION = 237;
 
     public static final int REGEXP_LIKE = 240;
@@ -299,8 +299,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
                 0, Value.INTEGER);
         addFunctionNotDeterministic("SESSION_ID", SESSION_ID,
                 0, Value.INTEGER);
-        addFunction("CARDINALITY", CARDINALITY, 1, Value.INTEGER);
-        addFunction("ARRAY_MAX_CARDINALITY", ARRAY_MAX_CARDINALITY, 1, Value.INTEGER, false, true, true);
         addFunctionNotDeterministic("LINK_SCHEMA", LINK_SCHEMA,
                 6, Value.RESULT_SET);
         addFunctionWithNull("LEAST", LEAST,
@@ -699,25 +697,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
                         }
                     }
                 }
-            }
-            break;
-        }
-        case CARDINALITY: {
-            Value[] list = getArray(v0);
-            if (list != null) {
-                result = ValueInteger.get(list.length);
-            } else {
-                result = ValueNull.INSTANCE;
-            }
-            break;
-        }
-        case ARRAY_MAX_CARDINALITY: {
-            Expression arg = args[0];
-            TypeInfo t = arg.getType();
-            if (t.getValueType() == Value.ARRAY) {
-                result = ValueInteger.get(MathUtils.convertLongToInt(t.getPrecision()));
-            } else {
-                throw DbException.getInvalidValueException("array", arg.getValue(session).getTraceSQL());
             }
             break;
         }

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -91,9 +91,7 @@ import org.h2.value.ValueVarchar;
  * This class implements most built-in functions of this database.
  */
 public class Function extends OperationN implements FunctionCall, ExpressionWithFlags {
-    public static final int ABS = 0,
-            CEILING = 8,
-            FLOOR = 13, MOD = 16,
+    public static final int
             PI = 17, RAND = 20, ROUND = 21,
             ROUNDMAGIC = 22, SIGN = 23,
             TRUNCATE = 27, SECURE_RAND = 28, HASH = 29, ENCRYPT = 30,
@@ -184,11 +182,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         }
 
         // FUNCTIONS
-        addFunction("ABS", ABS, 1, Value.NULL);
-        addFunction("CEILING", CEILING, 1, Value.NULL);
-        addFunction("CEIL", CEILING, 1, Value.NULL);
-        addFunction("FLOOR", FLOOR, 1, Value.NULL);
-        addFunction("MOD", MOD, 2, Value.BIGINT);
         addFunction("PI", PI, 0, Value.DOUBLE);
         // RAND without argument: get the next value
         // RAND with one argument: seed the random generator
@@ -478,15 +471,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
             Value[] values) {
         Value result;
         switch (info.type) {
-        case ABS:
-            result = v0.getSignum() >= 0 ? v0 : v0.negate();
-            break;
-        case CEILING:
-            result = getCeilOrFloor(v0, false);
-            break;
-        case FLOOR:
-            result = getCeilOrFloor(v0, true);
-            break;
         case PI:
             result = ValueDouble.get(Math.PI);
             break;
@@ -734,20 +718,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         return result;
     }
 
-    private static Value getCeilOrFloor(Value v0, boolean floor) {
-        Value result;
-        int t = v0.getValueType();
-        if (t == Value.DOUBLE || t == Value.REAL) {
-            double v = v0.getDouble();
-            v = floor ? Math.floor(v) : Math.ceil(v);
-            result = t == Value.DOUBLE ? ValueDouble.get(v) : ValueReal.get((float) v);
-        } else {
-            result = ValueNumeric
-                    .get(v0.getBigDecimal().setScale(0, floor ? RoundingMode.FLOOR : RoundingMode.CEILING));
-        }
-        return result;
-    }
-
     private static Value[] getArray(Value v0) {
         int t = v0.getValueType();
         Value[] list;
@@ -864,14 +834,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         Value v5 = getNullOrValue(session, args, values, 5);
         Value result;
         switch (info.type) {
-        case MOD: {
-            long x = v1.getLong();
-            if (x == 0) {
-                throw DbException.get(ErrorCode.DIVISION_BY_ZERO_1, getTraceSQL());
-            }
-            result = ValueBigint.get(v0.getLong() % x);
-            break;
-        }
         case ROUND:
             result = round(v0, v1);
             break;
@@ -2068,8 +2030,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
                 typeInfo = TypeInfo.TYPE_UNKNOWN;
             }
             break;
-        case CEILING:
-        case FLOOR:
         case ROUND:
             switch (p0.getType().getValueType()) {
             case Value.DOUBLE:
@@ -2108,14 +2068,6 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
                 typeInfo = getRoundNumericType(session);
             }
             break;
-        case ABS: {
-            TypeInfo type = p0.getType();
-            typeInfo = type;
-            if (typeInfo.getValueType() == Value.NULL) {
-                typeInfo = TypeInfo.TYPE_INTEGER;
-            }
-            break;
-        }
         case SET:
             typeInfo = args[1].getType();
             if (!(p0 instanceof Variable)) {

--- a/h2/src/main/org/h2/expression/function/FunctionCall.java
+++ b/h2/src/main/org/h2/expression/function/FunctionCall.java
@@ -14,13 +14,14 @@ import org.h2.value.ValueResultSet;
  * This interface is used by the built-in functions,
  * as well as the user-defined functions.
  */
-public interface FunctionCall extends HasSQL {
+public interface FunctionCall extends HasSQL, NamedExpression {
 
     /**
      * Get the name of the function.
      *
      * @return the name
      */
+    @Override
     String getName();
 
     /**

--- a/h2/src/main/org/h2/expression/function/FunctionInfo.java
+++ b/h2/src/main/org/h2/expression/function/FunctionInfo.java
@@ -41,12 +41,6 @@ public final class FunctionInfo {
     public final boolean deterministic;
 
     /**
-     * If arguments cannot be evaluated in normal way with
-     * {@link org.h2.expression.Expression#getValue(org.h2.engine.Session)}.
-     */
-    final boolean specialArguments;
-
-    /**
      * Creates new instance of built-in function information.
      *
      * @param name
@@ -63,19 +57,15 @@ public final class FunctionInfo {
      * @param deterministic
      *            if this function always returns the same value for the same
      *            parameters
-     * @param specialArguments
-     *            if arguments cannot be evaluated in normal way with
-     *            {@link org.h2.expression.Expression#getValue(org.h2.engine.Session)}.
      */
     public FunctionInfo(String name, int type, int parameterCount, int returnDataType, boolean nullIfParameterIsNull,
-            boolean deterministic, boolean specialArguments) {
+            boolean deterministic) {
         this.name = name;
         this.type = type;
         this.parameterCount = parameterCount;
         this.returnDataType = returnDataType;
         this.nullIfParameterIsNull = nullIfParameterIsNull;
         this.deterministic = deterministic;
-        this.specialArguments = specialArguments;
     }
 
     /**
@@ -94,7 +84,6 @@ public final class FunctionInfo {
         parameterCount = source.parameterCount;
         nullIfParameterIsNull = source.nullIfParameterIsNull;
         deterministic = source.deterministic;
-        specialArguments = source.specialArguments;
     }
 
 }

--- a/h2/src/main/org/h2/expression/function/JavaFunction.java
+++ b/h2/src/main/org/h2/expression/function/JavaFunction.java
@@ -9,13 +9,11 @@ import org.h2.command.Parser;
 import org.h2.engine.Constants;
 import org.h2.engine.FunctionAlias;
 import org.h2.engine.Session;
-import org.h2.engine.Mode.ExpressionNames;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionVisitor;
 import org.h2.expression.ValueExpression;
 import org.h2.table.ColumnResolver;
 import org.h2.table.TableFilter;
-import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueNull;
@@ -80,14 +78,6 @@ public class JavaFunction extends Expression implements FunctionCall {
                 e.setEvaluatable(tableFilter, b);
             }
         }
-    }
-
-    @Override
-    public String getAlias(Session session, int columnIndex) {
-        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
-            return StringUtils.toLowerEnglish(getName());
-        }
-        return super.getAlias(session, columnIndex);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/function/JsonConstructorFunction.java
+++ b/h2/src/main/org/h2/expression/function/JsonConstructorFunction.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+import java.io.ByteArrayOutputStream;
+
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionWithFlags;
+import org.h2.expression.Format;
+import org.h2.expression.OperationN;
+import org.h2.expression.Subquery;
+import org.h2.expression.TypedValueExpression;
+import org.h2.message.DbException;
+import org.h2.util.json.JSONByteArrayTarget;
+import org.h2.util.json.JSONBytesSource;
+import org.h2.util.json.JSONStringTarget;
+import org.h2.util.json.JSONValidationTargetWithUniqueKeys;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+import org.h2.value.ValueJson;
+import org.h2.value.ValueNull;
+
+/**
+ * JSON constructor function.
+ */
+public class JsonConstructorFunction extends OperationN implements ExpressionWithFlags {
+
+    /**
+     * The ABSENT ON NULL flag.
+     */
+    public static final int JSON_ABSENT_ON_NULL = 1;
+
+    /**
+     * The WITH UNIQUE KEYS flag.
+     */
+    public static final int JSON_WITH_UNIQUE_KEYS = 2;
+
+    /**
+     * Returns whether specified function is known by this class.
+     *
+     * @param upperName
+     *            the name of the function in upper case
+     * @return {@code true} if it exists
+     */
+    public static boolean exists(String upperName) {
+        return upperName.equals("JSON_OBJECT") || upperName.equals("JSON_ARRAY");
+    }
+
+    private final boolean array;
+
+    private int flags;
+
+    /**
+     * Creates a new instance of JSON constructor function.
+     *
+     * @param array
+     *            {@code false} for {@code JSON_OBJECT}, {@code true} for
+     *            {@code JSON_ARRAY}.
+     */
+    public JsonConstructorFunction(boolean array) {
+        super(new Expression[4]);
+        this.array = array;
+    }
+
+    @Override
+    public void setFlags(int flags) {
+        this.flags = flags;
+    }
+
+    @Override
+    public int getFlags() {
+        return flags;
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        return array ? jsonArray(session, args) : jsonObject(session, args);
+    }
+
+    private Value jsonObject(Session session, Expression[] args) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write('{');
+        for (int i = 0, l = args.length; i < l;) {
+            String name = args[i++].getValue(session).getString();
+            if (name == null) {
+                throw DbException.getInvalidValueException("JSON_OBJECT key", "NULL");
+            }
+            Value value = args[i++].getValue(session);
+            if (value == ValueNull.INSTANCE) {
+                if ((flags & JSON_ABSENT_ON_NULL) != 0) {
+                    continue;
+                } else {
+                    value = ValueJson.NULL;
+                }
+            }
+            jsonObjectAppend(baos, name, value);
+        }
+        return jsonObjectFinish(baos, flags);
+    }
+
+    /**
+     * Appends a value to a JSON object in the specified string builder.
+     *
+     * @param baos
+     *            the output stream to append to
+     * @param key
+     *            the name of the property
+     * @param value
+     *            the value of the property
+     */
+    public static void jsonObjectAppend(ByteArrayOutputStream baos, String key, Value value) {
+        if (baos.size() > 1) {
+            baos.write(',');
+        }
+        JSONByteArrayTarget.encodeString(baos, key).write(':');
+        byte[] b = value.convertTo(TypeInfo.TYPE_JSON).getBytesNoCopy();
+        baos.write(b, 0, b.length);
+    }
+
+    /**
+     * Appends trailing closing brace to the specified string builder with a
+     * JSON object, validates it, and converts to a JSON value.
+     *
+     * @param baos
+     *            the output stream with the object
+     * @param flags
+     *            the flags ({@link #JSON_WITH_UNIQUE_KEYS})
+     * @return the JSON value
+     * @throws DbException
+     *             if {@link #JSON_WITH_UNIQUE_KEYS} is specified and keys are
+     *             not unique
+     */
+    public static Value jsonObjectFinish(ByteArrayOutputStream baos, int flags) {
+        baos.write('}');
+        byte[] result = baos.toByteArray();
+        if ((flags & JSON_WITH_UNIQUE_KEYS) != 0) {
+            try {
+                JSONBytesSource.parse(result, new JSONValidationTargetWithUniqueKeys());
+            } catch (RuntimeException ex) {
+                String s = JSONBytesSource.parse(result, new JSONStringTarget());
+                throw DbException.getInvalidValueException("JSON WITH UNIQUE KEYS",
+                        s.length() < 128 ? result : s.substring(0, 128) + "...");
+            }
+        }
+        return ValueJson.getInternal(result);
+    }
+
+    private Value jsonArray(Session session, Expression[] args) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write('[');
+        int l = args.length;
+        evaluate: {
+            if (l == 1) {
+                Expression arg0 = args[0];
+                if (arg0 instanceof Subquery) {
+                    Subquery q = (Subquery) arg0;
+                    for (Value value : q.getAllRows(session)) {
+                        jsonArrayAppend(baos, value, flags);
+                    }
+                    break evaluate;
+                } else if (arg0 instanceof Format) {
+                    Format format = (Format) arg0;
+                    arg0 = format.getSubexpression(0);
+                    if (arg0 instanceof Subquery) {
+                        Subquery q = (Subquery) arg0;
+                        for (Value value : q.getAllRows(session)) {
+                            jsonArrayAppend(baos, format.getValue(value), flags);
+                        }
+                        break evaluate;
+                    }
+                }
+            }
+            for (int i = 0; i < l;) {
+                jsonArrayAppend(baos, args[i++].getValue(session), flags);
+            }
+        }
+        baos.write(']');
+        return ValueJson.getInternal(baos.toByteArray());
+    }
+
+    /**
+     * Appends a value to a JSON array in the specified string builder.
+     *
+     * @param baos
+     *            the output stream to append to
+     * @param value
+     *            the value
+     * @param flags
+     *            the flags ({@link #JSON_ABSENT_ON_NULL})
+     */
+    public static void jsonArrayAppend(ByteArrayOutputStream baos, Value value, int flags) {
+        if (value == ValueNull.INSTANCE) {
+            if ((flags & JSON_ABSENT_ON_NULL) != 0) {
+                return;
+            } else {
+                value = ValueJson.NULL;
+            }
+        }
+        if (baos.size() > 1) {
+            baos.write(',');
+        }
+        byte[] b = value.convertTo(TypeInfo.TYPE_JSON).getBytesNoCopy();
+        baos.write(b, 0, b.length);
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        boolean allConst = true;
+        for (int i = 0, l = args.length; i < l; i++) {
+            Expression e = args[i].optimize(session);
+            args[i] = e;
+            if (!e.isConstant()) {
+                allConst = false;
+            }
+        }
+        type = TypeInfo.TYPE_JSON;
+        if (allConst) {
+            return TypedValueExpression.getTypedIfNull(getValue(session), type);
+        }
+        return this;
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        if (array) {
+            writeExpressions(builder.append("JSON_ARRAY").append('('), args, sqlFlags);
+        } else {
+            builder.append("JSON_OBJECT").append('(');
+            for (int i = 0, l = args.length; i < l;) {
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                args[i++].getSQL(builder, sqlFlags).append(": ");
+                args[i++].getSQL(builder, sqlFlags);
+            }
+        }
+        return getJsonFunctionFlagsSQL(builder, flags, array).append(')');
+    }
+
+    /**
+     * Appends flags of a JSON function to the specified string builder.
+     *
+     * @param builder
+     *            string builder to append to
+     * @param flags
+     *            flags to append
+     * @param forArray
+     *            whether the function is an array function
+     * @return the specified string builder
+     */
+    public static StringBuilder getJsonFunctionFlagsSQL(StringBuilder builder, int flags, boolean forArray) {
+        if ((flags & JSON_ABSENT_ON_NULL) != 0) {
+            if (!forArray) {
+                builder.append(" ABSENT ON NULL");
+            }
+        } else if (forArray) {
+            builder.append(" NULL ON NULL");
+        }
+        if (!forArray && (flags & JSON_WITH_UNIQUE_KEYS) != 0) {
+            builder.append(" WITH UNIQUE KEYS");
+        }
+        return builder;
+    }
+
+}

--- a/h2/src/main/org/h2/expression/function/JsonConstructorFunction.java
+++ b/h2/src/main/org/h2/expression/function/JsonConstructorFunction.java
@@ -27,7 +27,7 @@ import org.h2.value.ValueNull;
 /**
  * JSON constructor function.
  */
-public class JsonConstructorFunction extends OperationN implements ExpressionWithFlags {
+public class JsonConstructorFunction extends OperationN implements ExpressionWithFlags, NamedExpression {
 
     /**
      * The ABSENT ON NULL flag.
@@ -226,10 +226,10 @@ public class JsonConstructorFunction extends OperationN implements ExpressionWit
 
     @Override
     public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        builder.append(getName()).append('(');
         if (array) {
-            writeExpressions(builder.append("JSON_ARRAY").append('('), args, sqlFlags);
+            writeExpressions(builder, args, sqlFlags);
         } else {
-            builder.append("JSON_OBJECT").append('(');
             for (int i = 0, l = args.length; i < l;) {
                 if (i > 0) {
                     builder.append(", ");
@@ -264,6 +264,11 @@ public class JsonConstructorFunction extends OperationN implements ExpressionWit
             builder.append(" WITH UNIQUE KEYS");
         }
         return builder;
+    }
+
+    @Override
+    public String getName() {
+        return array ? "JSON_ARRAY" : "JSON_OBJECT";
     }
 
 }

--- a/h2/src/main/org/h2/expression/function/MathFunction.java
+++ b/h2/src/main/org/h2/expression/function/MathFunction.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+import java.math.RoundingMode;
+
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.Operation1_2;
+import org.h2.expression.TypedValueExpression;
+import org.h2.message.DbException;
+import org.h2.value.DataType;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+import org.h2.value.ValueDouble;
+import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+import org.h2.value.ValueReal;
+
+/**
+ * A math function.
+ */
+public class MathFunction extends Operation1_2 implements NamedExpression {
+
+    /**
+     * ABS().
+     */
+    public static final int ABS = 0;
+
+    /**
+     * MOD().
+     */
+    public static final int MOD = ABS + 1;
+
+    /**
+     * FLOOR().
+     */
+    public static final int FLOOR = MOD + 1;
+
+    /**
+     * CEIL() or CEILING().
+     */
+    public static final int CEIL = FLOOR + 1;
+
+    private static final String[] NAMES = { //
+            "ABS", "MOD", "FLOOR", "CEIL" //
+    };
+
+    /**
+     * Returns whether specified function is known by this class.
+     *
+     * @param upperName
+     *            the name of the function in upper case
+     * @return {@code true} if it exists
+     */
+    public static boolean exists(String upperName) {
+        for (String n : NAMES) {
+            if (n.equals(upperName)) {
+                return true;
+            }
+        }
+        return "CEILING".equals(upperName);
+    }
+
+    private final int function;
+
+    private TypeInfo commonType;
+
+    public MathFunction(Expression arg1, Expression arg2, int function) {
+        super(arg1, arg2);
+        this.function = function;
+    }
+
+    @Override
+    public Value getValue(Session session) {
+        Value v1 = left.getValue(session);
+        if (v1 == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        switch (function) {
+        case ABS:
+            if (v1.getSignum() < 0) {
+                v1 = v1.negate();
+            }
+            break;
+        case FLOOR:
+        case CEIL:
+            int t = v1.getValueType();
+            if (t == Value.NUMERIC) {
+                v1 = ValueNumeric.get(
+                        v1.getBigDecimal().setScale(0, function == FLOOR ? RoundingMode.FLOOR : RoundingMode.CEILING));
+            } else {
+                double v = v1.getDouble();
+                v = function == FLOOR ? Math.floor(v) : Math.ceil(v);
+                v1 = t == Value.DOUBLE ? ValueDouble.get(v) : ValueReal.get((float) v);
+            }
+            break;
+        default:
+            Value v2 = right.getValue(session);
+            if (v2 == ValueNull.INSTANCE) {
+                return ValueNull.INSTANCE;
+            }
+            switch (function) {
+            case MOD:
+                v1 = v1.convertTo(commonType, session).modulus(v2.convertTo(commonType, session)).convertTo(type,
+                        session);
+                break;
+            default:
+                throw DbException.throwInternalError("function=" + function);
+            }
+            break;
+        }
+        return v1;
+    }
+
+    @Override
+    public Expression optimize(Session session) {
+        left = left.optimize(session);
+        if (right != null) {
+            right = right.optimize(session);
+        }
+        switch (function) {
+        case ABS:
+            type = left.getType();
+            if (type.getValueType() == Value.NULL) {
+                type = TypeInfo.TYPE_NUMERIC;
+            }
+            break;
+        case FLOOR:
+        case CEIL: {
+            type = left.getType();
+            int valueType = type.getValueType();
+            switch (valueType) {
+            case Value.NULL:
+                type = TypeInfo.TYPE_NUMERIC_SCALE_0;
+                break;
+            case Value.TINYINT:
+            case Value.SMALLINT:
+            case Value.INTEGER:
+            case Value.BIGINT:
+                return left;
+            case Value.REAL:
+            case Value.DOUBLE:
+                break;
+            case Value.NUMERIC:
+                if (type.getScale() > 0) {
+                    type = TypeInfo.getTypeInfo(Value.NUMERIC, type.getPrecision(), 0, null);
+                }
+                break;
+            default:
+                throw DbException.getInvalidValueException("numeric", commonType.getTraceSQL());
+            }
+            break;
+        }
+        case MOD:
+            TypeInfo divisorType = right.getType();
+            commonType = TypeInfo.getHigherType(left.getType(), divisorType);
+            int valueType = commonType.getValueType();
+            if (valueType == Value.NULL) {
+                commonType = TypeInfo.TYPE_BIGINT;
+            } else if (!DataType.isNumericType(valueType)) {
+                throw DbException.getInvalidValueException("numeric", commonType.getTraceSQL());
+            }
+            type = DataType.isNumericType(divisorType.getValueType()) ? divisorType : commonType;
+            break;
+        default:
+            type = TypeInfo.TYPE_DOUBLE;
+            break;
+        }
+        if (left.isConstant() && (right == null || right.isConstant())) {
+            return TypedValueExpression.getTypedIfNull(getValue(session), type);
+        }
+        return this;
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        builder.append(getName()).append('(');
+        left.getSQL(builder, sqlFlags);
+        if (right != null) {
+            right.getSQL(builder.append(", "), sqlFlags);
+        }
+        return builder.append(')');
+    }
+
+    @Override
+    public String getName() {
+        return NAMES[function];
+    }
+
+}

--- a/h2/src/main/org/h2/expression/function/MathFunction1.java
+++ b/h2/src/main/org/h2/expression/function/MathFunction1.java
@@ -5,14 +5,12 @@
  */
 package org.h2.expression.function;
 
-import org.h2.engine.Mode.ExpressionNames;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.expression.Operation1;
 import org.h2.expression.TypedValueExpression;
 import org.h2.message.DbException;
-import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueDouble;
@@ -21,7 +19,7 @@ import org.h2.value.ValueNull;
 /**
  * A math function with one argument and DOUBLE PRECISION result.
  */
-public class MathFunction1 extends Operation1 {
+public class MathFunction1 extends Operation1 implements NamedExpression {
 
     // Trigonometric functions
 
@@ -224,16 +222,13 @@ public class MathFunction1 extends Operation1 {
     }
 
     @Override
-    public String getAlias(Session session, int columnIndex) {
-        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
-            return StringUtils.toLowerEnglish(NAMES[function]);
-        }
-        return super.getAlias(session, columnIndex);
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        return arg.getSQL(builder.append(getName()).append('('), sqlFlags).append(')');
     }
 
     @Override
-    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
-        return arg.getSQL(builder.append(NAMES[function]).append('('), sqlFlags).append(')');
+    public String getName() {
+        return NAMES[function];
     }
 
 }

--- a/h2/src/main/org/h2/expression/function/MathFunction2.java
+++ b/h2/src/main/org/h2/expression/function/MathFunction2.java
@@ -5,13 +5,11 @@
  */
 package org.h2.expression.function;
 
-import org.h2.engine.Mode.ExpressionNames;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.expression.Operation2;
 import org.h2.expression.TypedValueExpression;
 import org.h2.message.DbException;
-import org.h2.util.StringUtils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueDouble;
@@ -20,7 +18,7 @@ import org.h2.value.ValueNull;
 /**
  * A math function with two arguments and DOUBLE PRECISION result.
  */
-public class MathFunction2 extends Operation2 {
+public class MathFunction2 extends Operation2 implements NamedExpression {
 
     /**
      * ATAN2() (non-standard).
@@ -121,18 +119,15 @@ public class MathFunction2 extends Operation2 {
     }
 
     @Override
-    public String getAlias(Session session, int columnIndex) {
-        if (session.getMode().expressionNames == ExpressionNames.POSTGRESQL_STYLE) {
-            return StringUtils.toLowerEnglish(NAMES[function]);
-        }
-        return super.getAlias(session, columnIndex);
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        builder.append(getName()).append('(');
+        left.getSQL(builder, sqlFlags).append(", ");
+        return right.getSQL(builder, sqlFlags).append(')');
     }
 
     @Override
-    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
-        builder.append(NAMES[function]).append('(');
-        left.getSQL(builder, sqlFlags).append(", ");
-        return right.getSQL(builder, sqlFlags).append(')');
+    public String getName() {
+        return NAMES[function];
     }
 
 }

--- a/h2/src/main/org/h2/expression/function/MathFunction2.java
+++ b/h2/src/main/org/h2/expression/function/MathFunction2.java
@@ -36,7 +36,7 @@ public class MathFunction2 extends Operation2 implements NamedExpression {
     public static final int POWER = LOG + 1;
 
     private static final String[] NAMES = { //
-            "LOG", "POWER", //
+            "ATAN2", "LOG", "POWER" //
     };
 
     /**

--- a/h2/src/main/org/h2/expression/function/NamedExpression.java
+++ b/h2/src/main/org/h2/expression/function/NamedExpression.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+/**
+ * A function-like expression with a name.
+ */
+public interface NamedExpression {
+
+    /**
+     * Returns the upper case name.
+     */
+    String getName();
+
+}

--- a/h2/src/main/org/h2/mode/FunctionsDB2Derby.java
+++ b/h2/src/main/org/h2/mode/FunctionsDB2Derby.java
@@ -27,7 +27,7 @@ public final class FunctionsDB2Derby extends FunctionsBase {
 
     static {
         FUNCTIONS.put("IDENTITY_VAL_LOCAL",
-                new FunctionInfo("IDENTITY_VAL_LOCAL", IDENTITY_VAL_LOCAL, 0, Value.BIGINT, true, false, false));
+                new FunctionInfo("IDENTITY_VAL_LOCAL", IDENTITY_VAL_LOCAL, 0, Value.BIGINT, true, false));
     }
 
     /**

--- a/h2/src/main/org/h2/mode/FunctionsMSSQLServer.java
+++ b/h2/src/main/org/h2/mode/FunctionsMSSQLServer.java
@@ -27,9 +27,8 @@ public final class FunctionsMSSQLServer extends FunctionsBase {
 
     static {
         copyFunction(FUNCTIONS, "LOCATE", "CHARINDEX");
-        FUNCTIONS.put("GETDATE", new FunctionInfo("GETDATE", GETDATE, 0, Value.TIMESTAMP, false, true, false));
-        FUNCTIONS.put("ISNULL", new FunctionInfo("ISNULL", Function.COALESCE,
-                2, Value.NULL, false, true, false));
+        FUNCTIONS.put("GETDATE", new FunctionInfo("GETDATE", GETDATE, 0, Value.TIMESTAMP, false, true));
+        FUNCTIONS.put("ISNULL", new FunctionInfo("ISNULL", Function.COALESCE, 2, Value.NULL, false, true));
         copyFunction(FUNCTIONS, "LENGTH", "LEN");
         copyFunction(FUNCTIONS, "RANDOM_UUID", "NEWID");
     }

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -41,15 +41,13 @@ public class FunctionsMySQL extends FunctionsBase {
     private static final HashMap<String, FunctionInfo> FUNCTIONS = new HashMap<>();
 
     static {
-        FUNCTIONS.put("UNIX_TIMESTAMP", new FunctionInfo("UNIX_TIMESTAMP", UNIX_TIMESTAMP,
-                VAR_ARGS, Value.INTEGER, false, false, false));
-        FUNCTIONS.put("FROM_UNIXTIME", new FunctionInfo("FROM_UNIXTIME", FROM_UNIXTIME,
-                VAR_ARGS, Value.VARCHAR, false, true, false));
-        FUNCTIONS.put("DATE", new FunctionInfo("DATE", DATE,
-                1, Value.DATE, false, true, false));
-        FUNCTIONS.put("LAST_INSERT_ID", new FunctionInfo("LAST_INSERT_ID", LAST_INSERT_ID,
-                VAR_ARGS, Value.BIGINT, false, false, false));
-
+        FUNCTIONS.put("UNIX_TIMESTAMP",
+                new FunctionInfo("UNIX_TIMESTAMP", UNIX_TIMESTAMP, VAR_ARGS, Value.INTEGER, false, false));
+        FUNCTIONS.put("FROM_UNIXTIME",
+                new FunctionInfo("FROM_UNIXTIME", FROM_UNIXTIME, VAR_ARGS, Value.VARCHAR, false, true));
+        FUNCTIONS.put("DATE", new FunctionInfo("DATE", DATE, 1, Value.DATE, false, true));
+        FUNCTIONS.put("LAST_INSERT_ID",
+                new FunctionInfo("LAST_INSERT_ID", LAST_INSERT_ID, VAR_ARGS, Value.BIGINT, false, false));
     }
 
     /**

--- a/h2/src/main/org/h2/mode/FunctionsOracle.java
+++ b/h2/src/main/org/h2/mode/FunctionsOracle.java
@@ -39,15 +39,15 @@ public final class FunctionsOracle extends FunctionsBase {
 
     static {
         FUNCTIONS.put("ADD_MONTHS",
-                new FunctionInfo("ADD_MONTHS", ADD_MONTHS, 2, Value.TIMESTAMP, true, true, false));
+                new FunctionInfo("ADD_MONTHS", ADD_MONTHS, 2, Value.TIMESTAMP, true, true));
         FUNCTIONS.put("SYS_GUID",
-                new FunctionInfo("SYS_GUID", SYS_GUID, 0, Value.VARBINARY, false, false, false));
+                new FunctionInfo("SYS_GUID", SYS_GUID, 0, Value.VARBINARY, false, false));
         FUNCTIONS.put("TO_DATE",
-                new FunctionInfo("TO_DATE", TO_DATE, VAR_ARGS, Value.TIMESTAMP, true, true, false));
+                new FunctionInfo("TO_DATE", TO_DATE, VAR_ARGS, Value.TIMESTAMP, true, true));
         FUNCTIONS.put("TO_TIMESTAMP",
-                new FunctionInfo("TO_TIMESTAMP", TO_TIMESTAMP, VAR_ARGS, Value.TIMESTAMP, true, true, false));
-        FUNCTIONS.put("TO_TIMESTAMP_TZ", new FunctionInfo("TO_TIMESTAMP_TZ", TO_TIMESTAMP_TZ, VAR_ARGS,
-                Value.TIMESTAMP_TZ, true, true, false));
+                new FunctionInfo("TO_TIMESTAMP", TO_TIMESTAMP, VAR_ARGS, Value.TIMESTAMP, true, true));
+        FUNCTIONS.put("TO_TIMESTAMP_TZ",
+                new FunctionInfo("TO_TIMESTAMP_TZ", TO_TIMESTAMP_TZ, VAR_ARGS, Value.TIMESTAMP_TZ, true, true));
     }
 
     /**

--- a/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
@@ -82,42 +82,40 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
     private static final HashMap<String, FunctionInfo> FUNCTIONS = new HashMap<>();
 
     static {
-        FUNCTIONS.put("CURRENT_DATABASE", new FunctionInfo("CURRENT_DATABASE", CURRENT_DATABASE, 0, Value.VARCHAR,
-                true, false, false));
-        FUNCTIONS.put("CURRTID2", new FunctionInfo("CURRTID2", CURRTID2, 2, Value.INTEGER, true, false, false));
-        FUNCTIONS.put("FORMAT_TYPE",
-                new FunctionInfo("FORMAT_TYPE", FORMAT_TYPE, 2, Value.VARCHAR, false, true, false));
+        FUNCTIONS.put("CURRENT_DATABASE",
+                new FunctionInfo("CURRENT_DATABASE", CURRENT_DATABASE, 0, Value.VARCHAR, true, false));
+        FUNCTIONS.put("CURRTID2", new FunctionInfo("CURRTID2", CURRTID2, 2, Value.INTEGER, true, false));
+        FUNCTIONS.put("FORMAT_TYPE", new FunctionInfo("FORMAT_TYPE", FORMAT_TYPE, 2, Value.VARCHAR, false, true));
         FUNCTIONS.put("HAS_DATABASE_PRIVILEGE", new FunctionInfo("HAS_DATABASE_PRIVILEGE", HAS_DATABASE_PRIVILEGE,
-                VAR_ARGS, Value.BOOLEAN, true, false, false));
-        FUNCTIONS.put("HAS_SCHEMA_PRIVILEGE", new FunctionInfo("HAS_SCHEMA_PRIVILEGE", HAS_SCHEMA_PRIVILEGE,
-                VAR_ARGS, Value.BOOLEAN, true, false, false));
-        FUNCTIONS.put("HAS_TABLE_PRIVILEGE", new FunctionInfo("HAS_TABLE_PRIVILEGE", HAS_TABLE_PRIVILEGE,
-                VAR_ARGS, Value.BOOLEAN, true, false, false));
-        FUNCTIONS.put("LASTVAL", new FunctionInfo("LASTVAL", LASTVAL, 0, Value.BIGINT, true, false, false));
-        FUNCTIONS.put("VERSION", new FunctionInfo("VERSION", VERSION, 0, Value.VARCHAR, true, false, false));
-        FUNCTIONS.put("OBJ_DESCRIPTION", new FunctionInfo("OBJ_DESCRIPTION", OBJ_DESCRIPTION, VAR_ARGS, Value.VARCHAR,
-                true, false, false));
-        FUNCTIONS.put("PG_ENCODING_TO_CHAR", new FunctionInfo("PG_ENCODING_TO_CHAR", PG_ENCODING_TO_CHAR, 1,
-                Value.VARCHAR, true, true, false));
-        FUNCTIONS.put("PG_GET_EXPR",
-                new FunctionInfo("PG_GET_EXPR", PG_GET_EXPR, VAR_ARGS, Value.VARCHAR, true, true, false));
-        FUNCTIONS.put("PG_GET_INDEXDEF", //
-                new FunctionInfo("PG_GET_INDEXDEF", PG_GET_INDEXDEF, VAR_ARGS, Value.VARCHAR, //
-                        true, false, false));
+                VAR_ARGS, Value.BOOLEAN, true, false));
+        FUNCTIONS.put("HAS_SCHEMA_PRIVILEGE",
+                new FunctionInfo("HAS_SCHEMA_PRIVILEGE", HAS_SCHEMA_PRIVILEGE, VAR_ARGS, Value.BOOLEAN, true, false));
+        FUNCTIONS.put("HAS_TABLE_PRIVILEGE",
+                new FunctionInfo("HAS_TABLE_PRIVILEGE", HAS_TABLE_PRIVILEGE, VAR_ARGS, Value.BOOLEAN, true, false));
+        FUNCTIONS.put("LASTVAL", new FunctionInfo("LASTVAL", LASTVAL, 0, Value.BIGINT, true, false));
+        FUNCTIONS.put("VERSION", new FunctionInfo("VERSION", VERSION, 0, Value.VARCHAR, true, false));
+        FUNCTIONS.put("OBJ_DESCRIPTION",
+                new FunctionInfo("OBJ_DESCRIPTION", OBJ_DESCRIPTION, VAR_ARGS, Value.VARCHAR, true, false));
+        FUNCTIONS.put("PG_ENCODING_TO_CHAR",
+                new FunctionInfo("PG_ENCODING_TO_CHAR", PG_ENCODING_TO_CHAR, 1, Value.VARCHAR, true, true));
+        FUNCTIONS.put("PG_GET_EXPR", //
+                new FunctionInfo("PG_GET_EXPR", PG_GET_EXPR, VAR_ARGS, Value.VARCHAR, true, true));
+        FUNCTIONS.put("PG_GET_INDEXDEF",
+                new FunctionInfo("PG_GET_INDEXDEF", PG_GET_INDEXDEF, VAR_ARGS, Value.VARCHAR, true, false));
         FUNCTIONS.put("PG_GET_USERBYID",
-                new FunctionInfo("PG_GET_USERBYID", PG_GET_USERBYID, 1, Value.VARCHAR, true, false, false));
-        FUNCTIONS.put("PG_POSTMASTER_START_TIME", new FunctionInfo("PG_POSTMASTER_START_TIME", //
-                PG_POSTMASTER_START_TIME, 0, Value.TIMESTAMP_TZ, true, false, false));
-        FUNCTIONS.put("PG_RELATION_SIZE", new FunctionInfo("PG_RELATION_SIZE", //
-                PG_RELATION_SIZE, VAR_ARGS, Value.BIGINT, true, false, false));
-        FUNCTIONS.put("PG_TABLE_IS_VISIBLE", new FunctionInfo("PG_TABLE_IS_VISIBLE", //
-                PG_TABLE_IS_VISIBLE, 1, Value.BOOLEAN, true, false, false));
-        FUNCTIONS.put("SET_CONFIG", new FunctionInfo("SET_CONFIG", //
-                SET_CONFIG, 3, Value.VARCHAR, true, false, false));
-        FUNCTIONS.put("ARRAY_TO_STRING", new FunctionInfo("ARRAY_TO_STRING", //
-                ARRAY_TO_STRING, VAR_ARGS, Value.VARCHAR, false, true, false));
-        FUNCTIONS.put("PG_STAT_GET_NUMSCANS", new FunctionInfo("PG_STAT_GET_NUMSCANS", //
-                PG_STAT_GET_NUMSCANS, 1, Value.INTEGER, true, true, false));
+                new FunctionInfo("PG_GET_USERBYID", PG_GET_USERBYID, 1, Value.VARCHAR, true, false));
+        FUNCTIONS.put("PG_POSTMASTER_START_TIME", //
+                new FunctionInfo("PG_POSTMASTER_START_TIME", PG_POSTMASTER_START_TIME, 0, Value.TIMESTAMP_TZ, true,
+                        false));
+        FUNCTIONS.put("PG_RELATION_SIZE",
+                new FunctionInfo("PG_RELATION_SIZE", PG_RELATION_SIZE, VAR_ARGS, Value.BIGINT, true, false));
+        FUNCTIONS.put("PG_TABLE_IS_VISIBLE",
+                new FunctionInfo("PG_TABLE_IS_VISIBLE", PG_TABLE_IS_VISIBLE, 1, Value.BOOLEAN, true, false));
+        FUNCTIONS.put("SET_CONFIG", new FunctionInfo("SET_CONFIG", SET_CONFIG, 3, Value.VARCHAR, true, false));
+        FUNCTIONS.put("ARRAY_TO_STRING",
+                new FunctionInfo("ARRAY_TO_STRING", ARRAY_TO_STRING, VAR_ARGS, Value.VARCHAR, false, true));
+        FUNCTIONS.put("PG_STAT_GET_NUMSCANS",
+                new FunctionInfo("PG_STAT_GET_NUMSCANS", PG_STAT_GET_NUMSCANS, 1, Value.INTEGER, true, true));
     }
 
     /**

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -21,7 +21,6 @@ import java.sql.Connection;
 import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;

--- a/h2/src/main/org/h2/value/TypeInfo.java
+++ b/h2/src/main/org/h2/value/TypeInfo.java
@@ -82,6 +82,11 @@ public class TypeInfo extends ExtTypeInfo {
     public static final TypeInfo TYPE_NUMERIC;
 
     /**
+     * NUMERIC type with maximum precision and scale 0.
+     */
+    public static final TypeInfo TYPE_NUMERIC_SCALE_0;
+
+    /**
      * NUMERIC type with parameters enough to hold a BIGINT value.
      */
     public static final TypeInfo TYPE_NUMERIC_BIGINT;
@@ -229,6 +234,7 @@ public class TypeInfo extends ExtTypeInfo {
                 ValueBigint.DISPLAY_SIZE, null);
         infos[Value.NUMERIC] = TYPE_NUMERIC = new TypeInfo(Value.NUMERIC, Integer.MAX_VALUE, //
                 ValueNumeric.MAXIMUM_SCALE, Integer.MAX_VALUE, null);
+        TYPE_NUMERIC_SCALE_0 = new TypeInfo(Value.NUMERIC, Integer.MAX_VALUE, 0, Integer.MAX_VALUE, null);
         TYPE_NUMERIC_BIGINT = new TypeInfo(Value.NUMERIC, ValueBigint.PRECISION, 0, ValueBigint.DISPLAY_SIZE, null);
         TYPE_NUMERIC_FLOATING_POINT = new TypeInfo(Value.NUMERIC, ValueNumeric.DEFAULT_PRECISION,
                 ValueNumeric.DEFAULT_PRECISION / 2, ValueNumeric.DEFAULT_PRECISION + 2, null);

--- a/h2/src/test/org/h2/test/db/TestAlterTableNotFound.java
+++ b/h2/src/test/org/h2/test/db/TestAlterTableNotFound.java
@@ -8,7 +8,6 @@ package org.h2.test.db;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 

--- a/h2/src/test/org/h2/test/db/TestSelectTableNotFound.java
+++ b/h2/src/test/org/h2/test/db/TestSelectTableNotFound.java
@@ -9,7 +9,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.h2.jdbc.JdbcConnection;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 

--- a/h2/src/test/org/h2/test/unit/TestBinaryOperation.java
+++ b/h2/src/test/org/h2/test/unit/TestBinaryOperation.java
@@ -35,7 +35,6 @@ public class TestBinaryOperation extends TestBase {
         testPlusMinus(BinaryOperation.OpType.MINUS);
         testMultiply();
         testDivide();
-        testModulus();
     }
 
     private void testPlusMinus(BinaryOperation.OpType type) {
@@ -61,14 +60,6 @@ public class TestBinaryOperation extends TestBase {
         assertPrecisionScale(3, 1, BinaryOperation.OpType.DIVIDE, 1, -1, 1, 0);
         assertPrecisionScale(3, 3, BinaryOperation.OpType.DIVIDE, 1, 0, 1, -1);
         assertPrecisionScale(19, -6, BinaryOperation.OpType.DIVIDE, 1, 3, 9, 27);
-    }
-
-    private void testModulus() {
-        assertPrecisionScale(1, 0, BinaryOperation.OpType.MODULUS, 1, 0, 1, 0);
-        assertPrecisionScale(1, 0, BinaryOperation.OpType.MODULUS, 1, 1, 1, 0);
-        assertPrecisionScale(1, 1, BinaryOperation.OpType.MODULUS, 1, 0, 1, 1);
-        assertPrecisionScale(1, 0, BinaryOperation.OpType.MODULUS, 1, -1, 1, 0);
-        assertPrecisionScale(1, -1, BinaryOperation.OpType.MODULUS, 1, 0, 1, -1);
     }
 
     private void assertPrecisionScale(int expectedPrecision, int expectedScale, BinaryOperation.OpType type,


### PR DESCRIPTION
1. Some additional groups of functions are moved into separate classes.

2. Non-standard `%` operation is removed from `BinaryOperation`, parser replaces it with the standard modulus expression. There is no reason to have two similar implementations of the same thing.

3. `FunctionInfo.specialArguments` is removed, it isn't used any more.