### PR TITLE
PgServer set type text to NULL value

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServer.java
+++ b/h2/src/main/org/h2/server/pg/PgServer.java
@@ -389,6 +389,7 @@ public class PgServer implements Service {
             return PG_TYPE_BOOL;
         case Value.VARCHAR:
             return PG_TYPE_VARCHAR;
+        case Value.NULL:
         case Value.CLOB:
             return PG_TYPE_TEXT;
         case Value.CHAR:

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -201,12 +201,13 @@ public class TestPgServer extends TestDb {
         prep.setInt(1, 1);
         prep.setString(2, "Hello");
         prep.execute();
-        rs = stat.executeQuery("select * from test");
+        rs = stat.executeQuery("select *, null nul from test");
         rs.next();
 
         ResultSetMetaData rsMeta = rs.getMetaData();
         assertEquals(Types.INTEGER, rsMeta.getColumnType(1));
         assertEquals(Types.VARCHAR, rsMeta.getColumnType(2));
+        assertEquals(Types.VARCHAR, rsMeta.getColumnType(3));
         assertEquals("test", rsMeta.getTableName(1));
 
         prep.close();


### PR DESCRIPTION
NULL value (e.g. `SELECT NULL`) should set type `text` (25) but not `unknown` (705) in column description. Otherwise, some clients (including PgJDBC) will fail to get column meta.