### PR TITLE
PgServer can send bool in binary mode

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -628,6 +628,10 @@ public class PgServerThread implements Runnable {
         } else {
             // binary
             switch (pgType) {
+            case PgServer.PG_TYPE_BOOL:
+                writeInt(1);
+                dataOut.writeByte(v.getBoolean() ? 't' : 'f');
+                break;
             case PgServer.PG_TYPE_INT2:
                 writeInt(2);
                 writeShort(v.getShort());

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -5,6 +5,7 @@
  */
 package org.h2.test.unit;
 
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -20,6 +21,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -380,6 +382,19 @@ public class TestPgServer extends TestDb {
     private void testTextualAndBinaryTypes() throws SQLException {
         testTextualAndBinaryTypes(false);
         testTextualAndBinaryTypes(true);
+        Set<Integer> supportedBinaryOids;
+        try {
+            Field supportedBinaryOidsField = Class
+                    .forName("org.postgresql.jdbc.PgConnection")
+                    .getDeclaredField("SUPPORTED_BINARY_OIDS");
+            supportedBinaryOidsField.setAccessible(true);
+            supportedBinaryOids = (Set<Integer>) supportedBinaryOidsField.get(null);
+            supportedBinaryOids.add(16);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        testTextualAndBinaryTypes(true);
+        supportedBinaryOids.remove(16);
     }
 
     private void testTextualAndBinaryTypes(boolean binary) throws SQLException {


### PR DESCRIPTION
Some PG clients will request bool data in binary mode. Just send it like text bool `{0, 0, 0, 1, 't|f'}`.