### PR TITLE
Small optimization for Page compression / decompression

### DIFF
--- a/h2/src/main/org/h2/compress/CompressDeflate.java
+++ b/h2/src/main/org/h2/compress/CompressDeflate.java
@@ -52,10 +52,10 @@ public class CompressDeflate implements Compressor {
     }
 
     @Override
-    public int compress(byte[] in, int inLen, byte[] out, int outPos) {
+    public int compress(byte[] in, int inPos, int inLen, byte[] out, int outPos) {
         Deflater deflater = new Deflater(level);
         deflater.setStrategy(strategy);
-        deflater.setInput(in, 0, inLen);
+        deflater.setInput(in, inPos, inLen);
         deflater.finish();
         int compressed = deflater.deflate(out, outPos, out.length - outPos);
         if (compressed == 0) {
@@ -64,7 +64,7 @@ public class CompressDeflate implements Compressor {
             // try again, using the default strategy and compression level
             strategy = Deflater.DEFAULT_STRATEGY;
             level = Deflater.DEFAULT_COMPRESSION;
-            return compress(in, inLen, out, outPos);
+            return compress(in, inPos, inLen, out, outPos);
         }
         deflater.end();
         return outPos + compressed;

--- a/h2/src/main/org/h2/compress/CompressLZF.java
+++ b/h2/src/main/org/h2/compress/CompressLZF.java
@@ -155,15 +155,16 @@ public final class CompressLZF implements Compressor {
     }
 
     @Override
-    public int compress(byte[] in, int inLen, byte[] out, int outPos) {
-        int inPos = 0;
+    public int compress(byte[] in, int inPos, int inLen, byte[] out, int outPos) {
+        int offset = inPos;
+        inLen += inPos;
         if (cachedHashTable == null) {
             cachedHashTable = new int[HASH_SIZE];
         }
         int[] hashTab = cachedHashTable;
         int literals = 0;
         outPos++;
-        int future = first(in, 0);
+        int future = first(in, inPos);
         while (inPos < inLen - 4) {
             byte p2 = in[inPos + 2];
             // next
@@ -178,7 +179,7 @@ public final class CompressLZF implements Compressor {
             //       && (((in[ref] & 255) << 8) | (in[ref + 1] & 255)) ==
             //           ((future >> 8) & 0xffff)) {
             if (ref < inPos
-                        && ref > 0
+                        && ref > offset
                         && (off = inPos - ref - 1) < MAX_OFF
                         && in[ref + 2] == p2
                         && in[ref + 1] == (byte) (future >> 8)
@@ -265,14 +266,15 @@ public final class CompressLZF implements Compressor {
      * @return the end position
      */
     public int compress(ByteBuffer in, int inPos, byte[] out, int outPos) {
-        int inLen = in.capacity() - inPos;
+        int offset = inPos;
+        int inLen = in.capacity();
         if (cachedHashTable == null) {
             cachedHashTable = new int[HASH_SIZE];
         }
         int[] hashTab = cachedHashTable;
         int literals = 0;
         outPos++;
-        int future = first(in, 0);
+        int future = first(in, inPos);
         while (inPos < inLen - 4) {
             byte p2 = in.get(inPos + 2);
             // next
@@ -287,7 +289,7 @@ public final class CompressLZF implements Compressor {
             //       && (((in[ref] & 255) << 8) | (in[ref + 1] & 255)) ==
             //           ((future >> 8) & 0xffff)) {
             if (ref < inPos
-                        && ref > 0
+                        && ref > offset
                         && (off = inPos - ref - 1) < MAX_OFF
                         && in.get(ref + 2) == p2
                         && in.get(ref + 1) == (byte) (future >> 8)

--- a/h2/src/main/org/h2/compress/CompressNo.java
+++ b/h2/src/main/org/h2/compress/CompressNo.java
@@ -23,8 +23,8 @@ public class CompressNo implements Compressor {
     }
 
     @Override
-    public int compress(byte[] in, int inLen, byte[] out, int outPos) {
-        System.arraycopy(in, 0, out, outPos, inLen);
+    public int compress(byte[] in, int inPos, int inLen, byte[] out, int outPos) {
+        System.arraycopy(in, inPos, out, outPos, inLen);
         return outPos + inLen;
     }
 

--- a/h2/src/main/org/h2/compress/Compressor.java
+++ b/h2/src/main/org/h2/compress/Compressor.java
@@ -37,12 +37,13 @@ public interface Compressor {
      * Compress a number of bytes.
      *
      * @param in the input data
+     * @param inPos the offset at the input array
      * @param inLen the number of bytes to compress
      * @param out the output area
      * @param outPos the offset at the output array
      * @return the end position
      */
-    int compress(byte[] in, int inLen, byte[] out, int outPos);
+    int compress(byte[] in, int inPos, int inLen, byte[] out, int outPos);
 
     /**
      * Expand a number of compressed bytes.

--- a/h2/src/main/org/h2/compress/LZFOutputStream.java
+++ b/h2/src/main/org/h2/compress/LZFOutputStream.java
@@ -54,7 +54,7 @@ public class LZFOutputStream extends OutputStream {
     private void compressAndWrite(byte[] buff, int len) throws IOException {
         if (len > 0) {
             ensureOutput(len);
-            int compressed = compress.compress(buff, len, outBuffer, 0);
+            int compressed = compress.compress(buff, 0, len, outBuffer, 0);
             if (compressed > len) {
                 writeInt(-len);
                 out.write(buff, 0, len);

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -623,7 +623,7 @@ public abstract class Page<K,V> implements Cloneable {
             int pos = 0;
             if (buff.hasArray()) {
                 comp = buff.array();
-                pos = buff.position();
+                pos = buff.arrayOffset() + buff.position();
             } else {
                 comp = Utils.newBytes(compLen);
                 buff.get(comp);
@@ -722,7 +722,7 @@ public abstract class Page<K,V> implements Cloneable {
                 byte[] exp;
                 if (byteBuffer.hasArray()) {
                     exp = byteBuffer.array();
-                    pos = compressStart;
+                    pos = byteBuffer.arrayOffset()  + compressStart;
                 } else {
                     exp = Utils.newBytes(expLen);
                     buff.position(compressStart).get(exp);

--- a/h2/src/main/org/h2/pagestore/PageLog.java
+++ b/h2/src/main/org/h2/pagestore/PageLog.java
@@ -508,7 +508,7 @@ public class PageLog {
         } else {
             int pageSize = store.getPageSize();
             if (COMPRESS_UNDO) {
-                int size = compress.compress(page.getBytes(),
+                int size = compress.compress(page.getBytes(), 0,
                         pageSize, compressBuffer, 0);
                 if (size < pageSize) {
                     buffer.writeVarInt(size);

--- a/h2/src/main/org/h2/store/fs/mem/FileMemData.java
+++ b/h2/src/main/org/h2/store/fs/mem/FileMemData.java
@@ -43,7 +43,7 @@ class FileMemData {
 
     static {
         byte[] n = new byte[BLOCK_SIZE];
-        int len = LZF.compress(n, BLOCK_SIZE, BUFFER, 0);
+        int len = LZF.compress(n, 0, BLOCK_SIZE, BUFFER, 0);
         COMPRESSED_EMPTY_BLOCK = Arrays.copyOf(BUFFER, len);
     }
 
@@ -230,7 +230,7 @@ class FileMemData {
             return;
         }
         synchronized (LZF) {
-            int len = LZF.compress(old, BLOCK_SIZE, BUFFER, 0);
+            int len = LZF.compress(old, 0, BLOCK_SIZE, BUFFER, 0);
             if (len <= BLOCK_SIZE) {
                 byte[] d = Arrays.copyOf(BUFFER, len);
                 // maybe data was changed in the meantime

--- a/h2/src/main/org/h2/store/fs/niomem/FileNioMemData.java
+++ b/h2/src/main/org/h2/store/fs/niomem/FileNioMemData.java
@@ -65,7 +65,7 @@ class FileNioMemData {
     static {
         final byte[] n = new byte[BLOCK_SIZE];
         final byte[] output = new byte[BLOCK_SIZE * 2];
-        int len = new CompressLZF().compress(n, BLOCK_SIZE, output, 0);
+        int len = new CompressLZF().compress(n, 0, BLOCK_SIZE, output, 0);
         COMPRESSED_EMPTY_BLOCK = ByteBuffer.allocateDirect(len);
         COMPRESSED_EMPTY_BLOCK.put(output, 0, len);
     }

--- a/h2/src/main/org/h2/tools/CompressTool.java
+++ b/h2/src/main/org/h2/tools/CompressTool.java
@@ -87,7 +87,7 @@ public class CompressTool {
         int newLen = 0;
         out[0] = (byte) compress.getAlgorithm();
         int start = 1 + writeVariableInt(out, 1, len);
-        newLen = compress.compress(in, len, out, start);
+        newLen = compress.compress(in, 0, len, out, start);
         if (newLen > len + start || newLen <= 0) {
             out[0] = Compressor.NO;
             System.arraycopy(in, 0, out, start, len);

--- a/h2/src/test/org/h2/test/unit/TestCompress.java
+++ b/h2/src/test/org/h2/test/unit/TestCompress.java
@@ -159,7 +159,7 @@ public class TestCompress extends TestDb {
         int pageSize = Constants.DEFAULT_PAGE_SIZE;
         byte[] buff2 = new byte[pageSize];
         byte[] test = new byte[2 * pageSize];
-        compress.compress(buff2, pageSize, test, 0);
+        compress.compress(buff2, 0, pageSize, test, 0);
         for (int j = 0; j < 4; j++) {
             long time = System.nanoTime();
             for (int i = 0; i < 1000; i++) {
@@ -169,7 +169,7 @@ public class TestCompress extends TestDb {
                     if (len < 0) {
                         break;
                     }
-                    compress.compress(buff2, pageSize, test, 0);
+                    compress.compress(buff2, 0, pageSize, test, 0);
                 }
                 in.close();
             }
@@ -186,7 +186,7 @@ public class TestCompress extends TestDb {
                 if (len < 0) {
                     break;
                 }
-                int b = compress.compress(buff2, pageSize, test, 0);
+                int b = compress.compress(buff2, 0, pageSize, test, 0);
                 byte[] data = Arrays.copyOf(test, b);
                 comp.add(data);
             }


### PR DESCRIPTION
This PR introduce input array offset to Compressor and eliminate array creation and copying data from ByteBuffer. Bytebuffer underlying array is used instead.