### PR TITLE
Fixed possible eternal wait(0)

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1272,7 +1272,7 @@ public final class Database implements DataHandler, CastDataProvider {
         long start = System.currentTimeMillis();
         // 'sleep' should be strictly greater than zero, otherwise real time is not taken into consideration
         // and the thread simply waits until notified
-        long sleep = Math.max(timeout / 20, 50);
+        long sleep = Math.max(timeout / 20, 1);
         boolean done = false;
         while (!done) {
             try {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1270,9 +1270,11 @@ public final class Database implements DataHandler, CastDataProvider {
 
         int timeout = 2 * getLockTimeout();
         long start = System.currentTimeMillis();
+        // 'sleep' should be strictly greater than zero, otherwise real time is not taken into consideration
+        // and the thread simply waits until notified
+        long sleep = Math.max(timeout / 20, 50);
         boolean done = false;
         while (!done) {
-            long sleep = timeout / 20;
             try {
                 // although nobody going to notify us
                 // it is vital to give up lock on a database


### PR DESCRIPTION
According to Javadoc https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-
If **timeout** is zero, then real time is not taken into consideration and the thread simply waits until notified.

In this particular case, we won't get notified, so we'll wait forever.
It happens when we set **LOCK_TIMEOUT < 10** ms.