### PR TITLE
return PG_TYPE_VARCHAR for Value.VARCHAR_IGNORECASE

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServer.java
+++ b/h2/src/main/org/h2/server/pg/PgServer.java
@@ -389,6 +389,7 @@ public class PgServer implements Service {
         case Value.BOOLEAN:
             return PG_TYPE_BOOL;
         case Value.VARCHAR:
+        case Value.VARCHAR_IGNORECASE:
             return PG_TYPE_VARCHAR;
         case Value.CLOB:
             return PG_TYPE_TEXT;

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -339,7 +339,7 @@ public class TestPgServer extends TestDb {
 
         rs = stat.executeQuery("select * from pg_type where oid = " + PgServer.PG_TYPE_VARCHAR_ARRAY);
         rs.next();
-        assertEquals("_varchar", rs.getString("typname"));
+        assertEquals("_varchar", rs.getObject("typname"));
         assertEquals("b", rs.getString("typtype"));
         assertEquals(",", rs.getString("typdelim"));
         assertEquals(PgServer.PG_TYPE_VARCHAR, rs.getInt("typelem"));


### PR DESCRIPTION
Fixes #2686: pgjdbc `rs.getObject()` on a varchar_ignorecase columns in pg_catalog no longer throws exception.