### PR TITLE
`= ANY(array)` support

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3944,7 +3944,11 @@ public class Parser {
             operation.setOverCondition(readWindowNameOrSpecification());
             currentSelect.setWindowQuery();
         } else if (operation.isAggregate()) {
-            currentSelect.setGroupQuery();
+            // setGroupQuery for ANY(...) in CommandContainer
+            if (!(operation instanceof Aggregate) ||
+                    ((Aggregate) operation).getAggregateType() != AggregateType.ANY) {
+                currentSelect.setGroupQuery();
+            }
         } else {
             throw getSyntaxError();
         }

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -1179,4 +1179,14 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
         return distinct;
     }
 
+    @Override
+    public int getSubexpressionCount() {
+        return args.length;
+    }
+
+    @Override
+    public Expression getSubexpression(int index) {
+        return args[index];
+    }
+
 }

--- a/h2/src/main/org/h2/expression/condition/Comparison.java
+++ b/h2/src/main/org/h2/expression/condition/Comparison.java
@@ -152,7 +152,7 @@ public final class Comparison extends Condition {
                 	ArrayFunction func = new ArrayFunction(arr, left, null, ArrayFunction.ARRAY_CONTAINS);
                     return func.optimize(session);
                 }
-            } 
+            }
         }
         // TODO check row values too
         if (right.getType().getValueType() == Value.ARRAY && left.getType().getValueType() != Value.ARRAY) {

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/any.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/any.sql
@@ -31,3 +31,45 @@ SELECT TRUE = (ANY((SELECT X < 0 FROM SYSTEM_RANGE(1, 1))));
 > ----------------------------------------------------
 > FALSE
 > rows: 1
+
+-- test `value = ANY(array)`
+
+SELECT 1 = ANY(ARRAY[1, 2] || ARRAY[3, 4]);
+>> TRUE
+
+SELECT 0 = ANY(1 || ARRAY[2, 3] || 4);
+>> FALSE
+
+SELECT 0 = ANY(ARRAY[]);
+>> FALSE
+
+CREATE TABLE test_array (id INT PRIMARY KEY, val INT ARRAY);
+> ok
+
+INSERT INTO test_array (id, val) VALUES (1, ARRAY[2, 3]), (2, ARRAY[4, 6]);
+> update count: 2
+
+SELECT id, val FROM test_array WHERE 4 = ANY(test_array.val);
+> ID VAL
+> -- ------
+> 2  [4, 6]
+> rows: 1
+
+CREATE TABLE test_int (id INT PRIMARY KEY, val INT);
+> ok
+
+INSERT INTO test_int (id, val) VALUES (1, 1), (2, 6);
+> update count: 2
+
+SELECT i.id, i.val, a.id, a.val FROM test_int i, test_array a
+WHERE i.id = a.id AND i.val = ANY(a.val);
+> ID VAL ID VAL
+> -- --- -- ------
+> 2  6   2  [4, 6]
+> rows: 1
+
+DROP TABLE test_int;
+> ok
+
+DROP TABLE test_array;
+> ok


### PR DESCRIPTION
Mentioned in #2480 .

Convert `value = ANY(array)` to`ARRAY_CONTAINS(array, value)`, and this feature can allow some PostgreSQL clients to get PK/UK from `pg_constraint`, mentioned in #2450 .

The conversion is in `optimize` stage, but `Select.setGroupQuery` is in `parse` stage. If any `ANY` function detected, skip `setGroupQuery`. Then `setGroupQuery` for real aggregate `ANY` before execute query.