### PR TITLE
Implement getRowCount() for some INFORMATION_SCHEMA tables

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #2722: Implement getRowCount() for some INFORMATION_SCHEMA tables
+</li>
+<li>PR #2721: Improve LOCKS, SESSIONS, and USERS and optimize COUNT(*) on other isolation levels in some cases
+</li>
+<li>Issue #2655: TestCrashAPI: AssertionError at MVPrimaryIndex.&lt;init&gt;
+</li>
 <li>Issue #2716: Fix URL of Maven repository
 </li>
 <li>Issue #2715: Mention `DB_CLOSE_DELAY=-1` flag in JDBC URL on the "Cheat Sheet" page

--- a/h2/src/main/org/h2/api/Aggregate.java
+++ b/h2/src/main/org/h2/api/Aggregate.java
@@ -19,6 +19,7 @@ public interface Aggregate {
      * A new object is created for each invocation.
      *
      * @param conn a connection to the database
+     * @throws SQLException on SQL exception
      */
     default void init(Connection conn) throws SQLException {
         // Do nothing by default

--- a/h2/src/main/org/h2/api/AggregateFunction.java
+++ b/h2/src/main/org/h2/api/AggregateFunction.java
@@ -24,6 +24,7 @@ public interface AggregateFunction {
      * A new object is created for each invocation.
      *
      * @param conn a connection to the database
+     * @throws SQLException on SQL exception
      */
     default void init(Connection conn) throws SQLException {
         // Do nothing by default

--- a/h2/src/main/org/h2/api/Trigger.java
+++ b/h2/src/main/org/h2/api/Trigger.java
@@ -49,6 +49,7 @@ public interface Trigger {
      *            operation is performed
      * @param type the operation type: INSERT, UPDATE, DELETE, SELECT, or a
      *            combination (this parameter is a bit field)
+     * @throws SQLException on SQL exception
      */
     default void init(Connection conn, String schemaName, String triggerName,
             String tableName, boolean before, int type) throws SQLException {
@@ -84,6 +85,8 @@ public interface Trigger {
      * This method is called when the database is closed.
      * If the method throws an exception, it will be logged, but
      * closing the database will continue.
+     *
+     * @throws SQLException on SQL exception
      */
     default void close() throws SQLException {
         // Does nothing by default
@@ -91,6 +94,8 @@ public interface Trigger {
 
     /**
      * This method is called when the trigger is dropped.
+     *
+     * @throws SQLException on SQL exception
      */
     default void remove() throws SQLException {
         // Does nothing by default

--- a/h2/src/main/org/h2/command/ddl/DropDatabase.java
+++ b/h2/src/main/org/h2/command/ddl/DropDatabase.java
@@ -102,22 +102,24 @@ public class DropDatabase extends DefineCommand {
             }
         }
         ArrayList<SchemaObject> list = new ArrayList<>();
-        for (SchemaObject obj : db.getAllSchemaObjects(DbObject.SEQUENCE))  {
-            // ignore these. the ones we want to drop will get dropped when we
-            // drop their associated tables, and we will ignore the problematic
-            // ones that belong to session-local temp tables.
-            if (!((Sequence) obj).getBelongsToTable()) {
-                list.add(obj);
+        for (Schema schema : schemas) {
+            for (Sequence sequence : schema.getAllSequences()) {
+                // ignore these. the ones we want to drop will get dropped when we
+                // drop their associated tables, and we will ignore the problematic
+                // ones that belong to session-local temp tables.
+                if (!sequence.getBelongsToTable()) {
+                    list.add(sequence);
+                }
             }
         }
         // maybe constraints and triggers on system tables will be allowed in
         // the future
-        list.addAll(db.getAllSchemaObjects(DbObject.CONSTRAINT));
-        list.addAll(db.getAllSchemaObjects(DbObject.TRIGGER));
-        list.addAll(db.getAllSchemaObjects(DbObject.CONSTANT));
-        list.addAll(db.getAllSchemaObjects(DbObject.FUNCTION_ALIAS));
-        list.addAll(db.getAllSchemaObjects(DbObject.AGGREGATE));
-        list.addAll(db.getAllSchemaObjects(DbObject.DOMAIN));
+        addAll(schemas, DbObject.CONSTRAINT, list);
+        addAll(schemas, DbObject.TRIGGER, list);
+        addAll(schemas, DbObject.CONSTANT, list);
+        addAll(schemas, DbObject.FUNCTION_ALIAS, list);
+        addAll(schemas, DbObject.AGGREGATE, list);
+        addAll(schemas, DbObject.DOMAIN, list);
         for (SchemaObject obj : list) {
             if (!obj.getSchema().isValid() || obj.isHidden()) {
                 continue;
@@ -144,6 +146,12 @@ public class DropDatabase extends DefineCommand {
             if (sql != null) {
                 db.removeDatabaseObject(session, obj);
             }
+        }
+    }
+
+    private static void addAll(Collection<Schema> schemas, int type, ArrayList<SchemaObject> list) {
+        for (Schema schema : schemas) {
+            schema.getAll(type, list);
         }
     }
 

--- a/h2/src/main/org/h2/command/ddl/DropDatabase.java
+++ b/h2/src/main/org/h2/command/ddl/DropDatabase.java
@@ -6,6 +6,7 @@
 package org.h2.command.ddl;
 
 import java.util.ArrayList;
+import java.util.Collection;
 
 import org.h2.command.CommandInterface;
 import org.h2.engine.Database;
@@ -94,7 +95,8 @@ public class DropDatabase extends DefineCommand {
         } while (runLoopAgain);
 
         // TODO session-local temp tables are not removed
-        for (Schema schema : db.getAllSchemas()) {
+        Collection<Schema> schemas = db.getAllSchemasNoMeta();
+        for (Schema schema : schemas) {
             if (schema.canDrop()) {
                 db.removeDatabaseObject(session, schema);
             }

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -294,8 +294,9 @@ public class ScriptCommand extends ScriptBase {
                     }
                 }
                 if (TableType.TABLE == tableType) {
-                    if (table.canGetRowCount()) {
-                        StringBuilder builder = new StringBuilder("-- ").append(table.getRowCountApproximation())
+                    if (table.canGetRowCount(session)) {
+                        StringBuilder builder = new StringBuilder("-- ")
+                                .append(table.getRowCountApproximation(session))
                                 .append(" +/- SELECT COUNT(*) FROM ");
                         table.getSQL(builder, HasSQL.TRACE_SQL_FLAGS);
                         add(builder.toString(), false);

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -187,6 +187,9 @@ public class ScriptCommand extends ScriptBase {
                 add(schema.getCreateSQL(), false);
             }
             for (SchemaObject obj : db.getAllSchemaObjects(DbObject.DOMAIN)) {
+                if (excludeSchema(obj.getSchema())) {
+                    continue;
+                }
                 Domain domain = (Domain) obj;
                 if (drop) {
                     add(domain.getDropSQL(), false);

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -28,6 +28,7 @@ import org.h2.engine.Comment;
 import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.engine.DbObject;
+import org.h2.engine.FunctionAlias;
 import org.h2.engine.Right;
 import org.h2.engine.Role;
 import org.h2.engine.Session;
@@ -45,9 +46,9 @@ import org.h2.result.Row;
 import org.h2.schema.Constant;
 import org.h2.schema.Domain;
 import org.h2.schema.Schema;
-import org.h2.schema.SchemaObject;
 import org.h2.schema.Sequence;
 import org.h2.schema.TriggerObject;
+import org.h2.schema.UserAggregate;
 import org.h2.table.Column;
 import org.h2.table.PlanItem;
 import org.h2.table.Table;
@@ -180,29 +181,26 @@ public class ScriptCommand extends ScriptBase {
             for (Role role : db.getAllRoles()) {
                 add(role.getCreateSQL(true), false);
             }
+            ArrayList<Schema> schemas = new ArrayList<>();
             for (Schema schema : db.getAllSchemas()) {
                 if (excludeSchema(schema)) {
                     continue;
                 }
+                schemas.add(schema);
                 add(schema.getCreateSQL(), false);
             }
-            for (SchemaObject obj : db.getAllSchemaObjects(DbObject.DOMAIN)) {
-                if (excludeSchema(obj.getSchema())) {
-                    continue;
+            for (Schema schema : schemas) {
+                for (Domain domain : schema.getAllDomains()) {
+                    if (drop) {
+                        add(domain.getDropSQL(), false);
+                    }
+                    add(domain.getCreateSQL(), false);
                 }
-                Domain domain = (Domain) obj;
-                if (drop) {
-                    add(domain.getDropSQL(), false);
-                }
-                add(domain.getCreateSQL(), false);
             }
-            for (SchemaObject obj : db.getAllSchemaObjects(
-                    DbObject.CONSTANT)) {
-                if (excludeSchema(obj.getSchema())) {
-                    continue;
+            for (Schema schema : schemas) {
+                for (Constant constant : schema.getAllConstants()) {
+                    add(constant.getCreateSQL(), false);
                 }
-                Constant constant = (Constant) obj;
-                add(constant.getCreateSQL(), false);
             }
 
             final ArrayList<Table> tables = db.getAllTablesAndViews(false);
@@ -231,40 +229,36 @@ public class ScriptCommand extends ScriptBase {
                     add(table.getDropSQL(), false);
                 }
             }
-            for (SchemaObject obj : db.getAllSchemaObjects(DbObject.FUNCTION_ALIAS)) {
-                if (excludeSchema(obj.getSchema())) {
-                    continue;
+            for (Schema schema : schemas) {
+                for (FunctionAlias obj : schema.getAllFunctionAliases()) {
+                    if (drop) {
+                        add(obj.getDropSQL(), false);
+                    }
+                    add(obj.getCreateSQL(), false);
                 }
-                if (drop) {
-                    add(obj.getDropSQL(), false);
-                }
-                add(obj.getCreateSQL(), false);
             }
-            for (SchemaObject obj : db.getAllSchemaObjects(DbObject.AGGREGATE)) {
-                if (excludeSchema(obj.getSchema())) {
-                    continue;
+            for (Schema schema : schemas) {
+                for (UserAggregate obj : schema.getAllAggregates()) {
+                    if (drop) {
+                        add(obj.getDropSQL(), false);
+                    }
+                    add(obj.getCreateSQL(), false);
                 }
-                if (drop) {
-                    add(obj.getDropSQL(), false);
-                }
-                add(obj.getCreateSQL(), false);
             }
-            for (SchemaObject obj : db.getAllSchemaObjects(DbObject.SEQUENCE)) {
-                if (excludeSchema(obj.getSchema())) {
-                    continue;
-                }
-                Sequence sequence = (Sequence) obj;
-                if (drop) {
-                    add(sequence.getDropSQL(), false);
-                }
-                String createSQL, alterSQL;
-                synchronized (sequence) {
-                    createSQL = sequence.getCreateSQL(true, false);
-                    alterSQL = sequence.getCreateSQL(true, true);
-                }
-                add(createSQL, false);
-                if (alterSQL != null) {
-                    add(alterSQL, false);
+            for (Schema schema : schemas) {
+                for (Sequence sequence : schema.getAllSequences()) {
+                    if (drop) {
+                        add(sequence.getDropSQL(), false);
+                    }
+                    String createSQL, alterSQL;
+                    synchronized (sequence) {
+                        createSQL = sequence.getCreateSQL(true, false);
+                        alterSQL = sequence.getCreateSQL(true, true);
+                    }
+                    add(createSQL, false);
+                    if (alterSQL != null) {
+                        add(alterSQL, false);
+                    }
                 }
             }
 
@@ -324,34 +318,33 @@ public class ScriptCommand extends ScriptBase {
                 tempLobTableCreated = false;
             }
             // Generate CREATE CONSTRAINT ...
-            final ArrayList<SchemaObject> constraints = db.getAllSchemaObjects(DbObject.CONSTRAINT);
-            constraints.sort(null);
-            for (SchemaObject obj : constraints) {
-                if (excludeSchema(obj.getSchema())) {
-                    continue;
-                }
-                Constraint constraint = (Constraint) obj;
-                if (excludeTable(constraint.getTable())) {
-                    continue;
-                }
-                Type constraintType = constraint.getConstraintType();
-                if (constraintType != Type.DOMAIN && constraint.getTable().isHidden()) {
-                    continue;
-                }
-                if (constraintType != Constraint.Type.PRIMARY_KEY) {
-                    add(constraint.getCreateSQLWithoutIndexes(), false);
+            ArrayList<Constraint> constraints = new ArrayList<>();
+            for (Schema schema : schemas) {
+                for (Constraint constraint : schema.getAllConstraints()) {
+                    if (excludeTable(constraint.getTable())) {
+                        continue;
+                    }
+                    Type constraintType = constraint.getConstraintType();
+                    if (constraintType != Type.DOMAIN && constraint.getTable().isHidden()) {
+                        continue;
+                    }
+                    if (constraintType != Constraint.Type.PRIMARY_KEY) {
+                        constraints.add(constraint);
+                    }
                 }
             }
+            constraints.sort(null);
+            for (Constraint constraint : constraints) {
+                add(constraint.getCreateSQLWithoutIndexes(), false);
+            }
             // Generate CREATE TRIGGER ...
-            for (SchemaObject obj : db.getAllSchemaObjects(DbObject.TRIGGER)) {
-                if (excludeSchema(obj.getSchema())) {
-                    continue;
+            for (Schema schema : schemas) {
+                for (TriggerObject trigger : schema.getAllTriggers()) {
+                    if (excludeTable(trigger.getTable())) {
+                        continue;
+                    }
+                    add(trigger.getCreateSQL(), false);
                 }
-                TriggerObject trigger = (TriggerObject) obj;
-                if (excludeTable(trigger.getTable())) {
-                    continue;
-                }
-                add(trigger.getCreateSQL(), false);
             }
             // Generate GRANT ...
             for (Right right : db.getAllRights()) {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1728,6 +1728,10 @@ public class Database implements DataHandler, CastDataProvider {
         return schemas.values();
     }
 
+    public Collection<Schema> getAllSchemasNoMeta() {
+        return schemas.values();
+    }
+
     public Collection<Setting> getAllSettings() {
         return settings.values();
     }

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1424,19 +1424,19 @@ public class Database implements DataHandler, CastDataProvider {
                                 table.close(systemSession);
                             }
                         }
-                        for (SchemaObject obj : getAllSchemaObjects(
-                                DbObject.SEQUENCE)) {
-                            Sequence sequence = (Sequence) obj;
-                            sequence.close();
+                        for (Schema schema : getAllSchemasNoMeta()) {
+                            for (Sequence sequence : schema.getAllSequences()) {
+                                sequence.close();
+                            }
                         }
                     }
-                    for (SchemaObject obj : getAllSchemaObjects(
-                            DbObject.TRIGGER)) {
-                        TriggerObject trigger = (TriggerObject) obj;
-                        try {
-                            trigger.close();
-                        } catch (SQLException e) {
-                            trace.error(e, "close");
+                    for (Schema schema : getAllSchemasNoMeta()) {
+                        for (TriggerObject trigger : schema.getAllTriggers()) {
+                            try {
+                                trigger.close();
+                            } catch (SQLException e) {
+                                trace.error(e, "close");
+                            }
                         }
                     }
                     if (powerOffCount != -1) {
@@ -1652,23 +1652,6 @@ public class Database implements DataHandler, CastDataProvider {
         ArrayList<SchemaObject> list = new ArrayList<>();
         for (Schema schema : schemas.values()) {
             schema.getAll(list);
-        }
-        return list;
-    }
-
-    /**
-     * Get all schema objects of the given type.
-     *
-     * @param type the object type
-     * @return all objects of that type
-     */
-    public ArrayList<SchemaObject> getAllSchemaObjects(int type) {
-        if (type == DbObject.TABLE_OR_VIEW) {
-            initMetaTables();
-        }
-        ArrayList<SchemaObject> list = new ArrayList<>();
-        for (Schema schema : schemas.values()) {
-            schema.getAll(type, list);
         }
         return list;
     }

--- a/h2/src/main/org/h2/expression/aggregate/Aggregate.java
+++ b/h2/src/main/org/h2/expression/aggregate/Aggregate.java
@@ -1000,11 +1000,11 @@ public class Aggregate extends AbstractAggregate implements ExpressionWithFlags 
             switch (aggregateType) {
             case COUNT:
                 if (!distinct && args[0].getNullable() == Column.NOT_NULLABLE) {
-                    return visitor.getTable().canGetRowCount();
+                    return visitor.getTable().canGetRowCount(select.getSession());
                 }
                 return false;
             case COUNT_ALL:
-                return visitor.getTable().canGetRowCount();
+                return visitor.getTable().canGetRowCount(select.getSession());
             case MIN:
             case MAX:
                 Index index = getMinMaxColumnIndex();

--- a/h2/src/main/org/h2/expression/function/ToChar.java
+++ b/h2/src/main/org/h2/expression/function/ToChar.java
@@ -842,7 +842,8 @@ public class ToChar {
                 i += 3;
 
             } else if (containsAt(format, i, "TZM") != null) {
-                StringUtils.appendTwoDigits(output, Math.abs(DateTimeFunction.extractDateTime(session, value, DateTimeFunction.TIMEZONE_MINUTE)));
+                StringUtils.appendTwoDigits(output,
+                        Math.abs(DateTimeFunction.extractDateTime(session, value, DateTimeFunction.TIMEZONE_MINUTE)));
                 i += 3;
 
                 // Week

--- a/h2/src/main/org/h2/index/Index.java
+++ b/h2/src/main/org/h2/index/Index.java
@@ -184,9 +184,10 @@ public interface Index extends SchemaObject {
     /**
      * Get the approximated row count for this table.
      *
+     * @param session the session
      * @return the approximated row count
      */
-    long getRowCountApproximation();
+    long getRowCountApproximation(Session session);
 
     /**
      * Get the used disk space for this index.

--- a/h2/src/main/org/h2/index/LinkedIndex.java
+++ b/h2/src/main/org/h2/index/LinkedIndex.java
@@ -260,7 +260,7 @@ public class LinkedIndex extends BaseIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return rowCount;
     }
 

--- a/h2/src/main/org/h2/index/MetaIndex.java
+++ b/h2/src/main/org/h2/index/MetaIndex.java
@@ -112,7 +112,7 @@ public class MetaIndex extends BaseIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return MetaTable.ROW_COUNT_APPROXIMATION;
     }
 

--- a/h2/src/main/org/h2/index/ViewIndex.java
+++ b/h2/src/main/org/h2/index/ViewIndex.java
@@ -400,7 +400,7 @@ public class ViewIndex extends BaseIndex implements SpatialIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return 0;
     }
 

--- a/h2/src/main/org/h2/index/VirtualConstructedTableIndex.java
+++ b/h2/src/main/org/h2/index/VirtualConstructedTableIndex.java
@@ -45,8 +45,8 @@ public class VirtualConstructedTableIndex extends VirtualTableIndex {
             throw DbException.getUnsupportedException("Virtual table");
         }
         long expectedRows;
-        if (table.canGetRowCount()) {
-            expectedRows = table.getRowCountApproximation();
+        if (table.canGetRowCount(session)) {
+            expectedRows = table.getRowCountApproximation(session);
         } else {
             expectedRows = database.getSettings().estimatedFunctionTableRows;
         }

--- a/h2/src/main/org/h2/index/VirtualTableIndex.java
+++ b/h2/src/main/org/h2/index/VirtualTableIndex.java
@@ -61,8 +61,8 @@ public abstract class VirtualTableIndex extends BaseIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
-        return table.getRowCountApproximation();
+    public long getRowCountApproximation(Session session) {
+        return table.getRowCountApproximation(session);
     }
 
     @Override

--- a/h2/src/main/org/h2/jdbc/JdbcLob.java
+++ b/h2/src/main/org/h2/jdbc/JdbcLob.java
@@ -116,6 +116,9 @@ public abstract class JdbcLob extends TraceObject {
     /**
      * Check the state of the LOB and throws the exception when check failed
      * (the LOB must be set completely before read).
+     *
+     * @throws SQLException on SQL exception
+     * @throws IOException on I/O exception
      */
     void checkReadable() throws SQLException, IOException {
         checkClosed();

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -181,7 +181,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements
         }
     }
 
-    private int executeUpdateInternal() throws SQLException {
+    private int executeUpdateInternal() {
         closeOldResultSet();
         synchronized (session) {
             try {

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -153,7 +153,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
         }
     }
 
-    private int executeUpdateInternal(String sql, Object generatedKeysRequest) throws SQLException {
+    private int executeUpdateInternal(String sql, Object generatedKeysRequest) {
         checkClosed();
         closeOldResultSet();
         sql = JdbcConnection.translateSQL(sql, escapeProcessing);
@@ -199,7 +199,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
         }
     }
 
-    private boolean executeInternal(String sql, Object generatedKeysRequest) throws SQLException {
+    private boolean executeInternal(String sql, Object generatedKeysRequest) {
         int id = getNextId(TraceObject.RESULT_SET);
         checkClosed();
         closeOldResultSet();

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocal.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocal.java
@@ -1295,7 +1295,8 @@ public final class DatabaseMetaLocal extends DatabaseMetaLocalBase {
                         // ASC_OR_DESC
                         getString((c.sortType & SortOrder.DESCENDING) != 0 ? "D" : "A"),
                         // CARDINALITY
-                        ValueBigint.get(approximate ? index.getRowCountApproximation() : index.getRowCount(session)),
+                        ValueBigint.get(approximate //
+                                ? index.getRowCountApproximation(session) : index.getRowCount(session)),
                         // PAGES
                         ValueBigint.get(index.getDiskSpaceUsed() / db.getPageSize()),
                         // FILTER_CONDITION

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -780,7 +780,7 @@ public abstract class Page<K,V> implements Cloneable {
      * update the position and the children.
      * @param chunk the chunk
      * @param buff the target buffer
-     * @param toc
+     * @param toc prospective table of content
      */
     abstract void writeUnsavedRecursive(Chunk chunk, WriteBuffer buff, List<Long> toc);
 

--- a/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVDelegateIndex.java
@@ -114,7 +114,7 @@ public class MVDelegateIndex extends BaseIndex implements MVIndex<Long,SearchRow
     public double getCost(Session session, int[] masks,
             TableFilter[] filters, int filter, SortOrder sortOrder,
             AllColumnsForPlan allColumnsSet) {
-        return 10 * getCostRangeIndex(masks, mainIndex.getRowCountApproximation(),
+        return 10 * getCostRangeIndex(masks, mainIndex.getRowCountApproximation(session),
                 filters, filter, sortOrder, true, allColumnsSet);
     }
 
@@ -149,8 +149,8 @@ public class MVDelegateIndex extends BaseIndex implements MVIndex<Long,SearchRow
     }
 
     @Override
-    public long getRowCountApproximation() {
-        return mainIndex.getRowCountApproximation();
+    public long getRowCountApproximation(Session session) {
+        return mainIndex.getRowCountApproximation(session);
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -18,7 +18,6 @@ import org.h2.index.Cursor;
 import org.h2.index.IndexType;
 import org.h2.index.SingleRowCursor;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStoreException;
 import org.h2.mvstore.tx.Transaction;

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -347,7 +347,7 @@ public class MVPrimaryIndex extends BaseIndex implements MVIndex<Long,SearchRow>
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return getRowCountMax();
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -19,7 +19,6 @@ import org.h2.index.Cursor;
 import org.h2.index.IndexType;
 import org.h2.index.SingleRowCursor;
 import org.h2.message.DbException;
-import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.MVStoreException;

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -359,7 +359,7 @@ public final class MVSecondaryIndex extends BaseIndex implements MVIndex<SearchR
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         try {
             return dataMap.sizeAsLongMax();
         } catch (MVStoreException e) {

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -339,7 +339,7 @@ public class MVSpatialIndex extends BaseIndex implements SpatialIndex, MVIndex<S
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         try {
             return dataMap.sizeAsLongMax();
         } catch (MVStoreException e) {

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -14,7 +14,6 @@ import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.command.ddl.CreateTableData;
 import org.h2.engine.Constants;
-import org.h2.engine.DbObject;
 import org.h2.engine.Session;
 import org.h2.engine.SysProperties;
 import org.h2.index.Cursor;
@@ -29,7 +28,6 @@ import org.h2.mvstore.tx.Transaction;
 import org.h2.mvstore.tx.TransactionStore;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
-import org.h2.schema.SchemaObject;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
 import org.h2.table.RegularTable;
@@ -615,16 +613,6 @@ public class MVTable extends RegularTable {
         }
         primaryIndex.remove(session);
         indexes.clear();
-        if (SysProperties.CHECK) {
-            for (SchemaObject obj : database
-                    .getAllSchemaObjects(DbObject.INDEX)) {
-                Index index = (Index) obj;
-                if (index.getTable() == this) {
-                    throw DbException.throwInternalError("index not dropped: " +
-                            index.getName());
-                }
-            }
-        }
         close(session);
         invalidate();
     }

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -635,8 +635,8 @@ public class MVTable extends RegularTable {
     }
 
     @Override
-    public long getRowCountApproximation() {
-        return primaryIndex.getRowCountApproximation();
+    public long getRowCountApproximation(Session session) {
+        return primaryIndex.getRowCountApproximation(session);
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
@@ -45,7 +45,8 @@ class TxDecisionMaker<K,V> extends MVMap.DecisionMaker<VersionedValue<V>> {
     private       long           undoKey;
 
     /**
-     * Id of the last operation, we decided to {@link MVMap.Decision#REPEAT}.
+     * Id of the last operation, we decided to
+     * {@link org.h2.mvstore.MVMap.Decision#REPEAT}.
      */
     private       long           lastOperationId;
 
@@ -145,12 +146,13 @@ class TxDecisionMaker<K,V> extends MVMap.DecisionMaker<VersionedValue<V>> {
     }
 
     /**
-     * Create undo log entry and record for future references {@link MVMap.Decision#PUT} decision
-     * along with last known committed value
+     * Create undo log entry and record for future references
+     * {@link org.h2.mvstore.MVMap.Decision#PUT} decision along with last known
+     * committed value
      *
      * @param valueToLog previous value to be logged
      * @param lastValue last known committed value
-     * @return {@link MVMap.Decision#PUT}
+     * @return {@link org.h2.mvstore.MVMap.Decision#PUT}
      */
     MVMap.Decision logAndDecideToPut(VersionedValue<V> valueToLog, V lastValue) {
         undoKey = transaction.log(new Record<>(mapId, key, valueToLog));
@@ -218,7 +220,9 @@ class TxDecisionMaker<K,V> extends MVMap.DecisionMaker<VersionedValue<V>> {
      * This is to prevent an infinite loop in case of uncommitted "leftover" entry
      * (one without a corresponding undo log entry, most likely as a result of unclean shutdown).
      *
-     * @param id for the operation we decided to {@link MVMap.Decision#REPEAT}
+     * @param id
+     *            for the operation we decided to
+     *            {@link org.h2.mvstore.MVMap.Decision#REPEAT}
      * @return true if the same as last operation id, false otherwise
      */
     final boolean isRepeatedOperation(long id) {

--- a/h2/src/main/org/h2/pagestore/db/HashIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/HashIndex.java
@@ -118,11 +118,11 @@ public class HashIndex extends BaseIndex {
 
     @Override
     public long getRowCount(Session session) {
-        return getRowCountApproximation();
+        return getRowCountApproximation(session);
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return rows.size() + nullRows.size();
     }
 

--- a/h2/src/main/org/h2/pagestore/db/NonUniqueHashIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/NonUniqueHashIndex.java
@@ -121,7 +121,7 @@ public class NonUniqueHashIndex extends BaseIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return rowCount;
     }
 

--- a/h2/src/main/org/h2/pagestore/db/PageBtreeIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/PageBtreeIndex.java
@@ -304,8 +304,8 @@ public class PageBtreeIndex extends PageIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
-        return tableData.getRowCountApproximation();
+    public long getRowCountApproximation(Session session) {
+        return tableData.getRowCountApproximation(session);
     }
 
     @Override

--- a/h2/src/main/org/h2/pagestore/db/PageDataIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/PageDataIndex.java
@@ -271,7 +271,7 @@ public class PageDataIndex extends PageIndex {
         // columns, will take precedence. This all works out easier in the MVStore case,
         // because MVStore uses the same cost calculation code for the ScanIndex (i.e.
         // the MVPrimaryIndex) and all other indices.
-        return 10 * (tableData.getRowCountApproximation() +
+        return 10 * (tableData.getRowCountApproximation(session) +
                 Constants.COST_ROW_OFFSET) + 200;
     }
 
@@ -374,7 +374,7 @@ public class PageDataIndex extends PageIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return rowCount;
     }
 

--- a/h2/src/main/org/h2/pagestore/db/PageDelegateIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/PageDelegateIndex.java
@@ -132,8 +132,8 @@ public class PageDelegateIndex extends PageIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
-        return mainIndex.getRowCountApproximation();
+    public long getRowCountApproximation(Session session) {
+        return mainIndex.getRowCountApproximation(session);
     }
 
     @Override

--- a/h2/src/main/org/h2/pagestore/db/PageStoreTable.java
+++ b/h2/src/main/org/h2/pagestore/db/PageStoreTable.java
@@ -12,7 +12,6 @@ import org.h2.api.DatabaseEventListener;
 import org.h2.api.ErrorCode;
 import org.h2.command.ddl.CreateTableData;
 import org.h2.engine.Constants;
-import org.h2.engine.DbObject;
 import org.h2.engine.Session;
 import org.h2.engine.SysProperties;
 import org.h2.index.Cursor;
@@ -21,7 +20,6 @@ import org.h2.index.IndexType;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.result.Row;
-import org.h2.schema.SchemaObject;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
 import org.h2.table.RegularTable;
@@ -483,14 +481,6 @@ public class PageStoreTable extends RegularTable {
             }
             // needed for session temporary indexes
             indexes.remove(index);
-        }
-        if (SysProperties.CHECK) {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.INDEX)) {
-                Index index = (Index) obj;
-                if (index.getTable() == this) {
-                    DbException.throwInternalError("index not dropped: " + index.getName());
-                }
-            }
         }
         scanIndex.remove(session);
         database.removeMeta(session, getId());

--- a/h2/src/main/org/h2/pagestore/db/PageStoreTable.java
+++ b/h2/src/main/org/h2/pagestore/db/PageStoreTable.java
@@ -506,8 +506,8 @@ public class PageStoreTable extends RegularTable {
     }
 
     @Override
-    public long getRowCountApproximation() {
-        return scanIndex.getRowCountApproximation();
+    public long getRowCountApproximation(Session session) {
+        return scanIndex.getRowCountApproximation(session);
     }
 
     @Override

--- a/h2/src/main/org/h2/pagestore/db/ScanIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/ScanIndex.java
@@ -117,7 +117,7 @@ public class ScanIndex extends BaseIndex {
     public double getCost(Session session, int[] masks,
             TableFilter[] filters, int filter, SortOrder sortOrder,
             AllColumnsForPlan allColumnsSet) {
-        return tableData.getRowCountApproximation() + Constants.COST_ROW_OFFSET;
+        return tableData.getRowCountApproximation(session) + Constants.COST_ROW_OFFSET;
     }
 
     @Override
@@ -172,7 +172,7 @@ public class ScanIndex extends BaseIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return rowCount;
     }
 

--- a/h2/src/main/org/h2/pagestore/db/SpatialTreeIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/SpatialTreeIndex.java
@@ -199,7 +199,7 @@ public class SpatialTreeIndex extends BaseIndex implements SpatialIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return treeMap.sizeAsLong();
     }
 

--- a/h2/src/main/org/h2/pagestore/db/TreeIndex.java
+++ b/h2/src/main/org/h2/pagestore/db/TreeIndex.java
@@ -313,7 +313,7 @@ public class TreeIndex extends BaseIndex {
     @Override
     public double getCost(Session session, int[] masks, TableFilter[] filters, int filter,
             SortOrder sortOrder, AllColumnsForPlan allColumnsSet) {
-        return getCostRangeIndex(masks, tableData.getRowCountApproximation(),
+        return getCostRangeIndex(masks, tableData.getRowCountApproximation(session),
                 filters, filter, sortOrder, false, allColumnsSet);
     }
 
@@ -387,7 +387,7 @@ public class TreeIndex extends BaseIndex {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return rowCount;
     }
 

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -700,8 +700,20 @@ public class Schema extends DbObjectBase {
         return domains.values();
     }
 
+    public Collection<Constraint> getAllConstraints() {
+        return constraints.values();
+    }
+
     public Collection<Constant> getAllConstants() {
         return constants.values();
+    }
+
+    public Collection<Sequence> getAllSequences() {
+        return sequences.values();
+    }
+
+    public Collection<TriggerObject> getAllTriggers() {
+        return triggers.values();
     }
 
     /**

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -725,6 +725,9 @@ public class Schema extends DbObjectBase {
         return tablesAndViews.values();
     }
 
+    public Collection<Index> getAllIndexes() {
+        return indexes.values();
+    }
 
     public Collection<TableSynonym> getAllSynonyms() {
         return synonyms.values();

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -681,19 +681,10 @@ public class Schema extends DbObjectBase {
      * @param type
      *                  the object type
      * @param addTo
-     *                  list to add objects to, or {@code null} to allocate a new
-     *                  list
-     * @return the specified list with added objects, or a new (possibly empty) list
-     *         with objects of the given type
+     *                  list to add objects to
      */
-    public ArrayList<SchemaObject> getAll(int type, ArrayList<SchemaObject> addTo) {
-        Collection<SchemaObject> values = getMap(type).values();
-        if (addTo != null) {
-            addTo.addAll(values);
-        } else {
-            addTo = new ArrayList<>(values);
-        }
-        return addTo;
+    public void getAll(int type, ArrayList<SchemaObject> addTo) {
+        addTo.addAll(getMap(type).values());
     }
 
     public Collection<Domain> getAllDomains() {

--- a/h2/src/main/org/h2/table/DataChangeDeltaTable.java
+++ b/h2/src/main/org/h2/table/DataChangeDeltaTable.java
@@ -68,7 +68,7 @@ public class DataChangeDeltaTable extends VirtualConstructedTable {
     }
 
     @Override
-    public boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         return false;
     }
 
@@ -78,7 +78,7 @@ public class DataChangeDeltaTable extends VirtualConstructedTable {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return Long.MAX_VALUE;
     }
 

--- a/h2/src/main/org/h2/table/DualTable.java
+++ b/h2/src/main/org/h2/table/DualTable.java
@@ -37,7 +37,7 @@ public class DualTable extends VirtualTable {
     }
 
     @Override
-    public boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         return true;
     }
 
@@ -62,7 +62,7 @@ public class DualTable extends VirtualTable {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return 1L;
     }
 

--- a/h2/src/main/org/h2/table/FunctionTable.java
+++ b/h2/src/main/org/h2/table/FunctionTable.java
@@ -55,7 +55,7 @@ public class FunctionTable extends VirtualConstructedTable {
     }
 
     @Override
-    public boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         return false;
     }
 
@@ -65,7 +65,7 @@ public class FunctionTable extends VirtualConstructedTable {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return Long.MAX_VALUE;
     }
 

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -2078,7 +2078,7 @@ public final class InformationSchemaTable extends MetaTable {
                     // TABLE_CLASS
                     table.getClass().getName(),
                     // ROW_COUNT_ESTIMATE
-                    ValueBigint.get(table.getRowCountApproximation())
+                    ValueBigint.get(table.getRowCountApproximation(session))
             );
         }
     }

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -6,7 +6,6 @@
 package org.h2.table;
 
 import java.io.IOException;
-import java.text.Collator;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashSet;
@@ -997,7 +996,7 @@ public final class InformationSchemaTable extends MetaTable {
     private void collations(Session session, ArrayList<Row> rows, String catalog) {
         String mainSchemaName = database.getMainSchema().getName();
         collations(session, rows, catalog, mainSchemaName, "OFF", null);
-        for (Locale l : Collator.getAvailableLocales()) {
+        for (Locale l : CompareMode.getCollationLocales(false)) {
             collations(session, rows, catalog, mainSchemaName, CompareMode.getName(l), l.toLanguageTag());
         }
     }

--- a/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
@@ -785,8 +785,9 @@ public final class InformationSchemaTableLegacy extends MetaTable {
                         // TYPE_NAME
                         null,
                         // TABLE_CLASS
-                        table.getClass().getName(), // ROW_COUNT_ESTIMATE
-                        ValueBigint.get(table.getRowCountApproximation())
+                        table.getClass().getName(),
+                        // ROW_COUNT_ESTIMATE
+                        ValueBigint.get(table.getRowCountApproximation(session))
                 );
             }
             break;

--- a/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
@@ -1199,7 +1199,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case SEQUENCES: {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.SEQUENCE)) {
+            for (SchemaObject obj : getAllSchemaObjects(DbObject.SEQUENCE)) {
                 Sequence s = (Sequence) obj;
                 TypeInfo dataType = s.getDataType();
                 String dataTypeName = Value.getTypeName(dataType.getValueType());
@@ -1351,7 +1351,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
         }
         case FUNCTION_ALIASES: {
             for (SchemaObject aliasAsSchemaObject :
-                    database.getAllSchemaObjects(DbObject.FUNCTION_ALIAS)) {
+                    getAllSchemaObjects(DbObject.FUNCTION_ALIAS)) {
                 FunctionAlias alias = (FunctionAlias) aliasAsSchemaObject;
                 JavaMethod[] methods;
                 try {
@@ -1393,7 +1393,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
                     );
                 }
             }
-            for (SchemaObject aggregateAsSchemaObject : database.getAllSchemaObjects(DbObject.AGGREGATE)) {
+            for (SchemaObject aggregateAsSchemaObject : getAllSchemaObjects(DbObject.AGGREGATE)) {
                 UserAggregate agg = (UserAggregate) aggregateAsSchemaObject;
                 add(session,
                         rows,
@@ -1428,7 +1428,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
         }
         case FUNCTION_COLUMNS: {
             for (SchemaObject aliasAsSchemaObject :
-                    database.getAllSchemaObjects(DbObject.FUNCTION_ALIAS)) {
+                    getAllSchemaObjects(DbObject.FUNCTION_ALIAS)) {
                 FunctionAlias alias = (FunctionAlias) aliasAsSchemaObject;
                 JavaMethod[] methods;
                 try {
@@ -1652,7 +1652,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case CROSS_REFERENCES: {
-            for (SchemaObject obj : database.getAllSchemaObjects(
+            for (SchemaObject obj : getAllSchemaObjects(
                     DbObject.CONSTRAINT)) {
                 Constraint constraint = (Constraint) obj;
                 if (constraint.getConstraintType() != Constraint.Type.REFERENTIAL) {
@@ -1705,7 +1705,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case CONSTRAINTS: {
-            for (SchemaObject obj : database.getAllSchemaObjects(
+            for (SchemaObject obj : getAllSchemaObjects(
                     DbObject.CONSTRAINT)) {
                 Constraint constraint = (Constraint) obj;
                 Constraint.Type constraintType = constraint.getConstraintType();
@@ -1777,7 +1777,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case CONSTANTS: {
-            for (SchemaObject obj : database.getAllSchemaObjects(
+            for (SchemaObject obj : getAllSchemaObjects(
                     DbObject.CONSTANT)) {
                 Constant constant = (Constant) obj;
                 ValueExpression expr = constant.getValue();
@@ -1801,7 +1801,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case DOMAINS: {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.DOMAIN)) {
+            for (SchemaObject obj : getAllSchemaObjects(DbObject.DOMAIN)) {
                 Domain domain = (Domain) obj;
                 Column col = domain.getColumn();
                 Domain parentDomain = col.getDomain();
@@ -1851,7 +1851,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case TRIGGERS: {
-            for (SchemaObject obj : database.getAllSchemaObjects(
+            for (SchemaObject obj : getAllSchemaObjects(
                     DbObject.TRIGGER)) {
                 TriggerObject trigger = (TriggerObject) obj;
                 Table table = trigger.getTable();
@@ -2063,7 +2063,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case TABLE_CONSTRAINTS: {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.CONSTRAINT)) {
+            for (SchemaObject obj : getAllSchemaObjects(DbObject.CONSTRAINT)) {
                 Constraint constraint = (Constraint) obj;
                 Constraint.Type constraintType = constraint.getConstraintType();
                 if (constraintType == Constraint.Type.DOMAIN) {
@@ -2107,7 +2107,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case DOMAIN_CONSTRAINTS: {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.CONSTRAINT)) {
+            for (SchemaObject obj : getAllSchemaObjects(DbObject.CONSTRAINT)) {
                 if (((Constraint) obj).getConstraintType() != Constraint.Type.DOMAIN) {
                     continue;
                 }
@@ -2141,7 +2141,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case KEY_COLUMN_USAGE: {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.CONSTRAINT)) {
+            for (SchemaObject obj : getAllSchemaObjects(DbObject.CONSTRAINT)) {
                 Constraint constraint = (Constraint) obj;
                 Constraint.Type constraintType = constraint.getConstraintType();
                 IndexColumn[] indexColumns = null;
@@ -2213,7 +2213,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case REFERENTIAL_CONSTRAINTS: {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.CONSTRAINT)) {
+            for (SchemaObject obj : getAllSchemaObjects(DbObject.CONSTRAINT)) {
                 if (((Constraint) obj).getConstraintType() != Constraint.Type.REFERENTIAL) {
                     continue;
                 }
@@ -2247,7 +2247,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case CHECK_CONSTRAINTS: {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.CONSTRAINT)) {
+            for (SchemaObject obj : getAllSchemaObjects(DbObject.CONSTRAINT)) {
                 Constraint constraint = (Constraint) obj;
                 Type constraintType = constraint.getConstraintType();
                 if (constraintType == Constraint.Type.CHECK) {
@@ -2274,7 +2274,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case CONSTRAINT_COLUMN_USAGE: {
-            for (SchemaObject obj : database.getAllSchemaObjects(DbObject.CONSTRAINT)) {
+            for (SchemaObject obj : getAllSchemaObjects(DbObject.CONSTRAINT)) {
                 Constraint constraint = (Constraint) obj;
                 switch (constraint.getConstraintType()) {
                 case CHECK:
@@ -2428,6 +2428,14 @@ public final class InformationSchemaTableLegacy extends MetaTable {
                     isGrantable
             );
         }
+    }
+
+    private ArrayList<SchemaObject> getAllSchemaObjects(int type) {
+        ArrayList<SchemaObject> list = new ArrayList<>();
+        for (Schema schema : database.getAllSchemas()) {
+            schema.getAll(type, list);
+        }
+        return list;
     }
 
     @Override

--- a/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
@@ -12,7 +12,6 @@ import java.io.Reader;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.Types;
-import java.text.Collator;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashSet;
@@ -1595,7 +1594,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case COLLATIONS: {
-            for (Locale l : Collator.getAvailableLocales()) {
+            for (Locale l : CompareMode.getCollationLocales(false)) {
                 add(session,
                         rows,
                         // NAME

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -233,12 +233,12 @@ public abstract class MetaTable extends Table {
     }
 
     @Override
-    public final long getRowCount(Session session) {
+    public long getRowCount(Session session) {
         throw DbException.throwInternalError(toString());
     }
 
     @Override
-    public final boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         return false;
     }
 
@@ -275,7 +275,7 @@ public abstract class MetaTable extends Table {
     }
 
     @Override
-    public final long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return ROW_COUNT_APPROXIMATION;
     }
 

--- a/h2/src/main/org/h2/table/RangeTable.java
+++ b/h2/src/main/org/h2/table/RangeTable.java
@@ -69,7 +69,7 @@ public class RangeTable extends VirtualTable {
     }
 
     @Override
-    public boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         return true;
     }
 
@@ -166,7 +166,7 @@ public class RangeTable extends VirtualTable {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return 100;
     }
 

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -134,7 +134,7 @@ public abstract class RegularTable extends TableBase {
     }
 
     @Override
-    public boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         return true;
     }
 

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -329,9 +329,10 @@ public abstract class Table extends SchemaObjectBase {
     /**
      * Check if the row count can be retrieved quickly.
      *
+     * @param session the session
      * @return true if it can
      */
-    public abstract boolean canGetRowCount();
+    public abstract boolean canGetRowCount(Session session);
 
     /**
      * Check if this table can be referenced.
@@ -360,9 +361,10 @@ public abstract class Table extends SchemaObjectBase {
     /**
      * Get the approximated row count for this table.
      *
+     * @param session the session
      * @return the approximated row count
      */
-    public abstract long getRowCountApproximation();
+    public abstract long getRowCountApproximation(Session session);
 
     public abstract long getDiskSpaceUsed();
 

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -563,7 +563,7 @@ public class TableLink extends Table {
     }
 
     @Override
-    public boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         return true;
     }
 
@@ -644,7 +644,7 @@ public class TableLink extends Table {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return ROW_COUNT_APPROXIMATION;
     }
 

--- a/h2/src/main/org/h2/table/TableValueConstructorTable.java
+++ b/h2/src/main/org/h2/table/TableValueConstructorTable.java
@@ -29,7 +29,7 @@ public class TableValueConstructorTable extends VirtualConstructedTable {
     }
 
     @Override
-    public boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         return true;
     }
 
@@ -39,7 +39,7 @@ public class TableValueConstructorTable extends VirtualConstructedTable {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return rows.size();
     }
 

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -380,7 +380,7 @@ public class TableView extends Table {
     }
 
     @Override
-    public boolean canGetRowCount() {
+    public boolean canGetRowCount(Session session) {
         // TODO view: could get the row count, but not that easy
         return false;
     }
@@ -537,7 +537,7 @@ public class TableView extends Table {
     }
 
     @Override
-    public long getRowCountApproximation() {
+    public long getRowCountApproximation(Session session) {
         return ROW_COUNT_APPROXIMATION;
     }
 

--- a/h2/src/main/org/h2/value/CompareMode.java
+++ b/h2/src/main/org/h2/value/CompareMode.java
@@ -56,6 +56,8 @@ public class CompareMode implements Comparator<Value> {
      */
     public static final String UNSIGNED = "UNSIGNED";
 
+    private static Locale[] LOCALES;
+
     private static volatile CompareMode lastUsed;
 
     private static final boolean CAN_USE_ICU4J;
@@ -151,6 +153,22 @@ public class CompareMode implements Comparator<Value> {
         }
         lastUsed = last;
         return last;
+    }
+
+    /**
+     * Returns available locales for collations.
+     *
+     * @param onlyIfInitialized
+     *            if {@code true}, returns {@code null} when locales are not yet
+     *            initialized
+     * @return available locales for collations.
+     */
+    public static Locale[] getCollationLocales(boolean onlyIfInitialized) {
+        Locale[] locales = LOCALES;
+        if (locales == null && !onlyIfInitialized) {
+            LOCALES = locales = Collator.getAvailableLocales();
+        }
+        return locales;
     }
 
     /**
@@ -261,7 +279,7 @@ public class CompareMode implements Comparator<Value> {
             }
         }
         if (result == null) {
-            for (Locale locale : Collator.getAvailableLocales()) {
+            for (Locale locale : getCollationLocales(false)) {
                 if (compareLocaleNames(locale, name)) {
                     result = Collator.getInstance(locale);
                     break;

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -523,8 +523,8 @@ public class TestTableEngines extends TestDb {
                 }
 
                 @Override
-                public long getRowCountApproximation() {
-                    return table.getRowCountApproximation();
+                public long getRowCountApproximation(Session session) {
+                    return table.getRowCountApproximation(session);
                 }
 
                 @Override
@@ -617,7 +617,7 @@ public class TestTableEngines extends TestDb {
             }
 
             @Override
-            public boolean canGetRowCount() {
+            public boolean canGetRowCount(Session session) {
                 return true;
             }
 
@@ -643,11 +643,11 @@ public class TestTableEngines extends TestDb {
 
             @Override
             public long getRowCount(Session session) {
-                return getRowCountApproximation();
+                return getRowCountApproximation(session);
             }
 
             @Override
-            public long getRowCountApproximation() {
+            public long getRowCountApproximation(Session session) {
                 return row == null ? 0 : 1;
             }
 
@@ -893,8 +893,8 @@ public class TestTableEngines extends TestDb {
         }
 
         @Override
-        public long getRowCountApproximation() {
-            return getScanIndex(null).getRowCountApproximation();
+        public long getRowCountApproximation(Session session) {
+            return getScanIndex(null).getRowCountApproximation(session);
         }
 
         @Override
@@ -928,7 +928,7 @@ public class TestTableEngines extends TestDb {
         }
 
         @Override
-        public boolean canGetRowCount() {
+        public boolean canGetRowCount(Session session) {
             return true;
         }
 
@@ -1054,7 +1054,7 @@ public class TestTableEngines extends TestDb {
         }
 
         @Override
-        public long getRowCountApproximation() {
+        public long getRowCountApproximation(Session session) {
             return getRowCount(null);
         }
 

--- a/h2/src/test/org/h2/test/scripts/information_schema.sql
+++ b/h2/src/test/org/h2/test/scripts/information_schema.sql
@@ -167,3 +167,18 @@ DROP TABLE T2, T1;
 > ok
 
 @reconnect on
+
+SELECT TABLE_NAME, ROW_COUNT_ESTIMATE FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'INFORMATION_SCHEMA'
+    AND TABLE_NAME IN ('INFORMATION_SCHEMA_CATALOG_NAME', 'SCHEMATA', 'ROLES', 'SESSIONS', 'IN_DOUBT', 'USERS');
+> TABLE_NAME                      ROW_COUNT_ESTIMATE
+> ------------------------------- ------------------
+> INFORMATION_SCHEMA_CATALOG_NAME 1
+> IN_DOUBT                        0
+> ROLES                           1
+> SCHEMATA                        2
+> SESSIONS                        1
+> USERS                           1
+> rows: 6
+
+EXPLAIN SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLLATIONS;
+>> SELECT COUNT(*) FROM "INFORMATION_SCHEMA"."COLLATIONS" /* meta */ /* direct lookup */

--- a/h2/src/tools/org/h2/build/doc/GenerateDoc.java
+++ b/h2/src/tools/org/h2/build/doc/GenerateDoc.java
@@ -142,7 +142,7 @@ public class GenerateDoc {
     /**
      * Process a file.
      *
-     * @param file the file
+     * @param inFile the file
      */
     void process(Path inFile) throws IOException {
         Path outFile = outDir.resolve(inDir.relativize(inFile));

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -838,4 +838,4 @@ usesuper tgdeferrable rolpassword relam relpages tginitdeferred rolsuper autovac
 nsp pgagent pga awoken serverencoding untyped ambiguities tons lhs letting rhs opportunities specifications
 usefully pipelining fetches reenable joiner visits dcl avxaaa german fold degree supertype overloads hierarchy locator
 conrelid conkey tabrelname refnamespace dsc pred typrelid conname contype confrelid numscans beaver typdelim typelem
-jsonb und decfloat attnums oids studio smells pvs
+jsonb und decfloat attnums oids studio smells pvs mention


### PR DESCRIPTION
`getRowCount()` is implemented for `INFORMATION_SCHEMA_CATALOG_NAME`, `SCHEMATA`, `ROLES`, `SESSIONS`, `IN_DOUBT`, `USERS`, and `COLLATIONS` to speed up `COUNT(*)` aggregate.

`getRowCountApproximation()` is also improved for them.

Some JDT compiler warnings are fixed.