### PR TITLE
Fix data types in Transfer

### DIFF
--- a/h2/src/main/org/h2/result/ResultColumn.java
+++ b/h2/src/main/org/h2/result/ResultColumn.java
@@ -7,6 +7,7 @@ package org.h2.result;
 
 import java.io.IOException;
 
+import org.h2.engine.Constants;
 import org.h2.value.Transfer;
 import org.h2.value.TypeInfo;
 
@@ -60,11 +61,10 @@ public class ResultColumn {
         schemaName = in.readString();
         tableName = in.readString();
         columnName = in.readString();
-        int valueType = in.readInt();
-        long precision = in.readLong();
-        int scale = in.readInt();
-        int displaySize = in.readInt();
-        columnType = new TypeInfo(valueType, precision, scale, displaySize, null);
+        columnType = in.readTypeInfo();
+        if (in.getVersion() < Constants.TCP_PROTOCOL_VERSION_20) {
+            in.readInt();
+        }
         autoIncrement = in.readBoolean();
         nullable = in.readInt();
     }
@@ -83,10 +83,10 @@ public class ResultColumn {
         out.writeString(result.getTableName(i));
         out.writeString(result.getColumnName(i));
         TypeInfo type = result.getColumnType(i);
-        out.writeInt(type.getValueType());
-        out.writeLong(type.getPrecision());
-        out.writeInt(type.getScale());
-        out.writeInt(type.getDisplaySize());
+        out.writeTypeInfo(type);
+        if (out.getVersion() < Constants.TCP_PROTOCOL_VERSION_20) {
+            out.writeInt(type.getDisplaySize());
+        }
         out.writeBoolean(result.isAutoIncrement(i));
         out.writeInt(result.getNullable(i));
     }

--- a/h2/src/main/org/h2/value/ValueInterval.java
+++ b/h2/src/main/org/h2/value/ValueInterval.java
@@ -47,8 +47,6 @@ public final class ValueInterval extends Value {
 
     private final int valueType;
 
-    private TypeInfo type;
-
     private final boolean negative;
 
     private final long leading;
@@ -150,21 +148,7 @@ public final class ValueInterval extends Value {
 
     @Override
     public TypeInfo getType() {
-        TypeInfo type = this.type;
-        if (type == null) {
-            long l = leading;
-            int precision = 0;
-            while (l > 0) {
-                precision++;
-                l /= 10;
-            }
-            if (precision == 0) {
-                precision = 1;
-            }
-            this.type = type = new TypeInfo(valueType, precision, 0,
-                    getDisplaySize(valueType, MAXIMUM_PRECISION, MAXIMUM_SCALE), null);
-        }
-        return type;
+        return TypeInfo.getTypeInfo(valueType);
     }
 
     @Override


### PR DESCRIPTION
1. Network format of `ResultColumn` is restored to be compatible with 1.4.200 and older versions.

2. `BINARY` data type is now passed as `VARBINARY` to 1.4.200 and older clients for compatibility.

3. `ROW` type descriptors are now passed correctly to current client.

4. Interval literals now return data type with max parameters (like date-time literals). Attempt to guess the smallest possible parameters for them creates more problems than resolves and parameters of these values don't affect their storage. Impact of this change is very small, it is only visible in DDL like `CREATE TABLE TEST AS VALUES INTERVAL '1' YEAR`.