### PR TITLE
Don't use JDBC layer in PgServerThread

### DIFF
--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -337,7 +337,7 @@ public abstract class Command implements CommandInterface {
 
     @Override
     public void cancel() {
-        this.cancel = true;
+        cancel = true;
     }
 
     @Override

--- a/h2/src/main/org/h2/command/CommandInterface.java
+++ b/h2/src/main/org/h2/command/CommandInterface.java
@@ -602,4 +602,5 @@ public interface CommandInterface extends AutoCloseable {
      * @return the empty result
      */
     ResultInterface getMetaData();
+
 }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSetMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSetMetaData.java
@@ -13,7 +13,6 @@ import org.h2.message.TraceObject;
 import org.h2.result.ResultInterface;
 import org.h2.util.MathUtils;
 import org.h2.value.DataType;
-import org.h2.value.TypeInfo;
 import org.h2.value.ValueToObjectConverter;
 
 /**
@@ -484,13 +483,6 @@ public class JdbcResultSetMetaData extends TraceObject implements
     @Override
     public String toString() {
         return getTraceObjectName() + ": columns=" + columnCount;
-    }
-
-    /**
-     * INTERNAL
-     */
-    public TypeInfo getColumnInternalType(int column) {
-        return result.getColumnType(--column);
     }
 
 }

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -39,7 +39,6 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
     protected final int resultSetType;
     protected final int resultSetConcurrency;
     private volatile CommandInterface executingCommand;
-    private int lastExecutedCommandType;
     private ArrayList<String> batchCommands;
     private boolean escapeProcessing = true;
     private volatile boolean cancelled;
@@ -1293,7 +1292,6 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
             conn.setExecutingStatement(null);
         } else {
             conn.setExecutingStatement(this);
-            lastExecutedCommandType = c.getCommandType();
         }
         executingCommand = c;
     }
@@ -1310,14 +1308,6 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
         if (closeCommand) {
             command.close();
         }
-    }
-
-    /**
-     * INTERNAL.
-     * Get the command type of the last executed command.
-     */
-    public int getLastExecutedCommandType() {
-        return lastExecutedCommandType;
     }
 
     /**


### PR DESCRIPTION
`PgServerThread` now uses internal session API directly instead of messing with both JDBC layer and internal API.