### PR TITLE
Add ALTER DOMAIN { SET | DROP } { DEFAULT | ON UPDATE }

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -361,6 +361,34 @@ WITH cte1 AS (
 SELECT sum(FIRST_COLUMN) FROM cte2;
 "
 
+"Commands (DDL)","ALTER DOMAIN","
+ALTER DOMAIN @h2@ [ IF EXISTS ] [schemaName.]domainName
+{ SET DEFAULT expression }
+    | { DROP DEFAULT }
+    | @h2@ { SET ON UPDATE expression }
+    | @h2@ { DROP ON UPDATE }
+","
+Changes the default or on update expression of a domain.
+
+SET DEFAULT changes the default expression of a domain.
+
+DROP DEFAULT removes the default expression of a domain.
+Old expression is copied into domains and columns that use this domain and don't have an own default expression.
+
+SET ON UPDATE changes the expression that is set on update if value for this domain is not specified in update
+statement.
+
+DROP ON UPDATE removes the expression that is set on update of a column with this domain.
+Old expression is copied into domains and columns that use this domain and don't have an own on update expression.
+
+This command commits an open transaction in this connection.
+","
+ALTER DOMAIN D1 SET DEFAULT '';
+ALTER DOMAIN D1 DROP DEFAULT;
+ALTER DOMAIN D1 SET ON UPDATE CURRENT_TIMESTAMP;
+ALTER DOMAIN D1 DROP ON UPDATE;
+"
+
 "Commands (DDL)","ALTER DOMAIN ADD CONSTRAINT","
 ALTER DOMAIN @h2@ [ IF EXISTS ] [schemaName.]domainName
 ADD [ constraintNameDefinition ]
@@ -1033,6 +1061,9 @@ DROP DOMAIN @h2@ [ IF EXISTS ] [schemaName.]domainName [ RESTRICT | CASCADE ]
 Drops a data type (domain).
 The command will fail if it is referenced by a column or another domain (the default).
 Column descriptors are replaced with original definition of specified domain if the CASCADE clause is used.
+Default and on update expressions are copied into domains and columns that use this domain and don't have own
+expressions. Domain constraints are copied into domains that use this domain and to columns (as check constraints) that
+use this domain.
 This command commits an open transaction in this connection.
 ","
 DROP DOMAIN EMAIL

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #2663: Add ALTER DOMAIN { SET | DROP } { DEFAULT | ON UPDATE }
+</li>
 <li>PR #2661: Don't allow construction of incomplete ARRAY and ROW data types
 </li>
 <li>Issue #2659: NULLIF with row values

--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -189,7 +189,7 @@ public class CommandContainer extends Command {
             Column[] columns = table.getColumns();
             Index primaryKey = table.findPrimaryKey();
             for (Column column : columns) {
-                Expression e = column.getDefaultExpression();
+                Expression e = column.getEffectiveDefaultExpression();
                 if ((e != null && !e.isConstant()) || (primaryKey != null && primaryKey.getColumnIndex(column) >= 0)) {
                     expressionColumns.add(new ExpressionColumn(db, column));
                 }

--- a/h2/src/main/org/h2/command/CommandInterface.java
+++ b/h2/src/main/org/h2/command/CommandInterface.java
@@ -458,7 +458,6 @@ public interface CommandInterface extends AutoCloseable {
      */
     int ALTER_TABLE_RENAME_CONSTRAINT = 85;
 
-
     /**
      * The type of an EXPLAIN ANALYZE statement.
      */
@@ -498,6 +497,18 @@ public interface CommandInterface extends AutoCloseable {
      * The type of ALTER DOMAIN DROP CONSTRAINT statement.
      */
     int ALTER_DOMAIN_DROP_CONSTRAINT = 93;
+
+    /**
+     * The type of an ALTER DOMAIN SET DEFAULT and ALTER DOMAIN DROP DEFAULT
+     * statements.
+     */
+    int ALTER_DOMAIN_DEFAULT = 94;
+
+    /**
+     * The type of an ALTER DOMAIN SET ON UPDATE and ALTER DOMAIN DROP ON UPDATE
+     * statements.
+     */
+    int ALTER_DOMAIN_ON_UPDATE = 95;
 
     /**
      * Get command type.

--- a/h2/src/main/org/h2/command/ddl/AlterDomain.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomain.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.command.ddl;
+
+import java.util.function.BiPredicate;
+
+import org.h2.api.ErrorCode;
+import org.h2.command.CommandInterface;
+import org.h2.engine.Database;
+import org.h2.engine.DbObject;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.message.DbException;
+import org.h2.schema.Domain;
+import org.h2.schema.Schema;
+import org.h2.schema.SchemaObject;
+import org.h2.table.Column;
+import org.h2.table.Table;
+
+/**
+ * This class represents the statements
+ * ALTER DOMAIN SET DEFAULT
+ * ALTER DOMAIN DROP DEFAULT
+ * ALTER DOMAIN SET ON UPDATE
+ * ALTER DOMAIN DROP ON UPDATE
+ */
+public class AlterDomain extends SchemaCommand {
+
+    static void copy(Session session, Domain domain, BiPredicate<Domain, Column> columnProcessor,
+            BiPredicate<Domain, Domain> domainProcessor) {
+        Database db = session.getDatabase();
+        for (SchemaObject obj : db.getAllSchemaObjects(DbObject.DOMAIN)) {
+            Domain targetDomain = (Domain) obj;
+            if (targetDomain.getColumn().getDomain() == domain) {
+                if (domainProcessor.test(domain, targetDomain)) {
+                    domain.getColumn().prepareExpression(session);
+                    db.updateMeta(session, targetDomain);
+                }
+            }
+        }
+        for (Table t : db.getAllTablesAndViews(false)) {
+            boolean modified = false;
+            for (Column targetColumn : t.getColumns()) {
+                if (targetColumn.getDomain() == domain) {
+                    boolean m = columnProcessor.test(domain, targetColumn);
+                    if (m) {
+                        targetColumn.prepareExpression(session);
+                        modified = true;
+                    }
+                }
+            }
+            if (modified) {
+                db.updateMeta(session, t);
+            }
+        }
+    }
+
+    private final int type;
+
+    private Expression expression;
+
+    private String domainName;
+    private boolean ifDomainExists;
+
+    public AlterDomain(Session session, Schema schema, int type) {
+        super(session, schema);
+        this.type = type;
+    }
+
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
+
+    public void setIfDomainExists(boolean b) {
+        ifDomainExists = b;
+    }
+
+    public void setExpression(Expression expression) {
+        this.expression = expression;
+    }
+
+    @Override
+    public int update() {
+        session.getUser().checkAdmin();
+        session.commit(true);
+        Domain domain = getSchema().findDomain(domainName);
+        if (domain == null) {
+            if (ifDomainExists) {
+                return 0;
+            }
+            throw DbException.get(ErrorCode.DOMAIN_NOT_FOUND_1, domainName);
+        }
+        switch (type) {
+        case CommandInterface.ALTER_DOMAIN_DEFAULT:
+            domain.getColumn().setDefaultExpression(session, expression);
+            break;
+        case CommandInterface.ALTER_DOMAIN_ON_UPDATE:
+            domain.getColumn().setOnUpdateExpression(session, expression);
+            break;
+        default:
+            DbException.throwInternalError("type=" + type);
+        }
+        if (expression != null) {
+            AlterDomain.copy(session, domain, this::copyColumn, this::copyDomain);
+        }
+        session.getDatabase().updateMeta(session, domain);
+        return 0;
+    }
+
+    private boolean copyColumn(Domain domain, Column targetColumn) {
+        return copyExpressions(session, domain.getColumn(), targetColumn);
+    }
+
+    private boolean copyDomain(Domain domain, Domain targetDomain) {
+        return copyExpressions(session, domain.getColumn(), targetDomain.getColumn());
+    }
+
+    private boolean copyExpressions(Session session, Column domainColumn, Column targetColumn) {
+        switch (type) {
+        case CommandInterface.ALTER_DOMAIN_DEFAULT: {
+            Expression e = domainColumn.getDefaultExpression();
+            if (e != null && targetColumn.getDefaultExpression() == null) {
+                targetColumn.setDefaultExpression(session, e);
+                return true;
+            }
+            break;
+        }
+        case CommandInterface.ALTER_DOMAIN_ON_UPDATE: {
+            Expression e = domainColumn.getOnUpdateExpression();
+            if (e != null && targetColumn.getOnUpdateExpression() == null) {
+                targetColumn.setOnUpdateExpression(session, e);
+                return true;
+            }
+        }
+        }
+        return false;
+    }
+
+    @Override
+    public int getType() {
+        return CommandInterface.ALTER_DOMAIN_DROP_CONSTRAINT;
+    }
+
+}

--- a/h2/src/main/org/h2/command/ddl/DropDomain.java
+++ b/h2/src/main/org/h2/command/ddl/DropDomain.java
@@ -6,18 +6,16 @@
 package org.h2.command.ddl;
 
 import java.util.ArrayList;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.constraint.ConstraintActionType;
 import org.h2.constraint.ConstraintDomain;
-import org.h2.engine.Database;
-import org.h2.engine.DbObject;
 import org.h2.engine.Session;
 import org.h2.expression.Expression;
 import org.h2.message.DbException;
 import org.h2.schema.Domain;
 import org.h2.schema.Schema;
-import org.h2.schema.SchemaObject;
 import org.h2.table.Column;
 import org.h2.table.Table;
 
@@ -48,7 +46,6 @@ public class DropDomain extends SchemaCommand {
     public int update() {
         session.getUser().checkAdmin();
         session.commit(true);
-        Database db = session.getDatabase();
         Schema schema = getSchema();
         Domain domain = schema.findDomain(typeName);
         if (domain == null) {
@@ -56,61 +53,67 @@ public class DropDomain extends SchemaCommand {
                 throw DbException.get(ErrorCode.DOMAIN_NOT_FOUND_1, typeName);
             }
         } else {
-            Column domainColumn = domain.getColumn();
-            for (SchemaObject obj : db.getAllSchemaObjects(DbObject.DOMAIN)) {
-                Domain d = (Domain) obj;
-                Column c = d.getColumn();
-                if (c.getDomain() == domain) {
-                    if (dropAction == ConstraintActionType.RESTRICT) {
-                        throw DbException.get(ErrorCode.CANNOT_DROP_2, typeName, d.getTraceSQL());
-                    }
-                    ArrayList<ConstraintDomain> constraints = domain.getConstraints();
-                    if (constraints != null && !constraints.isEmpty()) {
-                        for (ConstraintDomain constraint : constraints) {
-                            Expression checkCondition = constraint.getCheckConstraint(session, null);
-                            AlterDomainAddConstraint check = new AlterDomainAddConstraint(session, d.getSchema(),
-                                    false);
-                            check.setDomainName(d.getName());
-                            check.setCheckExpression(checkCondition);
-                            check.update();
-                        }
-                    }
-                    c.setOriginalSQL(domain.getColumn().getOriginalSQL());
-                    c.setDomain(domainColumn.getDomain());
-                    db.updateMeta(session, d);
-                }
-            }
-            for (Table t : db.getAllTablesAndViews(false)) {
-                boolean modified = false;
-                for (Column c : t.getColumns()) {
-                    if (c.getDomain() == domain) {
-                        if (dropAction == ConstraintActionType.RESTRICT) {
-                            throw DbException.get(ErrorCode.CANNOT_DROP_2, typeName, t.getCreateSQL());
-                        }
-                        String columnName = c.getName();
-                        ArrayList<ConstraintDomain> constraints = domain.getConstraints();
-                        if (constraints != null && !constraints.isEmpty()) {
-                            for (ConstraintDomain constraint : constraints) {
-                                Expression checkCondition = constraint.getCheckConstraint(session, columnName);
-                                AlterTableAddConstraint check = new AlterTableAddConstraint(session, t.getSchema(),
-                                        CommandInterface.ALTER_TABLE_ADD_CONSTRAINT_CHECK, false);
-                                check.setTableName(t.getName());
-                                check.setCheckExpression(checkCondition);
-                                check.update();
-                            }
-                        }
-                        c.setOriginalSQL(domain.getColumn().getOriginalSQL());
-                        c.setDomain(domainColumn.getDomain());
-                        modified = true;
-                    }
-                }
-                if (modified) {
-                    db.updateMeta(session, t);
-                }
-            }
+            AlterDomain.copy(session, domain, this::copyColumn, this::copyDomain);
             session.getDatabase().removeSchemaObject(session, domain);
         }
         return 0;
+    }
+
+    private boolean copyColumn(Domain domain, Column targetColumn) {
+        Table targetTable = targetColumn.getTable();
+        if (dropAction == ConstraintActionType.RESTRICT) {
+            throw DbException.get(ErrorCode.CANNOT_DROP_2, typeName, targetTable.getCreateSQL());
+        }
+        String columnName = targetColumn.getName();
+        ArrayList<ConstraintDomain> constraints = domain.getConstraints();
+        if (constraints != null && !constraints.isEmpty()) {
+            for (ConstraintDomain constraint : constraints) {
+                Expression checkCondition = constraint.getCheckConstraint(session, columnName);
+                AlterTableAddConstraint check = new AlterTableAddConstraint(session, targetTable.getSchema(),
+                        CommandInterface.ALTER_TABLE_ADD_CONSTRAINT_CHECK, false);
+                check.setTableName(targetTable.getName());
+                check.setCheckExpression(checkCondition);
+                check.update();
+            }
+        }
+        copyExpressions(session, domain.getColumn(), targetColumn);
+        return true;
+    }
+
+    private boolean copyDomain(Domain domain, Domain targetDomain) {
+        if (dropAction == ConstraintActionType.RESTRICT) {
+            throw DbException.get(ErrorCode.CANNOT_DROP_2, typeName, targetDomain.getTraceSQL());
+        }
+        ArrayList<ConstraintDomain> constraints = domain.getConstraints();
+        if (constraints != null && !constraints.isEmpty()) {
+            for (ConstraintDomain constraint : constraints) {
+                Expression checkCondition = constraint.getCheckConstraint(session, null);
+                AlterDomainAddConstraint check = new AlterDomainAddConstraint(session, targetDomain.getSchema(), //
+                        false);
+                check.setDomainName(targetDomain.getName());
+                check.setCheckExpression(checkCondition);
+                check.update();
+            }
+        }
+        copyExpressions(session, domain.getColumn(), targetDomain.getColumn());
+        return true;
+    }
+
+    private static boolean copyExpressions(Session session, Column domainColumn, Column targetColumn) {
+        targetColumn.setOriginalSQL(domainColumn.getOriginalSQL());
+        targetColumn.setDomain(domainColumn.getDomain());
+        Expression e = domainColumn.getDefaultExpression();
+        boolean modified = false;
+        if (e != null && targetColumn.getDefaultExpression() == null) {
+            targetColumn.setDefaultExpression(session, e);
+            modified = true;
+        }
+        e = domainColumn.getOnUpdateExpression();
+        if (e != null && targetColumn.getOnUpdateExpression() == null) {
+            targetColumn.setOnUpdateExpression(session, e);
+            modified = true;
+        }
+        return modified;
     }
 
     public void setTypeName(String name) {

--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -167,7 +167,7 @@ public class Merge extends CommandWithValues implements DataChangeStatement {
                 } else {
                     Value v = row.getValue(col.getColumnId());
                     if (v == null) {
-                        Expression defaultExpression = col.getDefaultExpression();
+                        Expression defaultExpression = col.getEffectiveDefaultExpression();
                         v = defaultExpression != null ? defaultExpression.getValue(session) : ValueNull.INSTANCE;
                     }
                     k.get(j++).setValue(v);

--- a/h2/src/main/org/h2/command/dml/SetClauseList.java
+++ b/h2/src/main/org/h2/command/dml/SetClauseList.java
@@ -264,7 +264,7 @@ public final class SetClauseList implements HasSQL {
             if (!oldRow.hasSameValues(newRow)) {
                 for (int i = 0; i < columnCount; i++) {
                     if (actions[i] == UpdateAction.ON_UPDATE) {
-                        newRow.setValue(i, columns[i].getOnUpdateExpression().getValue(session));
+                        newRow.setValue(i, columns[i].getEffectiveOnUpdateExpression().getValue(session));
                     }
                 }
                 // Convert on update expressions and reevaluate
@@ -329,7 +329,7 @@ public final class SetClauseList implements HasSQL {
                 action.mapAndOptimize(session, resolver1, resolver2);
             } else {
                 Column column = columns[i];
-                if (column.getOnUpdateExpression() != null) {
+                if (column.getEffectiveOnUpdateExpression() != null) {
                     actions[i] = UpdateAction.ON_UPDATE;
                     onUpdate = true;
                 }

--- a/h2/src/main/org/h2/constraint/ConstraintReferential.java
+++ b/h2/src/main/org/h2/constraint/ConstraintReferential.java
@@ -533,7 +533,7 @@ public class ConstraintReferential extends Constraint {
                 if (action == ConstraintActionType.SET_NULL) {
                     value = ValueNull.INSTANCE;
                 } else {
-                    Expression expr = column.getDefaultExpression();
+                    Expression expr = column.getEffectiveDefaultExpression();
                     if (expr == null) {
                         throw DbException.get(ErrorCode.NO_DEFAULT_SET_1, column.getName());
                     }

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -157,7 +157,7 @@ public class TestScript extends TestDb {
                 "uuid", "varbinary", "varchar", "varchar-ignorecase" }) {
             testScript("datatypes/" + s + ".sql");
         }
-        for (String s : new String[] { "alterTableAdd", "alterTableAlterColumn", "alterTableDropColumn",
+        for (String s : new String[] { "alterDomain", "alterTableAdd", "alterTableAlterColumn", "alterTableDropColumn",
                 "alterTableRename", "analyze", "createAlias", "createDomain", "createSequence", "createSynonym",
                 "createTable", "createTrigger", "createView", "dropAllObjects", "dropDomain", "dropIndex",
                 "dropSchema", "dropTable", "grant", "truncateTable" }) {

--- a/h2/src/test/org/h2/test/scripts/ddl/alterDomain.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/alterDomain.sql
@@ -1,0 +1,218 @@
+-- Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+CREATE DOMAIN D1 INT DEFAULT 1;
+> ok
+
+CREATE DOMAIN D2 D1 DEFAULT 2;
+> ok
+
+CREATE DOMAIN D3 D1;
+> ok
+
+CREATE TABLE TEST(ID INT PRIMARY KEY, S1 D1, S2 D2, S3 D3, C1 D1 DEFAULT 4, C2 D2 DEFAULT 5, C3 D3 DEFAULT 6);
+> ok
+
+INSERT INTO TEST(ID) VALUES 1;
+> update count: 1
+
+TABLE TEST;
+> ID S1 S2 S3 C1 C2 C3
+> -- -- -- -- -- -- --
+> 1  1  2  1  4  5  6
+> rows: 1
+
+ALTER DOMAIN D1 SET DEFAULT 3;
+> ok
+
+INSERT INTO TEST(ID) VALUES 2;
+> update count: 1
+
+SELECT * FROM TEST WHERE ID = 2;
+> ID S1 S2 S3 C1 C2 C3
+> -- -- -- -- -- -- --
+> 2  3  2  3  4  5  6
+> rows: 1
+
+ALTER DOMAIN D1 DROP DEFAULT;
+> ok
+
+SELECT DOMAIN_NAME, DOMAIN_DEFAULT FROM INFORMATION_SCHEMA.DOMAINS WHERE DOMAIN_SCHEMA = 'PUBLIC';
+> DOMAIN_NAME DOMAIN_DEFAULT
+> ----------- --------------
+> D1          null
+> D2          2
+> D3          3
+> rows: 3
+
+SELECT COLUMN_NAME, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'PUBLIC';
+> COLUMN_NAME COLUMN_DEFAULT
+> ----------- --------------
+> C1          4
+> C2          5
+> C3          6
+> ID          null
+> S1          3
+> S2          null
+> S3          null
+> rows: 7
+
+ALTER DOMAIN D1 SET DEFAULT 3;
+> ok
+
+ALTER DOMAIN D3 DROP DEFAULT;
+> ok
+
+ALTER TABLE TEST ALTER COLUMN S1 DROP DEFAULT;
+> ok
+
+SELECT DOMAIN_NAME, DOMAIN_DEFAULT FROM INFORMATION_SCHEMA.DOMAINS WHERE DOMAIN_SCHEMA = 'PUBLIC';
+> DOMAIN_NAME DOMAIN_DEFAULT
+> ----------- --------------
+> D1          3
+> D2          2
+> D3          null
+> rows: 3
+
+SELECT COLUMN_NAME, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'PUBLIC';
+> COLUMN_NAME COLUMN_DEFAULT
+> ----------- --------------
+> C1          4
+> C2          5
+> C3          6
+> ID          null
+> S1          null
+> S2          null
+> S3          null
+> rows: 7
+
+DROP DOMAIN D1 CASCADE;
+> ok
+
+SELECT DOMAIN_NAME, DOMAIN_DEFAULT FROM INFORMATION_SCHEMA.DOMAINS WHERE DOMAIN_SCHEMA = 'PUBLIC';
+> DOMAIN_NAME DOMAIN_DEFAULT
+> ----------- --------------
+> D2          2
+> D3          3
+> rows: 2
+
+SELECT COLUMN_NAME, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'PUBLIC';
+> COLUMN_NAME COLUMN_DEFAULT
+> ----------- --------------
+> C1          4
+> C2          5
+> C3          6
+> ID          null
+> S1          3
+> S2          null
+> S3          null
+> rows: 7
+
+DROP TABLE TEST;
+> ok
+
+DROP DOMAIN D2;
+> ok
+
+DROP DOMAIN D3;
+> ok
+
+CREATE DOMAIN D1 INT ON UPDATE 1;
+> ok
+
+CREATE DOMAIN D2 D1 ON UPDATE 2;
+> ok
+
+CREATE DOMAIN D3 D1;
+> ok
+
+CREATE TABLE TEST(ID INT PRIMARY KEY, S1 D1, S2 D2, S3 D3, C1 D1 ON UPDATE 4, C2 D2 ON UPDATE 5, C3 D3 ON UPDATE 6);
+> ok
+
+ALTER DOMAIN D1 SET ON UPDATE 3;
+> ok
+
+ALTER DOMAIN D1 DROP ON UPDATE;
+> ok
+
+SELECT DOMAIN_NAME, DOMAIN_ON_UPDATE FROM INFORMATION_SCHEMA.DOMAINS WHERE DOMAIN_SCHEMA = 'PUBLIC';
+> DOMAIN_NAME DOMAIN_ON_UPDATE
+> ----------- ----------------
+> D1          null
+> D2          2
+> D3          3
+> rows: 3
+
+SELECT COLUMN_NAME, COLUMN_ON_UPDATE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'PUBLIC';
+> COLUMN_NAME COLUMN_ON_UPDATE
+> ----------- ----------------
+> C1          4
+> C2          5
+> C3          6
+> ID          null
+> S1          3
+> S2          null
+> S3          null
+> rows: 7
+
+ALTER DOMAIN D1 SET ON UPDATE 3;
+> ok
+
+ALTER DOMAIN D3 DROP ON UPDATE;
+> ok
+
+ALTER TABLE TEST ALTER COLUMN S1 DROP ON UPDATE;
+> ok
+
+SELECT DOMAIN_NAME, DOMAIN_ON_UPDATE FROM INFORMATION_SCHEMA.DOMAINS WHERE DOMAIN_SCHEMA = 'PUBLIC';
+> DOMAIN_NAME DOMAIN_ON_UPDATE
+> ----------- ----------------
+> D1          3
+> D2          2
+> D3          null
+> rows: 3
+
+SELECT COLUMN_NAME, COLUMN_ON_UPDATE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'PUBLIC';
+> COLUMN_NAME COLUMN_ON_UPDATE
+> ----------- ----------------
+> C1          4
+> C2          5
+> C3          6
+> ID          null
+> S1          null
+> S2          null
+> S3          null
+> rows: 7
+
+DROP DOMAIN D1 CASCADE;
+> ok
+
+SELECT DOMAIN_NAME, DOMAIN_ON_UPDATE FROM INFORMATION_SCHEMA.DOMAINS WHERE DOMAIN_SCHEMA = 'PUBLIC';
+> DOMAIN_NAME DOMAIN_ON_UPDATE
+> ----------- ----------------
+> D2          2
+> D3          3
+> rows: 2
+
+SELECT COLUMN_NAME, COLUMN_ON_UPDATE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'PUBLIC';
+> COLUMN_NAME COLUMN_ON_UPDATE
+> ----------- ----------------
+> C1          4
+> C2          5
+> C3          6
+> ID          null
+> S1          3
+> S2          null
+> S3          null
+> rows: 7
+
+DROP TABLE TEST;
+> ok
+
+DROP DOMAIN D2;
+> ok
+
+DROP DOMAIN D3;
+> ok

--- a/h2/src/test/org/h2/test/scripts/ddl/createDomain.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/createDomain.sql
@@ -20,10 +20,10 @@ CREATE TABLE TEST(C1 S1.D1, C2 S2.D2);
 
 SELECT COLUMN_NAME, DOMAIN_CATALOG, DOMAIN_SCHEMA, DOMAIN_NAME, COLUMN_DEFAULT, COLUMN_TYPE, COLUMN_ON_UPDATE
     FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
-> COLUMN_NAME DOMAIN_CATALOG DOMAIN_SCHEMA DOMAIN_NAME COLUMN_DEFAULT COLUMN_TYPE                           COLUMN_ON_UPDATE
-> ----------- -------------- ------------- ----------- -------------- ------------------------------------- -----------------
-> C1          SCRIPT         S1            D1          1              "S1"."D1" DEFAULT 1                   null
-> C2          SCRIPT         S2            D2          null           "S2"."D2" ON UPDATE CURRENT_TIMESTAMP CURRENT_TIMESTAMP
+> COLUMN_NAME DOMAIN_CATALOG DOMAIN_SCHEMA DOMAIN_NAME COLUMN_DEFAULT COLUMN_TYPE COLUMN_ON_UPDATE
+> ----------- -------------- ------------- ----------- -------------- ----------- ----------------
+> C1          SCRIPT         S1            D1          null           "S1"."D1"   null
+> C2          SCRIPT         S2            D2          null           "S2"."D2"   null
 > rows (ordered): 2
 
 SELECT DOMAIN_CATALOG, DOMAIN_SCHEMA, DOMAIN_NAME, DOMAIN_DEFAULT, DOMAIN_ON_UPDATE, TYPE_NAME FROM INFORMATION_SCHEMA.DOMAINS;
@@ -176,7 +176,7 @@ SELECT DOMAIN_CATALOG, DOMAIN_SCHEMA, DOMAIN_NAME, DOMAIN_DEFAULT, DOMAIN_ON_UPD
 > -------------- ------------- ----------- -------------- ---------------- --------- --------- ----- --------- --------------------- -------------------- ------------------
 > SCRIPT         PUBLIC        D1          1              null             4         10        0     INTEGER   null                  null                 null
 > SCRIPT         PUBLIC        D2          2              null             4         10        0     INTEGER   SCRIPT                PUBLIC               D1
-> SCRIPT         PUBLIC        D3          1              null             4         10        0     INTEGER   SCRIPT                PUBLIC               D1
+> SCRIPT         PUBLIC        D3          null           null             4         10        0     INTEGER   SCRIPT                PUBLIC               D1
 > SCRIPT         PUBLIC        D4          4              null             4         10        0     INTEGER   SCRIPT                PUBLIC               D1
 > rows: 4
 

--- a/h2/src/test/org/h2/test/scripts/other/help.sql
+++ b/h2/src/test/org/h2/test/scripts/other/help.sql
@@ -16,11 +16,11 @@ HELP ABCDE EF_GH;
 HELP HELP;
 > ID SECTION          TOPIC SYNTAX                  TEXT
 > -- ---------------- ----- ----------------------- ----------------------------------------------------
-> 70 Commands (Other) HELP  HELP [ anything [...] ] Displays the help pages of SQL commands or keywords.
+> 71 Commands (Other) HELP  HELP [ anything [...] ] Displays the help pages of SQL commands or keywords.
 > rows: 1
 
 HELP he lp;
 > ID SECTION          TOPIC SYNTAX                  TEXT
 > -- ---------------- ----- ----------------------- ----------------------------------------------------
-> 70 Commands (Other) HELP  HELP [ anything [...] ] Displays the help pages of SQL commands or keywords.
+> 71 Commands (Other) HELP  HELP [ anything [...] ] Displays the help pages of SQL commands or keywords.
 > rows: 1

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -2167,18 +2167,18 @@ select * from test;
 
 select DOMAIN_NAME, DOMAIN_DEFAULT, DATA_TYPE, PRECISION, SCALE, TYPE_NAME, SELECTIVITY, REMARKS, SQL from information_schema.domains;
 > DOMAIN_NAME DOMAIN_DEFAULT DATA_TYPE PRECISION  SCALE TYPE_NAME SELECTIVITY REMARKS SQL
-> ----------- -------------- --------- ---------- ----- --------- ----------- ------- -------------------------------------------------------------------------
+> ----------- -------------- --------- ---------- ----- --------- ----------- ------- -----------------------------------------------------------------------
 > EMAIL       null           12        200        0     VARCHAR   50                  CREATE DOMAIN "PUBLIC"."EMAIL" AS VARCHAR(200)
 > GMAIL       '@gmail.com'   12        200        0     VARCHAR   50                  CREATE DOMAIN "PUBLIC"."GMAIL" AS "PUBLIC"."EMAIL" DEFAULT '@gmail.com'
 > STRING      ''             12        255        0     VARCHAR   50                  CREATE DOMAIN "PUBLIC"."STRING" AS VARCHAR(255) DEFAULT ''
 > STRING1     null           12        2147483647 0     VARCHAR   50                  CREATE DOMAIN "PUBLIC"."STRING1" AS VARCHAR
 > STRING2     '<empty>'      12        2147483647 0     VARCHAR   50                  CREATE DOMAIN "PUBLIC"."STRING2" AS VARCHAR DEFAULT '<empty>'
-> STRING_X    '<empty>'      12        2147483647 0     VARCHAR   50                  CREATE DOMAIN "PUBLIC"."STRING_X" AS "PUBLIC"."STRING2" DEFAULT '<empty>'
+> STRING_X    null           12        2147483647 0     VARCHAR   50                  CREATE DOMAIN "PUBLIC"."STRING_X" AS "PUBLIC"."STRING2"
 > rows: 6
 
 script nodata nopasswords nosettings;
 > SCRIPT
-> ------------------------------------------------------------------------------------------------------------------------------------------
+> -----------------------------------------------------------------------------------------------------------------
 > -- 1 +/- SELECT COUNT(*) FROM PUBLIC.ADDRESS;
 > -- 1 +/- SELECT COUNT(*) FROM PUBLIC.TEST;
 > ALTER DOMAIN "PUBLIC"."EMAIL" ADD CONSTRAINT "PUBLIC"."CONSTRAINT_3" CHECK(POSITION('@', VALUE) > 1) NOCHECK;
@@ -2189,9 +2189,9 @@ script nodata nopasswords nosettings;
 > CREATE DOMAIN "PUBLIC"."STRING" AS VARCHAR(255) DEFAULT '';
 > CREATE DOMAIN "PUBLIC"."STRING1" AS VARCHAR;
 > CREATE DOMAIN "PUBLIC"."STRING2" AS VARCHAR DEFAULT '<empty>';
-> CREATE DOMAIN "PUBLIC"."STRING_X" AS "PUBLIC"."STRING2" DEFAULT '<empty>';
-> CREATE MEMORY TABLE "PUBLIC"."ADDRESS"( "ID" INT NOT NULL, "NAME" "PUBLIC"."EMAIL", "NAME2" "PUBLIC"."GMAIL" DEFAULT '@gmail.com' );
-> CREATE MEMORY TABLE "PUBLIC"."TEST"( "A" "PUBLIC"."STRING" DEFAULT '', "B" "PUBLIC"."STRING1", "C" "PUBLIC"."STRING2" DEFAULT '<empty>' );
+> CREATE DOMAIN "PUBLIC"."STRING_X" AS "PUBLIC"."STRING2";
+> CREATE MEMORY TABLE "PUBLIC"."ADDRESS"( "ID" INT NOT NULL, "NAME" "PUBLIC"."EMAIL", "NAME2" "PUBLIC"."GMAIL" );
+> CREATE MEMORY TABLE "PUBLIC"."TEST"( "A" "PUBLIC"."STRING", "B" "PUBLIC"."STRING1", "C" "PUBLIC"."STRING2" );
 > CREATE USER IF NOT EXISTS "SA" PASSWORD '' ADMIN;
 > rows: 14
 


### PR DESCRIPTION
1. `ALTER DOMAIN SET DEFAULT` and `ALTER DOMAIN DROP DEFAULT` commands from the SQL Standard, and also similar non-standard `ON UPDATE` commands are implemented.

2. Default and on update expressions aren't initially copied any more to columns and child domains, parent expressions are used instead when columns or their domains don't have own ones. They are now copied only when domain or one of its expressions is dropped to columns and child domains that don't have own expressions.