### PR TITLE
Fix access permissions of database objects

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -377,6 +377,7 @@ ALTER DOMAIN @h2@ [ IF EXISTS ] [schemaName.]domainName
     | @h2@ { DROP ON UPDATE }
 ","
 Changes the default or on update expression of a domain.
+Schema owner rights are required to execute this command.
 
 SET DEFAULT changes the default expression of a domain.
 
@@ -403,6 +404,7 @@ ADD [ constraintNameDefinition ]
 CHECK (condition) @h2@ [ CHECK | NOCHECK ]
 ","
 Adds a constraint to a domain.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 ALTER DOMAIN D ADD CONSTRAINT D_POSITIVE CHECK (VALUE > 0)
@@ -413,6 +415,7 @@ ALTER DOMAIN @h2@ [ IF EXISTS ] [schemaName.]domainName
 DROP CONSTRAINT @h2@ [ IF EXISTS ] [schemaName.]constraintName
 ","
 Removes a constraint from a domain.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 ALTER DOMAIN D DROP CONSTRAINT D_POSITIVE
@@ -422,6 +425,7 @@ ALTER DOMAIN D DROP CONSTRAINT D_POSITIVE
 @h2@ ALTER DOMAIN [ IF EXISTS ] [schemaName.]domainName RENAME TO newName
 ","
 Renames a domain.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 ALTER DOMAIN TEST RENAME TO MY_TYPE
@@ -440,6 +444,7 @@ ALTER INDEX IDXNAME RENAME TO IDX_TEST_NAME
 @h2@ ALTER SCHEMA [ IF EXISTS ] schemaName RENAME TO newSchemaName
 ","
 Renames a schema.
+Schema admin rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 ALTER SCHEMA TEST RENAME TO PRODUCTION
@@ -449,6 +454,7 @@ ALTER SCHEMA TEST RENAME TO PRODUCTION
 ALTER SEQUENCE @h2@ [ IF EXISTS ] [schemaName.]sequenceName alterSequenceOption [...]
 ","
 Changes the parameters of a sequence.
+Schema owner rights are required to execute this command.
 This command does not commit the current transaction; however the new value is used by other
 transactions immediately, and rolling back this command has no effect.
 ","
@@ -664,6 +670,7 @@ ALTER USER SA SET PASSWORD 'rioyxlgt'
 @h2@ ALTER VIEW [ IF EXISTS ] [schemaName.]viewName RECOMPILE
 ","
 Recompiles a view after the underlying tables have been changed or created.
+Schema owner rights are required to execute this command.
 This command is used for views created using CREATE FORCE VIEW.
 This command commits an open transaction in this connection.
 ","
@@ -674,6 +681,7 @@ ALTER VIEW ADDRESS_VIEW RECOMPILE
 @h2@ ALTER VIEW [ IF EXISTS ] [schemaName.]viewName RENAME TO newName
 ","
 Renames a view.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 ALTER VIEW TEST RENAME TO MY_VIEW
@@ -705,7 +713,8 @@ ANALYZE SAMPLE_SIZE 1000
 ","
 Sets the comment of a database object. Use NULL or empty string to remove the comment.
 
-Admin rights are required to execute this command.
+Admin rights are required to execute this command if object is a USER or ROLE.
+Schema owner rights are required to execute this command for all other types of objects.
 This command commits an open transaction in this connection.
 ","
 COMMENT ON TABLE TEST IS 'Table used for testing'
@@ -780,6 +789,7 @@ CREATE ALIAS tr AS '@groovy.transform.CompileStatic
 VALUE expression
 ","
 Creates a new constant.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 CREATE CONSTANT ONE VALUE 1
@@ -794,6 +804,7 @@ CREATE DOMAIN @h2@ [ IF NOT EXISTS ] [schemaName.]domainName
 [ CHECK (condition) ] [...]
 ","
 Creates a new domain to define a set of permissible values.
+Schema owner rights are required to execute this command.
 Domains can be used as data types.
 The domain constraints must evaluate to TRUE or to UNKNOWN.
 In the conditions, the term VALUE refers to the value being tested.
@@ -878,12 +889,16 @@ CREATE SCHEMA @h2@ [ IF NOT EXISTS ]
 { name [ AUTHORIZATION ownerName ] | [ AUTHORIZATION ownerName ] }
 @h2@ [ WITH tableEngineParamName [,...] ]
 ","
-Creates a new schema. The user that executes the command must have admin rights.
+Creates a new schema.
+Schema admin rights are required to execute this command.
 
 If schema name is not specified, the owner name is used as a schema name.
 If schema name is specified, but no owner is specified, the current user is used as an owner.
 
-Untrusted users and roles should not be be specified in AUTHORIZATION clause.
+Schema owners can create, rename, and drop objects in the schema.
+Schema owners can drop the schema itself, but cannot rename it.
+Some objects may still require admin rights for their creation,
+see documentation of their CREATE statements for details.
 
 Optional table engine parameters are used when CREATE TABLE command
 is run on this schema without having its engine params set.
@@ -898,6 +913,7 @@ CREATE SEQUENCE @h2@ [ IF NOT EXISTS ] [schemaName.]sequenceName
 [ { AS dataType | sequenceOption } [...] ]
 ","
 Creates a new sequence.
+Schema owner rights are required to execute this command.
 
 The data type of a sequence must be a numeric type, the default is BIGINT.
 Sequence can produce only integer values.
@@ -970,6 +986,8 @@ CREATE TRIGGER @h2@ [ IF NOT EXISTS ] [schemaName.]triggerName
 @h2@ { CALL triggeredClassNameString | AS sourceCodeString }
 ","
 Creates a new trigger.
+Admin rights are required to execute this command.
+
 The trigger class must be public and implement ""org.h2.api.Trigger"".
 Inner classes are not supported.
 The class must be available in the classpath of the database engine
@@ -1048,6 +1066,7 @@ VIEW @h2@ [ IF NOT EXISTS ] [schemaName.]viewName
 ","
 Creates a new view. If the force option is used, then the view is created even
 if the underlying table(s) don't exist.
+Schema owner rights are required to execute this command.
 
 If the OR REPLACE clause is used an existing view will be replaced, and any
 dependent views will not need to be recreated. If dependent views will become
@@ -1056,7 +1075,6 @@ can be ignored if the FORCE clause is also used.
 
 Views are not updatable except when using 'instead of' triggers.
 
-Admin rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 CREATE VIEW TEST_VIEW AS SELECT * FROM TEST WHERE ID < 100
@@ -1066,8 +1084,8 @@ CREATE VIEW TEST_VIEW AS SELECT * FROM TEST WHERE ID < 100
 @h2@ DROP AGGREGATE [ IF EXISTS ] aggregateName
 ","
 Drops an existing user-defined aggregate function.
+Schema owner rights are required to execute this command.
 
-Admin rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 DROP AGGREGATE SIMPLE_MEDIAN
@@ -1077,8 +1095,8 @@ DROP AGGREGATE SIMPLE_MEDIAN
 @h2@ DROP ALIAS [ IF EXISTS ] [schemaName.]aliasName
 ","
 Drops an existing function alias.
+Schema owner rights are required to execute this command.
 
-Admin rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 DROP ALIAS MY_SQRT
@@ -1102,6 +1120,7 @@ DROP ALL OBJECTS
 @h2@ DROP CONSTANT [ IF EXISTS ] [schemaName.]constantName
 ","
 Drops a constant.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 DROP CONSTANT ONE
@@ -1111,6 +1130,8 @@ DROP CONSTANT ONE
 DROP DOMAIN @h2@ [ IF EXISTS ] [schemaName.]domainName [ RESTRICT | CASCADE ]
 ","
 Drops a data type (domain).
+Schema owner rights are required to execute this command.
+
 The command will fail if it is referenced by a column or another domain (the default).
 Column descriptors are replaced with original definition of specified domain if the CASCADE clause is used.
 Default and on update expressions are copied into domains and columns that use this domain and don't have own
@@ -1134,6 +1155,7 @@ DROP INDEX IF EXISTS IDXNAME
 DROP ROLE @h2@ [ IF EXISTS ] roleName
 ","
 Drops a role.
+Admin rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 DROP ROLE READONLY
@@ -1143,6 +1165,7 @@ DROP ROLE READONLY
 DROP SCHEMA @h2@ [ IF EXISTS ] schemaName [ RESTRICT | CASCADE ]
 ","
 Drops a schema.
+Schema owner rights are required to execute this command.
 The command will fail if objects in this schema exist and the RESTRICT clause is used (the default).
 All objects in this schema are dropped as well if the CASCADE clause is used.
 This command commits an open transaction in this connection.
@@ -1154,6 +1177,7 @@ DROP SCHEMA TEST_SCHEMA
 DROP SEQUENCE @h2@ [ IF EXISTS ] [schemaName.]sequenceName
 ","
 Drops a sequence.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 DROP SEQUENCE SEQ_ID
@@ -1196,6 +1220,7 @@ DROP USER TOM
 DROP VIEW @h2@ [ IF EXISTS ] [schemaName.]viewName [ RESTRICT | CASCADE ]
 ","
 Drops an existing view.
+Schema owner rights are required to execute this command.
 All dependent views are dropped as well if the CASCADE clause is used (the default).
 The command will fail if dependent views exist and the RESTRICT clause is used.
 This command commits an open transaction in this connection.
@@ -1266,7 +1291,7 @@ TO { PUBLIC | userName | roleName }
 ","
 Grants rights for a table to a user or role.
 
-Admin rights are required to execute this command.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 GRANT SELECT ON TEST TO READONLY
@@ -1275,7 +1300,9 @@ GRANT SELECT ON TEST TO READONLY
 "Commands (Other)","GRANT ALTER ANY SCHEMA","
 @h2@ GRANT ALTER ANY SCHEMA TO userName
 ","
-Grant schema altering rights to a user.
+Grant schema admin rights to a user.
+
+Schema admin can create, rename, or drop schemas and also has schema owner rights in every schema.
 
 Admin rights are required to execute this command.
 This command commits an open transaction in this connection.
@@ -1318,10 +1345,21 @@ FROM { PUBLIC | userName | roleName }
 ","
 Removes rights for a table from a user or role.
 
-Admin rights are required to execute this command.
+Schema owner rights are required to execute this command.
 This command commits an open transaction in this connection.
 ","
 REVOKE SELECT ON TEST FROM READONLY
+"
+
+"Commands (Other)","REVOKE ALTER ANY SCHEMA","
+@h2@ REVOKE ALTER ANY SCHEMA FROM userName
+","
+Removes schema admin rights from a user.
+
+Admin rights are required to execute this command.
+This command commits an open transaction in this connection.
+","
+GRANT ALTER ANY SCHEMA TO Bob
 "
 
 "Commands (Other)","REVOKE ROLE","

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -874,13 +874,17 @@ CREATE ROLE READONLY
 "
 
 "Commands (DDL)","CREATE SCHEMA","
-CREATE SCHEMA @h2@ [ IF NOT EXISTS ] name
-[ AUTHORIZATION ownerUserName ]
+CREATE SCHEMA @h2@ [ IF NOT EXISTS ]
+{ name [ AUTHORIZATION ownerName ] | [ AUTHORIZATION ownerName ] }
 @h2@ [ WITH tableEngineParamName [,...] ]
 ","
-Creates a new schema. If no owner is specified, the current user is used. The
-user that executes the command must have admin rights, as well as the owner.
-Specifying the owner currently has no effect.
+Creates a new schema. The user that executes the command must have admin rights.
+
+If schema name is not specified, the owner name is used as a schema name.
+If schema name is specified, but no owner is specified, the current user is used as an owner.
+
+Untrusted users and roles should not be be specified in AUTHORIZATION clause.
+
 Optional table engine parameters are used when CREATE TABLE command
 is run on this schema without having its engine params set.
 

--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -526,6 +526,8 @@ The following tokens are keywords in H2:
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
 <tr><td>ASYMMETRIC</td>
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>NR</td><td></td></tr>
+<tr><td>AUTHORIZATION</td>
+<td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
 <tr><td>BETWEEN</td>
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>NR</td><td>+</td></tr>
 <tr><td>BOTH</td>

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2846: GRANT SELECT, INSERT, UPDATE, DELETE incorrectly gives privileges to drop a table
+</li>
 <li>Issue #2882: NPE in UPDATE with SELECT UNION
 </li>
 <li>PR #2881: Store users and roles together and user-defined functions and aggregates together

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -13,6 +13,7 @@ import static org.h2.util.ParserUtil.AND;
 import static org.h2.util.ParserUtil.ARRAY;
 import static org.h2.util.ParserUtil.AS;
 import static org.h2.util.ParserUtil.ASYMMETRIC;
+import static org.h2.util.ParserUtil.AUTHORIZATION;
 import static org.h2.util.ParserUtil.BETWEEN;
 import static org.h2.util.ParserUtil.CASE;
 import static org.h2.util.ParserUtil.CAST;
@@ -568,6 +569,8 @@ public class Parser {
             "AS",
             // ASYMMETRIC
             "ASYMMETRIC",
+            // AUTHORIZATION
+            "AUTHORIZATION",
             // BETWEEN
             "BETWEEN",
             // CASE
@@ -7880,12 +7883,20 @@ public class Parser {
     private CreateSchema parseCreateSchema() {
         CreateSchema command = new CreateSchema(session);
         command.setIfNotExists(readIfNotExists());
-        command.setSchemaName(readIdentifier());
-        if (readIf("AUTHORIZATION")) {
-            command.setAuthorization(readIdentifier());
+        String authorization;
+        if (readIf(AUTHORIZATION)) {
+            authorization = readIdentifier();
+            command.setSchemaName(authorization);
+            command.setAuthorization(authorization);
         } else {
-            command.setAuthorization(session.getUser().getName());
+            command.setSchemaName(readIdentifier());
+            if (readIf(AUTHORIZATION)) {
+                authorization = readIdentifier();
+            } else {
+                authorization = session.getUser().getName();
+            }
         }
+        command.setAuthorization(authorization);
         if (readIf(WITH)) {
             command.setTableEngineParams(readTableEngineParams());
         }

--- a/h2/src/main/org/h2/command/ddl/AlterDomain.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomain.java
@@ -26,7 +26,7 @@ import org.h2.table.Table;
  * ALTER DOMAIN SET ON UPDATE
  * ALTER DOMAIN DROP ON UPDATE
  */
-public class AlterDomain extends SchemaCommand {
+public class AlterDomain extends SchemaOwnerCommand {
 
     /**
      * Processes all columns and domains that use the specified domain.
@@ -110,9 +110,7 @@ public class AlterDomain extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.getUser().checkAdmin();
-        session.commit(true);
+    long update(Schema schema) {
         Domain domain = getSchema().findDomain(domainName);
         if (domain == null) {
             if (ifDomainExists) {

--- a/h2/src/main/org/h2/command/ddl/AlterDomainDropConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomainDropConstraint.java
@@ -18,7 +18,7 @@ import org.h2.schema.Schema;
 /**
  * This class represents the statement ALTER DOMAIN DROP CONSTRAINT
  */
-public class AlterDomainDropConstraint extends SchemaCommand {
+public class AlterDomainDropConstraint extends SchemaOwnerCommand {
 
     private String constraintName;
     private String domainName;
@@ -43,23 +43,21 @@ public class AlterDomainDropConstraint extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.commit(true);
-        Domain domain = getSchema().findDomain(domainName);
+    long update(Schema schema) {
+        Domain domain = schema.findDomain(domainName);
         if (domain == null) {
             if (ifDomainExists) {
                 return 0;
             }
             throw DbException.get(ErrorCode.DOMAIN_NOT_FOUND_1, domainName);
         }
-        Constraint constraint = getSchema().findConstraint(session, constraintName);
+        Constraint constraint = schema.findConstraint(session, constraintName);
         if (constraint == null || constraint.getConstraintType() != Type.DOMAIN
                 || ((ConstraintDomain) constraint).getDomain() != domain) {
             if (!ifConstraintExists) {
                 throw DbException.get(ErrorCode.CONSTRAINT_NOT_FOUND_1, constraintName);
             }
         } else {
-            session.getUser().checkAdmin();
             session.getDatabase().removeSchemaObject(session, constraint);
         }
         return 0;

--- a/h2/src/main/org/h2/command/ddl/AlterDomainRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomainRename.java
@@ -17,7 +17,7 @@ import org.h2.schema.Schema;
  * This class represents the statement
  * ALTER DOMAIN RENAME
  */
-public class AlterDomainRename extends SchemaCommand {
+public class AlterDomainRename extends SchemaOwnerCommand {
 
     private boolean ifDomainExists;
     private String oldDomainName;
@@ -40,18 +40,16 @@ public class AlterDomainRename extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.getUser().checkAdmin();
-        session.commit(true);
+    long update(Schema schema) {
         Database db = session.getDatabase();
-        Domain oldDomain = getSchema().findDomain(oldDomainName);
+        Domain oldDomain = schema.findDomain(oldDomainName);
         if (oldDomain == null) {
             if (ifDomainExists) {
                 return 0;
             }
             throw DbException.get(ErrorCode.DOMAIN_NOT_FOUND_1, oldDomainName);
         }
-        Domain d = getSchema().findDomain(newDomainName);
+        Domain d = schema.findDomain(newDomainName);
         if (d != null) {
             if (oldDomain != d) {
                 throw DbException.get(ErrorCode.DOMAIN_ALREADY_EXISTS_1, newDomainName);

--- a/h2/src/main/org/h2/command/ddl/AlterIndexRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterIndexRename.java
@@ -62,7 +62,7 @@ public class AlterIndexRename extends DefineCommand {
             throw DbException.get(ErrorCode.INDEX_ALREADY_EXISTS_1,
                     newIndexName);
         }
-        session.getUser().checkRight(oldIndex.getTable(), Right.ALL);
+        session.getUser().checkTableRight(oldIndex.getTable(), Right.SCHEMA_OWNER);
         db.renameSchemaObject(session, oldIndex, newIndexName);
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/AlterSchemaRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterSchemaRename.java
@@ -37,18 +37,15 @@ public class AlterSchemaRename extends DefineCommand {
 
     @Override
     public long update() {
+        session.getUser().checkSchemaAdmin();
         session.commit(true);
         Database db = session.getDatabase();
         if (!oldSchema.canDrop()) {
-            throw DbException.get(ErrorCode.SCHEMA_CAN_NOT_BE_DROPPED_1,
-                    oldSchema.getName());
+            throw DbException.get(ErrorCode.SCHEMA_CAN_NOT_BE_DROPPED_1, oldSchema.getName());
         }
-        if (db.findSchema(newSchemaName) != null ||
-                newSchemaName.equals(oldSchema.getName())) {
-            throw DbException.get(ErrorCode.SCHEMA_ALREADY_EXISTS_1,
-                    newSchemaName);
+        if (db.findSchema(newSchemaName) != null || newSchemaName.equals(oldSchema.getName())) {
+            throw DbException.get(ErrorCode.SCHEMA_ALREADY_EXISTS_1, newSchemaName);
         }
-        session.getUser().checkSchemaAdmin();
         db.renameDatabaseObject(session, oldSchema, newSchemaName);
         ArrayList<SchemaObject> all = new ArrayList<>();
         for (Schema schema : db.getAllSchemas()) {

--- a/h2/src/main/org/h2/command/ddl/AlterSequence.java
+++ b/h2/src/main/org/h2/command/ddl/AlterSequence.java
@@ -17,7 +17,7 @@ import org.h2.table.Column;
 /**
  * This class represents the statement ALTER SEQUENCE.
  */
-public class AlterSequence extends SchemaCommand {
+public class AlterSequence extends SchemaOwnerCommand {
 
     private boolean ifExists;
 
@@ -33,6 +33,7 @@ public class AlterSequence extends SchemaCommand {
 
     public AlterSequence(SessionLocal session, Schema schema) {
         super(session, schema);
+        transactional = true;
     }
 
     public void setIfExists(boolean b) {
@@ -69,9 +70,9 @@ public class AlterSequence extends SchemaCommand {
     }
 
     @Override
-    public long update() {
+    long update(Schema schema) {
         if (sequence == null) {
-            sequence = getSchema().findSequence(sequenceName);
+            sequence = schema.findSequence(sequenceName);
             if (sequence == null) {
                 if (!ifExists) {
                     throw DbException.get(ErrorCode.SEQUENCE_NOT_FOUND_1, sequenceName);
@@ -80,7 +81,7 @@ public class AlterSequence extends SchemaCommand {
             }
         }
         if (column != null) {
-            session.getUser().checkRight(column.getTable(), Right.ALL);
+            session.getUser().checkTableRight(column.getTable(), Right.SCHEMA_OWNER);
         }
         options.setDataType(sequence.getDataType());
         Long startValue = options.getStartValue(session);

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -119,7 +119,7 @@ public class AlterTableAddConstraint extends SchemaCommand {
             throw DbException.get(ErrorCode.CONSTRAINT_ALREADY_EXISTS_1,
                     constraintName);
         }
-        session.getUser().checkRight(table, Right.ALL);
+        session.getUser().checkTableRight(table, Right.SCHEMA_OWNER);
         db.lockMeta(session);
         table.lock(session, true, true);
         Constraint constraint;
@@ -193,7 +193,7 @@ public class AlterTableAddConstraint extends SchemaCommand {
             if (refTable == null) {
                 throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, refTableName);
             }
-            session.getUser().checkRight(refTable, Right.ALL);
+            session.getUser().checkTableRight(refTable, Right.SCHEMA_OWNER);
             if (!refTable.canReference()) {
                 StringBuilder builder = new StringBuilder("Reference ");
                 refTable.getSQL(builder, HasSQL.TRACE_SQL_FLAGS);

--- a/h2/src/main/org/h2/command/ddl/AlterTableAlterColumn.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAlterColumn.java
@@ -115,7 +115,7 @@ public class AlterTableAlterColumn extends CommandWithColumns {
             }
             throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, tableName);
         }
-        session.getUser().checkRight(table, Right.ALL);
+        session.getUser().checkTableRight(table, Right.SCHEMA_OWNER);
         table.checkSupportAlter();
         table.lock(session, true, true);
         if (newColumn != null) {

--- a/h2/src/main/org/h2/command/ddl/AlterTableDropConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableDropConstraint.java
@@ -50,8 +50,8 @@ public class AlterTableDropConstraint extends SchemaCommand {
                 throw DbException.get(ErrorCode.CONSTRAINT_NOT_FOUND_1, constraintName);
             }
         } else {
-            session.getUser().checkRight(constraint.getTable(), Right.ALL);
-            session.getUser().checkRight(constraint.getRefTable(), Right.ALL);
+            session.getUser().checkTableRight(constraint.getTable(), Right.SCHEMA_OWNER);
+            session.getUser().checkTableRight(constraint.getRefTable(), Right.SCHEMA_OWNER);
             if (constraintType == Type.PRIMARY_KEY || constraintType == Type.UNIQUE) {
                 for (Constraint c : constraint.getTable().getConstraints()) {
                     if (c.getReferencedConstraint() == constraint) {
@@ -59,7 +59,7 @@ public class AlterTableDropConstraint extends SchemaCommand {
                             throw DbException.get(ErrorCode.CONSTRAINT_IS_USED_BY_CONSTRAINT_2,
                                     constraint.getTraceSQL(), c.getTraceSQL());
                         }
-                        session.getUser().checkRight(c.getTable(), Right.ALL);
+                        session.getUser().checkTableRight(c.getTable(), Right.SCHEMA_OWNER);
                     }
                 }
             }

--- a/h2/src/main/org/h2/command/ddl/AlterTableRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableRename.java
@@ -52,7 +52,11 @@ public class AlterTableRename extends SchemaCommand {
             }
             throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, oldTableName);
         }
-        session.getUser().checkRight(oldTable, Right.ALL);
+        if (oldTable.isView()) {
+            session.getUser().checkSchemaOwner(oldTable.getSchema());
+        } else {
+            session.getUser().checkTableRight(oldTable, Right.SCHEMA_OWNER);
+        }
         Table t = getSchema().findTableOrView(session, newTableName);
         if (t != null && hidden && newTableName.equals(oldTable.getName())) {
             if (!t.isHidden()) {

--- a/h2/src/main/org/h2/command/ddl/AlterTableRenameColumn.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableRenameColumn.java
@@ -68,7 +68,7 @@ public class AlterTableRenameColumn extends SchemaCommand {
         if (column == null) {
             return 0;
         }
-        session.getUser().checkRight(table, Right.ALL);
+        session.getUser().checkTableRight(table, Right.SCHEMA_OWNER);
         table.checkSupportAlter();
         table.renameColumn(column, newName);
         table.setModified();

--- a/h2/src/main/org/h2/command/ddl/AlterTableRenameConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableRenameConstraint.java
@@ -45,8 +45,8 @@ public class AlterTableRenameConstraint extends SchemaCommand {
             throw DbException.get(ErrorCode.CONSTRAINT_ALREADY_EXISTS_1,
                     newConstraintName);
         }
-        session.getUser().checkRight(constraint.getTable(), Right.ALL);
-        session.getUser().checkRight(constraint.getRefTable(), Right.ALL);
+        session.getUser().checkTableRight(constraint.getTable(), Right.SCHEMA_OWNER);
+        session.getUser().checkTableRight(constraint.getRefTable(), Right.SCHEMA_OWNER);
         session.getDatabase().renameSchemaObject(session, constraint, newConstraintName);
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/AlterUser.java
+++ b/h2/src/main/org/h2/command/ddl/AlterUser.java
@@ -85,9 +85,6 @@ public class AlterUser extends DefineCommand {
             break;
         case CommandInterface.ALTER_USER_ADMIN:
             session.getUser().checkAdmin();
-            if (!admin) {
-                user.checkOwnsNoSchemas();
-            }
             user.setAdmin(admin);
             break;
         default:

--- a/h2/src/main/org/h2/command/ddl/AlterView.java
+++ b/h2/src/main/org/h2/command/ddl/AlterView.java
@@ -6,7 +6,6 @@
 package org.h2.command.ddl;
 
 import org.h2.command.CommandInterface;
-import org.h2.engine.Right;
 import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
 import org.h2.table.TableView;
@@ -38,7 +37,7 @@ public class AlterView extends DefineCommand {
         if (view == null && ifExists) {
             return 0;
         }
-        session.getUser().checkRight(view, Right.ALL);
+        session.getUser().checkSchemaOwner(view.getSchema());
         DbException e = view.recompile(session, false, true);
         if (e != null) {
             throw e;

--- a/h2/src/main/org/h2/command/ddl/Analyze.java
+++ b/h2/src/main/org/h2/command/ddl/Analyze.java
@@ -112,7 +112,7 @@ public class Analyze extends DefineCommand {
                 || table.isTemporary() && !table.isGlobalTemporary() //
                         && session.findLocalTempTable(table.getName()) == null //
                 || table.isLockedExclusively() && !table.isLockedExclusivelyBy(session)
-                || !session.getUser().hasRight(table, Right.SELECT) //
+                || !session.getUser().hasTableRight(table, Right.SELECT) //
                 // if the connection is closed and there is something to undo
                 || session.getCancel() != 0) {
             return;

--- a/h2/src/main/org/h2/command/ddl/CreateAggregate.java
+++ b/h2/src/main/org/h2/command/ddl/CreateAggregate.java
@@ -30,8 +30,8 @@ public class CreateAggregate extends SchemaCommand {
 
     @Override
     public long update() {
-        session.commit(true);
         session.getUser().checkAdmin();
+        session.commit(true);
         Database db = session.getDatabase();
         Schema schema = getSchema();
         if (schema.findFunctionOrAggregate(name) != null) {

--- a/h2/src/main/org/h2/command/ddl/CreateConstant.java
+++ b/h2/src/main/org/h2/command/ddl/CreateConstant.java
@@ -19,7 +19,7 @@ import org.h2.value.Value;
  * This class represents the statement
  * CREATE CONSTANT
  */
-public class CreateConstant extends SchemaCommand {
+public class CreateConstant extends SchemaOwnerCommand {
 
     private String constantName;
     private Expression expression;
@@ -34,18 +34,16 @@ public class CreateConstant extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.commit(true);
-        session.getUser().checkAdmin();
+    long update(Schema schema) {
         Database db = session.getDatabase();
-        if (getSchema().findConstant(constantName) != null) {
+        if (schema.findConstant(constantName) != null) {
             if (ifNotExists) {
                 return 0;
             }
             throw DbException.get(ErrorCode.CONSTANT_ALREADY_EXISTS_1, constantName);
         }
         int id = getObjectId();
-        Constant constant = new Constant(getSchema(), id, constantName);
+        Constant constant = new Constant(schema, id, constantName);
         expression = expression.optimize(session);
         Value value = expression.getValue(session);
         constant.setValue(value);

--- a/h2/src/main/org/h2/command/ddl/CreateDomain.java
+++ b/h2/src/main/org/h2/command/ddl/CreateDomain.java
@@ -24,7 +24,7 @@ import org.h2.value.Value;
  * This class represents the statement
  * CREATE DOMAIN
  */
-public class CreateDomain extends SchemaCommand {
+public class CreateDomain extends SchemaOwnerCommand {
 
     private String typeName;
     private boolean ifNotExists;
@@ -74,11 +74,7 @@ public class CreateDomain extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.getUser().checkAdmin();
-        session.commit(true);
-        session.getUser().checkAdmin();
-        Schema schema = getSchema();
+    long update(Schema schema) {
         if (schema.findDomain(typeName) != null) {
             if (ifNotExists) {
                 return 0;

--- a/h2/src/main/org/h2/command/ddl/CreateFunctionAlias.java
+++ b/h2/src/main/org/h2/command/ddl/CreateFunctionAlias.java
@@ -33,8 +33,8 @@ public class CreateFunctionAlias extends SchemaCommand {
 
     @Override
     public long update() {
-        session.commit(true);
         session.getUser().checkAdmin();
+        session.commit(true);
         Database db = session.getDatabase();
         Schema schema = getSchema();
         if (schema.findFunctionOrAggregate(aliasName) != null) {

--- a/h2/src/main/org/h2/command/ddl/CreateIndex.java
+++ b/h2/src/main/org/h2/command/ddl/CreateIndex.java
@@ -75,7 +75,7 @@ public class CreateIndex extends SchemaCommand {
             }
             throw DbException.get(ErrorCode.INDEX_ALREADY_EXISTS_1, indexName);
         }
-        session.getUser().checkRight(table, Right.ALL);
+        session.getUser().checkTableRight(table, Right.SCHEMA_OWNER);
         table.lock(session, true, true);
         if (!table.isPersistIndexes()) {
             persistent = false;

--- a/h2/src/main/org/h2/command/ddl/CreateLinkedTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateLinkedTable.java
@@ -63,9 +63,9 @@ public class CreateLinkedTable extends SchemaCommand {
 
     @Override
     public long update() {
+        session.getUser().checkAdmin();
         session.commit(true);
         Database db = session.getDatabase();
-        session.getUser().checkAdmin();
         if (getSchema().resolveTableOrView(session, tableName) != null) {
             if (ifNotExists) {
                 return 0;

--- a/h2/src/main/org/h2/command/ddl/CreateSequence.java
+++ b/h2/src/main/org/h2/command/ddl/CreateSequence.java
@@ -16,7 +16,7 @@ import org.h2.schema.Sequence;
 /**
  * This class represents the statement CREATE SEQUENCE.
  */
-public class CreateSequence extends SchemaCommand {
+public class CreateSequence extends SchemaOwnerCommand {
 
     private String sequenceName;
 
@@ -28,6 +28,7 @@ public class CreateSequence extends SchemaCommand {
 
     public CreateSequence(SessionLocal session, Schema schema) {
         super(session, schema);
+        transactional = true;
     }
 
     public void setSequenceName(String sequenceName) {
@@ -43,17 +44,16 @@ public class CreateSequence extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.commit(true);
+    long update(Schema schema) {
         Database db = session.getDatabase();
-        if (getSchema().findSequence(sequenceName) != null) {
+        if (schema.findSequence(sequenceName) != null) {
             if (ifNotExists) {
                 return 0;
             }
             throw DbException.get(ErrorCode.SEQUENCE_ALREADY_EXISTS_1, sequenceName);
         }
         int id = getObjectId();
-        Sequence sequence = new Sequence(session, getSchema(), id, sequenceName, options, belongsToTable);
+        Sequence sequence = new Sequence(session, schema, id, sequenceName, options, belongsToTable);
         db.addSchemaObject(session, sequence);
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/CreateSynonym.java
+++ b/h2/src/main/org/h2/command/ddl/CreateSynonym.java
@@ -17,7 +17,7 @@ import org.h2.table.TableSynonym;
  * This class represents the statement
  * CREATE SYNONYM
  */
-public class CreateSynonym extends SchemaCommand {
+public class CreateSynonym extends SchemaOwnerCommand {
 
     private final CreateSynonymData data = new CreateSynonymData();
     private boolean ifNotExists;
@@ -47,16 +47,12 @@ public class CreateSynonym extends SchemaCommand {
     public void setOrReplace(boolean orReplace) { this.orReplace = orReplace; }
 
     @Override
-    public long update() {
-        if (!transactional) {
-            session.commit(true);
-        }
-        session.getUser().checkAdmin();
+    long update(Schema schema) {
         Database db = session.getDatabase();
         data.session = session;
         db.lockMeta(session);
 
-        if (getSchema().findTableOrView(session, data.synonymName) != null) {
+        if (schema.findTableOrView(session, data.synonymName) != null) {
             throw DbException.get(ErrorCode.TABLE_OR_VIEW_ALREADY_EXISTS_1, data.synonymName);
         }
 

--- a/h2/src/main/org/h2/command/ddl/CreateTrigger.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTrigger.java
@@ -86,6 +86,7 @@ public class CreateTrigger extends SchemaCommand {
 
     @Override
     public long update() {
+        session.getUser().checkAdmin();
         session.commit(true);
         Database db = session.getDatabase();
         if (getSchema().findTrigger(triggerName) != null) {

--- a/h2/src/main/org/h2/command/ddl/CreateView.java
+++ b/h2/src/main/org/h2/command/ddl/CreateView.java
@@ -25,7 +25,7 @@ import org.h2.value.TypeInfo;
  * This class represents the statement
  * CREATE VIEW
  */
-public class CreateView extends SchemaCommand {
+public class CreateView extends SchemaOwnerCommand {
 
     private Query select;
     private String viewName;
@@ -78,12 +78,10 @@ public class CreateView extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.commit(true);
-        session.getUser().checkAdmin();
+    long update(Schema schema) {
         Database db = session.getDatabase();
         TableView view = null;
-        Table old = getSchema().findTableOrView(session, viewName);
+        Table old = schema.findTableOrView(session, viewName);
         if (old != null) {
             if (ifNotExists) {
                 return 0;
@@ -118,11 +116,11 @@ public class CreateView extends SchemaCommand {
         }
         if (view == null) {
             if (isTableExpression) {
-                view = TableView.createTableViewMaybeRecursive(getSchema(), id, viewName, querySQL, null,
+                view = TableView.createTableViewMaybeRecursive(schema, id, viewName, querySQL, null,
                         columnTemplatesAsStrings, session, false /* literalsChecked */, isTableExpression,
                         false/*isTemporary*/, db);
             } else {
-                view = new TableView(getSchema(), id, viewName, querySQL, null, columnTemplatesAsUnknowns, session,
+                view = new TableView(schema, id, viewName, querySQL, null, columnTemplatesAsUnknowns, session,
                         false/* allow recursive */, false/* literalsChecked */, isTableExpression, false/*temporary*/);
             }
         } else {

--- a/h2/src/main/org/h2/command/ddl/DropAggregate.java
+++ b/h2/src/main/org/h2/command/ddl/DropAggregate.java
@@ -17,7 +17,7 @@ import org.h2.schema.UserAggregate;
  * This class represents the statement
  * DROP AGGREGATE
  */
-public class DropAggregate extends SchemaCommand {
+public class DropAggregate extends SchemaOwnerCommand {
 
     private String name;
     private boolean ifExists;
@@ -27,11 +27,9 @@ public class DropAggregate extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.getUser().checkAdmin();
-        session.commit(true);
+    long update(Schema schema) {
         Database db = session.getDatabase();
-        UserAggregate aggregate = getSchema().findAggregate(name);
+        UserAggregate aggregate = schema.findAggregate(name);
         if (aggregate == null) {
             if (!ifExists) {
                 throw DbException.get(ErrorCode.AGGREGATE_NOT_FOUND_1, name);

--- a/h2/src/main/org/h2/command/ddl/DropConstant.java
+++ b/h2/src/main/org/h2/command/ddl/DropConstant.java
@@ -17,7 +17,7 @@ import org.h2.schema.Schema;
  * This class represents the statement
  * DROP CONSTANT
  */
-public class DropConstant extends SchemaCommand {
+public class DropConstant extends SchemaOwnerCommand {
 
     private String constantName;
     private boolean ifExists;
@@ -35,11 +35,9 @@ public class DropConstant extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.getUser().checkAdmin();
-        session.commit(true);
+    long update(Schema schema) {
         Database db = session.getDatabase();
-        Constant constant = getSchema().findConstant(constantName);
+        Constant constant = schema.findConstant(constantName);
         if (constant == null) {
             if (!ifExists) {
                 throw DbException.get(ErrorCode.CONSTANT_NOT_FOUND_1, constantName);

--- a/h2/src/main/org/h2/command/ddl/DropDomain.java
+++ b/h2/src/main/org/h2/command/ddl/DropDomain.java
@@ -23,7 +23,7 @@ import org.h2.table.Table;
 /**
  * This class represents the statement DROP DOMAIN
  */
-public class DropDomain extends SchemaCommand {
+public class DropDomain extends SchemaOwnerCommand {
 
     private String typeName;
     private boolean ifExists;
@@ -44,10 +44,7 @@ public class DropDomain extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.getUser().checkAdmin();
-        session.commit(true);
-        Schema schema = getSchema();
+    long update(Schema schema) {
         Domain domain = schema.findDomain(typeName);
         if (domain == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropFunctionAlias.java
+++ b/h2/src/main/org/h2/command/ddl/DropFunctionAlias.java
@@ -17,7 +17,7 @@ import org.h2.schema.Schema;
  * This class represents the statement
  * DROP ALIAS
  */
-public class DropFunctionAlias extends SchemaCommand {
+public class DropFunctionAlias extends SchemaOwnerCommand {
 
     private String aliasName;
     private boolean ifExists;
@@ -27,11 +27,9 @@ public class DropFunctionAlias extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.getUser().checkAdmin();
-        session.commit(true);
+    long update(Schema schema) {
         Database db = session.getDatabase();
-        FunctionAlias functionAlias = getSchema().findFunction(aliasName);
+        FunctionAlias functionAlias = schema.findFunction(aliasName);
         if (functionAlias == null) {
             if (!ifExists) {
                 throw DbException.get(ErrorCode.FUNCTION_ALIAS_NOT_FOUND_1, aliasName);

--- a/h2/src/main/org/h2/command/ddl/DropIndex.java
+++ b/h2/src/main/org/h2/command/ddl/DropIndex.java
@@ -50,7 +50,7 @@ public class DropIndex extends SchemaCommand {
             }
         } else {
             Table table = index.getTable();
-            session.getUser().checkRight(index.getTable(), Right.ALL);
+            session.getUser().checkTableRight(index.getTable(), Right.SCHEMA_OWNER);
             Constraint pkConstraint = null;
             ArrayList<Constraint> constraints = table.getConstraints();
             for (int i = 0; constraints != null && i < constraints.size(); i++) {

--- a/h2/src/main/org/h2/command/ddl/DropRole.java
+++ b/h2/src/main/org/h2/command/ddl/DropRole.java
@@ -43,6 +43,7 @@ public class DropRole extends DefineCommand {
             if (role == db.getPublicRole()) {
                 throw DbException.get(ErrorCode.ROLE_CAN_NOT_BE_DROPPED_1, roleName);
             }
+            role.checkOwnsNoSchemas();
             db.removeDatabaseObject(session, role);
         }
         return 0;

--- a/h2/src/main/org/h2/command/ddl/DropSchema.java
+++ b/h2/src/main/org/h2/command/ddl/DropSchema.java
@@ -37,7 +37,6 @@ public class DropSchema extends DefineCommand {
 
     @Override
     public long update() {
-        session.getUser().checkSchemaAdmin();
         session.commit(true);
         Database db = session.getDatabase();
         Schema schema = db.findSchema(schemaName);
@@ -46,6 +45,7 @@ public class DropSchema extends DefineCommand {
                 throw DbException.get(ErrorCode.SCHEMA_NOT_FOUND_1, schemaName);
             }
         } else {
+            session.getUser().checkSchemaOwner(schema);
             if (!schema.canDrop()) {
                 throw DbException.get(ErrorCode.SCHEMA_CAN_NOT_BE_DROPPED_1, schemaName);
             }

--- a/h2/src/main/org/h2/command/ddl/DropSequence.java
+++ b/h2/src/main/org/h2/command/ddl/DropSequence.java
@@ -7,7 +7,6 @@ package org.h2.command.ddl;
 
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
-import org.h2.engine.Database;
 import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
 import org.h2.schema.Schema;
@@ -17,7 +16,7 @@ import org.h2.schema.Sequence;
  * This class represents the statement
  * DROP SEQUENCE
  */
-public class DropSequence extends SchemaCommand {
+public class DropSequence extends SchemaOwnerCommand {
 
     private String sequenceName;
     private boolean ifExists;
@@ -35,11 +34,8 @@ public class DropSequence extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.getUser().checkAdmin();
-        session.commit(true);
-        Database db = session.getDatabase();
-        Sequence sequence = getSchema().findSequence(sequenceName);
+    long update(Schema schema) {
+        Sequence sequence = schema.findSequence(sequenceName);
         if (sequence == null) {
             if (!ifExists) {
                 throw DbException.get(ErrorCode.SEQUENCE_NOT_FOUND_1, sequenceName);
@@ -48,7 +44,7 @@ public class DropSequence extends SchemaCommand {
             if (sequence.getBelongsToTable()) {
                 throw DbException.get(ErrorCode.SEQUENCE_BELONGS_TO_A_TABLE_1, sequenceName);
             }
-            db.removeSchemaObject(session, sequence);
+            session.getDatabase().removeSchemaObject(session, sequence);
         }
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/DropSynonym.java
+++ b/h2/src/main/org/h2/command/ddl/DropSynonym.java
@@ -16,7 +16,7 @@ import org.h2.table.TableSynonym;
  * This class represents the statement
  * DROP SYNONYM
  */
-public class DropSynonym extends SchemaCommand {
+public class DropSynonym extends SchemaOwnerCommand {
 
     private String synonymName;
     private boolean ifExists;
@@ -30,11 +30,8 @@ public class DropSynonym extends SchemaCommand {
     }
 
     @Override
-    public long update() {
-        session.commit(true);
-        session.getUser().checkAdmin();
-
-        TableSynonym synonym = getSchema().getSynonym(synonymName);
+    long update(Schema schema) {
+        TableSynonym synonym = schema.getSynonym(synonymName);
         if (synonym == null) {
             if (!ifExists) {
                 throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, synonymName);

--- a/h2/src/main/org/h2/command/ddl/DropTable.java
+++ b/h2/src/main/org/h2/command/ddl/DropTable.java
@@ -65,7 +65,7 @@ public class DropTable extends DefineCommand {
                     throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, tableName);
                 }
             } else {
-                session.getUser().checkRight(table, Right.ALL);
+                session.getUser().checkTableRight(table, Right.SCHEMA_OWNER);
                 if (!table.canDrop()) {
                     throw DbException.get(ErrorCode.CANNOT_DROP_TABLE_1, tableName);
                 }

--- a/h2/src/main/org/h2/command/ddl/DropTrigger.java
+++ b/h2/src/main/org/h2/command/ddl/DropTrigger.java
@@ -47,7 +47,7 @@ public class DropTrigger extends SchemaCommand {
             }
         } else {
             Table table = trigger.getTable();
-            session.getUser().checkRight(table, Right.ALL);
+            session.getUser().checkTableRight(table, Right.SCHEMA_OWNER);
             db.removeSchemaObject(session, trigger);
         }
         return 0;

--- a/h2/src/main/org/h2/command/ddl/DropView.java
+++ b/h2/src/main/org/h2/command/ddl/DropView.java
@@ -10,7 +10,6 @@ import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.constraint.ConstraintActionType;
 import org.h2.engine.DbObject;
-import org.h2.engine.Right;
 import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
 import org.h2.schema.Schema;
@@ -59,7 +58,7 @@ public class DropView extends SchemaCommand {
             if (TableType.VIEW != view.getTableType()) {
                 throw DbException.get(ErrorCode.VIEW_NOT_FOUND_1, viewName);
             }
-            session.getUser().checkRight(view, Right.ALL);
+            session.getUser().checkSchemaOwner(view.getSchema());
 
             if (dropAction == ConstraintActionType.RESTRICT) {
                 for (DbObject child : view.getChildren()) {

--- a/h2/src/main/org/h2/command/ddl/SchemaCommand.java
+++ b/h2/src/main/org/h2/command/ddl/SchemaCommand.java
@@ -31,7 +31,7 @@ public abstract class SchemaCommand extends DefineCommand {
      *
      * @return the schema
      */
-    protected Schema getSchema() {
+    protected final Schema getSchema() {
         return schema;
     }
 

--- a/h2/src/main/org/h2/command/ddl/SchemaOwnerCommand.java
+++ b/h2/src/main/org/h2/command/ddl/SchemaOwnerCommand.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.command.ddl;
+
+import org.h2.engine.SessionLocal;
+import org.h2.schema.Schema;
+
+/**
+ * This class represents a non-transaction statement that involves a schema and
+ * requires schema owner rights.
+ */
+abstract class SchemaOwnerCommand extends SchemaCommand {
+
+    /**
+     * Create a new command.
+     *
+     * @param session
+     *            the session
+     * @param schema
+     *            the schema
+     */
+    SchemaOwnerCommand(SessionLocal session, Schema schema) {
+        super(session, schema);
+    }
+
+    @Override
+    public final long update() {
+        Schema schema = getSchema();
+        session.getUser().checkSchemaOwner(schema);
+        if (!transactional) {
+            session.commit(true);
+        }
+        return update(schema);
+    }
+
+    abstract long update(Schema schema);
+
+}

--- a/h2/src/main/org/h2/command/ddl/SetComment.java
+++ b/h2/src/main/org/h2/command/ddl/SetComment.java
@@ -13,6 +13,7 @@ import org.h2.engine.DbObject;
 import org.h2.engine.SessionLocal;
 import org.h2.expression.Expression;
 import org.h2.message.DbException;
+import org.h2.schema.Schema;
 import org.h2.table.Table;
 
 /**
@@ -36,54 +37,81 @@ public class SetComment extends DefineCommand {
     public long update() {
         session.commit(true);
         Database db = session.getDatabase();
-        session.getUser().checkAdmin();
         DbObject object = null;
         int errorCode = ErrorCode.GENERAL_ERROR_1;
         if (schemaName == null) {
             schemaName = session.getCurrentSchemaName();
         }
         switch (objectType) {
-        case DbObject.CONSTANT:
-            object = db.getSchema(schemaName).getConstant(objectName);
+        case DbObject.CONSTANT: {
+            Schema schema = db.getSchema(schemaName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema.getConstant(objectName);
             break;
-        case DbObject.CONSTRAINT:
-            object = db.getSchema(schemaName).getConstraint(objectName);
+        }
+        case DbObject.CONSTRAINT: {
+            Schema schema = db.getSchema(schemaName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema.getConstraint(objectName);
             break;
-        case DbObject.FUNCTION_ALIAS:
-            object = db.getSchema(schemaName).findFunction(objectName);
+        }
+        case DbObject.FUNCTION_ALIAS: {
+            Schema schema = db.getSchema(schemaName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema.findFunction(objectName);
             errorCode = ErrorCode.FUNCTION_ALIAS_NOT_FOUND_1;
             break;
-        case DbObject.INDEX:
-            object = db.getSchema(schemaName).getIndex(objectName);
+        }
+        case DbObject.INDEX: {
+            Schema schema = db.getSchema(schemaName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema.getIndex(objectName);
             break;
+        }
         case DbObject.ROLE:
+            session.getUser().checkAdmin();
             schemaName = null;
             object = db.findRole(objectName);
             errorCode = ErrorCode.ROLE_NOT_FOUND_1;
             break;
-        case DbObject.SCHEMA:
+        case DbObject.SCHEMA: {
             schemaName = null;
-            object = db.findSchema(objectName);
-            errorCode = ErrorCode.SCHEMA_NOT_FOUND_1;
+            Schema schema = db.getSchema(objectName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema;
             break;
-        case DbObject.SEQUENCE:
-            object = db.getSchema(schemaName).getSequence(objectName);
+        }
+        case DbObject.SEQUENCE: {
+            Schema schema = db.getSchema(schemaName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema.getSequence(objectName);
             break;
-        case DbObject.TABLE_OR_VIEW:
-            object = db.getSchema(schemaName).getTableOrView(session, objectName);
+        }
+        case DbObject.TABLE_OR_VIEW: {
+            Schema schema = db.getSchema(schemaName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema.getTableOrView(session, objectName);
             break;
-        case DbObject.TRIGGER:
-            object = db.getSchema(schemaName).findTrigger(objectName);
+        }
+        case DbObject.TRIGGER: {
+            Schema schema = db.getSchema(schemaName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema.findTrigger(objectName);
             errorCode = ErrorCode.TRIGGER_NOT_FOUND_1;
             break;
+        }
         case DbObject.USER:
+            session.getUser().checkAdmin();
             schemaName = null;
             object = db.getUser(objectName);
             break;
-        case DbObject.DOMAIN:
-            object = db.getSchema(schemaName).findDomain(objectName);
-            errorCode = ErrorCode.DOMAIN_ALREADY_EXISTS_1;
+        case DbObject.DOMAIN: {
+            Schema schema = db.getSchema(schemaName);
+            session.getUser().checkSchemaOwner(schema);
+            object = schema.findDomain(objectName);
+            errorCode = ErrorCode.DOMAIN_NOT_FOUND_1;
             break;
+        }
         default:
         }
         if (object == null) {

--- a/h2/src/main/org/h2/command/ddl/TruncateTable.java
+++ b/h2/src/main/org/h2/command/ddl/TruncateTable.java
@@ -42,7 +42,7 @@ public class TruncateTable extends DefineCommand {
         if (!table.canTruncate()) {
             throw DbException.get(ErrorCode.CANNOT_TRUNCATE_1, table.getTraceSQL());
         }
-        session.getUser().checkRight(table, Right.DELETE);
+        session.getUser().checkTableRight(table, Right.DELETE);
         table.lock(session, true, true);
         long result = table.truncate(session);
         if (restart) {

--- a/h2/src/main/org/h2/command/dml/AlterTableSet.java
+++ b/h2/src/main/org/h2/command/dml/AlterTableSet.java
@@ -59,7 +59,7 @@ public class AlterTableSet extends SchemaCommand {
             }
             throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, tableName);
         }
-        session.getUser().checkRight(table, Right.ALL);
+        session.getUser().checkTableRight(table, Right.SCHEMA_OWNER);
         table.lock(session, true, true);
         switch (type) {
         case CommandInterface.ALTER_TABLE_SET_REFERENTIAL_INTEGRITY:

--- a/h2/src/main/org/h2/command/dml/Delete.java
+++ b/h2/src/main/org/h2/command/dml/Delete.java
@@ -67,7 +67,7 @@ public final class Delete extends DataChangeStatement {
         targetTableFilter.startQuery(session);
         targetTableFilter.reset();
         Table table = targetTableFilter.getTable();
-        session.getUser().checkRight(table, Right.DELETE);
+        session.getUser().checkTableRight(table, Right.DELETE);
         table.fire(session, Trigger.DELETE, true);
         table.lock(session, true, false);
         int limitRows = -1;

--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -159,7 +159,7 @@ public final class Insert extends CommandWithValues implements ResultTarget {
     }
 
     private long insertRows() {
-        session.getUser().checkRight(table, Right.INSERT);
+        session.getUser().checkTableRight(table, Right.INSERT);
         setCurrentRowNumber(0);
         table.fire(session, Trigger.INSERT, true);
         rowNumber = 0;

--- a/h2/src/main/org/h2/command/dml/Merge.java
+++ b/h2/src/main/org/h2/command/dml/Merge.java
@@ -86,8 +86,8 @@ public final class Merge extends CommandWithValues {
     @Override
     public long update(ResultTarget deltaChangeCollector, ResultOption deltaChangeCollectionMode) {
         long count = 0;
-        session.getUser().checkRight(table, Right.INSERT);
-        session.getUser().checkRight(table, Right.UPDATE);
+        session.getUser().checkTableRight(table, Right.INSERT);
+        session.getUser().checkTableRight(table, Right.UPDATE);
         setCurrentRowNumber(0);
         if (!valuesExpressionList.isEmpty()) {
             // process values in list

--- a/h2/src/main/org/h2/command/dml/MergeUsing.java
+++ b/h2/src/main/org/h2/command/dml/MergeUsing.java
@@ -173,8 +173,8 @@ public final class MergeUsing extends DataChangeStatement {
         for (When w : when) {
             w.checkRights();
         }
-        session.getUser().checkRight(targetTableFilter.getTable(), Right.SELECT);
-        session.getUser().checkRight(sourceTableFilter.getTable(), Right.SELECT);
+        session.getUser().checkTableRight(targetTableFilter.getTable(), Right.SELECT);
+        session.getUser().checkTableRight(sourceTableFilter.getTable(), Right.SELECT);
     }
 
     @Override
@@ -433,7 +433,7 @@ public final class MergeUsing extends DataChangeStatement {
 
         @Override
         void checkRights() {
-            mergeUsing.getSession().getUser().checkRight(mergeUsing.targetTableFilter.getTable(), Right.DELETE);
+            mergeUsing.getSession().getUser().checkTableRight(mergeUsing.targetTableFilter.getTable(), Right.DELETE);
         }
 
         @Override
@@ -480,7 +480,7 @@ public final class MergeUsing extends DataChangeStatement {
 
         @Override
         void checkRights() {
-            mergeUsing.getSession().getUser().checkRight(mergeUsing.targetTableFilter.getTable(), Right.UPDATE);
+            mergeUsing.getSession().getUser().checkTableRight(mergeUsing.targetTableFilter.getTable(), Right.UPDATE);
         }
 
         @Override
@@ -576,7 +576,7 @@ public final class MergeUsing extends DataChangeStatement {
 
         @Override
         void checkRights() {
-            mergeUsing.getSession().getUser().checkRight(mergeUsing.targetTableFilter.getTable(), Right.INSERT);
+            mergeUsing.getSession().getUser().checkTableRight(mergeUsing.targetTableFilter.getTable(), Right.INSERT);
         }
 
         @Override

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -74,7 +74,7 @@ public final class Update extends DataChangeStatement {
         targetTableFilter.reset();
         Table table = targetTableFilter.getTable();
         try (RowList rows = new RowList(session, table)) {
-            session.getUser().checkRight(table, Right.UPDATE);
+            session.getUser().checkTableRight(table, Right.UPDATE);
             table.fire(session, Trigger.UPDATE, true);
             table.lock(session, true, false);
             // get the old rows, compute the new rows

--- a/h2/src/main/org/h2/engine/Right.java
+++ b/h2/src/main/org/h2/engine/Right.java
@@ -42,6 +42,12 @@ public final class Right extends DbObject {
     public static final int ALTER_ANY_SCHEMA = 16;
 
     /**
+     * The right bit mask that means: user is a schema owner. This mask isn't
+     * used in GRANT / REVOKE statements.
+     */
+    public static final int SCHEMA_OWNER = 32;
+
+    /**
      * The right bit mask that means: select, insert, update, delete, and update
      * for this object is allowed.
      */
@@ -73,16 +79,14 @@ public final class Right extends DbObject {
         this.grantedRole = grantedRole;
     }
 
-    public Right(Database db, int id, RightOwner grantee, int grantedRight,
-            DbObject grantedObject) {
+    public Right(Database db, int id, RightOwner grantee, int grantedRight, DbObject grantedObject) {
         super(db, id, Integer.toString(id), Trace.USER);
         this.grantee = grantee;
         this.grantedRight = grantedRight;
         this.grantedObject = grantedObject;
     }
 
-    private static boolean appendRight(StringBuilder buff, int right, int mask,
-            String name, boolean comma) {
+    private static boolean appendRight(StringBuilder buff, int right, int mask, String name, boolean comma) {
         if ((right & mask) != 0) {
             if (comma) {
                 buff.append(", ");

--- a/h2/src/main/org/h2/engine/RightOwner.java
+++ b/h2/src/main/org/h2/engine/RightOwner.java
@@ -64,36 +64,69 @@ public abstract class RightOwner extends DbObject {
     }
 
     /**
-     * Check if a right is already granted to this object or to objects that
-     * were granted to this object. The rights for schemas takes
-     * precedence over rights of tables, in other words, the rights of schemas
-     * will be valid for every each table in the related schema.
+     * Checks if a right is already granted to this object or to objects that
+     * were granted to this object. The rights of schemas will be valid for
+     * every each table in the related schema. The ALTER ANY SCHEMA right gives
+     * all rights to all tables.
      *
-     * @param table the table to check
-     * @param rightMask the right mask to check
+     * @param table
+     *            the table to check
+     * @param rightMask
+     *            the right mask to check
      * @return true if the right was already granted
      */
-    boolean isRightGrantedRecursive(Table table, int rightMask) {
-        Right right;
+    final boolean isTableRightGrantedRecursive(Table table, int rightMask) {
+        Schema schema = table.getSchema();
+        if (schema.getOwner() == this) {
+            return true;
+        }
         if (grantedRights != null) {
-            if (table != null) {
-                right = grantedRights.get(table.getSchema());
-                if (right != null) {
-                    if ((right.getRightMask() & rightMask) == rightMask) {
-                        return true;
-                    }
-                }
+            Right right = grantedRights.get(null);
+            if (right != null && (right.getRightMask() & Right.ALTER_ANY_SCHEMA) == Right.ALTER_ANY_SCHEMA) {
+                return true;
+            }
+            right = grantedRights.get(schema);
+            if (right != null && (right.getRightMask() & rightMask) == rightMask) {
+                return true;
             }
             right = grantedRights.get(table);
-            if (right != null) {
-                if ((right.getRightMask() & rightMask) == rightMask) {
+            if (right != null && (right.getRightMask() & rightMask) == rightMask) {
+                return true;
+            }
+        }
+        if (grantedRoles != null) {
+            for (Role role : grantedRoles.keySet()) {
+                if (role.isTableRightGrantedRecursive(table, rightMask)) {
                     return true;
                 }
             }
         }
+        return false;
+    }
+
+    /**
+     * Checks if a schema owner right is already granted to this object or to
+     * objects that were granted to this object. The ALTER ANY SCHEMA right
+     * gives rights to all schemas.
+     *
+     * @param schema
+     *            the schema to check, or {@code null} to check for ALTER ANY
+     *            SCHEMA right only
+     * @return true if the right was already granted
+     */
+    final boolean isSchemaRightGrantedRecursive(Schema schema) {
+        if (schema != null && schema.getOwner() == this) {
+            return true;
+        }
+        if (grantedRights != null) {
+            Right right = grantedRights.get(null);
+            if (right != null && (right.getRightMask() & Right.ALTER_ANY_SCHEMA) == Right.ALTER_ANY_SCHEMA) {
+                return true;
+            }
+        }
         if (grantedRoles != null) {
-            for (RightOwner role : grantedRoles.keySet()) {
-                if (role.isRightGrantedRecursive(table, rightMask)) {
+            for (Role role : grantedRoles.keySet()) {
+                if (role.isSchemaRightGrantedRecursive(schema)) {
                     return true;
                 }
             }

--- a/h2/src/main/org/h2/engine/RightOwner.java
+++ b/h2/src/main/org/h2/engine/RightOwner.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 
+import org.h2.api.ErrorCode;
+import org.h2.message.DbException;
+import org.h2.schema.Schema;
 import org.h2.table.Table;
 import org.h2.util.StringUtils;
 
@@ -203,6 +206,21 @@ public abstract class RightOwner extends DbObject {
             return null;
         }
         return grantedRoles.get(role);
+    }
+
+    /**
+     * Check that this right owner does not own any schema. An exception is
+     * thrown if it owns one or more schemas.
+     *
+     * @throws DbException
+     *             if this right owner owns a schema
+     */
+    public final void checkOwnsNoSchemas() {
+        for (Schema s : database.getAllSchemas()) {
+            if (this == s.getOwner()) {
+                throw DbException.get(ErrorCode.CANNOT_DROP_2, getName(), s.getName());
+            }
+        }
     }
 
 }

--- a/h2/src/main/org/h2/engine/Role.java
+++ b/h2/src/main/org/h2/engine/Role.java
@@ -5,8 +5,11 @@
  */
 package org.h2.engine;
 
+import java.util.ArrayList;
+
 import org.h2.message.DbException;
 import org.h2.message.Trace;
+import org.h2.schema.Schema;
 import org.h2.table.Table;
 
 /**
@@ -51,6 +54,17 @@ public final class Role extends RightOwner {
     @Override
     public int getType() {
         return DbObject.ROLE;
+    }
+
+    @Override
+    public ArrayList<DbObject> getChildren() {
+        ArrayList<DbObject> children = new ArrayList<>();
+        for (Schema schema : database.getAllSchemas()) {
+            if (schema.getOwner() == this) {
+                children.add(schema);
+            }
+        }
+        return children;
     }
 
     @Override

--- a/h2/src/main/org/h2/engine/User.java
+++ b/h2/src/main/org/h2/engine/User.java
@@ -249,18 +249,4 @@ public final class User extends RightOwner {
         invalidate();
     }
 
-    /**
-     * Check that this user does not own any schema. An exception is thrown if
-     * he owns one or more schemas.
-     *
-     * @throws DbException if this user owns a schema
-     */
-    public void checkOwnsNoSchemas() {
-        for (Schema s : database.getAllSchemas()) {
-            if (this == s.getOwner()) {
-                throw DbException.get(ErrorCode.CANNOT_DROP_2, getName(), s.getName());
-            }
-        }
-    }
-
 }

--- a/h2/src/main/org/h2/engine/User.java
+++ b/h2/src/main/org/h2/engine/User.java
@@ -86,65 +86,6 @@ public final class User extends RightOwner {
     }
 
     /**
-     * Checks that this user has the given rights for this database object.
-     *
-     * @param table the database object
-     * @param rightMask the rights required
-     * @throws DbException if this user does not have the required rights
-     */
-    public void checkRight(Table table, int rightMask) {
-        if (!hasRight(table, rightMask)) {
-            throw DbException.get(ErrorCode.NOT_ENOUGH_RIGHTS_FOR_1, table.getTraceSQL());
-        }
-    }
-
-    /**
-     * See if this user has the given rights for this database object.
-     *
-     * @param table the database object, or null for schema-only check
-     * @param rightMask the rights required
-     * @return true if the user has the rights
-     */
-    public boolean hasRight(Table table, int rightMask) {
-        if (rightMask != Right.SELECT && !systemUser && table != null) {
-            table.checkWritingAllowed();
-        }
-        if (admin) {
-            return true;
-        }
-        Role publicRole = database.getPublicRole();
-        if (publicRole.isRightGrantedRecursive(table, rightMask)) {
-            return true;
-        }
-        if (table instanceof MetaTable || table instanceof DualTable || table instanceof RangeTable) {
-            // everybody has access to the metadata information
-            return true;
-        }
-        if (table != null) {
-            if (hasRight(null, Right.ALTER_ANY_SCHEMA)) {
-                return true;
-            }
-            TableType tableType = table.getTableType();
-            if (TableType.VIEW == tableType) {
-                TableView v = (TableView) table;
-                if (v.getOwner() == this) {
-                    // the owner of a view has access:
-                    // SELECT * FROM (SELECT * FROM ...)
-                    return true;
-                }
-            } else if (tableType == null) {
-                // function table
-                return true;
-            }
-            if (table.isTemporary() && !table.isGlobalTemporary()) {
-                // the owner has all rights on local temporary tables
-                return true;
-            }
-        }
-        return isRightGrantedRecursive(table, rightMask);
-    }
-
-    /**
      * Get the CREATE SQL statement for this object.
      *
      * @param password true if the password (actually the salt and hash) should
@@ -191,8 +132,8 @@ public final class User extends RightOwner {
     }
 
     /**
-     * Check if this user has admin rights. An exception is thrown if he does
-     * not have them.
+     * Checks if this user has admin rights. An exception is thrown if user
+     * doesn't have them.
      *
      * @throws DbException if this user is not an admin
      */
@@ -203,15 +144,99 @@ public final class User extends RightOwner {
     }
 
     /**
-     * Check if this user has schema admin rights. An exception is thrown if he
-     * does not have them.
+     * Checks if this user has schema admin rights for every schema. An
+     * exception is thrown if user doesn't have them.
      *
      * @throws DbException if this user is not a schema admin
      */
     public void checkSchemaAdmin() {
-        if (!hasRight(null, Right.ALTER_ANY_SCHEMA)) {
+        if (!hasSchemaRight(null)) {
             throw DbException.get(ErrorCode.ADMIN_RIGHTS_REQUIRED);
         }
+    }
+
+    /**
+     * Checks if this user has schema owner rights for the specified schema. An
+     * exception is thrown if user doesn't have them.
+     *
+     * @param schema the schema
+     * @throws DbException if this user is not a schema owner
+     */
+    public void checkSchemaOwner(Schema schema) {
+        if (!hasSchemaRight(schema)) {
+            throw DbException.get(ErrorCode.NOT_ENOUGH_RIGHTS_FOR_1, schema.getTraceSQL());
+        }
+    }
+
+    /**
+     * See if this user has owner rights for the specified schema
+     *
+     * @param schema the schema
+     * @return true if the user has the rights
+     */
+    private boolean hasSchemaRight(Schema schema) {
+        if (admin) {
+            return true;
+        }
+        Role publicRole = database.getPublicRole();
+        if (publicRole.isSchemaRightGrantedRecursive(schema)) {
+            return true;
+        }
+        return isSchemaRightGrantedRecursive(schema);
+    }
+
+    /**
+     * Checks that this user has the given rights for the specified table.
+     *
+     * @param table the table
+     * @param rightMask the rights required
+     * @throws DbException if this user does not have the required rights
+     */
+    public void checkTableRight(Table table, int rightMask) {
+        if (!hasTableRight(table, rightMask)) {
+            throw DbException.get(ErrorCode.NOT_ENOUGH_RIGHTS_FOR_1, table.getTraceSQL());
+        }
+    }
+
+    /**
+     * See if this user has the given rights for this database object.
+     *
+     * @param table the database object, or null for schema-only check
+     * @param rightMask the rights required
+     * @return true if the user has the rights
+     */
+    public boolean hasTableRight(Table table, int rightMask) {
+        if (rightMask != Right.SELECT && !systemUser) {
+            table.checkWritingAllowed();
+        }
+        if (admin) {
+            return true;
+        }
+        Role publicRole = database.getPublicRole();
+        if (publicRole.isTableRightGrantedRecursive(table, rightMask)) {
+            return true;
+        }
+        if (table instanceof MetaTable || table instanceof DualTable || table instanceof RangeTable) {
+            // everybody has access to the metadata information
+            return true;
+        }
+        TableType tableType = table.getTableType();
+        if (TableType.VIEW == tableType) {
+            TableView v = (TableView) table;
+            if (v.getOwner() == this) {
+                // the owner of a view has access:
+                // SELECT * FROM (SELECT * FROM ...)
+                return true;
+            }
+        } else if (tableType == null) {
+            // function table
+            return true;
+        }
+        if (table.isTemporary() && !table.isGlobalTemporary()) {
+            // the owner has all rights on local temporary tables
+            return true;
+        }
+        return isTableRightGrantedRecursive(table, rightMask);
     }
 
     @Override

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -19,9 +19,9 @@ import org.h2.engine.Database;
 import org.h2.engine.DbObject;
 import org.h2.engine.DbSettings;
 import org.h2.engine.Right;
+import org.h2.engine.RightOwner;
 import org.h2.engine.SessionLocal;
 import org.h2.engine.SysProperties;
-import org.h2.engine.User;
 import org.h2.index.Index;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
@@ -38,7 +38,7 @@ import org.h2.util.Utils;
  */
 public class Schema extends DbObject {
 
-    private User owner;
+    private RightOwner owner;
     private final boolean system;
     private ArrayList<String> tableEngineParams;
 
@@ -69,8 +69,7 @@ public class Schema extends DbObject {
      * @param system if this is a system schema (such a schema can not be
      *            dropped)
      */
-    public Schema(Database database, int id, String schemaName, User owner,
-            boolean system) {
+    public Schema(Database database, int id, String schemaName, RightOwner owner, boolean system) {
         super(database, id, schemaName, Trace.SCHEMA);
         tablesAndViews = database.newConcurrentStringMap();
         domains = database.newConcurrentStringMap();
@@ -197,7 +196,7 @@ public class Schema extends DbObject {
      *
      * @return the owner
      */
-    public User getOwner() {
+    public RightOwner getOwner() {
         return owner;
     }
 

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -163,7 +163,7 @@ public class TableFilter implements ColumnResolver {
         this.select = select;
         this.cursor = new IndexCursor();
         if (!rightsChecked) {
-            session.getUser().checkRight(table, Right.SELECT);
+            session.getUser().checkTableRight(table, Right.SELECT);
         }
         hashCode = session.nextObjectId();
         this.orderInFrom = orderInFrom;

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -45,9 +45,14 @@ public class ParserUtil {
     public static final int ASYMMETRIC = AS + 1;
 
     /**
+     * The token "AUTHORIZATION".
+     */
+    public static final int AUTHORIZATION = ASYMMETRIC + 1;
+
+    /**
      * The token "BETWEEN".
      */
-    public static final int BETWEEN = ASYMMETRIC + 1;
+    public static final int BETWEEN = AUTHORIZATION + 1;
 
     /**
      * The token "CASE".
@@ -641,6 +646,8 @@ public class ParserUtil {
                 return ARRAY;
             } else if (eq("ASYMMETRIC", s, ignoreCase, start, length)) {
                 return ASYMMETRIC;
+            } else if (eq("AUTHORIZATION", s, ignoreCase, start, length)) {
+                return AUTHORIZATION;
             }
             return IDENTIFIER;
         case 'B':

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -150,7 +150,7 @@ public class TestScript extends TestDb {
         }
         for (String s : new String[] { "alterDomain", "alterTableAdd", "alterTableAlterColumn", "alterTableDropColumn",
                 "alterTableRename", "analyze", "commentOn", "createAlias", "createConstant", "createDomain",
-                "createSequence", "createSynonym",
+                "createSchema", "createSequence", "createSynonym",
                 "createTable", "createTrigger", "createView", "dropAllObjects", "dropDomain", "dropIndex",
                 "dropSchema", "dropTable", "grant", "truncateTable" }) {
             testScript("ddl/" + s + ".sql");

--- a/h2/src/test/org/h2/test/scripts/ddl/createSchema.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/createSchema.sql
@@ -1,0 +1,64 @@
+-- Copyright 2004-2020 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+CREATE USER TEST_USER PASSWORD 'test';
+> ok
+
+CREATE ROLE TEST_ROLE;
+> ok
+
+CREATE SCHEMA S1;
+> ok
+
+CREATE SCHEMA S2 AUTHORIZATION TEST_USER;
+> ok
+
+CREATE SCHEMA S3 AUTHORIZATION TEST_ROLE;
+> ok
+
+CREATE SCHEMA AUTHORIZATION TEST_USER;
+> ok
+
+CREATE SCHEMA AUTHORIZATION TEST_ROLE;
+> ok
+
+TABLE INFORMATION_SCHEMA.SCHEMATA;
+> CATALOG_NAME SCHEMA_NAME        SCHEMA_OWNER DEFAULT_CHARACTER_SET_CATALOG DEFAULT_CHARACTER_SET_SCHEMA DEFAULT_CHARACTER_SET_NAME SQL_PATH DEFAULT_COLLATION_NAME REMARKS
+> ------------ ------------------ ------------ ----------------------------- ---------------------------- -------------------------- -------- ---------------------- -------
+> SCRIPT       INFORMATION_SCHEMA SA           SCRIPT                        PUBLIC                       Unicode                    null     OFF                    null
+> SCRIPT       PUBLIC             SA           SCRIPT                        PUBLIC                       Unicode                    null     OFF                    null
+> SCRIPT       S1                 SA           SCRIPT                        PUBLIC                       Unicode                    null     OFF                    null
+> SCRIPT       S2                 TEST_USER    SCRIPT                        PUBLIC                       Unicode                    null     OFF                    null
+> SCRIPT       S3                 TEST_ROLE    SCRIPT                        PUBLIC                       Unicode                    null     OFF                    null
+> SCRIPT       TEST_ROLE          TEST_ROLE    SCRIPT                        PUBLIC                       Unicode                    null     OFF                    null
+> SCRIPT       TEST_USER          TEST_USER    SCRIPT                        PUBLIC                       Unicode                    null     OFF                    null
+> rows: 7
+
+DROP SCHEMA S1;
+> ok
+
+DROP SCHEMA S2;
+> ok
+
+DROP SCHEMA S3;
+> ok
+
+DROP USER TEST_USER;
+> exception CANNOT_DROP_2
+
+DROP ROLE TEST_ROLE;
+> exception CANNOT_DROP_2
+
+DROP SCHEMA TEST_USER;
+> ok
+
+DROP SCHEMA TEST_ROLE;
+> ok
+
+DROP USER TEST_USER;
+> ok
+
+DROP ROLE TEST_ROLE;
+> ok


### PR DESCRIPTION
Closes #2846.

1. Schema owner can now be any user or role.

2. Schema owner now has all access permissions to the schema, with exception of creation permissions for objects that interact with JVM or other databases (Java functions, aggregate functions, triggers; linked tables).

3. Users with `ALL` permissions on the table now don't have unexpected implicit DDL permissions.

4. Missing access checks for some DDL commands were added.