### PR TITLE
Add IS_TRIGGER_UPDATABLE and other similar fields to INFORMATION_SCHEMA

### DIFF
--- a/h2/src/main/org/h2/schema/TriggerObject.java
+++ b/h2/src/main/org/h2/schema/TriggerObject.java
@@ -292,6 +292,15 @@ public class TriggerObject extends SchemaObjectBase {
     }
 
     /**
+     * Returns the trigger type.
+     *
+     * @return the trigger type
+     */
+    public int getTypeMask() {
+        return typeMask;
+    }
+
+    /**
      * Set the trigger type.
      *
      * @param typeMask the type

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -2234,6 +2234,7 @@ public final class InformationSchemaTable extends MetaTable {
                 sql = "-";
             }
         }
+        long lastModification = table.getMaxDataModificationId();
         add(session, rows,
                 // TABLE_CATALOG
                 catalog,
@@ -2255,7 +2256,7 @@ public final class InformationSchemaTable extends MetaTable {
                 // REMARKS
                 table.getComment(),
                 // LAST_MODIFICATION
-                ValueBigint.get(table.getMaxDataModificationId()),
+                lastModification != Long.MAX_VALUE ? ValueBigint.get(lastModification) : null,
                 // ID
                 ValueInteger.get(table.getId()),
                 // TABLE_CLASS

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.h2.api.IntervalQualifier;
+import org.h2.api.Trigger;
 import org.h2.command.Command;
 import org.h2.command.Parser;
 import org.h2.constraint.Constraint;
@@ -575,6 +576,7 @@ public final class InformationSchemaTable extends MetaTable {
                     "TABLE_SCHEMA",
                     "TABLE_NAME",
                     "TABLE_TYPE",
+                    "IS_INSERTABLE_INTO",
                     "COMMIT_ACTION",
                     // extensions
                     "STORAGE_TYPE",
@@ -654,6 +656,10 @@ public final class InformationSchemaTable extends MetaTable {
                     "VIEW_DEFINITION",
                     "CHECK_OPTION",
                     "IS_UPDATABLE",
+                    "INSERTABLE_INTO",
+                    "IS_TRIGGER_UPDATABLE",
+                    "IS_TRIGGER_DELETABLE",
+                    "IS_TRIGGER_INSERTABLE_INTO",
                     // extensions
                     "STATUS",
                     "REMARKS",
@@ -2237,6 +2243,8 @@ public final class InformationSchemaTable extends MetaTable {
                 tableName,
                 // TABLE_TYPE
                 table.getSQLTableType(),
+                // IS_INSERTABLE_INTO"
+                table.isInsertable() ? "YES" : "NO",
                 // COMMIT_ACTION
                 commitAction,
                 // extensions
@@ -2424,6 +2432,15 @@ public final class InformationSchemaTable extends MetaTable {
         } else {
             viewDefinition = null;
         }
+        int mask = 0;
+        ArrayList<TriggerObject> triggers = table.getTriggers();
+        if (triggers != null) {
+            for (TriggerObject trigger : triggers) {
+                if (trigger.isInsteadOf()) {
+                    mask |= trigger.getTypeMask();
+                }
+            }
+        }
         add(session, rows,
                 // TABLE_CATALOG
                 catalog,
@@ -2437,6 +2454,14 @@ public final class InformationSchemaTable extends MetaTable {
                 "NONE",
                 // IS_UPDATABLE
                 "NO",
+                // INSERTABLE_INTO
+                "NO",
+                // IS_TRIGGER_UPDATABLE
+                (mask & Trigger.UPDATE) != 0 ? "YES" : "NO",
+                // IS_TRIGGER_DELETABLE
+                (mask & Trigger.DELETE) != 0 ? "YES" : "NO",
+                // IS_TRIGGER_INSERTABLE_INTO
+                (mask & Trigger.INSERT) != 0 ? "YES" : "NO",
                 // extensions
                 // STATUS
                 status,

--- a/h2/src/main/org/h2/table/MetaTable.java
+++ b/h2/src/main/org/h2/table/MetaTable.java
@@ -175,6 +175,11 @@ public abstract class MetaTable extends Table {
     public abstract ArrayList<Row> generateRows(Session session, SearchRow first, SearchRow last);
 
     @Override
+    public boolean isInsertable() {
+        return false;
+    }
+
+    @Override
     public final void removeRow(Session session, Row row) {
         throw DbException.getUnsupportedException("META");
     }

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -170,6 +170,15 @@ public abstract class Table extends SchemaObjectBase {
     }
 
     /**
+     * Returns whether this table is insertable.
+     *
+     * @return whether this table is insertable
+     */
+    public boolean isInsertable() {
+        return true;
+    }
+
+    /**
      * Remove a row from the table and all indexes.
      *
      * @param session the session

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -422,6 +422,11 @@ public class TableLink extends Table {
         return linkedIndex;
     }
 
+    @Override
+    public boolean isInsertable() {
+        return !readOnly;
+    }
+
     private void checkReadOnly() {
         if (readOnly) {
             throw DbException.get(ErrorCode.DATABASE_IS_READ_ONLY);

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -355,6 +355,11 @@ public class TableView extends Table {
     }
 
     @Override
+    public boolean isInsertable() {
+        return false;
+    }
+
+    @Override
     public void removeRow(Session session, Row row) {
         throw DbException.getUnsupportedException("VIEW");
     }

--- a/h2/src/main/org/h2/table/VirtualTable.java
+++ b/h2/src/main/org/h2/table/VirtualTable.java
@@ -46,6 +46,11 @@ public abstract class VirtualTable extends Table {
     }
 
     @Override
+    public boolean isInsertable() {
+        return false;
+    }
+
+    @Override
     public void removeRow(Session session, Row row) {
         throw DbException.getUnsupportedException("Virtual table");
 

--- a/h2/src/test/org/h2/test/scripts/ddl/createTrigger.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/createTrigger.sql
@@ -126,5 +126,70 @@ INSERT INTO COUNT VALUES(NULL);
 UPDATE COUNT SET X=2 WHERE X=1;
 > exception ERROR_CREATING_TRIGGER_OBJECT_3
 
+DROP TABLE COUNT;
+> ok
+
 SET MODE Regular;
+> ok
+
+CREATE MEMORY TABLE T(ID INT PRIMARY KEY, V INT);
+> ok
+
+CREATE VIEW V1 AS TABLE T;
+> ok
+
+CREATE VIEW V2 AS TABLE T;
+> ok
+
+CREATE VIEW V3 AS TABLE T;
+> ok
+
+CREATE TRIGGER T1 INSTEAD OF INSERT ON V1 FOR EACH ROW AS STRINGDECODE(
+'org.h2.api.Trigger create() {
+    return new org.h2.api.Trigger() {
+        public void fire(Connection conn, Object[] oldRow, Object[] newRow) {
+        }
+    }\u003B
+}');
+> ok
+
+CREATE TRIGGER T2 INSTEAD OF UPDATE ON V2 FOR EACH ROW AS STRINGDECODE(
+'org.h2.api.Trigger create() {
+    return new org.h2.api.Trigger() {
+        public void fire(Connection conn, Object[] oldRow, Object[] newRow) {
+        }
+    }\u003B
+}');
+> ok
+
+CREATE TRIGGER T3 INSTEAD OF DELETE ON V3 FOR EACH ROW AS STRINGDECODE(
+'org.h2.api.Trigger create() {
+    return new org.h2.api.Trigger() {
+        public void fire(Connection conn, Object[] oldRow, Object[] newRow) {
+        }
+    }\u003B
+}');
+> ok
+
+SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, IS_INSERTABLE_INTO, COMMIT_ACTION
+    FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PUBLIC';
+> TABLE_CATALOG TABLE_SCHEMA TABLE_NAME TABLE_TYPE IS_INSERTABLE_INTO COMMIT_ACTION
+> ------------- ------------ ---------- ---------- ------------------ -------------
+> SCRIPT        PUBLIC       T          BASE TABLE YES                null
+> SCRIPT        PUBLIC       V1         VIEW       NO                 null
+> SCRIPT        PUBLIC       V2         VIEW       NO                 null
+> SCRIPT        PUBLIC       V3         VIEW       NO                 null
+> rows: 4
+
+SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, VIEW_DEFINITION, CHECK_OPTION, IS_UPDATABLE, INSERTABLE_INTO,
+    IS_TRIGGER_UPDATABLE, IS_TRIGGER_DELETABLE, IS_TRIGGER_INSERTABLE_INTO
+    FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = 'PUBLIC';
+> TABLE_CATALOG TABLE_SCHEMA TABLE_NAME VIEW_DEFINITION    CHECK_OPTION IS_UPDATABLE INSERTABLE_INTO IS_TRIGGER_UPDATABLE IS_TRIGGER_DELETABLE IS_TRIGGER_INSERTABLE_INTO
+> ------------- ------------ ---------- ------------------ ------------ ------------ --------------- -------------------- -------------------- --------------------------
+> SCRIPT        PUBLIC       V1         TABLE "PUBLIC"."T" NONE         NO           NO              NO                   NO                   YES
+> SCRIPT        PUBLIC       V2         TABLE "PUBLIC"."T" NONE         NO           NO              YES                  NO                   NO
+> SCRIPT        PUBLIC       V3         TABLE "PUBLIC"."T" NONE         NO           NO              NO                   YES                  NO
+> rows: 3
+
+DROP TABLE T CASCADE;
 > ok

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -838,4 +838,4 @@ usesuper tgdeferrable rolpassword relam relpages tginitdeferred rolsuper autovac
 nsp pgagent pga awoken serverencoding untyped ambiguities tons lhs letting rhs opportunities specifications
 usefully pipelining fetches reenable joiner visits dcl avxaaa german fold degree supertype overloads hierarchy locator
 conrelid conkey tabrelname refnamespace dsc pred typrelid conname contype confrelid numscans beaver typdelim typelem
-jsonb und decfloat attnums oids studio smells pvs mention statically
+jsonb und decfloat attnums oids studio smells pvs mention statically deletable insertable


### PR DESCRIPTION
1. `INFORMATION_SCHEMA.TABLES.IS_INSERTABLE_INTO` field from the SQL Standard. It returns `YES` for our normal tables and writeable linked tables. It returns `NO` for views, meta tables, and read-only linked tables.

2. `INSERTABLE_INTO`, `IS_TRIGGER_UPDATABLE`, `IS_TRIGGER_DELETABLE`, and `IS_TRIGGER_INSERTABLE_INTO` fields in `INFORMATION_SCHEMA.VIEWS` from the SQL Standard. First one returns `NO`, others return `YES` or `NO` depending on presence of `ON UPDATE` triggers. `TABLES.IS_INSERTABLE_INTO` and `VIEWS.INSERTABLE_INTO` have the same source in the SQL Standard, but use different names for a some reason. H2 also already had `VIEWS.IS_UPDATABLE` from the Standard. As I understand they definitions in SQL/Schemata, all of them should return `NO` in H2, only `IS_TRIGGER_*` may return `YES`.

3. Our own non-standard `INFORMATION_SCHEMA.TABLES.LAST_MODIFICATION` now returns `NULL` when last modification is not applicable to the specified table, mostly to reduce column width in H2 Console, because earlier it returned `9223372036854775807`. for them 