### PR TITLE
Implement CHAR whitespace handling correctly

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4048,6 +4048,9 @@ For large text data CLOB should be used; see there for details.
 Too short strings are right-padded with space characters.
 Too long strings are truncated by CAST specification and rejected by column assignment.
 
+Two CHAR strings of different length are considered as equal if all additional characters in the longer string
+are space characters.
+
 See also [string](https://h2database.com/html/grammar.html#string) literal grammar.
 Mapped to ""java.lang.String"".
 ","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3950,10 +3950,18 @@ VARBINARY(1000)
 "Data Types","BINARY Type","
 BINARY [ ( lengthInt ) ]
 ","
-Represents a byte array of fixed predefined length. For very long arrays, use BLOB.
-The maximum size is 2 GB, but the whole object is kept in
-memory when using this data type. If length is not specified, 1 byte is used by default.
-Too short arrays will be zero-expanded to the declared length.
+Represents a binary string (byte array) of fixed predefined length.
+
+If length is not specified, 1 byte is used by default.
+
+The whole binary string is kept in memory when using this data type.
+For variable-length binary strings use VARBINARY data type instead.
+For large binary data BLOB should be used; see there for details.
+
+Too short binary string are right-padded with zero bytes.
+Too long binary strings are truncated by CAST specification and rejected by column assignment.
+
+Binary strings of different length are considered as not equal to each other.
 
 See also [bytes](https://h2database.com/html/grammar.html#bytes) literal grammar.
 Mapped to byte[].

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -4036,15 +4036,17 @@ VARCHAR_IGNORECASE
 { CHAR | CHARACTER | NCHAR | NATIONAL { CHARACTER | CHAR } }
 [ ( lengthInt [CHARACTERS|OCTETS] ) ]
 ","
-A Unicode String of known length.
-The difference to VARCHAR is that trailing spaces are ignored and not persisted.
+A Unicode String of fixed length.
 
-The maximum length is ""Integer.MAX_VALUE"".
 Length, if any, should be specified in characters, CHARACTERS and OCTETS units have no effect in H2.
 If length is not specified, 1 character is used by default.
 
 The whole text is kept in memory when using this data type.
+For variable-length strings use VARCHAR data type instead.
 For large text data CLOB should be used; see there for details.
+
+Too short strings are right-padded with space characters.
+Too long strings are truncated by CAST specification and rejected by column assignment.
 
 See also [string](https://h2database.com/html/grammar.html#string) literal grammar.
 Mapped to ""java.lang.String"".

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2407: Implement CHAR whitespace handling correctly
+</li>
 <li>PR #2685: Check existing data in ALTER DOMAIN ADD CONSTRAINT
 </li>
 <li>PR #2683: Fix data types in Transfer

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -956,6 +956,7 @@ Do not change value of DATABASE_TO_LOWER after creation of database.
 </li><li>INSERT IGNORE is partially supported and may be used to skip rows with duplicate keys if ON DUPLICATE KEY
     UPDATE is not specified.
 </li><li>REPLACE INTO is partially supported.
+</li><li>Spaces are trimmed from the right side of CHAR values.
 </li><li>REGEXP_REPLACE() uses \ for back-references for compatibility with MariaDB.
 </li><li>Datetime value functions return the same value within a command.
 </li><li>0x literals are parsed as binary string literals.
@@ -1016,7 +1017,8 @@ Do not change value of DATABASE_TO_LOWER after creation of database.
     <li>replaces only the first matched substring in the absence of the 'g' flag in the <code>flagsString</code> parameter.</li>
     </ul>
 </li><li>ON CONFLICT DO NOTHING is supported in INSERT statements.
-</li><li>Fixed-width strings are padded with spaces.
+</li><li>Spaces are trimmed from the right side of CHAR values, but CHAR values in result sets are right-padded with
+    spaces to the declared length.
 </li><li>MONEY data type is treated like NUMERIC(19, 2) data type.
 </li><li>Datetime value functions return the same value within a transaction.
 </li><li>ARRAY_SLICE() out of bounds parameters are silently corrected.

--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -13,6 +13,7 @@ import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.engine.DbObject;
+import org.h2.engine.Mode.CharPadding;
 import org.h2.engine.Session;
 import org.h2.expression.ParameterInterface;
 import org.h2.message.DbException;
@@ -188,7 +189,7 @@ public abstract class Command implements CommandInterface {
                     try {
                         ResultInterface result = query(maxrows);
                         callStop = !result.isLazy();
-                        if (database.getMode().padFixedLengthStrings) {
+                        if (database.getMode().charPadding == CharPadding.IN_RESULT_SETS) {
                             return ResultWithPaddedStrings.get(result);
                         }
                         return result;

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -105,6 +105,28 @@ public class Mode {
         MYSQL_STYLE,
     }
 
+    /**
+     * When CHAR values are right-padded with spaces.
+     */
+    public enum CharPadding {
+        /**
+         * CHAR values are always right-padded with spaces.
+         */
+        ALWAYS,
+
+        /**
+         * Spaces are trimmed from the right side of CHAR values, but CHAR
+         * values in result sets are right-padded with spaces to the declared
+         * length
+         */
+        IN_RESULT_SETS,
+
+        /**
+         * Spaces are trimmed from the right side of CHAR values.
+         */
+        NEVER
+    }
+
     private static final HashMap<String, Mode> MODES = new HashMap<>();
 
     // Modes are also documented in the features section
@@ -225,9 +247,9 @@ public class Mode {
     public boolean allowEmptyInPredicate;
 
     /**
-     * Whether to right-pad fixed strings with spaces.
+     * How to pad or trim CHAR values.
      */
-    public boolean padFixedLengthStrings;
+    public CharPadding charPadding = CharPadding.ALWAYS;
 
     /**
      * Whether DB2 TIMESTAMP formats are allowed.
@@ -436,6 +458,7 @@ public class Mode {
         mode.regexpReplaceBackslashReferences = true;
         mode.onDuplicateKeyUpdate = true;
         mode.replaceInto = true;
+        mode.charPadding = CharPadding.NEVER;
         // MySQL allows to use any key for client info entries. See
         // https://github.com/mysql/mysql-connector-j/blob/5.1.47/src/com/mysql/jdbc/JDBC4CommentClientInfoProvider.java
         mode.supportedClientInfoPropertiesRegEx =
@@ -494,7 +517,7 @@ public class Mode {
         //     org/postgresql/jdbc4/AbstractJdbc4Connection.java
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile("ApplicationName");
-        mode.padFixedLengthStrings = true;
+        mode.charPadding = CharPadding.IN_RESULT_SETS;
         mode.nextValueReturnsDifferentValues = true;
         mode.expressionNames = ExpressionNames.POSTGRESQL_STYLE;
         // Enumerate all H2 types NOT supported by PostgreSQL:

--- a/h2/src/main/org/h2/expression/function/Function.java
+++ b/h2/src/main/org/h2/expression/function/Function.java
@@ -176,9 +176,9 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         addFunction("BIT_LENGTH", BIT_LENGTH, 1, Value.BIGINT);
         addFunction("CHAR", CHAR, 1, Value.VARCHAR);
         addFunction("CHR", CHAR, 1, Value.VARCHAR);
-        addFunction("CHAR_LENGTH", CHAR_LENGTH, 1, Value.INTEGER);
+        addFunction("CHAR_LENGTH", CHAR_LENGTH, 1, Value.BIGINT);
         // same as CHAR_LENGTH
-        addFunction("CHARACTER_LENGTH", CHAR_LENGTH, 1, Value.INTEGER);
+        addFunction("CHARACTER_LENGTH", CHAR_LENGTH, 1, Value.BIGINT);
         addFunctionWithNull("CONCAT", CONCAT, VAR_ARGS, Value.VARCHAR);
         addFunctionWithNull("CONCAT_WS", CONCAT_WS, VAR_ARGS, Value.VARCHAR);
         addFunctionWithNull("INSERT", INSERT, 4, Value.VARCHAR);
@@ -1214,7 +1214,7 @@ public class Function extends OperationN implements FunctionCall, ExpressionWith
         return value;
     }
 
-    private static long length(Value v) {
+    public static long length(Value v) {
         switch (v.getValueType()) {
         case Value.BLOB:
         case Value.CLOB:

--- a/h2/src/main/org/h2/expression/function/ToChar.java
+++ b/h2/src/main/org/h2/expression/function/ToChar.java
@@ -517,6 +517,13 @@ public class ToChar {
     }
 
     /**
+     * Used for testing.
+     */
+    public static void clearNames() {
+        NAMES = null;
+    }
+
+    /**
      * Returns time zone display name or ID for the specified date-time value.
      *
      * @param session

--- a/h2/src/main/org/h2/value/ValueChar.java
+++ b/h2/src/main/org/h2/value/ValueChar.java
@@ -5,6 +5,7 @@
  */
 package org.h2.value;
 
+import org.h2.engine.CastDataProvider;
 import org.h2.engine.SysProperties;
 import org.h2.util.StringUtils;
 
@@ -19,23 +20,14 @@ public final class ValueChar extends ValueStringBase {
         super(value);
     }
 
-    private static String trimRight(String s) {
-        return trimRight(s, 0);
-    }
-
-    private static String trimRight(String s, int minLength) {
-        int endIndex = s.length() - 1;
-        int i = endIndex;
-        while (i >= minLength && s.charAt(i) == ' ') {
-            i--;
-        }
-        s = i == endIndex ? s : s.substring(0, i + 1);
-        return s;
-    }
-
     @Override
     public int getValueType() {
         return CHAR;
+    }
+
+    @Override
+    public int compareTypeSafe(Value v, CompareMode mode, CastDataProvider provider) {
+        return mode.compareString(convertToChar().getString(), v.convertToChar().getString(), false);
     }
 
     @Override
@@ -56,7 +48,6 @@ public final class ValueChar extends ValueStringBase {
      * @return the value
      */
     public static ValueChar get(String s) {
-        s = trimRight(s);
         int length = s.length();
         if (length == 0) {
             return EMPTY;

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -52,6 +52,7 @@ import org.h2.api.AggregateFunction;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.Session;
+import org.h2.expression.function.ToChar;
 import org.h2.expression.function.ToChar.Capitalization;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.message.DbException;
@@ -1432,6 +1433,7 @@ public class TestFunctions extends TestDb implements AggregateFunction {
     }
 
     private void testToCharFromDateTime() throws SQLException {
+        ToChar.clearNames();
         deleteDb("functions");
         Connection conn = getConnection("functions");
         Statement stat = conn.createStatement();

--- a/h2/src/test/org/h2/test/scripts/datatypes/char.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/char.sql
@@ -39,7 +39,7 @@ SELECT C || 'x' V FROM TEST;
 > V
 > ---
 > aax
-> bx
+> b x
 > rows: 2
 
 DROP TABLE TEST;
@@ -80,7 +80,7 @@ EXPLAIN VALUES CAST('a' AS CHAR(1));
 >> VALUES (CAST('a' AS CHAR(1)))
 
 EXPLAIN VALUES CAST('' AS CHAR(1));
->> VALUES (CAST('' AS CHAR(1)))
+>> VALUES (CAST(' ' AS CHAR(1)))
 
 CREATE TABLE T(C CHAR(0));
 > exception INVALID_VALUE_2
@@ -93,3 +93,81 @@ DROP TABLE T;
 
 VALUES CAST('ab' AS CHAR);
 >> a
+
+CREATE TABLE TEST(A CHAR(2) NOT NULL, B CHAR(3) NOT NULL);
+> ok
+
+INSERT INTO TEST VALUES ('a', 'a'), ('aa', 'aaa'), ('bb   ', 'bb');
+> update count: 3
+
+INSERT INTO TEST VALUES ('a a', 'a a');
+> exception VALUE_TOO_LONG_2
+
+VALUES CAST('a a' AS CHAR(2)) || '*';
+>> a *
+
+SELECT A || '*', B || '*', A || B || '*', CHAR_LENGTH(A), A = B FROM TEST;
+> A || '*' B || '*' A || B || '*' CHAR_LENGTH(A) A = B
+> -------- -------- ------------- -------------- -----
+> a *      a *      a a *         2              TRUE
+> aa*      aaa*     aaaaa*        2              FALSE
+> bb*      bb *     bbbb *        2              TRUE
+> rows: 3
+
+DROP TABLE TEST;
+> ok
+
+SET MODE MySQL;
+> ok
+
+CREATE TABLE TEST(A CHAR(2) NOT NULL, B CHAR(3) NOT NULL);
+> ok
+
+INSERT INTO TEST VALUES ('a', 'a'), ('aa', 'aaa'), ('bb   ', 'bb');
+> update count: 3
+
+INSERT INTO TEST VALUES ('a a', 'a a');
+> exception VALUE_TOO_LONG_2
+
+VALUES CAST('a a' AS CHAR(2)) || '*';
+>> a*
+
+SELECT A || '*', B || '*', A || B || '*', CHAR_LENGTH(A), A = B FROM TEST;
+> A || '*' B || '*' A || B || '*' CHAR_LENGTH(A) A = B
+> -------- -------- ------------- -------------- -----
+> a*       a*       aa*           1              TRUE
+> aa*      aaa*     aaaaa*        2              FALSE
+> bb*      bb*      bbbb*         2              TRUE
+> rows: 3
+
+DROP TABLE TEST;
+> ok
+
+SET MODE PostgreSQL;
+> ok
+
+CREATE TABLE TEST(A CHAR(2) NOT NULL, B CHAR(3) NOT NULL);
+> ok
+
+INSERT INTO TEST VALUES ('a', 'a'), ('aa', 'aaa'), ('bb   ', 'bb');
+> update count: 3
+
+INSERT INTO TEST VALUES ('a a', 'a a');
+> exception VALUE_TOO_LONG_2
+
+VALUES CAST('a a' AS CHAR(2)) || '*';
+>> a*
+
+SELECT A || '*', B || '*', A || B || '*', CHAR_LENGTH(A), A = B FROM TEST;
+> ?column? ?column? ?column? char_length ?column?
+> -------- -------- -------- ----------- --------
+> a*       a*       aa*      1           TRUE
+> aa*      aaa*     aaaaa*   2           FALSE
+> bb*      bb*      bbbb*    2           TRUE
+> rows: 3
+
+DROP TABLE TEST;
+> ok
+
+SET MODE Regular;
+> ok

--- a/h2/src/test/org/h2/test/scripts/functions/string/length.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/length.sql
@@ -21,5 +21,11 @@ select len(null) en, len('MSSQLServer uses the len keyword') e_32;
 > null 32
 > rows: 1
 
+SELECT LEN('A ');
+>> 2
+
+SELECT LEN(CAST('A ' AS CHAR(2)));
+>> 1
+
 SET MODE Regular;
 > ok

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -1002,10 +1002,10 @@ INSERT INTO TEST VALUES (1, 'Mouse', 'MOUSE'), (2, 'MOUSE', 'Mouse');
 > update count: 2
 
 SELECT * FROM TEST;
-> ID LABEL LOOKUP
-> -- ----- ------
-> 1  Mouse MOUSE
-> 2  MOUSE Mouse
+> ID LABEL  LOOKUP
+> -- ------ ------
+> 1  Mouse  MOUSE
+> 2  MOUSE  Mouse
 > rows: 2
 
 DROP TABLE TEST;
@@ -1614,15 +1614,14 @@ insert into test set id = 3, c = 'abcde      ', v = 'abcde';
 select distinct length(c) from test order by length(c);
 > LENGTH(C)
 > ---------
-> 1
 > 5
-> rows (ordered): 2
+> rows (ordered): 1
 
 select id, c, v, length(c), length(v) from test order by id;
 > ID C     V     LENGTH(C) LENGTH(V)
 > -- ----- ----- --------- ---------
-> 1  a     a     1         1
-> 2  a     a     1         2
+> 1  a     a     5         1
+> 2  a     a     5         2
 > 3  abcde abcde 5         5
 > rows (ordered): 3
 

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -1179,7 +1179,7 @@ public class TestMVTableEngine extends TestDb {
         rs.next();
         assertEquals(1000, rs.getInt(1));
         assertEquals("", rs.getString(2));
-        assertEquals("", rs.getString(3));
+        assertEquals("          ", rs.getString(3));
         assertFalse(rs.getBoolean(4));
         assertEquals(0, rs.getByte(5));
         assertEquals(0, rs.getShort(6));
@@ -1197,7 +1197,7 @@ public class TestMVTableEngine extends TestDb {
         rs.next();
         assertEquals(1, rs.getInt(1));
         assertEquals("vc", rs.getString(2));
-        assertEquals("ch", rs.getString(3));
+        assertEquals("ch        ", rs.getString(3));
         assertTrue(rs.getBoolean(4));
         assertEquals(8, rs.getByte(5));
         assertEquals(16, rs.getShort(6));
@@ -1216,7 +1216,7 @@ public class TestMVTableEngine extends TestDb {
         assertEquals(-1, rs.getInt(1));
         assertEquals("quite a long string \u1234 \u00ff",
                 rs.getString(2));
-        assertEquals("ch", rs.getString(3));
+        assertEquals("ch        ", rs.getString(3));
         assertFalse(rs.getBoolean(4));
         assertEquals(-8, rs.getByte(5));
         assertEquals(-16, rs.getShort(6));
@@ -1234,7 +1234,7 @@ public class TestMVTableEngine extends TestDb {
         rs.next();
         assertEquals(-1000, rs.getInt(1));
         assertEquals(1000, rs.getString(2).length());
-        assertEquals("ch", rs.getString(3));
+        assertEquals("ch        ", rs.getString(3));
         assertFalse(rs.getBoolean(4));
         assertEquals(-8, rs.getByte(5));
         assertEquals(-16, rs.getShort(6));


### PR DESCRIPTION
1. `CHAR` values are now padded with spaces as they should be. This behavior is configurable, three options are supported through the flag in `Mode`. Closes #2407. The default for `Regular` mode should be re-considered if we plan to release a some intermediate compatibility version. However, I think that impact of this change is relatively small.

2. Failures in non-English locales when `TestFunctions` is invoked multiple times from `TestAll` are fixed.

3. `TestAll` now accepts `-exclude test` flags, such as `-exclude org.h2.test.unit.TestFileLockProcess`. This specific test performs too much disk I/O and creates problems for other applications.