### PR TITLE
Add comment explaining seemingly dummy operation

### DIFF
--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -380,6 +380,7 @@ public class TestPgServer extends TestDb {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void testTextualAndBinaryTypes() throws SQLException {
         testTextualAndBinaryTypes(false);
         testTextualAndBinaryTypes(true);


### PR DESCRIPTION
to avoid accidental removal like in #2749.
Suppress compilation warning