### PR TITLE
Removal of the map with outstanding transactional changes

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -501,7 +501,7 @@ public class TransactionStore {
                     Record<?,?> op = cursor.getValue();
                     int mapId = op.mapId;
                     MVMap<Object, VersionedValue<Object>> map = openMap(mapId);
-                    if (map != null) { // might be null if map was removed later
+                    if (map != null && !map.isClosed()) { // might be null if map was removed later
                         Object key = op.key;
                         commitDecisionMaker.setUndoKey(undoKey);
                         // second parameter (value) is not really
@@ -509,9 +509,12 @@ public class TransactionStore {
                         map.operate(key, null, commitDecisionMaker);
                     }
                 }
-                undoLog.clear();
             } finally {
-                flipCommittingTransactionsBit(transactionId, false);
+                try {
+                    undoLog.clear();
+                } finally {
+                    flipCommittingTransactionsBit(transactionId, false);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #2786 
After introduction of two-step map removal procedure, TransactionStore.commit() was failing and leave non-empty transaction log behind. Nevertheless, transaction itself was closed in "finally" block, so log become an orphan, and later this causes problem for the next transaction taking this slot. 