### PR TITLE
Store users and roles together and user-defined functions and aggregates together

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -326,7 +326,6 @@ import org.h2.result.SortOrder;
 import org.h2.schema.Domain;
 import org.h2.schema.FunctionAlias;
 import org.h2.schema.Schema;
-import org.h2.schema.SchemaObject;
 import org.h2.schema.Sequence;
 import org.h2.schema.UserAggregate;
 import org.h2.schema.UserDefinedFunction;

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -329,6 +329,7 @@ import org.h2.schema.Schema;
 import org.h2.schema.SchemaObject;
 import org.h2.schema.Sequence;
 import org.h2.schema.UserAggregate;
+import org.h2.schema.UserDefinedFunction;
 import org.h2.table.Column;
 import org.h2.table.DataChangeDeltaTable;
 import org.h2.table.DataChangeDeltaTable.ResultOption;
@@ -2269,10 +2270,7 @@ public class Parser {
                 return readParameters(new LinkSchemaFunction());
             }
         }
-        FunctionAlias functionAlias = findSchemaObjectWithinPath(schema, name, DbObject.FUNCTION_ALIAS);
-        if (functionAlias == null) {
-            throw DbException.get(ErrorCode.FUNCTION_NOT_FOUND_1, name);
-        }
+        FunctionAlias functionAlias = getFunctionAliasWithinPath(name, schema);
         if (!functionAlias.isDeterministic()) {
             recompileAlways = true;
         }
@@ -2771,11 +2769,8 @@ public class Parser {
                 name = readIdentifier();
             }
         }
-        FunctionAlias functionAlias = findSchemaObjectWithinPath(
-                schemaName != null ? database.getSchema(schemaName) : null, name, DbObject.FUNCTION_ALIAS);
-        if (functionAlias == null) {
-            throw DbException.get(ErrorCode.FUNCTION_NOT_FOUND_1, name);
-        }
+        FunctionAlias functionAlias = getFunctionAliasWithinPath(name,
+                schemaName != null ? database.getSchema(schemaName) : null);
         Expression[] args;
         ArrayList<Expression> argList = Utils.newSmallArrayList();
         if (currentTokenType != SEMICOLON && currentTokenType != END_OF_INPUT) {
@@ -2786,6 +2781,14 @@ public class Parser {
         args = argList.toArray(new Expression[0]);
         command.setExpression(new JavaFunction(functionAlias, args));
         return command;
+    }
+
+    private FunctionAlias getFunctionAliasWithinPath(String name, Schema schema) {
+        UserDefinedFunction userDefinedFunction = findUserDefinedFunctionWithinPath(schema, name);
+        if (userDefinedFunction instanceof FunctionAlias) {
+            return (FunctionAlias) userDefinedFunction;
+        }
+        throw DbException.get(ErrorCode.FUNCTION_NOT_FOUND_1, name);
     }
 
     private DeallocateProcedure parseDeallocate() {
@@ -3882,34 +3885,31 @@ public class Parser {
         return order;
     }
 
-    private JavaFunction readJavaFunction(Schema schema, String functionName) {
-        FunctionAlias functionAlias = findSchemaObjectWithinPath(schema, functionName, DbObject.FUNCTION_ALIAS);
-        if (functionAlias == null) {
+    private Expression readUserDefinedFunctionIf(Schema schema, String functionName) {
+        UserDefinedFunction userDefinedFunction = findUserDefinedFunctionWithinPath(schema, functionName);
+        if (userDefinedFunction == null) {
             return null;
-        }
-        ArrayList<Expression> argList = Utils.newSmallArrayList();
-        if (!readIf(CLOSE_PAREN)) {
+        } else if (userDefinedFunction instanceof FunctionAlias) {
+            FunctionAlias functionAlias = (FunctionAlias) userDefinedFunction;
+            ArrayList<Expression> argList = Utils.newSmallArrayList();
+            if (!readIf(CLOSE_PAREN)) {
+                do {
+                    argList.add(readExpression());
+                } while (readIfMore());
+            }
+            return new JavaFunction(functionAlias, argList.toArray(new Expression[0]));
+        } else {
+            UserAggregate aggregate = (UserAggregate) userDefinedFunction;
+            boolean distinct = readDistinctAgg();
+            ArrayList<Expression> params = Utils.newSmallArrayList();
             do {
-                argList.add(readExpression());
+                params.add(readExpression());
             } while (readIfMore());
+            Expression[] list = params.toArray(new Expression[0]);
+            JavaAggregate agg = new JavaAggregate(aggregate, list, currentSelect, distinct);
+            readFilterAndOver(agg);
+            return agg;
         }
-        return new JavaFunction(functionAlias, argList.toArray(new Expression[0]));
-    }
-
-    private JavaAggregate readJavaAggregate(Schema schema, String aggregateName) {
-        UserAggregate aggregate = findSchemaObjectWithinPath(schema, aggregateName, DbObject.AGGREGATE);
-        if (aggregate == null) {
-            return null;
-        }
-        boolean distinct = readDistinctAgg();
-        ArrayList<Expression> params = Utils.newSmallArrayList();
-        do {
-            params.add(readExpression());
-        } while (readIfMore());
-        Expression[] list = params.toArray(new Expression[0]);
-        JavaAggregate agg = new JavaAggregate(aggregate, list, currentSelect, distinct);
-        readFilterAndOver(agg);
-        return agg;
     }
 
     private boolean readDistinctAgg() {
@@ -4058,9 +4058,9 @@ public class Parser {
         }
         boolean allowOverride = database.isAllowBuiltinAliasOverride();
         if (allowOverride) {
-            JavaFunction jf = readJavaFunction(null, name);
-            if (jf != null) {
-                return jf;
+            Expression e = readUserDefinedFunctionIf(null, name);
+            if (e != null) {
+                return e;
             }
         }
         AggregateType agg = Aggregate.getAggregateType(upperName);
@@ -4079,12 +4079,8 @@ public class Parser {
         if (e != null) {
             return e;
         }
-        e = readJavaAggregate(null, name);
-        if (e != null) {
-            return e;
-        }
         if (!allowOverride) {
-            e = readJavaFunction(null, name);
+            e = readUserDefinedFunctionIf(null, name);
             if (e != null) {
                 return e;
             }
@@ -4100,11 +4096,7 @@ public class Parser {
                 return readParameters(function);
             }
         }
-        Expression function = readJavaFunction(schema, name);
-        if (function != null) {
-            return function;
-        }
-        function = readJavaAggregate(schema, name);
+        Expression function = readUserDefinedFunctionIf(schema, name);
         if (function != null) {
             return function;
         }
@@ -9280,24 +9272,23 @@ public class Parser {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private <T extends SchemaObject> T findSchemaObjectWithinPath(Schema schema, String name, int type) {
+    private UserDefinedFunction findUserDefinedFunctionWithinPath(Schema schema, String name) {
         if (schema != null) {
-            return (T) schema.find(type, name);
+            return schema.findFunctionOrAggregate(name);
         }
         schema = database.getSchema(session.getCurrentSchemaName());
-        SchemaObject object = schema.find(type, name);
-        if (object != null) {
-            return (T) object;
+        UserDefinedFunction userDefinedFunction = schema.findFunctionOrAggregate(name);
+        if (userDefinedFunction != null) {
+            return userDefinedFunction;
         }
         String[] schemaNames = session.getSchemaSearchPath();
         if (schemaNames != null) {
             for (String schemaName : schemaNames) {
                 Schema schemaFromPath = database.getSchema(schemaName);
                 if (schemaFromPath != schema) {
-                    object = schemaFromPath.find(type, name);
-                    if (object != null) {
-                        return (T) object;
+                    userDefinedFunction = schemaFromPath.findFunctionOrAggregate(name);
+                    if (userDefinedFunction != null) {
+                        return userDefinedFunction;
                     }
                 }
             }

--- a/h2/src/main/org/h2/command/ddl/AlterSchemaRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterSchemaRename.java
@@ -50,9 +50,13 @@ public class AlterSchemaRename extends DefineCommand {
         }
         session.getUser().checkSchemaAdmin();
         db.renameDatabaseObject(session, oldSchema, newSchemaName);
-        ArrayList<SchemaObject> all = db.getAllSchemaObjects();
-        for (SchemaObject schemaObject : all) {
-            db.updateMeta(session, schemaObject);
+        ArrayList<SchemaObject> all = new ArrayList<>();
+        for (Schema schema : db.getAllSchemas()) {
+            schema.getAll(all);
+            for (SchemaObject schemaObject : all) {
+                db.updateMeta(session, schemaObject);
+            }
+            all.clear();
         }
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/CreateAggregate.java
+++ b/h2/src/main/org/h2/command/ddl/CreateAggregate.java
@@ -34,7 +34,7 @@ public class CreateAggregate extends SchemaCommand {
         session.getUser().checkAdmin();
         Database db = session.getDatabase();
         Schema schema = getSchema();
-        if (schema.findAggregate(name) != null || schema.findFunction(name) != null) {
+        if (schema.findFunctionOrAggregate(name) != null) {
             if (!ifNotExists) {
                 throw DbException.get(ErrorCode.FUNCTION_ALIAS_ALREADY_EXISTS_1, name);
             }

--- a/h2/src/main/org/h2/command/ddl/CreateFunctionAlias.java
+++ b/h2/src/main/org/h2/command/ddl/CreateFunctionAlias.java
@@ -37,7 +37,7 @@ public class CreateFunctionAlias extends SchemaCommand {
         session.getUser().checkAdmin();
         Database db = session.getDatabase();
         Schema schema = getSchema();
-        if (schema.findFunction(aliasName) != null || schema.findAggregate(aliasName) != null) {
+        if (schema.findFunctionOrAggregate(aliasName) != null) {
             if (!ifNotExists) {
                 throw DbException.get(ErrorCode.FUNCTION_ALIAS_ALREADY_EXISTS_1, aliasName);
             }

--- a/h2/src/main/org/h2/command/ddl/CreateRole.java
+++ b/h2/src/main/org/h2/command/ddl/CreateRole.java
@@ -8,6 +8,7 @@ package org.h2.command.ddl;
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.engine.Database;
+import org.h2.engine.RightOwner;
 import org.h2.engine.Role;
 import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
@@ -38,14 +39,15 @@ public class CreateRole extends DefineCommand {
         session.getUser().checkAdmin();
         session.commit(true);
         Database db = session.getDatabase();
-        if (db.findUser(roleName) != null) {
-            throw DbException.get(ErrorCode.USER_ALREADY_EXISTS_1, roleName);
-        }
-        if (db.findRole(roleName) != null) {
-            if (ifNotExists) {
-                return 0;
+        RightOwner rightOwner = db.findUserOrRole(roleName);
+        if (rightOwner != null) {
+            if (rightOwner instanceof Role) {
+                if (ifNotExists) {
+                    return 0;
+                }
+                throw DbException.get(ErrorCode.ROLE_ALREADY_EXISTS_1, roleName);
             }
-            throw DbException.get(ErrorCode.ROLE_ALREADY_EXISTS_1, roleName);
+            throw DbException.get(ErrorCode.USER_ALREADY_EXISTS_1, roleName);
         }
         int id = getObjectId();
         Role role = new Role(db, id, roleName, false);

--- a/h2/src/main/org/h2/command/ddl/DropDatabase.java
+++ b/h2/src/main/org/h2/command/ddl/DropDatabase.java
@@ -120,8 +120,8 @@ public class DropDatabase extends DefineCommand {
         addAll(schemas, DbObject.CONSTRAINT, list);
         addAll(schemas, DbObject.TRIGGER, list);
         addAll(schemas, DbObject.CONSTANT, list);
+        // Function aliases and aggregates are stored together
         addAll(schemas, DbObject.FUNCTION_ALIAS, list);
-        addAll(schemas, DbObject.AGGREGATE, list);
         addAll(schemas, DbObject.DOMAIN, list);
         for (SchemaObject obj : list) {
             if (!obj.getSchema().isValid() || obj.isHidden()) {

--- a/h2/src/main/org/h2/command/ddl/DropDatabase.java
+++ b/h2/src/main/org/h2/command/ddl/DropDatabase.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import org.h2.command.CommandInterface;
 import org.h2.engine.Database;
 import org.h2.engine.DbObject;
+import org.h2.engine.Right;
 import org.h2.engine.RightOwner;
 import org.h2.engine.Role;
 import org.h2.engine.SessionLocal;
@@ -135,14 +136,8 @@ public class DropDatabase extends DefineCommand {
                 db.removeDatabaseObject(session, rightOwner);
             }
         }
-        ArrayList<DbObject> dbObjects = new ArrayList<>();
-        dbObjects.addAll(db.getAllRights());
-        for (DbObject obj : dbObjects) {
-            String sql = obj.getCreateSQL();
-            // the role PUBLIC must not be dropped
-            if (sql != null) {
-                db.removeDatabaseObject(session, obj);
-            }
+        for (Right right : db.getAllRights()) {
+            db.removeDatabaseObject(session, right);
         }
         for (SessionLocal s : db.getSessions(false)) {
             s.setLastIdentity(ValueNull.INSTANCE);

--- a/h2/src/main/org/h2/command/ddl/DropRole.java
+++ b/h2/src/main/org/h2/command/ddl/DropRole.java
@@ -7,7 +7,6 @@ package org.h2.command.ddl;
 
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
-import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.engine.Role;
 import org.h2.engine.SessionLocal;
@@ -35,15 +34,15 @@ public class DropRole extends DefineCommand {
         session.getUser().checkAdmin();
         session.commit(true);
         Database db = session.getDatabase();
-        if (roleName.equals(Constants.PUBLIC_ROLE_NAME)) {
-            throw DbException.get(ErrorCode.ROLE_CAN_NOT_BE_DROPPED_1, roleName);
-        }
         Role role = db.findRole(roleName);
         if (role == null) {
             if (!ifExists) {
                 throw DbException.get(ErrorCode.ROLE_NOT_FOUND_1, roleName);
             }
         } else {
+            if (role == db.getPublicRole()) {
+                throw DbException.get(ErrorCode.ROLE_CAN_NOT_BE_DROPPED_1, roleName);
+            }
             db.removeDatabaseObject(session, role);
         }
         return 0;

--- a/h2/src/main/org/h2/command/ddl/DropUser.java
+++ b/h2/src/main/org/h2/command/ddl/DropUser.java
@@ -8,6 +8,7 @@ package org.h2.command.ddl;
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.engine.Database;
+import org.h2.engine.RightOwner;
 import org.h2.engine.SessionLocal;
 import org.h2.engine.User;
 import org.h2.message.DbException;
@@ -46,8 +47,8 @@ public class DropUser extends DefineCommand {
         } else {
             if (user == session.getUser()) {
                 int adminUserCount = 0;
-                for (User u : db.getAllUsers()) {
-                    if (u.isAdmin()) {
+                for (RightOwner rightOwner : db.getAllUsersAndRoles()) {
+                    if (rightOwner instanceof User && ((User) rightOwner).isAdmin()) {
                         adminUserCount++;
                     }
                 }

--- a/h2/src/main/org/h2/command/ddl/GrantRevoke.java
+++ b/h2/src/main/org/h2/command/ddl/GrantRevoke.java
@@ -67,12 +67,9 @@ public class GrantRevoke extends DefineCommand {
 
     public void setGranteeName(String granteeName) {
         Database db = session.getDatabase();
-        grantee = db.findUser(granteeName);
+        grantee = db.findUserOrRole(granteeName);
         if (grantee == null) {
-            grantee = db.findRole(granteeName);
-            if (grantee == null) {
-                throw DbException.get(ErrorCode.USER_OR_ROLE_NOT_FOUND_1, granteeName);
-            }
+            throw DbException.get(ErrorCode.USER_OR_ROLE_NOT_FOUND_1, granteeName);
         }
     }
 

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -29,6 +29,7 @@ import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.engine.DbObject;
 import org.h2.engine.Right;
+import org.h2.engine.RightOwner;
 import org.h2.engine.Role;
 import org.h2.engine.SessionLocal;
 import org.h2.engine.Setting;
@@ -176,11 +177,12 @@ public class ScriptCommand extends ScriptBase {
             if (out != null) {
                 add("", true);
             }
-            for (User user : db.getAllUsers()) {
-                add(user.getCreateSQL(passwords), false);
-            }
-            for (Role role : db.getAllRoles()) {
-                add(role.getCreateSQL(true), false);
+            for (RightOwner rightOwner : db.getAllUsersAndRoles()) {
+                if (rightOwner instanceof User) {
+                    add(((User) rightOwner).getCreateSQL(passwords), false);
+                } else {
+                    add(((Role) rightOwner).getCreateSQL(true), false);
+                }
             }
             ArrayList<Schema> schemas = new ArrayList<>();
             for (Schema schema : db.getAllSchemas()) {

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -46,11 +46,10 @@ import org.h2.result.ResultInterface;
 import org.h2.result.Row;
 import org.h2.schema.Constant;
 import org.h2.schema.Domain;
-import org.h2.schema.FunctionAlias;
+import org.h2.schema.UserDefinedFunction;
 import org.h2.schema.Schema;
 import org.h2.schema.Sequence;
 import org.h2.schema.TriggerObject;
-import org.h2.schema.UserAggregate;
 import org.h2.table.Column;
 import org.h2.table.PlanItem;
 import org.h2.table.Table;
@@ -233,19 +232,11 @@ public class ScriptCommand extends ScriptBase {
                 }
             }
             for (Schema schema : schemas) {
-                for (FunctionAlias obj : schema.getAllFunctionAliases()) {
+                for (UserDefinedFunction userDefinedFunction : schema.getAllFunctionsAndAggregates()) {
                     if (drop) {
-                        add(obj.getDropSQL(), false);
+                        add(userDefinedFunction.getDropSQL(), false);
                     }
-                    add(obj.getCreateSQL(), false);
-                }
-            }
-            for (Schema schema : schemas) {
-                for (UserAggregate obj : schema.getAllAggregates()) {
-                    if (drop) {
-                        add(obj.getDropSQL(), false);
-                    }
-                    add(obj.getCreateSQL(), false);
+                    add(userDefinedFunction.getCreateSQL(), false);
                 }
             }
             for (Schema schema : schemas) {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1576,19 +1576,6 @@ public final class Database implements DataHandler, CastDataProvider {
     }
 
     /**
-     * Get all schema objects.
-     *
-     * @return all objects of all types
-     */
-    public ArrayList<SchemaObject> getAllSchemaObjects() {
-        ArrayList<SchemaObject> list = new ArrayList<>();
-        for (Schema schema : schemas.values()) {
-            schema.getAll(list);
-        }
-        return list;
-    }
-
-    /**
      * Get all tables and views. Meta data tables may be excluded.
      *
      * @return all objects of that type

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -91,11 +91,15 @@ public final class Engine {
                 }
                 database = new Database(ci, cipher);
                 opened = true;
-                if (database.getAllUsers().isEmpty()) {
+                checkUserExists: {
+                    for (RightOwner rightOwner : database.getAllUsersAndRoles()) {
+                        if (rightOwner instanceof User) {
+                            break checkUserExists;
+                        }
+                    }
                     // users is the last thing we add, so if no user is around,
                     // the database is new (or not initialized correctly)
-                    user = new User(database, database.allocateObjectId(),
-                            ci.getUserName(), false);
+                    user = new User(database, database.allocateObjectId(), ci.getUserName(), false);
                     user.setAdmin(true);
                     user.setUserPasswordHash(ci.getUserPasswordHash());
                     database.setMasterUser(user);

--- a/h2/src/main/org/h2/engine/Role.java
+++ b/h2/src/main/org/h2/engine/Role.java
@@ -55,14 +55,8 @@ public final class Role extends RightOwner {
 
     @Override
     public void removeChildrenAndResources(SessionLocal session) {
-        for (User user : database.getAllUsers()) {
-            Right right = user.getRightForRole(this);
-            if (right != null) {
-                database.removeDatabaseObject(session, right);
-            }
-        }
-        for (Role r2 : database.getAllRoles()) {
-            Right right = r2.getRightForRole(this);
+        for (RightOwner rightOwner : database.getAllUsersAndRoles()) {
+            Right right = rightOwner.getRightForRole(this);
             if (right != null) {
                 database.removeDatabaseObject(session, right);
             }

--- a/h2/src/main/org/h2/expression/function/DBObjectFunction.java
+++ b/h2/src/main/org/h2/expression/function/DBObjectFunction.java
@@ -69,10 +69,7 @@ public final class DBObjectFunction extends FunctionN {
                 object = schema.findIndex(session, objectName);
                 break;
             case "ROUTINE":
-                object = schema.findFunction(objectName);
-                if (object == null) {
-                    object = schema.findAggregate(objectName);
-                }
+                object = schema.findFunctionOrAggregate(objectName);
                 break;
             case "SEQUENCE":
                 object = schema.findSequence(objectName);

--- a/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsPostgreSQL.java
@@ -11,6 +11,7 @@ import java.util.StringJoiner;
 import org.h2.api.ErrorCode;
 import org.h2.command.Parser;
 import org.h2.engine.Constants;
+import org.h2.engine.RightOwner;
 import org.h2.engine.SessionLocal;
 import org.h2.engine.User;
 import org.h2.expression.Expression;
@@ -324,9 +325,9 @@ public final class FunctionsPostgreSQL extends ModeFunction {
                 break search;
             } else {
                 if (u.isAdmin()) {
-                    for (User user : session.getDatabase().getAllUsers()) {
-                        if (user.getId() == uid) {
-                            name = user.getName();
+                    for (RightOwner rightOwner : session.getDatabase().getAllUsersAndRoles()) {
+                        if (rightOwner.getId() == uid) {
+                            name = rightOwner.getName();
                             break search;
                         }
                     }

--- a/h2/src/main/org/h2/schema/FunctionAlias.java
+++ b/h2/src/main/org/h2/schema/FunctionAlias.java
@@ -30,7 +30,6 @@ import org.h2.message.Trace;
 import org.h2.result.LocalResult;
 import org.h2.result.ResultInterface;
 import org.h2.table.Column;
-import org.h2.table.Table;
 import org.h2.util.JdbcUtils;
 import org.h2.util.SourceCompiler;
 import org.h2.util.StringUtils;
@@ -48,9 +47,8 @@ import org.h2.value.ValueToObjectConverter2;
  * @author Thomas Mueller
  * @author Gary Tong
  */
-public final class FunctionAlias extends SchemaObject {
+public final class FunctionAlias extends UserDefinedFunction {
 
-    private String className;
     private String methodName;
     private String source;
     private JavaMethod[] javaMethods;
@@ -202,11 +200,6 @@ public final class FunctionAlias extends SchemaObject {
     }
 
     @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
-    }
-
-    @Override
     public String getDropSQL() {
         return getSQL(new StringBuilder("DROP ALIAS IF EXISTS "), DEFAULT_SQL_FLAGS).toString();
     }
@@ -240,11 +233,6 @@ public final class FunctionAlias extends SchemaObject {
         invalidate();
     }
 
-    @Override
-    public void checkRename() {
-        throw DbException.getUnsupportedException("RENAME");
-    }
-
     /**
      * Find the Java method that matches the arguments.
      *
@@ -264,10 +252,6 @@ public final class FunctionAlias extends SchemaObject {
         }
         throw DbException.get(ErrorCode.METHOD_NOT_FOUND_1, getName() + " (" +
                 className + ", parameter count: " + parameterCount + ")");
-    }
-
-    public String getJavaClassName() {
-        return this.className;
     }
 
     public String getJavaMethodName() {

--- a/h2/src/main/org/h2/schema/UserAggregate.java
+++ b/h2/src/main/org/h2/schema/UserAggregate.java
@@ -14,7 +14,6 @@ import org.h2.engine.DbObject;
 import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
-import org.h2.table.Table;
 import org.h2.util.JdbcUtils;
 import org.h2.util.StringUtils;
 import org.h2.value.DataType;
@@ -23,9 +22,8 @@ import org.h2.value.TypeInfo;
 /**
  * Represents a user-defined aggregate function.
  */
-public final class UserAggregate extends SchemaObject {
+public final class UserAggregate extends UserDefinedFunction {
 
-    private String className;
     private Class<?> javaClass;
 
     public UserAggregate(Schema schema, int id, String name, String className,
@@ -57,11 +55,6 @@ public final class UserAggregate extends SchemaObject {
     }
 
     @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
-    }
-
-    @Override
     public String getDropSQL() {
         StringBuilder builder = new StringBuilder("DROP AGGREGATE IF EXISTS ");
         return getSQL(builder, DEFAULT_SQL_FLAGS).toString();
@@ -85,15 +78,6 @@ public final class UserAggregate extends SchemaObject {
         className = null;
         javaClass = null;
         invalidate();
-    }
-
-    @Override
-    public void checkRename() {
-        throw DbException.getUnsupportedException("AGGREGATE");
-    }
-
-    public String getJavaClassName() {
-        return this.className;
     }
 
     /**

--- a/h2/src/main/org/h2/schema/UserDefinedFunction.java
+++ b/h2/src/main/org/h2/schema/UserDefinedFunction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.schema;
+
+import org.h2.message.DbException;
+import org.h2.table.Table;
+
+/**
+ * User-defined Java function or aggregate function.
+ */
+public abstract class UserDefinedFunction extends SchemaObject {
+
+    String className;
+
+    UserDefinedFunction(Schema newSchema, int id, String name, int traceModuleId) {
+        super(newSchema, id, name, traceModuleId);
+    }
+
+    @Override
+    public final String getCreateSQLForCopy(Table table, String quotedName) {
+        throw DbException.getInternalError(toString());
+    }
+
+    @Override
+    public final void checkRename() {
+        throw DbException.getUnsupportedException("RENAME");
+    }
+
+    public final String getJavaClassName() {
+        return className;
+    }
+
+}

--- a/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
@@ -31,6 +31,7 @@ import org.h2.engine.Constants;
 import org.h2.engine.DbObject;
 import org.h2.engine.QueryStatisticsData;
 import org.h2.engine.Right;
+import org.h2.engine.RightOwner;
 import org.h2.engine.Role;
 import org.h2.engine.SessionLocal;
 import org.h2.engine.SessionLocal.State;
@@ -1265,35 +1266,41 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             break;
         }
         case USERS: {
-            for (User u : database.getAllUsers()) {
-                if (admin || session.getUser() == u) {
-                    add(session,
-                            rows,
-                            // NAME
-                            identifier(u.getName()),
-                            // ADMIN
-                            String.valueOf(u.isAdmin()),
-                            // REMARKS
-                            replaceNullWithEmpty(u.getComment()),
-                            // ID
-                            ValueInteger.get(u.getId())
-                    );
+            for (RightOwner rightOwner : database.getAllUsersAndRoles()) {
+                if (rightOwner instanceof User) {
+                    User u = (User) rightOwner;
+                    if (admin || session.getUser() == u) {
+                        add(session,
+                                rows,
+                                // NAME
+                                identifier(u.getName()),
+                                // ADMIN
+                                String.valueOf(u.isAdmin()),
+                                // REMARKS
+                                replaceNullWithEmpty(u.getComment()),
+                                // ID
+                                ValueInteger.get(u.getId())
+                        );
+                    }
                 }
             }
             break;
         }
         case ROLES: {
-            for (Role r : database.getAllRoles()) {
-                if (admin || session.getUser().isRoleGranted(r)) {
-                    add(session,
-                            rows,
-                            // NAME
-                            identifier(r.getName()),
-                            // REMARKS
-                            replaceNullWithEmpty(r.getComment()),
-                            // ID
-                            ValueInteger.get(r.getId())
-                    );
+            for (RightOwner rightOwner : database.getAllUsersAndRoles()) {
+                if (rightOwner instanceof Role) {
+                    Role r = (Role) rightOwner;
+                    if (admin || session.getUser().isRoleGranted(r)) {
+                        add(session,
+                                rows,
+                                // NAME
+                                identifier(r.getName()),
+                                // REMARKS
+                                replaceNullWithEmpty(r.getComment()),
+                                // ID
+                                ValueInteger.get(r.getId())
+                        );
+                    }
                 }
             }
             break;

--- a/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
@@ -57,7 +57,7 @@ import org.h2.schema.Schema;
 import org.h2.schema.SchemaObject;
 import org.h2.schema.Sequence;
 import org.h2.schema.TriggerObject;
-import org.h2.schema.UserAggregate;
+import org.h2.schema.UserDefinedFunction;
 import org.h2.schema.FunctionAlias.JavaMethod;
 import org.h2.store.InDoubtTransaction;
 import org.h2.tools.Csv;
@@ -1368,188 +1368,190 @@ public final class InformationSchemaTableLegacy extends MetaTable {
             }
             break;
         }
-        case FUNCTION_ALIASES: {
-            for (SchemaObject aliasAsSchemaObject :
-                    getAllSchemaObjects(DbObject.FUNCTION_ALIAS)) {
-                FunctionAlias alias = (FunctionAlias) aliasAsSchemaObject;
-                JavaMethod[] methods;
-                try {
-                    methods = alias.getJavaMethods();
-                } catch (DbException e) {
-                    methods = new JavaMethod[0];
-                }
-                for (FunctionAlias.JavaMethod method : methods) {
-                    TypeInfo typeInfo = method.getDataType();
-                    add(session,
-                            rows,
-                            // ALIAS_CATALOG
-                            catalog,
-                            // ALIAS_SCHEMA
-                            alias.getSchema().getName(),
-                            // ALIAS_NAME
-                            alias.getName(),
-                            // JAVA_CLASS
-                            alias.getJavaClassName(),
-                            // JAVA_METHOD
-                            alias.getJavaMethodName(),
-                            // DATA_TYPE
-                            ValueInteger.get(DataType.convertTypeToSQLType(typeInfo)),
-                            // TYPE_NAME
-                            getDataTypeName(typeInfo),
-                            // COLUMN_COUNT
-                            ValueInteger.get(method.getParameterCount()),
-                            // RETURNS_RESULT
-                            ValueSmallint.get(typeInfo.getValueType() == Value.NULL
-                                    ? (short) DatabaseMetaData.procedureNoResult
-                                    : (short) DatabaseMetaData.procedureReturnsResult),
-                            // REMARKS
-                            replaceNullWithEmpty(alias.getComment()),
-                            // ID
-                            ValueInteger.get(alias.getId()),
-                            // SOURCE
-                            alias.getSource()
-                            // when adding more columns, see also below
-                    );
-                }
-            }
-            for (SchemaObject aggregateAsSchemaObject : getAllSchemaObjects(DbObject.AGGREGATE)) {
-                UserAggregate agg = (UserAggregate) aggregateAsSchemaObject;
-                add(session,
-                        rows,
-                        // ALIAS_CATALOG
-                        catalog,
-                        // ALIAS_SCHEMA
-                        database.getMainSchema().getName(),
-                        // ALIAS_NAME
-                        agg.getName(),
-                        // JAVA_CLASS
-                        agg.getJavaClassName(),
-                        // JAVA_METHOD
-                        "",
-                        // DATA_TYPE
-                        ValueInteger.get(Types.NULL),
-                        // TYPE_NAME
-                        "NULL",
-                        // COLUMN_COUNT
-                        ValueInteger.get(1),
-                        // RETURNS_RESULT
-                        ValueSmallint.get((short) DatabaseMetaData.procedureReturnsResult),
-                        // REMARKS
-                        replaceNullWithEmpty(agg.getComment()),
-                        // ID
-                        ValueInteger.get(agg.getId()),
-                        // SOURCE
-                        ""
-                        // when adding more columns, see also below
-                );
-            }
-            break;
-        }
-        case FUNCTION_COLUMNS: {
-            for (SchemaObject aliasAsSchemaObject :
-                    getAllSchemaObjects(DbObject.FUNCTION_ALIAS)) {
-                FunctionAlias alias = (FunctionAlias) aliasAsSchemaObject;
-                JavaMethod[] methods;
-                try {
-                    methods = alias.getJavaMethods();
-                } catch (DbException e) {
-                    methods = new JavaMethod[0];
-                }
-                for (FunctionAlias.JavaMethod method : methods) {
-                    // Add return column index 0
-                    TypeInfo typeInfo = method.getDataType();
-                    if (typeInfo.getValueType() != Value.NULL) {
-                        DataType dt = DataType.getDataType(typeInfo.getValueType());
-                        add(session,
-                                rows,
-                                // ALIAS_CATALOG
-                                catalog,
-                                // ALIAS_SCHEMA
-                                alias.getSchema().getName(),
-                                // ALIAS_NAME
-                                alias.getName(),
-                                // JAVA_CLASS
-                                alias.getJavaClassName(),
-                                // JAVA_METHOD
-                                alias.getJavaMethodName(),
-                                // COLUMN_COUNT
-                                ValueInteger.get(method.getParameterCount()),
-                                // POS
-                                ValueInteger.get(0),
-                                // COLUMN_NAME
-                                "P0",
-                                // DATA_TYPE
-                                ValueInteger.get(DataType.convertTypeToSQLType(typeInfo)),
-                                // TYPE_NAME
-                                getDataTypeName(typeInfo),
-                                // PRECISION
-                                ValueInteger.get(MathUtils.convertLongToInt(dt.defaultPrecision)),
-                                // SCALE
-                                ValueSmallint.get(MathUtils.convertIntToShort(dt.defaultScale)),
-                                // RADIX
-                                ValueSmallint.get((short) 10),
-                                // NULLABLE
-                                ValueSmallint.get((short) DatabaseMetaData.columnNullableUnknown),
-                                // COLUMN_TYPE
-                                ValueSmallint.get((short) DatabaseMetaData.procedureColumnReturn),
-                                // REMARKS
-                                "",
-                                // COLUMN_DEFAULT
-                                null
-                        );
-                    }
-                    Class<?>[] columnList = method.getColumnClasses();
-                    for (int k = 0; k < columnList.length; k++) {
-                        if (method.hasConnectionParam() && k == 0) {
+        case FUNCTION_ALIASES:
+            for (Schema schema : database.getAllSchemas()) {
+                for (UserDefinedFunction userDefinedFunction : schema.getAllFunctionsAndAggregates()) {
+                    if (userDefinedFunction instanceof FunctionAlias) {
+                        FunctionAlias alias = (FunctionAlias) userDefinedFunction;
+                        JavaMethod[] methods;
+                        try {
+                            methods = alias.getJavaMethods();
+                        } catch (DbException e) {
                             continue;
                         }
-                        Class<?> clazz = columnList[k];
-                        TypeInfo columnTypeInfo = ValueToObjectConverter2.classToType(clazz);
-                        DataType dt = DataType.getDataType(columnTypeInfo.getValueType());
+                        for (FunctionAlias.JavaMethod method : methods) {
+                            TypeInfo typeInfo = method.getDataType();
+                            add(session,
+                                    rows,
+                                    // ALIAS_CATALOG
+                                    catalog,
+                                    // ALIAS_SCHEMA
+                                    alias.getSchema().getName(),
+                                    // ALIAS_NAME
+                                    alias.getName(),
+                                    // JAVA_CLASS
+                                    alias.getJavaClassName(),
+                                    // JAVA_METHOD
+                                    alias.getJavaMethodName(),
+                                    // DATA_TYPE
+                                    ValueInteger.get(DataType.convertTypeToSQLType(typeInfo)),
+                                    // TYPE_NAME
+                                    getDataTypeName(typeInfo),
+                                    // COLUMN_COUNT
+                                    ValueInteger.get(method.getParameterCount()),
+                                    // RETURNS_RESULT
+                                    ValueSmallint.get(typeInfo.getValueType() == Value.NULL
+                                            ? (short) DatabaseMetaData.procedureNoResult
+                                            : (short) DatabaseMetaData.procedureReturnsResult),
+                                    // REMARKS
+                                    replaceNullWithEmpty(alias.getComment()),
+                                    // ID
+                                    ValueInteger.get(alias.getId()),
+                                    // SOURCE
+                                    alias.getSource()
+                                    // when adding more columns, see also below
+                            );
+                        }
+                    } else {
                         add(session,
                                 rows,
                                 // ALIAS_CATALOG
                                 catalog,
                                 // ALIAS_SCHEMA
-                                alias.getSchema().getName(),
+                                database.getMainSchema().getName(),
                                 // ALIAS_NAME
-                                alias.getName(),
+                                userDefinedFunction.getName(),
                                 // JAVA_CLASS
-                                alias.getJavaClassName(),
+                                userDefinedFunction.getJavaClassName(),
                                 // JAVA_METHOD
-                                alias.getJavaMethodName(),
-                                // COLUMN_COUNT
-                                ValueInteger.get(method.getParameterCount()),
-                                // POS
-                                ValueInteger.get(k + (method.hasConnectionParam() ? 0 : 1)),
-                                // COLUMN_NAME
-                                "P" + (k + 1),
-                                // DATA_TYPE
-                                ValueInteger.get(DataType.convertTypeToSQLType(columnTypeInfo)),
-                                // TYPE_NAME
-                                getDataTypeName(columnTypeInfo),
-                                // PRECISION
-                                ValueInteger.get(MathUtils.convertLongToInt(dt.defaultPrecision)),
-                                // SCALE
-                                ValueSmallint.get(MathUtils.convertIntToShort(dt.defaultScale)),
-                                // RADIX
-                                ValueSmallint.get((short) 10),
-                                // NULLABLE
-                                ValueSmallint.get(clazz.isPrimitive()
-                                        ? (short) DatabaseMetaData.columnNoNulls
-                                        : (short) DatabaseMetaData.columnNullable),
-                                // COLUMN_TYPE
-                                ValueSmallint.get((short) DatabaseMetaData.procedureColumnIn),
-                                // REMARKS
                                 "",
-                                // COLUMN_DEFAULT
-                                null
+                                // DATA_TYPE
+                                ValueInteger.get(Types.NULL),
+                                // TYPE_NAME
+                                "NULL",
+                                // COLUMN_COUNT
+                                ValueInteger.get(1),
+                                // RETURNS_RESULT
+                                ValueSmallint.get((short) DatabaseMetaData.procedureReturnsResult),
+                                // REMARKS
+                                replaceNullWithEmpty(userDefinedFunction.getComment()),
+                                // ID
+                                ValueInteger.get(userDefinedFunction.getId()),
+                                // SOURCE
+                                ""
+                                // when adding more columns, see also below
                         );
                     }
                 }
             }
             break;
-        }
+        case FUNCTION_COLUMNS:
+            for (Schema schema : database.getAllSchemas()) {
+                for (UserDefinedFunction userDefinedFunction : schema.getAllFunctionsAndAggregates()) {
+                    if (userDefinedFunction instanceof FunctionAlias) {
+                        FunctionAlias alias = (FunctionAlias) userDefinedFunction;
+                        JavaMethod[] methods;
+                        try {
+                            methods = alias.getJavaMethods();
+                        } catch (DbException e) {
+                            continue;
+                        }
+                        for (FunctionAlias.JavaMethod method : methods) {
+                            // Add return column index 0
+                            TypeInfo typeInfo = method.getDataType();
+                            if (typeInfo.getValueType() != Value.NULL) {
+                                DataType dt = DataType.getDataType(typeInfo.getValueType());
+                                add(session,
+                                        rows,
+                                        // ALIAS_CATALOG
+                                        catalog,
+                                        // ALIAS_SCHEMA
+                                        alias.getSchema().getName(),
+                                        // ALIAS_NAME
+                                        alias.getName(),
+                                        // JAVA_CLASS
+                                        alias.getJavaClassName(),
+                                        // JAVA_METHOD
+                                        alias.getJavaMethodName(),
+                                        // COLUMN_COUNT
+                                        ValueInteger.get(method.getParameterCount()),
+                                        // POS
+                                        ValueInteger.get(0),
+                                        // COLUMN_NAME
+                                        "P0",
+                                        // DATA_TYPE
+                                        ValueInteger.get(DataType.convertTypeToSQLType(typeInfo)),
+                                        // TYPE_NAME
+                                        getDataTypeName(typeInfo),
+                                        // PRECISION
+                                        ValueInteger.get(MathUtils.convertLongToInt(dt.defaultPrecision)),
+                                        // SCALE
+                                        ValueSmallint.get(MathUtils.convertIntToShort(dt.defaultScale)),
+                                        // RADIX
+                                        ValueSmallint.get((short) 10),
+                                        // NULLABLE
+                                        ValueSmallint.get((short) DatabaseMetaData.columnNullableUnknown),
+                                        // COLUMN_TYPE
+                                        ValueSmallint.get((short) DatabaseMetaData.procedureColumnReturn),
+                                        // REMARKS
+                                        "",
+                                        // COLUMN_DEFAULT
+                                        null
+                                );
+                            }
+                            Class<?>[] columnList = method.getColumnClasses();
+                            for (int k = 0; k < columnList.length; k++) {
+                                if (method.hasConnectionParam() && k == 0) {
+                                    continue;
+                                }
+                                Class<?> clazz = columnList[k];
+                                TypeInfo columnTypeInfo = ValueToObjectConverter2.classToType(clazz);
+                                DataType dt = DataType.getDataType(columnTypeInfo.getValueType());
+                                add(session,
+                                        rows,
+                                        // ALIAS_CATALOG
+                                        catalog,
+                                        // ALIAS_SCHEMA
+                                        alias.getSchema().getName(),
+                                        // ALIAS_NAME
+                                        alias.getName(),
+                                        // JAVA_CLASS
+                                        alias.getJavaClassName(),
+                                        // JAVA_METHOD
+                                        alias.getJavaMethodName(),
+                                        // COLUMN_COUNT
+                                        ValueInteger.get(method.getParameterCount()),
+                                        // POS
+                                        ValueInteger.get(k + (method.hasConnectionParam() ? 0 : 1)),
+                                        // COLUMN_NAME
+                                        "P" + (k + 1),
+                                        // DATA_TYPE
+                                        ValueInteger.get(DataType.convertTypeToSQLType(columnTypeInfo)),
+                                        // TYPE_NAME
+                                        getDataTypeName(columnTypeInfo),
+                                        // PRECISION
+                                        ValueInteger.get(MathUtils.convertLongToInt(dt.defaultPrecision)),
+                                        // SCALE
+                                        ValueSmallint.get(MathUtils.convertIntToShort(dt.defaultScale)),
+                                        // RADIX
+                                        ValueSmallint.get((short) 10),
+                                        // NULLABLE
+                                        ValueSmallint.get(clazz.isPrimitive()
+                                                ? (short) DatabaseMetaData.columnNoNulls
+                                                : (short) DatabaseMetaData.columnNullable),
+                                        // COLUMN_TYPE
+                                        ValueSmallint.get((short) DatabaseMetaData.procedureColumnIn),
+                                        // REMARKS
+                                        "",
+                                        // COLUMN_DEFAULT
+                                        null
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            break;
         case SCHEMATA: {
             String collation = database.getCompareMode().getName();
             for (Schema schema : database.getAllSchemas()) {


### PR DESCRIPTION
Users and roles in H2 and in the Standard reside in the same namespace, but they were stored in the separate maps, so both maps were checked for presence of an object. Now they are stored within the same map.

User-defined Java functions and user-defined aggregate functions are now also stored together in the same map in the schema due to same reasons.