### PR TITLE
Improve LOCKS, SESSIONS, and USERS and optimize COUNT(*) on other isolation levels in some cases

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -901,19 +901,18 @@ public class Database implements DataHandler, CastDataProvider {
         synchronized (infoSchema) {
             if (!metaTablesInitialized) {
                 if (dbSettings.oldInformationSchema) {
-                    for (int type = 0, count = InformationSchemaTableLegacy.getMetaTableTypeCount(); type < count;
-                            type++) {
+                    for (int type = 0; type < InformationSchemaTableLegacy.META_TABLE_TYPE_COUNT; type++) {
                         infoSchema.add(new InformationSchemaTableLegacy(infoSchema,
                                 Constants.INFORMATION_SCHEMA_ID - type, type));
                     }
                 } else {
-                    for (int type = 0, count = InformationSchemaTable.getMetaTableTypeCount(); type < count; type++) {
+                    for (int type = 0; type < InformationSchemaTable.META_TABLE_TYPE_COUNT; type++) {
                         infoSchema.add(new InformationSchemaTable(infoSchema, Constants.INFORMATION_SCHEMA_ID - type,
                                 type));
                     }
                 }
                 if (pgCatalogSchema != null) {
-                    for (int type = 0, count = PgCatalogTable.getMetaTableTypeCount(); type < count; type++) {
+                    for (int type = 0; type < PgCatalogTable.META_TABLE_TYPE_COUNT; type++) {
                         pgCatalogSchema.add(new PgCatalogTable(pgCatalogSchema, Constants.PG_CATALOG_SCHEMA_ID - type,
                                 type));
                     }

--- a/h2/src/main/org/h2/mode/PgCatalogTable.java
+++ b/h2/src/main/org/h2/mode/PgCatalogTable.java
@@ -79,7 +79,11 @@ public class PgCatalogTable extends MetaTable {
 
     private static final int PG_USER = PG_TYPE + 1;
 
-    private static final int META_TABLE_TYPE_COUNT = PG_USER + 1;
+    /**
+     * The number of meta table types. Supported meta table types are
+     * {@code 0..META_TABLE_TYPE_COUNT - 1}.
+     */
+    public static final int META_TABLE_TYPE_COUNT = PG_USER + 1;
 
     private static final Object[][] PG_EXTRA_TYPES = {
             { 18, "char", 1, 0 },
@@ -91,16 +95,6 @@ public class PgCatalogTable extends MetaTable {
             { PgServer.PG_TYPE_VARCHAR_ARRAY, "_varchar", -1, PgServer.PG_TYPE_VARCHAR },
             { 2205, "regclass", 4, 0 },
     };
-
-    /**
-     * Get the number of meta table types. Supported meta table types are 0 ..
-     * this value - 1.
-     *
-     * @return the number of meta table types
-     */
-    public static int getMetaTableTypeCount() {
-        return META_TABLE_TYPE_COUNT;
-    }
 
     /**
      * Create a new metadata table.

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -1002,14 +1002,14 @@ public final class InformationSchemaTable extends MetaTable {
 
     private void collations(Session session, ArrayList<Row> rows, String catalog) {
         String mainSchemaName = database.getMainSchema().getName();
-        generateCollationRow(session, rows, catalog, mainSchemaName, "OFF", null);
+        collations(session, rows, catalog, mainSchemaName, "OFF", null);
         for (Locale l : Collator.getAvailableLocales()) {
-            generateCollationRow(session, rows, catalog, mainSchemaName, CompareMode.getName(l), l.toLanguageTag());
+            collations(session, rows, catalog, mainSchemaName, CompareMode.getName(l), l.toLanguageTag());
         }
     }
 
-    private void generateCollationRow(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName,
-            String name, String languageTag) {
+    private void collations(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName, String name,
+            String languageTag) {
         if ("und".equals(languageTag)) {
             languageTag = null;
         }
@@ -1054,13 +1054,13 @@ public final class InformationSchemaTable extends MetaTable {
             Column[] cols = table.getColumns();
             for (int j = 0; j < cols.length; j++) {
                 Column c = cols[j];
-                generateColumnRow(session, rows, catalog, mainSchemaName, collation, table, tableName, j + 1, c);
+                columns(session, rows, catalog, mainSchemaName, collation, table, tableName, j + 1, c);
             }
         }
     }
 
-    private void generateColumnRow(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName,
-            String collation, Table table, String tableName, int ordinalPosition, Column c) {
+    private void columns(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName, String collation,
+            Table table, String tableName, int ordinalPosition, Column c) {
         TypeInfo typeInfo = c.getType();
         DataTypeInformation dt = DataTypeInformation.valueOf(typeInfo);
         String fullTypeName = c.getOriginalSQL();
@@ -1377,7 +1377,7 @@ public final class InformationSchemaTable extends MetaTable {
                         table);
             }
             for (Domain domain : schema.getAllDomains()) {
-                generateElementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, schemaName,
+                elementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, schemaName,
                         domain.getName(), "DOMAIN", "TYPE", domain.getColumn().getType());
             }
             for (FunctionAlias alias : schema.getAllFunctionAliases()) {
@@ -1393,19 +1393,19 @@ public final class InformationSchemaTable extends MetaTable {
                     TypeInfo typeInfo = method.getDataType();
                     String specificName = name + '_' + (i + 1);
                     if (typeInfo.getValueType() != Value.NULL) {
-                        generateElementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation,
+                        elementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation,
                                 schemaName, specificName, "ROUTINE", "RESULT", typeInfo);
                     }
                     Class<?>[] columnList = method.getColumnClasses();
                     for (int o = 1, p = method.hasConnectionParam() ? 1 : 0, n = columnList.length; p < n; o++, p++) {
-                        generateElementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation,
+                        elementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation,
                                 schemaName, specificName, "ROUTINE", Integer.toString(o),
                                 ValueToObjectConverter2.classToType(columnList[p]));
                     }
                 }
             }
             for (Constant constant : schema.getAllConstants()) {
-                generateElementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, schemaName,
+                elementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, schemaName,
                         constant.getName(), "CONSTANT", "TYPE", constant.getValue().getType());
             }
         }
@@ -1424,12 +1424,12 @@ public final class InformationSchemaTable extends MetaTable {
         String tableName = table.getName();
         Column[] cols = table.getColumns();
         for (int i = 0; i < cols.length; i++) {
-            generateElementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, schemaName,
+            elementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, schemaName,
                     tableName, "TABLE", Integer.toString(i + 1), cols[i].getType());
         }
     }
 
-    private void generateElementTypesFieldsRow(Session session, ArrayList<Row> rows, String catalog, boolean fields,
+    private void elementTypesFieldsRow(Session session, ArrayList<Row> rows, String catalog, boolean fields,
             String mainSchemaName, String collation, String objectSchema, String objectName, String objectType,
             String identifier, TypeInfo typeInfo) {
         switch (typeInfo.getValueType()) {
@@ -1437,10 +1437,10 @@ public final class InformationSchemaTable extends MetaTable {
             typeInfo = (TypeInfo) typeInfo.getExtTypeInfo();
             String dtdIdentifier = identifier + '_';
             if (!fields) {
-                generateElementTypesRow(session, rows, catalog, mainSchemaName, collation, objectSchema, objectName,
+                elementTypes(session, rows, catalog, mainSchemaName, collation, objectSchema, objectName,
                         objectType, identifier, dtdIdentifier, typeInfo);
             }
-            generateElementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, objectSchema,
+            elementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, objectSchema,
                     objectName, objectType, dtdIdentifier, typeInfo);
             break;
         }
@@ -1452,17 +1452,17 @@ public final class InformationSchemaTable extends MetaTable {
                 String fieldName = entry.getKey();
                 String dtdIdentifier = identifier + '_' + ++ordinalPosition;
                 if (fields) {
-                    generateFieldsRow(session, rows, catalog, mainSchemaName, collation, objectSchema, objectName,
+                    fields(session, rows, catalog, mainSchemaName, collation, objectSchema, objectName,
                             objectType, identifier, fieldName, ordinalPosition, dtdIdentifier, typeInfo);
                 }
-                generateElementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, objectSchema,
+                elementTypesFieldsRow(session, rows, catalog, fields, mainSchemaName, collation, objectSchema,
                         objectName, objectType, dtdIdentifier, typeInfo);
             }
         }
         }
     }
 
-    private void generateElementTypesRow(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName,
+    private void elementTypes(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName,
             String collation, String objectSchema, String objectName, String objectType, String collectionIdentifier,
             String dtdIdentifier, TypeInfo typeInfo) {
         DataTypeInformation dt = DataTypeInformation.valueOf(typeInfo);
@@ -1534,9 +1534,9 @@ public final class InformationSchemaTable extends MetaTable {
         );
     }
 
-    private void generateFieldsRow(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName,
-            String collation, String objectSchema, String objectName, String objectType, String rowIdentifier,
-            String fieldName, int ordinalPosition, String dtdIdentifier, TypeInfo typeInfo) {
+    private void fields(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName, String collation,
+            String objectSchema, String objectName, String objectType, String rowIdentifier, String fieldName,
+            int ordinalPosition, String dtdIdentifier, TypeInfo typeInfo) {
         DataTypeInformation dt = DataTypeInformation.valueOf(typeInfo);
         String characterSetCatalog, characterSetSchema, characterSetName, collationName;
         if (dt.hasCharsetAndCollation) {
@@ -1691,7 +1691,7 @@ public final class InformationSchemaTable extends MetaTable {
                 FunctionAlias.JavaMethod method = methods[i];
                 Class<?>[] columnList = method.getColumnClasses();
                 for (int o = 1, p = method.hasConnectionParam() ? 1 : 0, n = columnList.length; p < n; o++, p++) {
-                    generateParameterRow(session, rows, catalog, mainSchemaName, collation, schema,
+                    parameters(session, rows, catalog, mainSchemaName, collation, schema,
                             alias.getName() + '_' + (i + 1), ValueToObjectConverter2.classToType(columnList[p]), //
                             o);
                 }
@@ -1699,7 +1699,7 @@ public final class InformationSchemaTable extends MetaTable {
         }
     }
 
-    private void generateParameterRow(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName,
+    private void parameters(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName,
             String collation, String schema, String specificName, TypeInfo typeInfo, int pos) {
         DataTypeInformation dt = DataTypeInformation.valueOf(typeInfo);
         String characterSetCatalog, characterSetSchema, characterSetName, collationName;
@@ -1838,7 +1838,7 @@ public final class InformationSchemaTable extends MetaTable {
                     } else {
                         routineType = "FUNCTION";
                     }
-                    generateRoutineRow(session, rows, catalog, mainSchemaName, collation, schemaName, name,
+                    routines(session, rows, catalog, mainSchemaName, collation, schemaName, name,
                             name + '_' + (i + 1), routineType, admin ? alias.getSource() : null,
                             alias.getJavaClassName() + '.' + alias.getJavaMethodName(), typeInfo,
                             alias.isDeterministic(), alias.getComment(), alias.getId());
@@ -1846,14 +1846,14 @@ public final class InformationSchemaTable extends MetaTable {
             }
             for (UserAggregate agg : schema.getAllAggregates()) {
                 String name = agg.getName();
-                generateRoutineRow(session, rows, catalog, mainSchemaName, collation, schemaName, name, name,
+                routines(session, rows, catalog, mainSchemaName, collation, schemaName, name, name,
                         "AGGREGATE", null, agg.getJavaClassName(), TypeInfo.TYPE_NULL, false, agg.getComment(),
                         agg.getId());
             }
         }
     }
 
-    private void generateRoutineRow(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName,
+    private void routines(Session session, ArrayList<Row> rows, String catalog, String mainSchemaName, //
             String collation, String schema, String name, String specificName, String routineType, String definition,
             String externalName, TypeInfo typeInfo, boolean deterministic, String remarks, int id) {
         DataTypeInformation dt = typeInfo != null ? DataTypeInformation.valueOf(typeInfo) : DataTypeInformation.NULL;
@@ -2417,22 +2417,27 @@ public final class InformationSchemaTable extends MetaTable {
     }
 
     private void locks(Session session, ArrayList<Row> rows) {
-        boolean admin = session.getUser().isAdmin();
-        for (Session s : database.getSessions(false)) {
-            if (admin || s == session) {
-                for (Table table : s.getLocks()) {
-                    add(session, rows,
-                            // TABLE_SCHEMA
-                            table.getSchema().getName(),
-                            // TABLE_NAME
-                            table.getName(),
-                            // SESSION_ID
-                            ValueInteger.get(s.getId()),
-                            // LOCK_TYPE
-                            table.isLockedExclusivelyBy(s) ? "WRITE" : "READ"
-                    );
-                }
+        if (session.getUser().isAdmin()) {
+            for (Session s : database.getSessions(false)) {
+                locks(session, rows, s);
             }
+        } else {
+            locks(session, rows, session);
+        }
+    }
+
+    private void locks(Session session, ArrayList<Row> rows, Session sessionWithLocks) {
+        for (Table table : sessionWithLocks.getLocks()) {
+            add(session, rows,
+                    // TABLE_SCHEMA
+                    table.getSchema().getName(),
+                    // TABLE_NAME
+                    table.getName(),
+                    // SESSION_ID
+                    ValueInteger.get(sessionWithLocks.getId()),
+                    // LOCK_TYPE
+                    table.isLockedExclusivelyBy(sessionWithLocks) ? "WRITE" : "READ"
+            );
         }
     }
 
@@ -2549,42 +2554,47 @@ public final class InformationSchemaTable extends MetaTable {
     }
 
     private void sessions(Session session, ArrayList<Row> rows) {
-        boolean admin = session.getUser().isAdmin();
-        for (Session s : database.getSessions(false)) {
-            if (admin || s == session) {
-                NetworkConnectionInfo networkConnectionInfo = s.getNetworkConnectionInfo();
-                Command command = s.getCurrentCommand();
-                int blockingSessionId = s.getBlockingSessionId();
-                add(session, rows,
-                        // ID
-                        ValueInteger.get(s.getId()),
-                        // USER_NAME
-                        s.getUser().getName(),
-                        // SERVER
-                        networkConnectionInfo == null ? null : networkConnectionInfo.getServer(),
-                        // CLIENT_ADDR
-                        networkConnectionInfo == null ? null : networkConnectionInfo.getClient(),
-                        // CLIENT_INFO
-                        networkConnectionInfo == null ? null : networkConnectionInfo.getClientInfo(),
-                        // SESSION_START
-                        s.getSessionStart(),
-                        // ISOLATION_LEVEL
-                        session.getIsolationLevel().getSQL(),
-                        // STATEMENT
-                        command == null ? null : command.toString(),
-                        // STATEMENT_START
-                        command == null ? null : s.getCommandStartOrEnd(),
-                        // CONTAINS_UNCOMMITTED
-                        ValueBoolean.get(s.containsUncommitted()),
-                        // STATE
-                        String.valueOf(s.getState()),
-                        // BLOCKER_ID
-                        blockingSessionId == 0 ? null : ValueInteger.get(blockingSessionId),
-                        // SLEEP_SINCE
-                        s.getState() == State.SLEEP ? s.getCommandStartOrEnd() : null
-                );
+        if (session.getUser().isAdmin()) {
+            for (Session s : database.getSessions(false)) {
+                sessions(session, rows, s);
             }
+        } else {
+            sessions(session, rows, session);
         }
+    }
+
+    private void sessions(Session session, ArrayList<Row> rows, Session s) {
+        NetworkConnectionInfo networkConnectionInfo = s.getNetworkConnectionInfo();
+        Command command = s.getCurrentCommand();
+        int blockingSessionId = s.getBlockingSessionId();
+        add(session, rows,
+                // ID
+                ValueInteger.get(s.getId()),
+                // USER_NAME
+                s.getUser().getName(),
+                // SERVER
+                networkConnectionInfo == null ? null : networkConnectionInfo.getServer(),
+                // CLIENT_ADDR
+                networkConnectionInfo == null ? null : networkConnectionInfo.getClient(),
+                // CLIENT_INFO
+                networkConnectionInfo == null ? null : networkConnectionInfo.getClientInfo(),
+                // SESSION_START
+                s.getSessionStart(),
+                // ISOLATION_LEVEL
+                session.getIsolationLevel().getSQL(),
+                // STATEMENT
+                command == null ? null : command.toString(),
+                // STATEMENT_START
+                command == null ? null : s.getCommandStartOrEnd(),
+                // CONTAINS_UNCOMMITTED
+                ValueBoolean.get(s.containsUncommitted()),
+                // STATE
+                String.valueOf(s.getState()),
+                // BLOCKER_ID
+                blockingSessionId == 0 ? null : ValueInteger.get(blockingSessionId),
+                // SLEEP_SINCE
+                s.getState() == State.SLEEP ? s.getCommandStartOrEnd() : null
+        );
     }
 
     private void sessionState(Session session, ArrayList<Row> rows) {
@@ -2775,21 +2785,27 @@ public final class InformationSchemaTable extends MetaTable {
     }
 
     private void users(Session session, ArrayList<Row> rows) {
-        boolean admin = session.getUser().isAdmin();
-        for (User u : database.getAllUsers()) {
-            if (admin || session.getUser() == u) {
-                add(session, rows,
-                        // NAME
-                        identifier(u.getName()),
-                        // ADMIN
-                        String.valueOf(u.isAdmin()),
-                        // REMARKS
-                        u.getComment(),
-                        // ID
-                        ValueInteger.get(u.getId())
-                );
+        User currentUser = session.getUser();
+        if (currentUser.isAdmin()) {
+            for (User u : database.getAllUsers()) {
+                users(session, rows, u);
             }
+        } else {
+            users(session, rows, currentUser);
         }
+    }
+
+    private void users(Session session, ArrayList<Row> rows, User user) {
+        add(session, rows,
+                // NAME
+                identifier(user.getName()),
+                // ADMIN
+                String.valueOf(user.isAdmin()),
+                // REMARKS
+                user.getComment(),
+                // ID
+                ValueInteger.get(user.getId())
+        );
     }
 
     private void addConstraintColumnUsage(Session session, ArrayList<Row> rows, String catalog, Constraint constraint,

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -158,17 +158,11 @@ public final class InformationSchemaTable extends MetaTable {
 
     private static final int USERS = SYNONYMS + 1;
 
-    private static final int META_TABLE_TYPE_COUNT = USERS + 1;
-
     /**
-     * Get the number of meta table types. Supported meta table
-     * types are 0 .. this value - 1.
-     *
-     * @return the number of meta table types
+     * The number of meta table types. Supported meta table types are
+     * {@code 0..META_TABLE_TYPE_COUNT - 1}.
      */
-    public static int getMetaTableTypeCount() {
-        return META_TABLE_TYPE_COUNT;
-    }
+    public static final int META_TABLE_TYPE_COUNT = USERS + 1;
 
     private final boolean isView;
 

--- a/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
@@ -124,17 +124,11 @@ public final class InformationSchemaTableLegacy extends MetaTable {
     private static final int CHECK_CONSTRAINTS = REFERENTIAL_CONSTRAINTS + 1;
     private static final int CONSTRAINT_COLUMN_USAGE = CHECK_CONSTRAINTS + 1;
 
-    private static final int META_TABLE_TYPE_COUNT = CONSTRAINT_COLUMN_USAGE + 1;
-
     /**
-     * Get the number of meta table types. Supported meta table
-     * types are 0 .. this value - 1.
-     *
-     * @return the number of meta table types
+     * The number of meta table types. Supported meta table types are
+     * {@code 0..META_TABLE_TYPE_COUNT - 1}.
      */
-    public static int getMetaTableTypeCount() {
-        return META_TABLE_TYPE_COUNT;
-    }
+    public static final int META_TABLE_TYPE_COUNT = CONSTRAINT_COLUMN_USAGE + 1;
 
     /**
      * Create a new metadata table.

--- a/h2/src/test/org/h2/test/db/TestTransaction.java
+++ b/h2/src/test/org/h2/test/db/TestTransaction.java
@@ -1227,18 +1227,18 @@ public class TestTransaction extends TestDb {
     }
 
     private void testIsolationLevelsCountAggregate() throws SQLException {
-        testIsolationLevelsCountAggregate(Connection.TRANSACTION_READ_UNCOMMITTED, 12, 15, 15);
+        testIsolationLevelsCountAggregate(Connection.TRANSACTION_READ_UNCOMMITTED, 12, 15, 15, 16);
         if (!config.mvStore) {
             return;
         }
-        testIsolationLevelsCountAggregate(Connection.TRANSACTION_READ_COMMITTED, 6, 9, 15);
-        testIsolationLevelsCountAggregate(Connection.TRANSACTION_REPEATABLE_READ, 6, 9, 9);
-        testIsolationLevelsCountAggregate(Constants.TRANSACTION_SNAPSHOT, 6, 9, 9);
-        testIsolationLevelsCountAggregate(Connection.TRANSACTION_SERIALIZABLE, 6, 9, 9);
+        testIsolationLevelsCountAggregate(Connection.TRANSACTION_READ_COMMITTED, 6, 9, 15, 16);
+        testIsolationLevelsCountAggregate(Connection.TRANSACTION_REPEATABLE_READ, 6, 9, 9, 15);
+        testIsolationLevelsCountAggregate(Constants.TRANSACTION_SNAPSHOT, 6, 9, 9, 15);
+        testIsolationLevelsCountAggregate(Connection.TRANSACTION_SERIALIZABLE, 6, 9, 9, 15);
     }
 
     private void testIsolationLevelsCountAggregate(int isolationLevel, long uncommitted1, long uncommitted2,
-            long committed) throws SQLException {
+            long committed, long committedOther) throws SQLException {
         deleteDb("transaction");
         try (Connection conn1 = getConnection("transaction"); Connection conn2 = getConnection("transaction")) {
             Statement stat1 = conn1.createStatement();
@@ -1260,6 +1260,10 @@ public class TestTransaction extends TestDb {
             testIsolationLevelsCountAggregate(all, simple, committed);
             conn1.commit();
             testIsolationLevelsCountAggregate(all, simple, 15);
+            stat2.executeUpdate("DELETE FROM TEST WHERE V = 17");
+            stat2.executeUpdate("INSERT INTO TEST VALUES 19, 20");
+            conn2.commit();
+            testIsolationLevelsCountAggregate(all, simple, committedOther);
         }
     }
 


### PR DESCRIPTION
1. `LOCKS`, `SESSIONS`, and `USERS` from `INFORMATION_SCHEMA` are now faster for non-admin users in databases with many users and many active connections. I also renamed some helper methods in `InformationSchemaTable` to improve their order is code search results in Eclipse.

2. `COUNT(*)` and `COUNT(nullable value)` are now tested on all isolation levels to avoid regressions in optimized implementation of `COUNT(*)`.

3. `COUNT(*)` on `READ UNCOMMITTED` isolation level now uses the same optimization as default `READ COMMITTED` (old implementation wasn't optimized).

4. `COUNT(*)` on high isolation levels (`REPEATABLE READ`, `SNAPSHOT`, …) is optimized for ~tables~ transactions without changes since their start.