### PR TITLE
Reimplement getPrimaryKeys(), getBestRowIdentifier(), getIndexInfo() and others

### DIFF
--- a/h2/src/main/org/h2/command/CommandInterface.java
+++ b/h2/src/main/org/h2/command/CommandInterface.java
@@ -516,6 +516,11 @@ public interface CommandInterface extends AutoCloseable {
     int ALTER_DOMAIN_RENAME = 96;
 
     /**
+     * The type of a HELP statement.
+     */
+    int HELP = 97;
+
+    /**
      * Get command type.
      *
      * @return one of the constants above

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -178,6 +178,7 @@ import org.h2.command.dml.Delete;
 import org.h2.command.dml.ExecuteImmediate;
 import org.h2.command.dml.ExecuteProcedure;
 import org.h2.command.dml.Explain;
+import org.h2.command.dml.Help;
 import org.h2.command.dml.Insert;
 import org.h2.command.dml.Merge;
 import org.h2.command.dml.MergeUsing;
@@ -1569,24 +1570,12 @@ public class Parser {
     }
 
     private Prepared parseHelp() {
-        Select select = new Select(session, null);
-        select.setWildcard();
-        String informationSchema = database.sysIdentifier("INFORMATION_SCHEMA");
-        Table table = database.getSchema(informationSchema)
-                .resolveTableOrView(session, database.sysIdentifier("HELP"));
-        StringFunction1 function = new StringFunction1(new ExpressionColumn(database, informationSchema,
-                database.sysIdentifier("HELP"), database.sysIdentifier("TOPIC"), false), StringFunction1.UPPER);
-        TableFilter filter = new TableFilter(session, table, null, rightsChecked, select, 0, null);
-        select.addTableFilter(filter, true);
+        HashSet<String> conditions = new HashSet<>();
         while (currentTokenType != END_OF_INPUT) {
-            String s = currentToken;
+            conditions.add(StringUtils.toUpperEnglish(currentToken));
             read();
-            CompareLike like = new CompareLike(database, function, false, false,
-                    ValueExpression.get(ValueVarchar.get('%' + s + '%')), null, LikeType.LIKE);
-            select.addCondition(like);
         }
-        select.init();
-        return select;
+        return new Help(session, conditions.toArray(new String[0]));
     }
 
     private Prepared parseShow() {

--- a/h2/src/main/org/h2/command/dml/Help.java
+++ b/h2/src/main/org/h2/command/dml/Help.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.command.dml;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.sql.ResultSet;
+
+import org.h2.command.CommandInterface;
+import org.h2.command.Prepared;
+import org.h2.engine.Database;
+import org.h2.engine.Session;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionColumn;
+import org.h2.message.DbException;
+import org.h2.result.LocalResult;
+import org.h2.result.ResultInterface;
+import org.h2.table.Column;
+import org.h2.tools.Csv;
+import org.h2.util.Utils;
+import org.h2.value.TypeInfo;
+import org.h2.value.ValueInteger;
+import org.h2.value.ValueVarchar;
+
+/**
+ * This class represents the statement CALL.
+ */
+public class Help extends Prepared {
+
+    private final String[] conditions;
+
+    private final Expression[] expressions;
+
+    public Help(Session session, String[] conditions) {
+        super(session);
+        this.conditions = conditions;
+        Database db = session.getDatabase();
+        expressions = new Expression[] { //
+                new ExpressionColumn(db, new Column("ID", TypeInfo.TYPE_INTEGER)), //
+                new ExpressionColumn(db, new Column("SECTION", TypeInfo.TYPE_VARCHAR)), //
+                new ExpressionColumn(db, new Column("TOPIC", TypeInfo.TYPE_VARCHAR)), //
+                new ExpressionColumn(db, new Column("SYNTAX", TypeInfo.TYPE_VARCHAR)), //
+                new ExpressionColumn(db, new Column("TEXT", TypeInfo.TYPE_VARCHAR)), //
+        };
+    }
+
+    @Override
+    public ResultInterface queryMeta() {
+        LocalResult result = new LocalResult(session, expressions, 5, 5);
+        result.done();
+        return result;
+    }
+
+    @Override
+    public ResultInterface query(int maxrows) {
+        LocalResult result = new LocalResult(session, expressions, 5, 5);
+        try {
+            ResultSet rs = getTable();
+            loop: for (int i = 0; rs.next(); i++) {
+                String topic = rs.getString(2).trim();
+                for (String condition : conditions) {
+                    if (!topic.contains(condition)) {
+                        continue loop;
+                    }
+                }
+                result.addRow(
+                        // ID
+                        ValueInteger.get(i),
+                        // SECTION
+                        ValueVarchar.get(rs.getString(1).trim(), session),
+                        // TOPIC
+                        ValueVarchar.get(topic, session),
+                        // SYNTAX
+                        ValueVarchar.get(rs.getString(3).trim(), session),
+                        // TEXT
+                        ValueVarchar.get(rs.getString(4).trim(), session));
+            }
+        } catch (Exception e) {
+            throw DbException.convert(e);
+        }
+        result.done();
+        return result;
+    }
+
+    /**
+     * Returns HELP table.
+     *
+     * @return HELP table
+     * @throws IOException
+     *             on I/O exception
+     */
+    public static ResultSet getTable() throws IOException {
+        Reader reader = new InputStreamReader(new ByteArrayInputStream(Utils.getResource("/org/h2/res/help.csv")));
+        Csv csv = new Csv();
+        csv.setLineCommentCharacter('#');
+        return csv.read(reader, null);
+    }
+
+    @Override
+    public boolean isQuery() {
+        return true;
+    }
+
+    @Override
+    public boolean isTransactional() {
+        return true;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    public int getType() {
+        return CommandInterface.CALL;
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return true;
+    }
+
+}

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -132,7 +132,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * <li>SQL (String) the create table statement or NULL for systems tables.</li>
      * </ol>
      *
-     * @param catalogPattern null (to get all objects) or the catalog name
+     * @param catalog null (to get all objects) or the catalog name
      * @param schemaPattern null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
      * @param tableNamePattern null (to get all objects) or a table name
@@ -142,15 +142,15 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getTables(String catalogPattern, String schemaPattern,
-            String tableNamePattern, String[] types) throws SQLException {
+    public ResultSet getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types)
+            throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("getTables(" + quote(catalogPattern) + ", " +
+                debugCode("getTables(" + quote(catalog) + ", " +
                         quote(schemaPattern) + ", " + quote(tableNamePattern) +
                         ", " + quoteArray(types) + ");");
             }
-            return getResultSet(meta.getTables(catalogPattern, schemaPattern, tableNamePattern, types));
+            return getResultSet(meta.getTables(catalog, schemaPattern, tableNamePattern, types));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -188,7 +188,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * <li>IS_GENERATEDCOLUMN (String) "NO" or "YES"</li>
      * </ol>
      *
-     * @param catalogPattern null (to get all objects) or the catalog name
+     * @param catalog null (to get all objects) or the catalog name
      * @param schemaPattern null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
      * @param tableNamePattern null (to get all objects) or a table name
@@ -199,16 +199,16 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getColumns(String catalogPattern, String schemaPattern, String tableNamePattern,
+    public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern,
             String columnNamePattern) throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("getColumns(" + quote(catalogPattern)+", "
+                debugCode("getColumns(" + quote(catalog)+", "
                         +quote(schemaPattern)+", "
                         +quote(tableNamePattern)+", "
                         +quote(columnNamePattern)+");");
             }
-            return getResultSet(meta.getColumns(catalogPattern, schemaPattern, tableNamePattern, columnNamePattern));
+            return getResultSet(meta.getColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -238,26 +238,25 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * 2=NULLS_FIRST, 4=NULLS_LAST</li>
      * </ol>
      *
-     * @param catalogPattern null or the catalog name
-     * @param schemaPattern null (to get all objects) or a schema name
+     * @param catalog null or the catalog name
+     * @param schema null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
-     * @param tableName table name (must be specified)
+     * @param table table name (must be specified)
      * @param unique only unique indexes
      * @param approximate is ignored
      * @return the list of indexes and columns
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getIndexInfo(String catalogPattern, String schemaPattern,
-            String tableName, boolean unique, boolean approximate)
+    public ResultSet getIndexInfo(String catalog, String schema, String table, boolean unique, boolean approximate)
             throws SQLException {
         try {
             if (isDebugEnabled()) {
-                debugCode("getIndexInfo(" + quote(catalogPattern) + ", " +
-                        quote(schemaPattern) + ", " + quote(tableName) + ", " +
+                debugCode("getIndexInfo(" + quote(catalog) + ", " +
+                        quote(schema) + ", " + quote(table) + ", " +
                         unique + ", " + approximate + ");");
             }
-            return getResultSet(meta.getIndexInfo(catalogPattern, schemaPattern, tableName, unique, approximate));
+            return getResultSet(meta.getIndexInfo(catalog, schema, table, unique, approximate));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -276,24 +275,23 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * <li>PK_NAME (String) the name of the primary key index</li>
      * </ol>
      *
-     * @param catalogPattern null or the catalog name
-     * @param schemaPattern null (to get all objects) or a schema name
+     * @param catalog null or the catalog name
+     * @param schema null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
-     * @param tableName table name (must be specified)
+     * @param table table name (must be specified)
      * @return the list of primary key columns
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getPrimaryKeys(String catalogPattern,
-            String schemaPattern, String tableName) throws SQLException {
+    public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getPrimaryKeys("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableName)+");");
+                        +quote(catalog)+", "
+                        +quote(schema)+", "
+                        +quote(table)+");");
             }
-            return getResultSet(meta.getPrimaryKeys(catalogPattern, schemaPattern, tableName));
+            return getResultSet(meta.getPrimaryKeys(catalog, schema, table));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -452,7 +450,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * <li>SPECIFIC_NAME (String) name</li>
      * </ol>
      *
-     * @param catalogPattern null or the catalog name
+     * @param catalog null or the catalog name
      * @param schemaPattern null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
      * @param procedureNamePattern the procedure name pattern
@@ -460,16 +458,16 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getProcedures(String catalogPattern, String schemaPattern,
+    public ResultSet getProcedures(String catalog, String schemaPattern,
             String procedureNamePattern) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getProcedures("
-                        +quote(catalogPattern)+", "
+                        +quote(catalog)+", "
                         +quote(schemaPattern)+", "
                         +quote(procedureNamePattern)+");");
             }
-            return getResultSet(meta.getProcedures(catalogPattern, schemaPattern, procedureNamePattern));
+            return getResultSet(meta.getProcedures(catalog, schemaPattern, procedureNamePattern));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -508,7 +506,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * <li>SPECIFIC_NAME (String) name</li>
      * </ol>
      *
-     * @param catalogPattern null or the catalog name
+     * @param catalog null or the catalog name
      * @param schemaPattern null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
      * @param procedureNamePattern the procedure name pattern
@@ -517,19 +515,19 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getProcedureColumns(String catalogPattern, String schemaPattern, String procedureNamePattern,
+    public ResultSet getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern,
             String columnNamePattern) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getProcedureColumns("
-                        +quote(catalogPattern)+", "
+                        +quote(catalog)+", "
                         +quote(schemaPattern)+", "
                         +quote(procedureNamePattern)+", "
                         +quote(columnNamePattern)+");");
             }
             checkClosed();
             return getResultSet(
-                    meta.getProcedureColumns(catalogPattern, schemaPattern, procedureNamePattern, columnNamePattern));
+                    meta.getProcedureColumns(catalog, schemaPattern, procedureNamePattern, columnNamePattern));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -615,8 +613,8 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * others</li>
      * </ol>
      *
-     * @param catalogPattern null (to get all objects) or the catalog name
-     * @param schemaPattern null (to get all objects) or a schema name
+     * @param catalog null (to get all objects) or the catalog name
+     * @param schema null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
      * @param table a table name (uppercase for unquoted names)
      * @param columnNamePattern null (to get all objects) or a column name
@@ -625,18 +623,17 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getColumnPrivileges(String catalogPattern,
-            String schemaPattern, String table, String columnNamePattern)
+    public ResultSet getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern)
             throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getColumnPrivileges("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
+                        +quote(catalog)+", "
+                        +quote(schema)+", "
                         +quote(table)+", "
                         +quote(columnNamePattern)+");");
             }
-            return getResultSet(meta.getColumnPrivileges(catalogPattern, schemaPattern, table, columnNamePattern));
+            return getResultSet(meta.getColumnPrivileges(catalog, schema, table, columnNamePattern));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -658,7 +655,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * others</li>
      * </ol>
      *
-     * @param catalogPattern null (to get all objects) or the catalog name
+     * @param catalog null (to get all objects) or the catalog name
      * @param schemaPattern null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
      * @param tableNamePattern null (to get all objects) or a table name
@@ -667,17 +664,17 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getTablePrivileges(String catalogPattern,
-            String schemaPattern, String tableNamePattern) throws SQLException {
+    public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern)
+            throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getTablePrivileges("
-                        +quote(catalogPattern)+", "
+                        +quote(catalog)+", "
                         +quote(schemaPattern)+", "
                         +quote(tableNamePattern)+");");
             }
             checkClosed();
-            return getResultSet(meta.getTablePrivileges(catalogPattern, schemaPattern, tableNamePattern));
+            return getResultSet(meta.getTablePrivileges(catalog, schemaPattern, tableNamePattern));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -699,27 +696,27 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * <li>PSEUDO_COLUMN (short) (always bestRowNotPseudo)</li>
      * </ol>
      *
-     * @param catalogPattern null (to get all objects) or the catalog name
-     * @param schemaPattern null (to get all objects) or a schema name
+     * @param catalog null (to get all objects) or the catalog name
+     * @param schema null (to get all objects) or a schema name
      *            (uppercase for unquoted names)
-     * @param tableName table name (must be specified)
+     * @param table table name (must be specified)
      * @param scope ignored
      * @param nullable ignored
      * @return the primary key index
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getBestRowIdentifier(String catalogPattern, String schemaPattern, String tableName, int scope,
-            boolean nullable) throws SQLException {
+    public ResultSet getBestRowIdentifier(String catalog, String schema, String table, int scope, boolean nullable)
+            throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getBestRowIdentifier("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableName)+", "
+                        +quote(catalog)+", "
+                        +quote(schema)+", "
+                        +quote(table)+", "
                         +scope+", "+nullable+");");
             }
-            return getResultSet(meta.getBestRowIdentifier(catalogPattern, schemaPattern, tableName, scope, nullable));
+            return getResultSet(meta.getBestRowIdentifier(catalog, schema, table, scope, nullable));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -743,21 +740,20 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      *
      * @param catalog null (to get all objects) or the catalog name
      * @param schema null (to get all objects) or a schema name
-     * @param tableName table name (must be specified)
+     * @param table table name (must be specified)
      * @return an empty result set
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getVersionColumns(String catalog, String schema,
-            String tableName) throws SQLException {
+    public ResultSet getVersionColumns(String catalog, String schema, String table) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getVersionColumns("
                         +quote(catalog)+", "
                         +quote(schema)+", "
-                        +quote(tableName)+");");
+                        +quote(table)+");");
             }
-            return getResultSet(meta.getVersionColumns(catalog, schema, tableName));
+            return getResultSet(meta.getVersionColumns(catalog, schema, table));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -788,23 +784,22 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * importedKeyNotDeferrable)</li>
      * </ol>
      *
-     * @param catalogPattern null (to get all objects) or the catalog name
-     * @param schemaPattern the schema name of the foreign table
-     * @param tableName the name of the foreign table
+     * @param catalog null (to get all objects) or the catalog name
+     * @param schema the schema name of the foreign table
+     * @param table the name of the foreign table
      * @return the result set
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getImportedKeys(String catalogPattern,
-            String schemaPattern, String tableName) throws SQLException {
+    public ResultSet getImportedKeys(String catalog, String schema, String table) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getImportedKeys("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableName)+");");
+                        +quote(catalog)+", "
+                        +quote(schema)+", "
+                        +quote(table)+");");
             }
-            return getResultSet(meta.getImportedKeys(catalogPattern, schemaPattern, tableName));
+            return getResultSet(meta.getImportedKeys(catalog, schema, table));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -835,23 +830,22 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * importedKeyNotDeferrable)</li>
      * </ol>
      *
-     * @param catalogPattern null or the catalog name
-     * @param schemaPattern the schema name of the primary table
-     * @param tableName the name of the primary table
+     * @param catalog null or the catalog name
+     * @param schema the schema name of the primary table
+     * @param table the name of the primary table
      * @return the result set
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getExportedKeys(String catalogPattern,
-            String schemaPattern, String tableName) throws SQLException {
+    public ResultSet getExportedKeys(String catalog, String schema, String table) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getExportedKeys("
-                        +quote(catalogPattern)+", "
-                        +quote(schemaPattern)+", "
-                        +quote(tableName)+");");
+                        +quote(catalog)+", "
+                        +quote(schema)+", "
+                        +quote(table)+");");
             }
-            return getResultSet(meta.getExportedKeys(catalogPattern, schemaPattern, tableName));
+            return getResultSet(meta.getExportedKeys(catalog, schema, table));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -883,33 +877,32 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * importedKeyNotDeferrable)</li>
      * </ol>
      *
-     * @param primaryCatalogPattern null or the catalog name
-     * @param primarySchemaPattern the schema name of the primary table
+     * @param primaryCatalog null or the catalog name
+     * @param primarySchema the schema name of the primary table
      *          (optional)
      * @param primaryTable the name of the primary table (must be specified)
-     * @param foreignCatalogPattern null or the catalog name
-     * @param foreignSchemaPattern the schema name of the foreign table
+     * @param foreignCatalog null or the catalog name
+     * @param foreignSchema the schema name of the foreign table
      *          (optional)
      * @param foreignTable the name of the foreign table (must be specified)
      * @return the result set
      * @throws SQLException if the connection is closed
      */
     @Override
-    public ResultSet getCrossReference(String primaryCatalogPattern,
-            String primarySchemaPattern, String primaryTable, String foreignCatalogPattern,
-            String foreignSchemaPattern, String foreignTable) throws SQLException {
+    public ResultSet getCrossReference(String primaryCatalog, String primarySchema, String primaryTable,
+            String foreignCatalog, String foreignSchema, String foreignTable) throws SQLException {
         try {
             if (isDebugEnabled()) {
                 debugCode("getCrossReference("
-                        +quote(primaryCatalogPattern)+", "
-                        +quote(primarySchemaPattern)+", "
+                        +quote(primaryCatalog)+", "
+                        +quote(primarySchema)+", "
                         +quote(primaryTable)+", "
-                        +quote(foreignCatalogPattern)+", "
-                        +quote(foreignSchemaPattern)+", "
+                        +quote(foreignCatalog)+", "
+                        +quote(foreignSchema)+", "
                         +quote(foreignTable)+");");
             }
-            return getResultSet(meta.getCrossReference(primaryCatalogPattern, primarySchemaPattern, primaryTable,
-                    foreignCatalogPattern, foreignSchemaPattern, foreignTable));
+            return getResultSet(meta.getCrossReference(primaryCatalog, primarySchema, primaryTable, foreignCatalog,
+                    foreignSchema, foreignTable));
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -227,15 +227,16 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      * <li>NON_UNIQUE (boolean) 'true' if non-unique</li>
      * <li>INDEX_QUALIFIER (String) index catalog</li>
      * <li>INDEX_NAME (String) index name</li>
-     * <li>TYPE (short) the index type (always tableIndexOther)</li>
+     * <li>TYPE (short) the index type (tableIndexOther or tableIndexHash for
+     * unique indexes on non-nullable columns, tableIndexStatistics for other
+     * indexes)</li>
      * <li>ORDINAL_POSITION (short) column index (1, 2, ...)</li>
      * <li>COLUMN_NAME (String) column name</li>
      * <li>ASC_OR_DESC (String) ascending or descending (always 'A')</li>
-     * <li>CARDINALITY (int) numbers of unique values</li>
-     * <li>PAGES (int) number of pages use (always 0)</li>
+     * <li>CARDINALITY (long) number of rows or numbers of unique values for
+     * unique indexes on non-nullable columns</li>
+     * <li>PAGES (long) number of pages use</li>
      * <li>FILTER_CONDITION (String) filter condition (always empty)</li>
-     * <li>SORT_TYPE (int) the sort type bit map: 1=DESCENDING,
-     * 2=NULLS_FIRST, 4=NULLS_LAST</li>
      * </ol>
      *
      * @param catalog null or the catalog name
@@ -243,7 +244,7 @@ public class JdbcDatabaseMetaData extends TraceObject implements
      *            (uppercase for unquoted names)
      * @param table table name (must be specified)
      * @param unique only unique indexes
-     * @param approximate is ignored
+     * @param approximate if true, return fast, but approximate CARDINALITY
      * @return the list of indexes and columns
      * @throws SQLException if the connection is closed
      */

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMeta.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMeta.java
@@ -73,8 +73,7 @@ public abstract class DatabaseMeta {
      *
      * @see java.sql.DatabaseMetaData#getProcedures(String, String, String)
      */
-    public abstract ResultInterface getProcedures(String catalogPattern, String schemaPattern,
-            String procedureNamePattern);
+    public abstract ResultInterface getProcedures(String catalog, String schemaPattern, String procedureNamePattern);
 
     /**
      * INTERNAL
@@ -82,7 +81,7 @@ public abstract class DatabaseMeta {
      * @see java.sql.DatabaseMetaData#getProcedureColumns(String, String,
      *      String, String)
      */
-    public abstract ResultInterface getProcedureColumns(String catalogPattern, String schemaPattern,
+    public abstract ResultInterface getProcedureColumns(String catalog, String schemaPattern,
             String procedureNamePattern, String columnNamePattern);
 
     /**
@@ -91,7 +90,7 @@ public abstract class DatabaseMeta {
      * @see java.sql.DatabaseMetaData#getTables(String, String, String,
      *      String[])
      */
-    public abstract ResultInterface getTables(String catalogPattern, String schemaPattern, String tableNamePattern,
+    public abstract ResultInterface getTables(String catalog, String schemaPattern, String tableNamePattern,
             String[] types);
 
     /**
@@ -120,7 +119,7 @@ public abstract class DatabaseMeta {
      *
      * @see java.sql.DatabaseMetaData#getColumns(String, String, String, String)
      */
-    public abstract ResultInterface getColumns(String catalogPattern, String schemaPattern, String tableNamePattern,
+    public abstract ResultInterface getColumns(String catalog, String schemaPattern, String tableNamePattern,
             String columnNamePattern);
 
     /**
@@ -129,7 +128,7 @@ public abstract class DatabaseMeta {
      * @see java.sql.DatabaseMetaData#getColumnPrivileges(String, String,
      *      String, String)
      */
-    public abstract ResultInterface getColumnPrivileges(String catalogPattern, String schemaPattern, String table,
+    public abstract ResultInterface getColumnPrivileges(String catalog, String schema, String table,
             String columnNamePattern);
 
     /**
@@ -137,8 +136,7 @@ public abstract class DatabaseMeta {
      *
      * @see java.sql.DatabaseMetaData#getTablePrivileges(String, String, String)
      */
-    public abstract ResultInterface getTablePrivileges(String catalogPattern, String schemaPattern,
-            String tableNamePattern);
+    public abstract ResultInterface getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern);
 
     /**
      * INTERNAL
@@ -154,28 +152,28 @@ public abstract class DatabaseMeta {
      *
      * @see java.sql.DatabaseMetaData#getVersionColumns(String, String, String)
      */
-    public abstract ResultInterface getVersionColumns(String catalog, String schema, String tableName);
+    public abstract ResultInterface getVersionColumns(String catalog, String schema, String table);
 
     /**
      * INTERNAL
      *
      * @see java.sql.DatabaseMetaData#getPrimaryKeys(String, String, String)
      */
-    public abstract ResultInterface getPrimaryKeys(String catalogPattern, String schemaPattern, String tableName);
+    public abstract ResultInterface getPrimaryKeys(String catalog, String schema, String table);
 
     /**
      * INTERNAL
      *
      * @see java.sql.DatabaseMetaData#getImportedKeys(String, String, String)
      */
-    public abstract ResultInterface getImportedKeys(String catalogPattern, String schemaPattern, String tableName);
+    public abstract ResultInterface getImportedKeys(String catalog, String schema, String table);
 
     /**
      * INTERNAL
      *
      * @see java.sql.DatabaseMetaData#getExportedKeys(String, String, String)
      */
-    public abstract ResultInterface getExportedKeys(String catalogPattern, String schemaPattern, String tableName);
+    public abstract ResultInterface getExportedKeys(String catalog, String schema, String table);
 
     /**
      * INTERNAL
@@ -183,8 +181,8 @@ public abstract class DatabaseMeta {
      * @see java.sql.DatabaseMetaData#getCrossReference(String, String, String,
      *      String, String, String)
      */
-    public abstract ResultInterface getCrossReference(String primaryCatalogPattern, String primarySchemaPattern,
-            String primaryTable, String foreignCatalogPattern, String foreignSchemaPattern, String foreignTable);
+    public abstract ResultInterface getCrossReference(String primaryCatalog, String primarySchema, String primaryTable,
+            String foreignCatalog, String foreignSchema, String foreignTable);
 
     /**
      * INTERNAL
@@ -199,8 +197,8 @@ public abstract class DatabaseMeta {
      * @see java.sql.DatabaseMetaData#getIndexInfo(String, String, String,
      *      boolean, boolean)
      */
-    public abstract ResultInterface getIndexInfo(String catalogPattern, String schemaPattern, String tableName,
-            boolean unique, boolean approximate);
+    public abstract ResultInterface getIndexInfo(String catalog, String schema, String table, boolean unique,
+            boolean approximate);
 
     /**
      * INTERNAL
@@ -251,7 +249,7 @@ public abstract class DatabaseMeta {
      *
      * @see java.sql.DatabaseMetaData#getSchemas(String, String)
      */
-    public abstract ResultInterface getSchemas(String catalogPattern, String schemaPattern);
+    public abstract ResultInterface getSchemas(String catalog, String schemaPattern);
 
     /**
      * INTERNAL

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLegacy.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLegacy.java
@@ -111,7 +111,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
     }
 
     @Override
-    public ResultInterface getProcedures(String catalogPattern, String schemaPattern, String procedureNamePattern) {
+    public ResultInterface getProcedures(String catalog, String schemaPattern, String procedureNamePattern) {
         return executeQuery("SELECT " //
                 + "ALIAS_CATALOG PROCEDURE_CAT, " //
                 + "ALIAS_SCHEMA PROCEDURE_SCHEM, " //
@@ -127,15 +127,15 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND ALIAS_SCHEMA LIKE ?2 ESCAPE ?4 " //
                 + "AND ALIAS_NAME LIKE ?3 ESCAPE ?4 " //
                 + "ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, NUM_INPUT_PARAMS", //
-                getCatalogPattern(catalogPattern), //
+                getCatalogPattern(catalog), //
                 getSchemaPattern(schemaPattern), //
                 getPattern(procedureNamePattern), //
                 BACKSLASH);
     }
 
     @Override
-    public ResultInterface getProcedureColumns(String catalogPattern, String schemaPattern, //
-            String procedureNamePattern, String columnNamePattern) {
+    public ResultInterface getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern,
+            String columnNamePattern) {
         return executeQuery("SELECT " //
                 + "ALIAS_CATALOG PROCEDURE_CAT, " //
                 + "ALIAS_SCHEMA PROCEDURE_SCHEM, " //
@@ -164,7 +164,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND COLUMN_NAME LIKE ?5 ESCAPE ?6 " //
                 + "ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, ORDINAL_POSITION", //
                 YES, //
-                getCatalogPattern(catalogPattern), //
+                getCatalogPattern(catalog), //
                 getSchemaPattern(schemaPattern), //
                 getPattern(procedureNamePattern), //
                 getPattern(columnNamePattern), //
@@ -172,8 +172,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
     }
 
     @Override
-    public ResultInterface getTables(String catalogPattern, String schemaPattern, String tableNamePattern,
-            String[] types) {
+    public ResultInterface getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types) {
         int typesLength = types != null ? types.length : 0;
         boolean includeSynonyms = hasSynonyms() && (types == null || Arrays.asList(types).contains("SYNONYM"));
         // (1024 - 16) is enough for the most cases
@@ -240,7 +239,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
             select.append(')');
         }
         Value[] args = new Value[typesLength + 4];
-        args[0] = getCatalogPattern(catalogPattern);
+        args[0] = getCatalogPattern(catalog);
         args[1] = getSchemaPattern(schemaPattern);
         args[2] = getPattern(tableNamePattern);
         args[3] = BACKSLASH;
@@ -274,7 +273,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
     }
 
     @Override
-    public ResultInterface getColumns(String catalogPattern, String schemaPattern, String tableNamePattern,
+    public ResultInterface getColumns(String catalog, String schemaPattern, String tableNamePattern,
             String columnNamePattern) {
         boolean includeSynonyms = hasSynonyms();
         StringBuilder select = new StringBuilder(2432);
@@ -379,7 +378,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
         return executeQuery(select.append(" ORDER BY TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION").toString(), //
                 NO, //
                 YES, //
-                getCatalogPattern(catalogPattern), //
+                getCatalogPattern(catalog), //
                 getSchemaPattern(schemaPattern), //
                 getPattern(tableNamePattern), //
                 getPattern(columnNamePattern), //
@@ -387,8 +386,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
     }
 
     @Override
-    public ResultInterface getColumnPrivileges(String catalogPattern, String schemaPattern, String table,
-            String columnNamePattern) {
+    public ResultInterface getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern) {
         return executeQuery("SELECT " //
                 + "TABLE_CATALOG TABLE_CAT, " //
                 + "TABLE_SCHEMA TABLE_SCHEM, " //
@@ -404,15 +402,15 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND TABLE_NAME = ?3 " //
                 + "AND COLUMN_NAME LIKE ?4 ESCAPE ?5 " //
                 + "ORDER BY COLUMN_NAME, PRIVILEGE", //
-                getCatalogPattern(catalogPattern), //
-                getSchemaPattern(schemaPattern), //
+                getCatalogPattern(catalog), //
+                getSchemaPattern(schema), //
                 getString(table), //
                 getPattern(columnNamePattern), //
                 BACKSLASH);
     }
 
     @Override
-    public ResultInterface getTablePrivileges(String catalogPattern, String schemaPattern, String tableNamePattern) {
+    public ResultInterface getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern) {
         return executeQuery("SELECT " //
                 + "TABLE_CATALOG TABLE_CAT, " //
                 + "TABLE_SCHEMA TABLE_SCHEM, " //
@@ -426,7 +424,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND TABLE_SCHEMA LIKE ?2 ESCAPE ?4 " //
                 + "AND TABLE_NAME LIKE ?3 ESCAPE ?4 " //
                 + "ORDER BY TABLE_SCHEM, TABLE_NAME, PRIVILEGE", //
-                getCatalogPattern(catalogPattern), //
+                getCatalogPattern(catalog), //
                 getSchemaPattern(schemaPattern), //
                 getPattern(tableNamePattern), //
                 BACKSLASH);
@@ -464,7 +462,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
     }
 
     @Override
-    public ResultInterface getPrimaryKeys(String catalogPattern, String schemaPattern, String tableName) {
+    public ResultInterface getPrimaryKeys(String catalog, String schema, String table) {
         return executeQuery("SELECT " //
                 + "TABLE_CATALOG TABLE_CAT, " //
                 + "TABLE_SCHEMA TABLE_SCHEM, " //
@@ -478,14 +476,14 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND TABLE_NAME = ?3 " //
                 + "AND PRIMARY_KEY = TRUE " //
                 + "ORDER BY COLUMN_NAME", //
-                getCatalogPattern(catalogPattern), //
-                getSchemaPattern(schemaPattern), //
-                getString(tableName), //
+                getCatalogPattern(catalog), //
+                getSchemaPattern(schema), //
+                getString(table), //
                 BACKSLASH);
     }
 
     @Override
-    public ResultInterface getImportedKeys(String catalogPattern, String schemaPattern, String tableName) {
+    public ResultInterface getImportedKeys(String catalog, String schema, String table) {
         return executeQuery("SELECT " //
                 + "PKTABLE_CATALOG PKTABLE_CAT, " //
                 + "PKTABLE_SCHEMA PKTABLE_SCHEM, " //
@@ -506,14 +504,14 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND FKTABLE_SCHEMA LIKE ?2 ESCAPE ?4 " //
                 + "AND FKTABLE_NAME = ?3 " //
                 + "ORDER BY PKTABLE_CAT, PKTABLE_SCHEM, PKTABLE_NAME, FK_NAME, KEY_SEQ", //
-                getCatalogPattern(catalogPattern), //
-                getSchemaPattern(schemaPattern), //
-                getString(tableName), //
+                getCatalogPattern(catalog), //
+                getSchemaPattern(schema), //
+                getString(table), //
                 BACKSLASH);
     }
 
     @Override
-    public ResultInterface getExportedKeys(String catalogPattern, String schemaPattern, String tableName) {
+    public ResultInterface getExportedKeys(String catalog, String schema, String table) {
         return executeQuery("SELECT " //
                 + "PKTABLE_CATALOG PKTABLE_CAT, " //
                 + "PKTABLE_SCHEMA PKTABLE_SCHEM, " //
@@ -534,15 +532,15 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND PKTABLE_SCHEMA LIKE ?2 ESCAPE ?4 " //
                 + "AND PKTABLE_NAME = ?3 " //
                 + "ORDER BY FKTABLE_CAT, FKTABLE_SCHEM, FKTABLE_NAME, FK_NAME, KEY_SEQ", //
-                getCatalogPattern(catalogPattern), //
-                getSchemaPattern(schemaPattern), //
-                getString(tableName), //
+                getCatalogPattern(catalog), //
+                getSchemaPattern(schema), //
+                getString(table), //
                 BACKSLASH);
     }
 
     @Override
-    public ResultInterface getCrossReference(String primaryCatalogPattern, String primarySchemaPattern,
-            String primaryTable, String foreignCatalogPattern, String foreignSchemaPattern, String foreignTable) {
+    public ResultInterface getCrossReference(String primaryCatalog, String primarySchema, String primaryTable,
+            String foreignCatalog, String foreignSchema, String foreignTable) {
         return executeQuery("SELECT " //
                 + "PKTABLE_CATALOG PKTABLE_CAT, " //
                 + "PKTABLE_SCHEMA PKTABLE_SCHEM, " //
@@ -566,11 +564,11 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND FKTABLE_SCHEMA LIKE ?5 ESCAPE ?7 " //
                 + "AND FKTABLE_NAME = ?6 " //
                 + "ORDER BY FKTABLE_CAT, FKTABLE_SCHEM, FKTABLE_NAME, FK_NAME, KEY_SEQ", //
-                getCatalogPattern(primaryCatalogPattern), //
-                getSchemaPattern(primarySchemaPattern), //
+                getCatalogPattern(primaryCatalog), //
+                getSchemaPattern(primarySchema), //
                 getString(primaryTable), //
-                getCatalogPattern(foreignCatalogPattern), //
-                getSchemaPattern(foreignSchemaPattern), //
+                getCatalogPattern(foreignCatalog), //
+                getSchemaPattern(foreignSchema), //
                 getString(foreignTable), //
                 BACKSLASH);
     }
@@ -601,7 +599,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
     }
 
     @Override
-    public ResultInterface getIndexInfo(String catalogPattern, String schemaPattern, String tableName, boolean unique,
+    public ResultInterface getIndexInfo(String catalog, String schema, String table, boolean unique,
             boolean approximate) {
         String uniqueCondition = unique ? "NON_UNIQUE=FALSE" : "TRUE";
         return executeQuery("SELECT " //
@@ -626,14 +624,14 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "AND (" + uniqueCondition + ") " //
                 + "AND TABLE_NAME = ?3 " //
                 + "ORDER BY NON_UNIQUE, TYPE, TABLE_SCHEM, INDEX_NAME, ORDINAL_POSITION", //
-                getCatalogPattern(catalogPattern), //
-                getSchemaPattern(schemaPattern), //
-                getString(tableName), //
+                getCatalogPattern(catalog), //
+                getSchemaPattern(schema), //
+                getString(table), //
                 BACKSLASH);
     }
 
     @Override
-    public ResultInterface getSchemas(String catalogPattern, String schemaPattern) {
+    public ResultInterface getSchemas(String catalog, String schemaPattern) {
         return executeQuery("SELECT " //
                 + "SCHEMA_NAME TABLE_SCHEM, " //
                 + "CATALOG_NAME TABLE_CATALOG " //
@@ -641,7 +639,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "WHERE CATALOG_NAME LIKE ?1 ESCAPE ?3 " //
                 + "AND SCHEMA_NAME LIKE ?2 ESCAPE ?3 " //
                 + "ORDER BY SCHEMA_NAME", //
-                getCatalogPattern(catalogPattern), //
+                getCatalogPattern(catalog), //
                 getSchemaPattern(schemaPattern), //
                 BACKSLASH);
     }

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocal.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocal.java
@@ -592,7 +592,7 @@ public final class DatabaseMetaLocal extends DatabaseMetaLocalBase {
                 }
             }
         }
-        result.sortRows(new SortOrder(session, new int[] { 3 }, new int[0], null));
+        result.sortRows(new SortOrder(session, new int[] { 3 }, new int[1], null));
         return result;
     }
 

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocalBase.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocalBase.java
@@ -27,7 +27,7 @@ abstract class DatabaseMetaLocalBase extends DatabaseMeta {
     }
 
     @Override
-    public final ResultInterface getVersionColumns(String catalog, String schema, String tableName) {
+    public final ResultInterface getVersionColumns(String catalog, String schema, String table) {
         checkClosed();
         SimpleResult result = new SimpleResult();
         result.addColumn("SCOPE", TypeInfo.TYPE_SMALLINT);

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaRemote.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaRemote.java
@@ -163,23 +163,22 @@ public class DatabaseMetaRemote extends DatabaseMeta {
     }
 
     @Override
-    public ResultInterface getProcedures(String catalogPattern, String schemaPattern, String procedureNamePattern) {
-        return executeQuery(GET_PROCEDURES_3, getString(catalogPattern), getString(schemaPattern),
+    public ResultInterface getProcedures(String catalog, String schemaPattern, String procedureNamePattern) {
+        return executeQuery(GET_PROCEDURES_3, getString(catalog), getString(schemaPattern),
                 getString(procedureNamePattern));
     }
 
     @Override
-    public ResultInterface getProcedureColumns(String catalogPattern, String schemaPattern, //
-            String procedureNamePattern, String columnNamePattern) {
-        return executeQuery(GET_PROCEDURE_COLUMNS_4, getString(catalogPattern), getString(schemaPattern),
+    public ResultInterface getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern,
+            String columnNamePattern) {
+        return executeQuery(GET_PROCEDURE_COLUMNS_4, getString(catalog), getString(schemaPattern),
                 getString(procedureNamePattern), getString(columnNamePattern));
     }
 
     @Override
-    public ResultInterface getTables(String catalogPattern, String schemaPattern, String tableNamePattern,
-            String[] types) {
-        return executeQuery(GET_TABLES_4, getString(catalogPattern), getString(schemaPattern),
-                getString(tableNamePattern), getStringArray(types));
+    public ResultInterface getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types) {
+        return executeQuery(GET_TABLES_4, getString(catalog), getString(schemaPattern), getString(tableNamePattern),
+                getStringArray(types));
     }
 
     @Override
@@ -198,61 +197,56 @@ public class DatabaseMetaRemote extends DatabaseMeta {
     }
 
     @Override
-    public ResultInterface getColumns(String catalogPattern, String schemaPattern, String tableNamePattern,
+    public ResultInterface getColumns(String catalog, String schemaPattern, String tableNamePattern,
             String columnNamePattern) {
-        return executeQuery(GET_COLUMNS_4, getString(catalogPattern), getString(schemaPattern),
-                getString(tableNamePattern), getString(columnNamePattern));
+        return executeQuery(GET_COLUMNS_4, getString(catalog), getString(schemaPattern), getString(tableNamePattern),
+                getString(columnNamePattern));
     }
 
     @Override
-    public ResultInterface getColumnPrivileges(String catalogPattern, String schemaPattern, String table,
-            String columnNamePattern) {
-        return executeQuery(GET_COLUMN_PRIVILEGES_4, getString(catalogPattern), getString(schemaPattern),
-                getString(table), getString(columnNamePattern));
+    public ResultInterface getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern) {
+        return executeQuery(GET_COLUMN_PRIVILEGES_4, getString(catalog), getString(schema), getString(table),
+                getString(columnNamePattern));
     }
 
     @Override
-    public ResultInterface getTablePrivileges(String catalogPattern, String schemaPattern, String tableNamePattern) {
-        return executeQuery(GET_TABLE_PRIVILEGES_3, getString(catalogPattern), getString(schemaPattern),
+    public ResultInterface getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern) {
+        return executeQuery(GET_TABLE_PRIVILEGES_3, getString(catalog), getString(schemaPattern), //
                 getString(tableNamePattern));
     }
 
     @Override
-    public ResultInterface getBestRowIdentifier(String catalogPattern, String schemaPattern, String tableName,
-            int scope, boolean nullable) {
-        return executeQuery(GET_BEST_ROW_IDENTIFIER_5, getString(catalogPattern), getString(schemaPattern),
-                getString(tableName), ValueInteger.get(scope), ValueBoolean.get(nullable));
+    public ResultInterface getBestRowIdentifier(String catalog, String schema, String table, int scope,
+            boolean nullable) {
+        return executeQuery(GET_BEST_ROW_IDENTIFIER_5, getString(catalog), getString(schema), getString(table),
+                ValueInteger.get(scope), ValueBoolean.get(nullable));
     }
 
     @Override
-    public ResultInterface getVersionColumns(String catalog, String schema, String tableName) {
-        return executeQuery(GET_VERSION_COLUMNS_3, getString(catalog), getString(schema), getString(tableName));
+    public ResultInterface getVersionColumns(String catalog, String schema, String table) {
+        return executeQuery(GET_VERSION_COLUMNS_3, getString(catalog), getString(schema), getString(table));
     }
 
     @Override
-    public ResultInterface getPrimaryKeys(String catalogPattern, String schemaPattern, String tableName) {
-        return executeQuery(GET_PRIMARY_KEYS_3, getString(catalogPattern), getString(schemaPattern),
-                getString(tableName));
+    public ResultInterface getPrimaryKeys(String catalog, String schema, String table) {
+        return executeQuery(GET_PRIMARY_KEYS_3, getString(catalog), getString(schema), getString(table));
     }
 
     @Override
-    public ResultInterface getImportedKeys(String catalogPattern, String schemaPattern, String tableName) {
-        return executeQuery(GET_IMPORTED_KEYS_3, getString(catalogPattern), getString(schemaPattern),
-                getString(tableName));
+    public ResultInterface getImportedKeys(String catalog, String schema, String table) {
+        return executeQuery(GET_IMPORTED_KEYS_3, getString(catalog), getString(schema), getString(table));
     }
 
     @Override
-    public ResultInterface getExportedKeys(String catalogPattern, String schemaPattern, String tableName) {
-        return executeQuery(GET_EXPORTED_KEYS_3, getString(catalogPattern), getString(schemaPattern),
-                getString(tableName));
+    public ResultInterface getExportedKeys(String catalog, String schema, String table) {
+        return executeQuery(GET_EXPORTED_KEYS_3, getString(catalog), getString(schema), getString(table));
     }
 
     @Override
-    public ResultInterface getCrossReference(String primaryCatalogPattern, String primarySchemaPattern,
-            String primaryTable, String foreignCatalogPattern, String foreignSchemaPattern, String foreignTable) {
-        return executeQuery(GET_CROSS_REFERENCE_6, getString(primaryCatalogPattern), getString(primarySchemaPattern),
-                getString(primaryTable), getString(foreignCatalogPattern), getString(foreignSchemaPattern),
-                getString(foreignTable));
+    public ResultInterface getCrossReference(String primaryCatalog, String primarySchema, String primaryTable,
+            String foreignCatalog, String foreignSchema, String foreignTable) {
+        return executeQuery(GET_CROSS_REFERENCE_6, getString(primaryCatalog), getString(primarySchema),
+                getString(primaryTable), getString(foreignCatalog), getString(foreignSchema), getString(foreignTable));
     }
 
     @Override
@@ -261,10 +255,10 @@ public class DatabaseMetaRemote extends DatabaseMeta {
     }
 
     @Override
-    public ResultInterface getIndexInfo(String catalogPattern, String schemaPattern, String tableName, boolean unique,
+    public ResultInterface getIndexInfo(String catalog, String schema, String table, boolean unique,
             boolean approximate) {
-        return executeQuery(GET_INDEX_INFO_5, getString(catalogPattern), getString(schemaPattern), //
-                getString(tableName), ValueBoolean.get(unique), ValueBoolean.get(approximate));
+        return executeQuery(GET_INDEX_INFO_5, getString(catalog), getString(schema), //
+                getString(table), ValueBoolean.get(unique), ValueBoolean.get(approximate));
     }
 
     @Override
@@ -307,8 +301,8 @@ public class DatabaseMetaRemote extends DatabaseMeta {
     }
 
     @Override
-    public ResultInterface getSchemas(String catalogPattern, String schemaPattern) {
-        return executeQuery(GET_SCHEMAS_2, getString(catalogPattern), getString(schemaPattern));
+    public ResultInterface getSchemas(String catalog, String schemaPattern) {
+        return executeQuery(GET_SCHEMAS_2, getString(catalog), getString(schemaPattern));
     }
 
     @Override

--- a/h2/src/main/org/h2/result/SimpleResult.java
+++ b/h2/src/main/org/h2/result/SimpleResult.java
@@ -7,6 +7,7 @@ package org.h2.result;
 
 import java.sql.ResultSetMetaData;
 import java.util.ArrayList;
+import java.util.Comparator;
 
 import org.h2.engine.SessionInterface;
 import org.h2.util.Utils;
@@ -19,7 +20,7 @@ import org.h2.value.Value;
 public class SimpleResult implements ResultInterface, ResultTarget {
 
     /**
-     *  Column info for the simple result.
+     * Column info for the simple result.
      */
     static final class Column {
         /** Column alias. */
@@ -93,11 +94,16 @@ public class SimpleResult implements ResultInterface, ResultTarget {
     /**
      * Add column to the result.
      *
-     * @param alias Column's alias.
-     * @param columnName Column's name.
-     * @param columnType Column's value type.
-     * @param columnPrecision Column's  precision.
-     * @param columnScale Column's scale.
+     * @param alias
+     *            Column's alias.
+     * @param columnName
+     *            Column's name.
+     * @param columnType
+     *            Column's value type.
+     * @param columnPrecision
+     *            Column's precision.
+     * @param columnScale
+     *            Column's scale.
      */
     public void addColumn(String alias, String columnName, int columnType, long columnPrecision, int columnScale) {
         addColumn(alias, columnName, TypeInfo.getTypeInfo(columnType, columnPrecision, columnScale, null));
@@ -106,8 +112,10 @@ public class SimpleResult implements ResultInterface, ResultTarget {
     /**
      * Add column to the result.
      *
-     * @param columnName Column's name.
-     * @param columnType Column's type.
+     * @param columnName
+     *            Column's name.
+     * @param columnType
+     *            Column's type.
      */
     public void addColumn(String columnName, TypeInfo columnType) {
         addColumn(new Column(columnName, columnName, columnType));
@@ -116,9 +124,12 @@ public class SimpleResult implements ResultInterface, ResultTarget {
     /**
      * Add column to the result.
      *
-     * @param alias Column's alias.
-     * @param columnName Column's name.
-     * @param columnType Column's type.
+     * @param alias
+     *            Column's alias.
+     * @param columnName
+     *            Column's name.
+     * @param columnType
+     *            Column's type.
      */
     public void addColumn(String alias, String columnName, TypeInfo columnType) {
         addColumn(new Column(alias, columnName, columnType));
@@ -127,7 +138,8 @@ public class SimpleResult implements ResultInterface, ResultTarget {
     /**
      * Add column to the result.
      *
-     * @param column Column info.
+     * @param column
+     *            Column info.
      */
     void addColumn(Column column) {
         assert rows.isEmpty();
@@ -257,6 +269,16 @@ public class SimpleResult implements ResultInterface, ResultTarget {
     @Override
     public void limitsWereApplied() {
         // Nothing to do
+    }
+
+    /**
+     * Sort rows in the list.
+     *
+     * @param comparator
+     *            the comparator
+     */
+    public void sortRows(Comparator<? super Value[]> comparator) {
+        rows.sort(comparator);
     }
 
 }

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -46,7 +46,6 @@ import org.h2.mvstore.db.MVTableEngine.Store;
 import org.h2.pagestore.PageStore;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
-import org.h2.result.SortOrder;
 import org.h2.schema.Constant;
 import org.h2.schema.Domain;
 import org.h2.schema.Schema;
@@ -211,17 +210,11 @@ public final class InformationSchemaTable extends MetaTable {
                     "TABLE_CATALOG",
                     "TABLE_SCHEMA",
                     "TABLE_NAME",
-                    "NON_UNIQUE BIT",
                     "INDEX_NAME",
                     "ORDINAL_POSITION SMALLINT",
                     "COLUMN_NAME",
-                    "CARDINALITY INT",
                     "INDEX_TYPE_NAME",
                     "IS_GENERATED BIT",
-                    "INDEX_TYPE SMALLINT",
-                    "ASC_OR_DESC",
-                    "PAGES INT",
-                    "FILTER_CONDITION",
                     "REMARKS",
                     "SQL",
                     "ID INT",
@@ -919,28 +912,16 @@ public final class InformationSchemaTable extends MetaTable {
                                 table.getSchema().getName(),
                                 // TABLE_NAME
                                 tableName,
-                                // NON_UNIQUE
-                                ValueBoolean.get(!index.getIndexType().isUnique()),
                                 // INDEX_NAME
                                 index.getName(),
                                 // ORDINAL_POSITION
                                 ValueSmallint.get((short) (k + 1)),
                                 // COLUMN_NAME
                                 column.getName(),
-                                // CARDINALITY
-                                ValueInteger.get(0),
                                 // INDEX_TYPE_NAME
                                 index.getIndexType().getSQL(),
                                 // IS_GENERATED
                                 ValueBoolean.get(index.getIndexType().getBelongsToConstraint()),
-                                // INDEX_TYPE
-                                ValueSmallint.get(DatabaseMetaData.tableIndexOther),
-                                // ASC_OR_DESC
-                                (idxCol.sortType & SortOrder.DESCENDING) != 0 ? "D" : "A",
-                                // PAGES
-                                ValueInteger.get(0),
-                                // FILTER_CONDITION
-                                "",
                                 // REMARKS
                                 replaceNullWithEmpty(index.getComment()),
                                 // SQL

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -216,7 +216,6 @@ public final class InformationSchemaTable extends MetaTable {
                     "ORDINAL_POSITION SMALLINT",
                     "COLUMN_NAME",
                     "CARDINALITY INT",
-                    "PRIMARY_KEY BIT",
                     "INDEX_TYPE_NAME",
                     "IS_GENERATED BIT",
                     "INDEX_TYPE SMALLINT",
@@ -930,8 +929,6 @@ public final class InformationSchemaTable extends MetaTable {
                                 column.getName(),
                                 // CARDINALITY
                                 ValueInteger.get(0),
-                                // PRIMARY_KEY
-                                ValueBoolean.get(index.getIndexType().isPrimaryKey()),
                                 // INDEX_TYPE_NAME
                                 index.getIndexType().getSQL(),
                                 // IS_GENERATED

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -5,12 +5,8 @@
  */
 package org.h2.table;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
 import java.sql.Types;
 import java.text.Collator;
 import java.util.ArrayList;
@@ -58,7 +54,6 @@ import org.h2.schema.SchemaObject;
 import org.h2.schema.Sequence;
 import org.h2.schema.TriggerObject;
 import org.h2.store.InDoubtTransaction;
-import org.h2.tools.Csv;
 import org.h2.util.DateTimeUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.NetworkConnectionInfo;
@@ -89,8 +84,7 @@ public final class InformationSchemaTable extends MetaTable {
     private static final int INDEXES = COLUMNS + 1;
     private static final int TABLE_TYPES = INDEXES + 1;
     private static final int SETTINGS = TABLE_TYPES + 1;
-    private static final int HELP = SETTINGS + 1;
-    private static final int SEQUENCES = HELP + 1;
+    private static final int SEQUENCES = SETTINGS + 1;
     private static final int USERS = SEQUENCES + 1;
     private static final int ROLES = USERS + 1;
     private static final int RIGHTS = ROLES + 1;
@@ -247,17 +241,6 @@ public final class InformationSchemaTable extends MetaTable {
             setMetaTableName("SETTINGS");
             isView = false;
             cols = createColumns("NAME", "VALUE");
-            break;
-        case HELP:
-            setMetaTableName("HELP");
-            isView = false;
-            cols = createColumns(
-                    "ID INT",
-                    "SECTION",
-                    "TOPIC",
-                    "SYNTAX",
-                    "TEXT"
-            );
             break;
         case SEQUENCES:
             setMetaTableName("SEQUENCES");
@@ -1093,35 +1076,6 @@ public final class InformationSchemaTable extends MetaTable {
                                 "info.LEAF_RATIO", Integer.toString(mvStore.getLeafRatio()));
                     }
                 }
-            }
-            break;
-        }
-        case HELP: {
-            String resource = "/org/h2/res/help.csv";
-            try {
-                byte[] data = Utils.getResource(resource);
-                Reader reader = new InputStreamReader(
-                        new ByteArrayInputStream(data));
-                Csv csv = new Csv();
-                csv.setLineCommentCharacter('#');
-                ResultSet rs = csv.read(reader, null);
-                for (int i = 0; rs.next(); i++) {
-                    add(session,
-                        rows,
-                        // ID
-                        ValueInteger.get(i),
-                        // SECTION
-                        rs.getString(1).trim(),
-                        // TOPIC
-                        rs.getString(2).trim(),
-                        // SYNTAX
-                        rs.getString(3).trim(),
-                        // TEXT
-                        rs.getString(4).trim()
-                    );
-                }
-            } catch (Exception e) {
-                throw DbException.convert(e);
             }
             break;
         }

--- a/h2/src/test/org/h2/test/db/TestFullText.java
+++ b/h2/src/test/org/h2/test/db/TestFullText.java
@@ -446,9 +446,18 @@ public class TestFullText extends TestDb {
         initFullText(stat, lucene);
         stat.execute("DROP TABLE IF EXISTS TEST");
         stat.execute(
-                "CREATE TABLE TEST AS SELECT * FROM INFORMATION_SCHEMA.HELP");
-        stat.execute("ALTER TABLE TEST ALTER COLUMN ID INT NOT NULL");
-        stat.execute("CREATE PRIMARY KEY ON TEST(ID)");
+                "CREATE TABLE TEST(ID INT PRIMARY KEY, SECTION VARCHAR, TOPIC VARCHAR, SYNTAX VARCHAR, TEXT VARCHAR)");
+        PreparedStatement ps = conn.prepareStatement("INSERT INTO TEST VALUES (?, ?, ?, ?, ?)");
+        try (ResultSet rs = stat.executeQuery("HELP \"\"")) {
+            while (rs.next()) {
+                ps.setInt(1, rs.getInt(1));
+                for (int i = 2; i <= 5; i++) {
+                    ps.setString(i, rs.getString(i));
+                }
+                ps.addBatch();
+            }
+        }
+        ps.executeUpdate();
         long time = System.nanoTime();
         stat.execute("CALL " + prefix + "_CREATE_INDEX('PUBLIC', 'TEST', NULL)");
         println("create " + prefix + ": " +

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -461,7 +461,6 @@ public class TestIndex extends TestDb {
         rs = conn.getMetaData().getIndexInfo(null, null, "TEST", false, false);
         rs.next();
         assertEquals("D", rs.getString("ASC_OR_DESC"));
-        assertEquals(SortOrder.DESCENDING, rs.getInt("SORT_TYPE"));
         stat.execute("INSERT INTO TEST SELECT X FROM SYSTEM_RANGE(1, 30)");
         rs = stat.executeQuery(
                 "SELECT COUNT(*) FROM TEST WHERE ID BETWEEN 10 AND 20");
@@ -471,7 +470,6 @@ public class TestIndex extends TestDb {
         rs = conn.getMetaData().getIndexInfo(null, null, "TEST", false, false);
         rs.next();
         assertEquals("D", rs.getString("ASC_OR_DESC"));
-        assertEquals(SortOrder.DESCENDING, rs.getInt("SORT_TYPE"));
         rs = stat.executeQuery(
                 "SELECT COUNT(*) FROM TEST WHERE ID BETWEEN 10 AND 20");
         rs.next();

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1300,7 +1300,7 @@ public class TestMetaData extends TestDb {
         stat.execute("SET ALLOW_LITERALS NONE");
         DatabaseMetaData meta = conn.getMetaData();
         // meta.getAttributes(null, null, null, null);
-        meta.getBestRowIdentifier(null, null, null, 0, false);
+        meta.getBestRowIdentifier(null, null, "TEST", 0, false);
         meta.getCatalogs();
         // meta.getClientInfoProperties();
         meta.getColumnPrivileges(null, null, null, null);

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -905,44 +905,44 @@ public class TestMetaData extends TestDb {
         stat.executeUpdate("CREATE INDEX IDX_TEXT_DEC ON TEST(TEXT_V,DEC_V)");
         stat.executeUpdate("CREATE UNIQUE INDEX IDX_DATE ON TEST(DATE_V)");
         rs = meta.getIndexInfo(null, null, "TEST", false, false);
-        assertResultSetMeta(rs, 14, new String[] { "TABLE_CAT", "TABLE_SCHEM",
+        assertResultSetMeta(rs, 13, new String[] { "TABLE_CAT", "TABLE_SCHEM",
                 "TABLE_NAME", "NON_UNIQUE", "INDEX_QUALIFIER", "INDEX_NAME",
                 "TYPE", "ORDINAL_POSITION", "COLUMN_NAME", "ASC_OR_DESC",
-                "CARDINALITY", "PAGES", "FILTER_CONDITION", "SORT_TYPE" },
+                "CARDINALITY", "PAGES", "FILTER_CONDITION" },
                 new int[] { Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
                         Types.BOOLEAN, Types.VARCHAR, Types.VARCHAR,
                         Types.SMALLINT, Types.SMALLINT, Types.VARCHAR,
-                        Types.VARCHAR, Types.INTEGER, Types.INTEGER,
-                        Types.VARCHAR, Types.INTEGER }, null, null);
+                        Types.VARCHAR, Types.BIGINT, Types.BIGINT,
+                        Types.VARCHAR }, null, null);
         assertResultSetOrdered(rs, new String[][] {
                 { CATALOG, Constants.SCHEMA_MAIN, "TEST", "FALSE", CATALOG,
                         "IDX_DATE", "" + DatabaseMetaData.tableIndexOther, "1",
-                        "DATE_V", "A", "0", "0", "" },
+                        "DATE_V", "A", "0", "0" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TEST", "FALSE", CATALOG,
                         "PRIMARY_KEY_2", "" + DatabaseMetaData.tableIndexOther,
-                        "1", "ID", "A", "0", "0", "" },
+                        "1", "ID", "A", "0", "0" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TEST", "TRUE", CATALOG,
                         "IDX_TEXT_DEC", "" + DatabaseMetaData.tableIndexOther,
-                        "1", "TEXT_V", "A", "0", "0", "" },
+                        "1", "TEXT_V", "A", "0", "0" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TEST", "TRUE", CATALOG,
                         "IDX_TEXT_DEC", "" + DatabaseMetaData.tableIndexOther,
-                        "2", "DEC_V", "A", "0", "0", "" }, });
+                        "2", "DEC_V", "A", "0", "0" }, });
         stat.executeUpdate("DROP INDEX IDX_TEXT_DEC");
         stat.executeUpdate("DROP INDEX IDX_DATE");
         rs = meta.getIndexInfo(null, null, "TEST", false, false);
-        assertResultSetMeta(rs, 14, new String[] { "TABLE_CAT", "TABLE_SCHEM",
+        assertResultSetMeta(rs, 13, new String[] { "TABLE_CAT", "TABLE_SCHEM",
                 "TABLE_NAME", "NON_UNIQUE", "INDEX_QUALIFIER", "INDEX_NAME",
                 "TYPE", "ORDINAL_POSITION", "COLUMN_NAME", "ASC_OR_DESC",
-                "CARDINALITY", "PAGES", "FILTER_CONDITION", "SORT_TYPE" },
+                "CARDINALITY", "PAGES", "FILTER_CONDITION" },
                 new int[] { Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
                         Types.BOOLEAN, Types.VARCHAR, Types.VARCHAR,
                         Types.SMALLINT, Types.SMALLINT, Types.VARCHAR,
-                        Types.VARCHAR, Types.INTEGER, Types.INTEGER,
-                        Types.VARCHAR, Types.INTEGER }, null, null);
+                        Types.VARCHAR, Types.BIGINT, Types.BIGINT,
+                        Types.VARCHAR }, null, null);
         assertResultSetOrdered(rs, new String[][] { { CATALOG,
                 Constants.SCHEMA_MAIN, "TEST", "FALSE", CATALOG,
                 "PRIMARY_KEY_2", "" + DatabaseMetaData.tableIndexOther, "1",
-                "ID", "A", "0", "0", "" } });
+                "ID", "A", "0", "0" } });
         trace("getPrimaryKeys");
         rs = meta.getPrimaryKeys(null, null, "TEST");
         assertResultSetMeta(rs, 6, new String[] { "TABLE_CAT", "TABLE_SCHEM",
@@ -1310,7 +1310,7 @@ public class TestMetaData extends TestDb {
         // meta.getFunctionColumns(null, null, null, null);
         // meta.getFunctions(null, null, null);
         meta.getImportedKeys(null, null, "TEST");
-        meta.getIndexInfo(null, null, null, false, false);
+        meta.getIndexInfo(null, null, "TEST", false, false);
         meta.getPrimaryKeys(null, null, "TEST");
         meta.getProcedureColumns(null, null, null, null);
         meta.getProcedures(null, null, null);

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1311,7 +1311,7 @@ public class TestMetaData extends TestDb {
         // meta.getFunctions(null, null, null);
         meta.getImportedKeys(null, null, "TEST");
         meta.getIndexInfo(null, null, null, false, false);
-        meta.getPrimaryKeys(null, null, null);
+        meta.getPrimaryKeys(null, null, "TEST");
         meta.getProcedureColumns(null, null, null, null);
         meta.getProcedures(null, null, null);
         meta.getSchemas();

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -916,17 +916,18 @@ public class TestMetaData extends TestDb {
                         Types.VARCHAR }, null, null);
         assertResultSetOrdered(rs, new String[][] {
                 { CATALOG, Constants.SCHEMA_MAIN, "TEST", "FALSE", CATALOG,
-                        "IDX_DATE", "" + DatabaseMetaData.tableIndexOther, "1",
+                        "IDX_DATE", "" + DatabaseMetaData.tableIndexStatistic, "1",
                         "DATE_V", "A", "0", "0" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TEST", "FALSE", CATALOG,
                         "PRIMARY_KEY_2", "" + DatabaseMetaData.tableIndexOther,
                         "1", "ID", "A", "0", "0" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TEST", "TRUE", CATALOG,
-                        "IDX_TEXT_DEC", "" + DatabaseMetaData.tableIndexOther,
+                        "IDX_TEXT_DEC", "" + DatabaseMetaData.tableIndexStatistic,
                         "1", "TEXT_V", "A", "0", "0" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TEST", "TRUE", CATALOG,
-                        "IDX_TEXT_DEC", "" + DatabaseMetaData.tableIndexOther,
-                        "2", "DEC_V", "A", "0", "0" }, });
+                        "IDX_TEXT_DEC", "" + DatabaseMetaData.tableIndexStatistic,
+                        "2", "DEC_V", "A", "0", "0" }, },
+                new int[] { 11 });
         stat.executeUpdate("DROP INDEX IDX_TEXT_DEC");
         stat.executeUpdate("DROP INDEX IDX_DATE");
         rs = meta.getIndexInfo(null, null, "TEST", false, false);
@@ -942,7 +943,8 @@ public class TestMetaData extends TestDb {
         assertResultSetOrdered(rs, new String[][] { { CATALOG,
                 Constants.SCHEMA_MAIN, "TEST", "FALSE", CATALOG,
                 "PRIMARY_KEY_2", "" + DatabaseMetaData.tableIndexOther, "1",
-                "ID", "A", "0", "0" } });
+                "ID", "A", "0", "0" } },
+                new int[] { 11 });
         trace("getPrimaryKeys");
         rs = meta.getPrimaryKeys(null, null, "TEST");
         assertResultSetMeta(rs, 6, new String[] { "TABLE_CAT", "TABLE_SCHEM",
@@ -1013,14 +1015,15 @@ public class TestMetaData extends TestDb {
                         "PRIMARY_KEY_14",
                         "" + DatabaseMetaData.tableIndexOther, "3", "B", "A" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TX2", "TRUE", CATALOG,
-                        "B_INDEX", "" + DatabaseMetaData.tableIndexOther, "1",
+                        "B_INDEX", "" + DatabaseMetaData.tableIndexStatistic, "1",
                         "A", "A" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TX2", "TRUE", CATALOG,
-                        "B_INDEX", "" + DatabaseMetaData.tableIndexOther, "2",
+                        "B_INDEX", "" + DatabaseMetaData.tableIndexStatistic, "2",
                         "B", "A" },
                 { CATALOG, Constants.SCHEMA_MAIN, "TX2", "TRUE", CATALOG,
-                        "B_INDEX", "" + DatabaseMetaData.tableIndexOther, "3",
-                        "C", "A" }, });
+                        "B_INDEX", "" + DatabaseMetaData.tableIndexStatistic, "3",
+                        "C", "A" }, },
+                new int[] { 11 });
         trace("getPrimaryKeys");
         rs = meta.getPrimaryKeys(null, null, "T_2");
         assertResultSetOrdered(rs, new String[][] {

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1214,7 +1214,7 @@ public class TestMetaData extends TestDb {
 
         rs = meta.getTables(null, "INFORMATION_SCHEMA", null, new String[] { "TABLE", "VIEW", "SYSTEM TABLE" });
         for (String name : new String[] { "CONSTANTS", "FUNCTION_ALIASES",
-                "FUNCTION_COLUMNS", "HELP", "INDEXES", "INFORMATION_SCHEMA_CATALOG_NAME", "IN_DOUBT", "LOCKS",
+                "FUNCTION_COLUMNS", "INDEXES", "INFORMATION_SCHEMA_CATALOG_NAME", "IN_DOUBT", "LOCKS",
                 "QUERY_STATISTICS", "RIGHTS", "ROLES", "SESSIONS", "SESSION_STATE", "SETTINGS", "SYNONYMS",
                 "TABLE_TYPES", "USERS", "CHECK_CONSTRAINTS", "COLLATIONS", "COLUMNS", "COLUMN_PRIVILEGES",
                 "CONSTRAINT_COLUMN_USAGE", "DOMAINS", "DOMAIN_CONSTRAINTS", "KEY_COLUMN_USAGE",

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -2757,12 +2757,12 @@ alter table test add constraint nu unique(parent);
 alter table test add constraint fk foreign key(parent) references(id);
 > ok
 
-select TABLE_NAME, NON_UNIQUE, INDEX_NAME, ORDINAL_POSITION, COLUMN_NAME, CARDINALITY, PRIMARY_KEY from INFORMATION_SCHEMA.INDEXES;
-> TABLE_NAME NON_UNIQUE INDEX_NAME    ORDINAL_POSITION COLUMN_NAME CARDINALITY PRIMARY_KEY
-> ---------- ---------- ------------- ---------------- ----------- ----------- -----------
-> TEST       FALSE      NU_INDEX_2    1                PARENT      0           FALSE
-> TEST       FALSE      PRIMARY_KEY_2 1                ID          0           TRUE
-> TEST       TRUE       NI            1                PARENT      0           FALSE
+select TABLE_NAME, INDEX_NAME, ORDINAL_POSITION, COLUMN_NAME, INDEX_TYPE_NAME from INFORMATION_SCHEMA.INDEXES;
+> TABLE_NAME INDEX_NAME    ORDINAL_POSITION COLUMN_NAME INDEX_TYPE_NAME
+> ---------- ------------- ---------------- ----------- ---------------
+> TEST       NI            1                PARENT      INDEX
+> TEST       NU_INDEX_2    1                PARENT      UNIQUE INDEX
+> TEST       PRIMARY_KEY_2 1                ID          PRIMARY KEY
 > rows: 3
 
 select SEQUENCE_NAME, CURRENT_VALUE, INCREMENT, IS_GENERATED, REMARKS from INFORMATION_SCHEMA.SEQUENCES;

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -847,7 +847,7 @@ SELECT CONSTRAINT_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE;
 drop table test;
 > ok
 
-alter table information_schema.help rename to information_schema.help2;
+ALTER TABLE INFORMATION_SCHEMA.INFORMATION_SCHEMA_CATALOG_NAME RENAME TO INFORMATION_SCHEMA.CAT;
 > exception FEATURE_NOT_SUPPORTED_1
 
 CREATE TABLE test (id bigserial NOT NULL primary key);

--- a/h2/src/test/org/h2/test/server/TestWeb.java
+++ b/h2/src/test/org/h2/test/server/TestWeb.java
@@ -476,20 +476,15 @@ public class TestWeb extends TestDb {
             assertContains(result, "Ok");
             result = client.get(url, "query.do?sql=@catalogs");
             assertContains(result, "PUBLIC");
-            result = client.get(url,
-                    "query.do?sql=@column_privileges null null null TEST null");
+            result = client.get(url, "query.do?sql=@column_privileges null null null TEST null");
             assertContains(result, "PRIVILEGE");
-            result = client.get(url,
-                    "query.do?sql=@cross_references null null TEST null null TEST");
+            result = client.get(url, "query.do?sql=@cross_references null null TEST null null TEST");
             assertContains(result, "PKTABLE_NAME");
-            result = client.get(url,
-                    "query.do?sql=@exported_keys null null TEST");
+            result = client.get(url, "query.do?sql=@exported_keys null null TEST");
             assertContains(result, "PKTABLE_NAME");
-            result = client.get(url,
-                    "query.do?sql=@imported_keys null null TEST");
+            result = client.get(url, "query.do?sql=@imported_keys null null TEST");
             assertContains(result, "PKTABLE_NAME");
-            result = client.get(url,
-                    "query.do?sql=@primary_keys null null null TEST");
+            result = client.get(url, "query.do?sql=@primary_keys null null TEST");
             assertContains(result, "PK_NAME");
             result = client.get(url, "query.do?sql=@procedures null null null");
             assertContains(result, "PROCEDURE_NAME");
@@ -515,8 +510,7 @@ public class TestWeb extends TestDb {
             assertContains(result, "Ok");
             result = client.get(url, "query.do?sql=@prof_stop");
             assertContains(result, "Top Stack Trace(s)");
-            result = client.get(url,
-                    "query.do?sql=@best_row_identifier null null TEST");
+            result = client.get(url, "query.do?sql=@best_row_identifier null null TEST");
             assertContains(result, "SCOPE");
             assertContains(result, "COLUMN_NAME");
             assertContains(result, "ID");

--- a/h2/src/tools/org/h2/build/doc/GenerateDoc.java
+++ b/h2/src/tools/org/h2/build/doc/GenerateDoc.java
@@ -30,7 +30,7 @@ import org.h2.util.StringUtils;
 
 /**
  * This application generates sections of the documentation
- * by converting the built-in help section (INFORMATION_SCHEMA.HELP)
+ * by converting the built-in help section
  * to cross linked html.
  */
 public class GenerateDoc {
@@ -71,7 +71,6 @@ public class GenerateDoc {
         session.put("versionDate", Constants.BUILD_DATE);
         session.put("stableVersion", Constants.VERSION_STABLE);
         session.put("stableVersionDate", Constants.BUILD_DATE_STABLE);
-        // String help = "SELECT * FROM INFORMATION_SCHEMA.HELP WHERE SECTION";
         String help = "SELECT ROWNUM ID, * FROM CSVREAD('" +
                 IN_HELP + "', NULL, 'lineComment=#') WHERE SECTION ";
         map("commandsDML",

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -836,5 +836,5 @@ datallowconn atthasdef dattablespace rolcreatedb inhrelid inhparent attlen rolna
 indpred tgfoid indisprimary adsrc spcowner tgnargs typtype typinput rolcatupdate typnamespace tgrelid authid indexrelid
 usesuper tgdeferrable rolpassword relam relpages tginitdeferred rolsuper autovacuum typnotnull spclocation cancreate
 nsp pgagent pga awoken serverencoding untyped ambiguities tons lhs letting rhs opportunities specifications
-usefully pipelining fetches reenable joiner visits dcl avxaaa german fold degree
+usefully pipelining fetches reenable joiner visits dcl avxaaa german fold degree supertype
 conrelid conkey tabrelname refnamespace dsc pred typrelid conname contype confrelid numscans beaver typdelim typelem


### PR DESCRIPTION
1. `getPrimaryKeys()`, `getBestRowIdentifier()`, `getIndexInfo()`, and `get***Functions()` methods are reimplemented without queries.

2. Implementations of `getImportedKeys()`, `getExportedKeys()`, and `getCrossReference()` are optimized, they don't scan over all constraints any more.

3. Incorrect names of many metadata parameters (`Pattern` suffix for non-pattern parameters and others) are fixed to avoid confusion.

4. `HELP` command is reimplemented.