### PR TITLE
Enable some compatibility settings for old clients automatically

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,14 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2746: Old TCP clients with current server
+</li>
+<li>PR #2745: PgServer can send bool in binary mode
+</li>
+<li>PR #2744: Remove jarSmall and jarClient targets
+</li>
+<li>PR #2743: Add IS_TRIGGER_UPDATABLE and other similar fields to INFORMATION_SCHEMA
+</li>
 <li>PR #2738: Fix VIEWS.VIEW_DEFINITION and support it for other databases in H2 Console
 </li>
 <li>PR #2737: Assorted changes

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1640,7 +1640,7 @@ public class Parser {
                 schemaName = readUniqueIdentifier();
             }
             buff.append("C.COLUMN_NAME FIELD, ");
-            boolean oldInformationSchema = database.getSettings().oldInformationSchema;
+            boolean oldInformationSchema = session.isOldInformationSchema();
             buff.append(oldInformationSchema
                     ? "C.COLUMN_TYPE"
                     : "DATA_TYPE_SQL(?2, ?1, 'TABLE', C.DTD_IDENTIFIER)");
@@ -8570,6 +8570,10 @@ public class Parser {
             Set command = new Set(session, SetTypes.DEFAULT_NULL_ORDERING);
             command.setString(readAliasIdentifier());
             return command;
+        } else if (readIf("OLD_INFORMATION_SCHEMA")) {
+            readIfEqualOrTo();
+            read();
+            return new NoOperation(session);
         } else {
             ModeEnum modeEnum = database.getMode().getEnum();
             if (modeEnum != ModeEnum.REGULAR) {
@@ -8940,7 +8944,7 @@ public class Parser {
     private void findTableNameCandidates(String schemaName, String tableName, java.util.Set<String> candidates) {
         Schema schema = database.getSchema(schemaName);
         String ucTableName = StringUtils.toUpperEnglish(tableName);
-        Collection<Table> allTablesAndViews = schema.getAllTablesAndViews();
+        Collection<Table> allTablesAndViews = schema.getAllTablesAndViews(session);
         for (Table candidate : allTablesAndViews) {
             String candidateName = candidate.getName();
             if (ucTableName.equals(StringUtils.toUpperEnglish(candidateName))) {

--- a/h2/src/main/org/h2/command/ddl/AlterDomain.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomain.java
@@ -56,7 +56,7 @@ public class AlterDomain extends SchemaCommand {
                     }
                 }
             }
-            for (Table t : schema.getAllTablesAndViews()) {
+            for (Table t : schema.getAllTablesAndViews(null)) {
                 if (forTable(session, domain, columnProcessor, recompileExpressions, t)) {
                     db.updateMeta(session, t);
                 }

--- a/h2/src/main/org/h2/command/ddl/Analyze.java
+++ b/h2/src/main/org/h2/command/ddl/Analyze.java
@@ -88,7 +88,7 @@ public class Analyze extends DefineCommand {
             analyzeTable(session, table, sampleRows, true);
         } else {
             for (Schema schema : db.getAllSchemasNoMeta()) {
-                for (Table table : schema.getAllTablesAndViews()) {
+                for (Table table : schema.getAllTablesAndViews(null)) {
                     analyzeTable(session, table, sampleRows, true);
                 }
             }

--- a/h2/src/main/org/h2/command/ddl/DropDatabase.java
+++ b/h2/src/main/org/h2/command/ddl/DropDatabase.java
@@ -54,7 +54,7 @@ public class DropDatabase extends DefineCommand {
         // so we might need to loop over them multiple times.
         boolean runLoopAgain;
         do {
-            ArrayList<Table> tables = db.getAllTablesAndViews(false);
+            ArrayList<Table> tables = db.getAllTablesAndViews();
             ArrayList<Table> toRemove = new ArrayList<>(tables.size());
             for (Table t : tables) {
                 if (t.getName() != null &&

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -203,7 +203,7 @@ public class ScriptCommand extends ScriptBase {
                 }
             }
 
-            final ArrayList<Table> tables = db.getAllTablesAndViews(false);
+            final ArrayList<Table> tables = db.getAllTablesAndViews();
             // sort by id, so that views are after tables and views on views
             // after the base views
             tables.sort(Comparator.comparingInt(Table::getId));
@@ -664,7 +664,7 @@ public class ScriptCommand extends ScriptBase {
         }
         if (tables != null) {
             // if filtering on specific tables, only include those schemas
-            for (Table table : schema.getAllTablesAndViews()) {
+            for (Table table : schema.getAllTablesAndViews(session)) {
                 if (tables.contains(table)) {
                     return false;
                 }

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -98,7 +98,7 @@ public class ConnectionInfo implements Cloneable {
                 "IFEXISTS", "INIT", "FORBID_CREATION", "PASSWORD", "RECOVER", "RECOVER_TEST",
                 "USER", "AUTO_SERVER", "AUTO_SERVER_PORT", "NO_UPGRADE",
                 "AUTO_RECONNECT", "OPEN_NEW", "PAGE_SIZE", "PASSWORD_HASH", "JMX",
-                "SCOPE_GENERATED_KEYS", "AUTHREALM", "AUTHZPWD", "NETWORK_TIMEOUT"};
+                "SCOPE_GENERATED_KEYS", "AUTHREALM", "AUTHZPWD", "NETWORK_TIMEOUT", "OLD_INFORMATION_SCHEMA"};
         HashSet<String> set = new HashSet<>(128);
         set.addAll(SetTypes.getTypes());
         for (String key : connectionTime) {

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -315,13 +315,6 @@ public class DbSettings extends SettingsBase {
     public final boolean ignoreCatalogs = get("IGNORE_CATALOGS", false);
 
     /**
-     * Database setting <code>OLD_INFORMATION_SCHEMA</code>
-     * (default: false).<br />
-     * If set, INFORMATION_SCHEMA contains old-style tables.
-     */
-    public final boolean oldInformationSchema = get("OLD_INFORMATION_SCHEMA", false);
-
-    /**
      * Database setting <code>ZERO_BASED_ENUMS</code>
      * (default: false).<br />
      * If set, ENUM ordinal values are 0-based.

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -160,6 +160,9 @@ public final class Engine {
             // concurrently closing
             return null;
         }
+        if (ci.getProperty("OLD_INFORMATION_SCHEMA", false)) {
+            session.setOldInformationSchema(true);
+        }
         if (ci.getProperty("JMX", false)) {
             try {
                 Utils.callStaticMethod(

--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -239,6 +239,11 @@ public class SessionLocal extends Session implements TransactionStore.RollbackLi
      */
     private boolean variableBinary;
 
+    /**
+     * Whether INFORMATION_SCHEMA contains old-style tables.
+     */
+    private boolean oldInformationSchema;
+
     public SessionLocal(Database database, User user, int id) {
         this.database = database;
         this.queryTimeout = database.getSettings().maxQueryTimeout;
@@ -1782,7 +1787,7 @@ public class SessionLocal extends Session implements TransactionStore.RollbackLi
                 case SERIALIZABLE:
                     if (!transaction.hasStatementDependencies()) {
                         for (Schema schema : database.getAllSchemasNoMeta()) {
-                            for (Table table : schema.getAllTablesAndViews()) {
+                            for (Table table : schema.getAllTablesAndViews(null)) {
                                 if (table instanceof MVTable) {
                                     addTableToDependencies((MVTable)table, maps);
                                 }
@@ -2069,7 +2074,7 @@ public class SessionLocal extends Session implements TransactionStore.RollbackLi
         if (settings == null) {
             DbSettings dbSettings = database.getSettings();
             staticSettings = settings = new StaticSettings(dbSettings.databaseToUpper, dbSettings.databaseToLower,
-                    dbSettings.caseInsensitiveIdentifiers, dbSettings.oldInformationSchema);
+                    dbSettings.caseInsensitiveIdentifiers, oldInformationSchema);
         }
         return settings;
     }
@@ -2184,6 +2189,26 @@ public class SessionLocal extends Session implements TransactionStore.RollbackLi
      */
     public boolean isVariableBinary() {
         return variableBinary;
+    }
+
+    /**
+     * Changes INFORMATION_SCHEMA content.
+     *
+     * @param oldInformationSchema
+     *            {@code true} to have old-style tables in INFORMATION_SCHEMA,
+     *            {@code false} to have modern tables
+     */
+    public void setOldInformationSchema(boolean oldInformationSchema) {
+        this.oldInformationSchema = oldInformationSchema;
+    }
+
+    /**
+     * Returns whether INFORMATION_SCHEMA contains old-style tables.
+     *
+     * @return whether INFORMATION_SCHEMA contains old-style tables
+     */
+    public boolean isOldInformationSchema() {
+        return oldInformationSchema;
     }
 
     @Override

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocal.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocal.java
@@ -1393,7 +1393,7 @@ public final class DatabaseMetaLocal extends DatabaseMetaLocalBase {
     }
 
     private Collection<? extends SchemaObjectBase> getTablesForPattern(Schema schema, String tablePattern) {
-        Collection<Table> tables = schema.getAllTablesAndViews();
+        Collection<Table> tables = schema.getAllTablesAndViews(session);
         Collection<TableSynonym> synonyms = schema.getAllSynonyms();
         if (tablePattern == null) {
             if (tables.isEmpty()) {

--- a/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
@@ -345,7 +345,7 @@ public final class FunctionsPostgreSQL extends FunctionsBase {
         if (tableOidOrName.getValueType() == Value.INTEGER) {
             int tid = tableOidOrName.getInt();
             for (Schema schema : session.getDatabase().getAllSchemasNoMeta()) {
-                for (Table table : schema.getAllTablesAndViews()) {
+                for (Table table : schema.getAllTablesAndViews(session)) {
                     if (tid == table.getId()) {
                         t = table;
                         break;

--- a/h2/src/main/org/h2/mode/PgCatalogSchema.java
+++ b/h2/src/main/org/h2/mode/PgCatalogSchema.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.mode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.h2.engine.Constants;
+import org.h2.engine.Database;
+import org.h2.engine.SessionLocal;
+import org.h2.engine.User;
+import org.h2.schema.MetaSchema;
+import org.h2.table.Table;
+
+/**
+ * {@code pg_catalog} schema.
+ */
+public final class PgCatalogSchema extends MetaSchema {
+
+    private volatile HashMap<String, Table> tables;
+
+    /**
+     * Creates new instance of {@code pg_catalog} schema.
+     *
+     * @param database
+     *            the database
+     * @param owner
+     *            the owner of the schema (system user)
+     */
+    public PgCatalogSchema(Database database, User owner) {
+        super(database, Constants.PG_CATALOG_SCHEMA_ID, database.sysIdentifier(Constants.SCHEMA_PG_CATALOG), owner);
+    }
+
+    @Override
+    protected Map<String, Table> getMap(SessionLocal session) {
+        HashMap<String, Table> map = tables;
+        if (map == null) {
+            map = fillMap();
+        }
+        return map;
+    }
+
+    private synchronized HashMap<String, Table> fillMap() {
+        HashMap<String, Table> map = tables;
+        if (map == null) {
+            map = database.newStringMap();
+            for (int type = 0; type < PgCatalogTable.META_TABLE_TYPE_COUNT; type++) {
+                PgCatalogTable table = new PgCatalogTable(this, Constants.PG_CATALOG_SCHEMA_ID - type, type);
+                map.put(table.getName(), table);
+            }
+            tables = map;
+        }
+        return map;
+    }
+
+}

--- a/h2/src/main/org/h2/mode/PgCatalogTable.java
+++ b/h2/src/main/org/h2/mode/PgCatalogTable.java
@@ -352,7 +352,7 @@ public class PgCatalogTable extends MetaTable {
             break;
         case PG_ATTRIBUTE:
             for (Schema schema : database.getAllSchemas()) {
-                for (Table table : schema.getAllTablesAndViews()) {
+                for (Table table : schema.getAllTablesAndViews(session)) {
                     if (!hideTable(table, session)) {
                         pgAttribute(session, rows, table);
                     }
@@ -368,7 +368,7 @@ public class PgCatalogTable extends MetaTable {
             break;
         case PG_CLASS:
             for (Schema schema : database.getAllSchemas()) {
-                for (Table table : schema.getAllTablesAndViews()) {
+                for (Table table : schema.getAllTablesAndViews(session)) {
                     if (!hideTable(table, session)) {
                         pgClass(session, rows, table);
                     }

--- a/h2/src/main/org/h2/pagestore/PageStore.java
+++ b/h2/src/main/org/h2/pagestore/PageStore.java
@@ -547,7 +547,7 @@ public class PageStore implements CacheWriter {
             log.checkpoint();
             writeBack();
             cache.clear();
-            ArrayList<Table> tables = database.getAllTablesAndViews(false);
+            ArrayList<Table> tables = database.getAllTablesAndViews();
             recordedPagesList = new ArrayList<>();
             recordedPagesIndex = new IntIntHashMap();
             recordPageReads = true;

--- a/h2/src/main/org/h2/schema/InformationSchema.java
+++ b/h2/src/main/org/h2/schema/InformationSchema.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.schema;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.h2.engine.Constants;
+import org.h2.engine.Database;
+import org.h2.engine.SessionLocal;
+import org.h2.engine.User;
+import org.h2.table.InformationSchemaTable;
+import org.h2.table.InformationSchemaTableLegacy;
+import org.h2.table.Table;
+
+/**
+ * Information schema.
+ */
+public final class InformationSchema extends MetaSchema {
+
+    private volatile HashMap<String, Table> newTables;
+
+    private volatile HashMap<String, Table> oldTables;
+
+    /**
+     * Creates new instance of information schema.
+     *
+     * @param database
+     *            the database
+     * @param owner
+     *            the owner of the schema (system user)
+     */
+    public InformationSchema(Database database, User owner) {
+        super(database, Constants.INFORMATION_SCHEMA_ID, database.sysIdentifier("INFORMATION_SCHEMA"), owner);
+    }
+
+    @Override
+    protected Map<String, Table> getMap(SessionLocal session) {
+        if (session == null) {
+            return Collections.emptyMap();
+        }
+        boolean old = session.isOldInformationSchema();
+        HashMap<String, Table> map = old ? oldTables : newTables;
+        if (map == null) {
+            map = fillMap(old);
+        }
+        return map;
+    }
+
+    private synchronized HashMap<String, Table> fillMap(boolean old) {
+        HashMap<String, Table> map = old ? oldTables : newTables;
+        if (map == null) {
+            map = database.newStringMap();
+            if (old) {
+                for (int type = 0; type < InformationSchemaTableLegacy.META_TABLE_TYPE_COUNT; type++) {
+                    InformationSchemaTableLegacy table = new InformationSchemaTableLegacy(this,
+                            Constants.INFORMATION_SCHEMA_ID - type, type);
+                    map.put(table.getName(), table);
+                }
+                oldTables = map;
+            } else {
+                for (int type = 0; type < InformationSchemaTable.META_TABLE_TYPE_COUNT; type++) {
+                    InformationSchemaTable table = new InformationSchemaTable(this,
+                            Constants.INFORMATION_SCHEMA_ID - type, type);
+                    map.put(table.getName(), table);
+                }
+                newTables = map;
+            }
+        }
+        return map;
+    }
+
+}

--- a/h2/src/main/org/h2/schema/MetaSchema.java
+++ b/h2/src/main/org/h2/schema/MetaSchema.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.schema;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import org.h2.engine.Database;
+import org.h2.engine.SessionLocal;
+import org.h2.engine.User;
+import org.h2.table.Table;
+
+/**
+ * Meta data schema.
+ */
+public abstract class MetaSchema extends Schema {
+
+    /**
+     * Creates a new instance of meta data schema.
+     *
+     * @param database
+     *            the database
+     * @param id
+     *            the object id
+     * @param schemaName
+     *            the schema name
+     * @param owner
+     *            the owner of the schema
+     */
+    public MetaSchema(Database database, int id, String schemaName, User owner) {
+        super(database, id, schemaName, owner, true);
+    }
+
+    @Override
+    public Table findTableOrView(SessionLocal session, String name) {
+        Map<String, Table> map = getMap(session);
+        Table table = map.get(name);
+        if (table != null) {
+            return table;
+        }
+        return super.findTableOrView(session, name);
+    }
+
+    @Override
+    public Collection<Table> getAllTablesAndViews(SessionLocal session) {
+        Collection<Table> userTables = super.getAllTablesAndViews(session);
+        if (session == null) {
+            return userTables;
+        }
+        Collection<Table> systemTables = getMap(session).values();
+        if (userTables.isEmpty()) {
+            return systemTables;
+        }
+        ArrayList<Table> list = new ArrayList<>(systemTables.size() + userTables.size());
+        list.addAll(systemTables);
+        list.addAll(userTables);
+        return list;
+    }
+
+    @Override
+    public Table getTableOrView(SessionLocal session, String name) {
+        Map<String, Table> map = getMap(session);
+        Table table = map.get(name);
+        if (table != null) {
+            return table;
+        }
+        return super.getTableOrView(session, name);
+    }
+
+    @Override
+    public Table getTableOrViewByName(SessionLocal session, String name) {
+        Map<String, Table> map = getMap(session);
+        Table table = map.get(name);
+        if (table != null) {
+            return table;
+        }
+        return super.getTableOrViewByName(session, name);
+    }
+
+    protected abstract Map<String, Table> getMap(SessionLocal session);
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+}

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -28,6 +28,7 @@ import org.h2.index.Index;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.pagestore.db.PageStoreTable;
+import org.h2.table.MetaTable;
 import org.h2.table.Table;
 import org.h2.table.TableLink;
 import org.h2.table.TableSynonym;
@@ -292,7 +293,7 @@ public class Schema extends DbObjectBase {
         int type = obj.getType();
         Map<String, SchemaObject> map = getMap(type);
         if (SysProperties.CHECK) {
-            if (!map.containsKey(obj.getName())) {
+            if (!map.containsKey(obj.getName()) && !(obj instanceof MetaTable)) {
                 DbException.throwInternalError("not found: " + obj.getName());
             }
             if (obj.getName().equals(newName) || map.containsKey(newName)) {
@@ -709,9 +710,10 @@ public class Schema extends DbObjectBase {
     /**
      * Get all tables and views.
      *
+     * @param session the session, {@code null} to exclude meta tables
      * @return a (possible empty) list of all objects
      */
-    public Collection<Table> getAllTablesAndViews() {
+    public Collection<Table> getAllTablesAndViews(SessionLocal session) {
         return tablesAndViews.values();
     }
 
@@ -734,10 +736,11 @@ public class Schema extends DbObjectBase {
     /**
      * Get the table with the given name, if any.
      *
+     * @param session the session
      * @param name the table name
      * @return the table or null if not found
      */
-    public Table getTableOrViewByName(String name) {
+    public Table getTableOrViewByName(SessionLocal session, String name) {
         return tablesAndViews.get(name);
     }
 

--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -163,6 +163,12 @@ public class TcpServerThread implements Runnable {
                                 .append(':').append(socket.getLocalPort()).toString(), //
                         socket.getInetAddress().getAddress(), socket.getPort(),
                         new StringBuilder().append('P').append(clientVersion).toString()));
+                if (clientVersion < Constants.TCP_PROTOCOL_VERSION_20) {
+                    // For DatabaseMetaData
+                    ci.setProperty("OLD_INFORMATION_SCHEMA", "TRUE");
+                    // For H2 Console
+                    ci.setProperty("NON_KEYWORDS", "VALUE");
+                }
                 session = Engine.createSession(ci);
                 transfer.setSession(session);
                 server.addConnection(threadId, originalURL, ci.getUserName());

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -1093,7 +1093,7 @@ public final class InformationSchemaTable extends MetaTable {
                 return;
             }
             for (Schema schema : database.getAllSchemas()) {
-                Table table = schema.getTableOrViewByName(tableName);
+                Table table = schema.getTableOrViewByName(session, tableName);
                 if (table != null) {
                     columns(session, rows, catalog, mainSchemaName, collation, table, table.getName());
                 }
@@ -1104,7 +1104,7 @@ public final class InformationSchemaTable extends MetaTable {
             }
         } else {
             for (Schema schema : database.getAllSchemas()) {
-                for (Table table : schema.getAllTablesAndViews()) {
+                for (Table table : schema.getAllTablesAndViews(session)) {
                     String tableName = table.getName();
                     if (checkIndex(session, tableName, indexFrom, indexTo)) {
                         columns(session, rows, catalog, mainSchemaName, collation, table, tableName);
@@ -1504,7 +1504,7 @@ public final class InformationSchemaTable extends MetaTable {
         String collation = database.getCompareMode().getName();
         for (Schema schema : database.getAllSchemas()) {
             String schemaName = schema.getName();
-            for (Table table : schema.getAllTablesAndViews()) {
+            for (Table table : schema.getAllTablesAndViews(session)) {
                 elementTypesFieldsForTable(session, rows, catalog, type, mainSchemaName, collation, schemaName,
                         table);
             }
@@ -2190,7 +2190,7 @@ public final class InformationSchemaTable extends MetaTable {
     private void tables(SessionLocal session, Value indexFrom, Value indexTo, ArrayList<Row> rows, String catalog) {
         boolean admin = session.getUser().isAdmin();
         for (Schema schema : database.getAllSchemas()) {
-            for (Table table : schema.getAllTablesAndViews()) {
+            for (Table table : schema.getAllTablesAndViews(session)) {
                 String tableName = table.getName();
                 if (checkIndex(session, tableName, indexFrom, indexTo)) {
                     tables(session, rows, catalog, admin, table, tableName);
@@ -2404,7 +2404,7 @@ public final class InformationSchemaTable extends MetaTable {
 
     private void views(SessionLocal session, Value indexFrom, Value indexTo, ArrayList<Row> rows, String catalog) {
         for (Schema schema : database.getAllSchemas()) {
-            for (Table table : schema.getAllTablesAndViews()) {
+            for (Table table : schema.getAllTablesAndViews(session)) {
                 if (table.isView()) {
                     String tableName = table.getName();
                     if (checkIndex(session, tableName, indexFrom, indexTo)) {
@@ -2596,7 +2596,7 @@ public final class InformationSchemaTable extends MetaTable {
                 return;
             }
             for (Schema schema : database.getAllSchemas()) {
-                Table table = schema.getTableOrViewByName(tableName);
+                Table table = schema.getTableOrViewByName(session, tableName);
                 if (table != null) {
                     indexes(session, rows, catalog, columns, table, table.getName());
                 }
@@ -2607,7 +2607,7 @@ public final class InformationSchemaTable extends MetaTable {
             }
         } else {
             for (Schema schema : database.getAllSchemas()) {
-                for (Table table : schema.getAllTablesAndViews()) {
+                for (Table table : schema.getAllTablesAndViews(session)) {
                     String tableName = table.getName();
                     if (checkIndex(session, tableName, indexFrom, indexTo)) {
                         indexes(session, rows, catalog, columns, table, tableName);
@@ -2989,6 +2989,7 @@ public final class InformationSchemaTable extends MetaTable {
         add(session, rows, "QUERY_TIMEOUT", Integer.toString(session.getQueryTimeout()));
         add(session, rows, "TIME ZONE", session.currentTimeZone().getId());
         add(session, rows, "VARIABLE_BINARY", session.isVariableBinary() ? "TRUE" : "FALSE");
+        add(session, rows, "OLD_INFORMATION_SCHEMA", session.isOldInformationSchema() ? "TRUE" : "FALSE");
         BitSet nonKeywords = session.getNonKeywords();
         if (nonKeywords != null) {
             add(session, rows, "NON_KEYWORDS", Parser.formatNonKeywords(nonKeywords));

--- a/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
@@ -1094,6 +1094,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             add(session, rows, "QUERY_TIMEOUT", Integer.toString(session.getQueryTimeout()));
             add(session, rows, "TIME ZONE", session.currentTimeZone().getId());
             add(session, rows, "VARIABLE_BINARY", session.isVariableBinary() ? "TRUE" : "FALSE");
+            add(session, rows, "OLD_INFORMATION_SCHEMA", session.isOldInformationSchema() ? "TRUE" : "FALSE");
             BitSet nonKeywords = session.getNonKeywords();
             if (nonKeywords != null) {
                 add(session, rows, "NON_KEYWORDS", Parser.formatNonKeywords(nonKeywords));
@@ -2448,7 +2449,10 @@ public final class InformationSchemaTableLegacy extends MetaTable {
      * @return the array of tables
      */
     private ArrayList<Table> getAllTables(SessionLocal session) {
-        ArrayList<Table> tables = database.getAllTablesAndViews(true);
+        ArrayList<Table> tables = new ArrayList<>();
+        for (Schema schema : database.getAllSchemas()) {
+            tables.addAll(schema.getAllTablesAndViews(session));
+        }
         tables.addAll(session.getLocalTempTables());
         return tables;
     }
@@ -2457,7 +2461,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
         // we expect that at most one table matches, at least in most cases
         ArrayList<Table> tables = new ArrayList<>(1);
         for (Schema schema : database.getAllSchemas()) {
-            Table table = schema.getTableOrViewByName(tableName);
+            Table table = schema.getTableOrViewByName(session, tableName);
             if (table != null) {
                 tables.add(table);
             }


### PR DESCRIPTION
1. Initialization and table name resolution logic for `INFORMATION_SCHEMA` and `pg_catalog` is reimplemented. Now all meta schemas can have different content for different sessions.

2. `OLD_INFORMATION_SCHEMA` setting is now a connection-time per-session setting, different sessions may use different values.

3. For 1.4.200 and older clients `OLD_INFORMATION_SCHEMA` is enabled automatically and `VALUE` is accepted as identifier, because H2 Console uses it without quotes. Closes #2746.