### PR TITLE
Assorted changes

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2888: H2 should pass time zone of client to the server
+</li>
 <li>Issue #2846: GRANT SELECT, INSERT, UPDATE, DELETE incorrectly gives privileges to drop a table
 </li>
 <li>Issue #2882: NPE in UPDATE with SELECT UNION

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -302,7 +302,12 @@ public class AlterTableAddConstraint extends SchemaCommand {
         Schema tableSchema = table.getSchema();
         if (forForeignKey) {
             id = session.getDatabase().allocateObjectId();
-            name = tableSchema.getUniqueConstraintName(session, table);
+            try {
+                tableSchema.reserveUniqueName(constraintName);
+                name = tableSchema.getUniqueConstraintName(session, table);
+            } finally {
+                tableSchema.freeUniqueName(constraintName);
+            }
         } else {
             id = getObjectId();
             name = generateConstraintName(table);

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -33,7 +33,6 @@ import org.h2.engine.RightOwner;
 import org.h2.engine.Role;
 import org.h2.engine.SessionLocal;
 import org.h2.engine.Setting;
-import org.h2.engine.SysProperties;
 import org.h2.engine.User;
 import org.h2.expression.Expression;
 import org.h2.expression.ExpressionColumn;
@@ -667,7 +666,7 @@ public class ScriptCommand extends ScriptBase {
     private void reset() {
         result = null;
         buffer = null;
-        lineSeparatorString = SysProperties.LINE_SEPARATOR;
+        lineSeparatorString = System.lineSeparator();
         lineSeparator = lineSeparatorString.getBytes(charset);
     }
 

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -5,6 +5,7 @@
  */
 package org.h2.engine;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -18,6 +19,7 @@ import org.h2.security.SHA256;
 import org.h2.store.fs.FileUtils;
 import org.h2.store.fs.encrypt.FilePathEncrypt;
 import org.h2.store.fs.rec.FilePathRec;
+import org.h2.util.IOUtils;
 import org.h2.util.NetworkConnectionInfo;
 import org.h2.util.SortedProperties;
 import org.h2.util.StringUtils;
@@ -196,11 +198,7 @@ public class ConnectionInfo implements Cloneable {
             persistent = true;
         }
         if (persistent && !remote) {
-            if ("/".equals(SysProperties.FILE_SEPARATOR)) {
-                name = name.replace('\\', '/');
-            } else {
-                name = name.replace('/', '\\');
-            }
+            name = IOUtils.nameSeparatorsToNative(name);
         }
     }
 
@@ -216,7 +214,7 @@ public class ConnectionInfo implements Cloneable {
             boolean absolute = FileUtils.isAbsolute(name);
             String n;
             String prefix = null;
-            if (dir.endsWith(SysProperties.FILE_SEPARATOR)) {
+            if (dir.endsWith(File.separator)) {
                 dir = dir.substring(0, dir.length() - 1);
             }
             if (absolute) {
@@ -224,7 +222,7 @@ public class ConnectionInfo implements Cloneable {
             } else {
                 n  = FileUtils.unwrap(name);
                 prefix = name.substring(0, name.length() - n.length());
-                n = dir + SysProperties.FILE_SEPARATOR + n;
+                n = dir + File.separatorChar + n;
             }
             String normalizedName = FileUtils.unwrap(FileUtils.toRealPath(n));
             if (normalizedName.equals(absDir) || !normalizedName.startsWith(absDir)) {
@@ -243,7 +241,7 @@ public class ConnectionInfo implements Cloneable {
                         absDir);
             }
             if (!absolute) {
-                name = prefix + dir + SysProperties.FILE_SEPARATOR + FileUtils.unwrap(name);
+                name = prefix + dir + File.separatorChar + FileUtils.unwrap(name);
             }
         }
     }

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -23,6 +23,7 @@ import org.h2.util.IOUtils;
 import org.h2.util.NetworkConnectionInfo;
 import org.h2.util.SortedProperties;
 import org.h2.util.StringUtils;
+import org.h2.util.TimeZoneProvider;
 import org.h2.util.Utils;
 
 /**
@@ -41,6 +42,8 @@ public class ConnectionInfo implements Cloneable {
     private byte[] filePasswordHash;
     private byte[] fileEncryptionKey;
     private byte[] userPasswordHash;
+
+    private TimeZoneProvider timeZone;
 
     /**
      * The database name
@@ -81,6 +84,10 @@ public class ConnectionInfo implements Cloneable {
         this.url = u;
         readProperties(info);
         readSettingsFromURL();
+        Object timeZoneName = prop.remove("TIME ZONE");
+        if (timeZoneName != null) {
+            timeZone = TimeZoneProvider.ofId(timeZoneName.toString());
+        }
         setUserName(removeProperty("USER", ""));
         name = url.substring(Constants.START_URL.length());
         parseName();
@@ -655,6 +662,15 @@ public class ConnectionInfo implements Cloneable {
      */
     public void setOriginalURL(String url) {
         originalURL = url;
+    }
+
+    /**
+     * Returns the time zone.
+     *
+     * @return the time zone
+     */
+    public TimeZoneProvider getTimeZone() {
+        return timeZone;
     }
 
     /**

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -436,22 +436,14 @@ public class ConnectionInfo implements Cloneable {
             return name;
         }
         if (nameNormalized == null) {
-            if (!SysProperties.IMPLICIT_RELATIVE_PATH) {
-                if (!FileUtils.isAbsolute(name)) {
-                    if (!name.contains("./") &&
-                            !name.contains(".\\") &&
-                            !name.contains(":/") &&
-                            !name.contains(":\\")) {
-                        // the name could start with "./", or
-                        // it could start with a prefix such as "nioMapped:./"
-                        // for Windows, the path "\test" is not considered
-                        // absolute as the drive letter is missing,
-                        // but we consider it absolute
-                        throw DbException.get(
-                                ErrorCode.URL_RELATIVE_TO_CWD,
-                                originalURL);
-                    }
-                }
+            if (!FileUtils.isAbsolute(name) && !name.contains("./") && !name.contains(".\\") && !name.contains(":/")
+                    && !name.contains(":\\")) {
+                // the name could start with "./", or
+                // it could start with a prefix such as "nioMapped:./"
+                // for Windows, the path "\test" is not considered
+                // absolute as the drive letter is missing,
+                // but we consider it absolute
+                throw DbException.get(ErrorCode.URL_RELATIVE_TO_CWD, originalURL);
             }
             String suffix = Constants.SUFFIX_PAGE_FILE;
             String n;

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -22,6 +22,7 @@ import org.h2.util.MathUtils;
 import org.h2.util.ParserUtil;
 import org.h2.util.StringUtils;
 import org.h2.util.ThreadDeadlockDetector;
+import org.h2.util.TimeZoneProvider;
 import org.h2.util.Utils;
 
 /**
@@ -268,6 +269,10 @@ public final class Engine {
                         throw e;
                     }
                 }
+            }
+            TimeZoneProvider timeZone = ci.getTimeZone();
+            if (timeZone != null) {
+                session.setTimeZone(timeZone);
             }
             if (init != null) {
                 try {

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -127,8 +127,8 @@ public final class SessionRemote extends Session implements DataHandler {
 
     private Transfer initTransfer(ConnectionInfo ci, String db, String server)
             throws IOException {
-        Socket socket = NetUtils.createSocket(server,
-                Constants.DEFAULT_TCP_PORT, ci.isSSL(), ci.getProperty("NETWORK_TIMEOUT",0 ));
+        Socket socket = NetUtils.createSocket(server, Constants.DEFAULT_TCP_PORT, ci.isSSL(),
+                ci.getProperty("NETWORK_TIMEOUT", 0));
         Transfer trans = new Transfer(this, socket);
         trans.setSSL(ci.isSSL());
         trans.init();
@@ -153,6 +153,13 @@ public final class SessionRemote extends Session implements DataHandler {
             }
             trans.writeInt(SessionRemote.SESSION_SET_ID);
             trans.writeString(sessionId);
+            if (clientVersion >= Constants.TCP_PROTOCOL_VERSION_20) {
+                TimeZoneProvider timeZone = ci.getTimeZone();
+                if (timeZone == null) {
+                    timeZone = DateTimeUtils.getTimeZone();
+                }
+                trans.writeString(timeZone.getId());
+            }
             done(trans);
             if (clientVersion >= Constants.TCP_PROTOCOL_VERSION_15) {
                 autoCommit = trans.readBoolean();

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -872,7 +872,7 @@ public final class SessionRemote extends Session implements DataHandler {
                 parameters.get(0).setValue(ValueVarchar.get("DATABASE_TO_UPPER"), false);
                 parameters.get(1).setValue(ValueVarchar.get("DATABASE_TO_LOWER"), false);
                 parameters.get(2).setValue(ValueVarchar.get("CASE_INSENSITIVE_IDENTIFIERS"), false);
-                try (ResultInterface result = command.executeQuery(Integer.MAX_VALUE, false)) {
+                try (ResultInterface result = command.executeQuery(0, false)) {
                     while (result.next()) {
                         Value[] row = result.currentRow();
                         String value = row[1].getString();
@@ -910,7 +910,7 @@ public final class SessionRemote extends Session implements DataHandler {
                 parameters.get(0).setValue(ValueVarchar.get("MODE"), false);
                 parameters.get(1).setValue(ValueVarchar.get("TIME ZONE"), false);
                 parameters.get(2).setValue(ValueVarchar.get("JAVA_OBJECT_SERIALIZER"), false);
-                try (ResultInterface result = command.executeQuery(Integer.MAX_VALUE, false)) {
+                try (ResultInterface result = command.executeQuery(0, false)) {
                     while (result.next()) {
                         Value[] row = result.currentRow();
                         String value = row[1].getString();

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -353,15 +353,6 @@ public class SysProperties {
             Utils.getProperty("h2.threadDeadlockDetector", false);
 
     /**
-     * System property <code>h2.implicitRelativePath</code>
-     * (default: false).<br />
-     * If disabled, relative paths in database URLs need to be written as
-     * jdbc:h2:./test instead of jdbc:h2:test.
-     */
-    public static final boolean IMPLICIT_RELATIVE_PATH =
-            Utils.getProperty("h2.implicitRelativePath", false);
-
-    /**
      * System property <code>h2.urlMap</code> (default: null).<br />
      * A properties file that contains a mapping between database URLs. New
      * connections are written into the file. An empty value in the map means no

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -184,14 +184,6 @@ public class SysProperties {
             Utils.getProperty("h2.lobCloseBetweenReads", false);
 
     /**
-     * System property <code>h2.lobFilesPerDirectory</code>
-     * (default: 256).<br />
-     * Maximum number of LOB files per directory.
-     */
-    public static final int LOB_FILES_PER_DIRECTORY =
-            Utils.getProperty("h2.lobFilesPerDirectory", 256);
-
-    /**
      * System property <code>h2.lobClientMaxSizeMemory</code> (default:
      * 1048576).<br />
      * The maximum size of a LOB object to keep in memory on the client side

--- a/h2/src/main/org/h2/engine/SysProperties.java
+++ b/h2/src/main/org/h2/engine/SysProperties.java
@@ -5,8 +5,6 @@
  */
 package org.h2.engine;
 
-import java.io.File;
-
 import org.h2.util.MathUtils;
 import org.h2.util.Utils;
 
@@ -42,18 +40,6 @@ public class SysProperties {
      * INTERNAL
      */
     public static final String H2_BROWSER = "h2.browser";
-
-    /**
-     * System property <code>file.separator</code>.<br />
-     * It is set by the system, and used to build absolute file names.
-     */
-    public static final String FILE_SEPARATOR = File.separator;
-
-    /**
-     * System property <code>line.separator</code>.<br />
-     * It is set by the system, and used by the script and trace tools.
-     */
-    public static final String LINE_SEPARATOR = System.lineSeparator();
 
     /**
      * System property <code>user.home</code> (empty string if not set).<br />

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -98,25 +98,17 @@ public class JdbcConnection extends TraceObject implements Connection, JdbcConne
     /**
      * INTERNAL
      */
-    public JdbcConnection(String url, Properties info) throws SQLException {
-        this(new ConnectionInfo(url, info), true);
-    }
-
-    /**
-     * INTERNAL
-     */
     /*
      * the session closable object does not leak as Eclipse warns - due to the
      * CloseWatcher.
      */
     @SuppressWarnings("resource")
-    public JdbcConnection(ConnectionInfo ci, boolean useBaseDir) throws SQLException {
+    public JdbcConnection(String url, Properties info) throws SQLException {
+        ConnectionInfo ci = new ConnectionInfo(url, info);
         try {
-            if (useBaseDir) {
-                String baseDir = SysProperties.getBaseDir();
-                if (baseDir != null) {
-                    ci.setBaseDir(baseDir);
-                }
+            String baseDir = SysProperties.getBaseDir();
+            if (baseDir != null) {
+                ci.setBaseDir(baseDir);
             }
             // this will return an embedded or server connection
             session = new SessionRemote(ci).connectEmbeddedOrServer(false);

--- a/h2/src/main/org/h2/message/Trace.java
+++ b/h2/src/main/org/h2/message/Trace.java
@@ -8,7 +8,6 @@ package org.h2.message;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 
-import org.h2.engine.SysProperties;
 import org.h2.expression.ParameterInterface;
 import org.h2.util.StringUtils;
 
@@ -131,7 +130,7 @@ public class Trace {
     Trace(TraceWriter traceWriter, String module) {
         this.traceWriter = traceWriter;
         this.module = module;
-        this.lineSeparator = SysProperties.LINE_SEPARATOR;
+        this.lineSeparator = System.lineSeparator();
     }
 
     /**

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -461,6 +461,19 @@ public class Schema extends DbObject {
     }
 
     /**
+     * Reserve a unique object name.
+     *
+     * @param name the object name
+     */
+    public void reserveUniqueName(String name) {
+        if (name != null) {
+            synchronized (temporaryUniqueNames) {
+                temporaryUniqueNames.add(name);
+            }
+        }
+    }
+
+    /**
      * Release a unique object name.
      *
      * @param name the object name

--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -40,6 +40,7 @@ import org.h2.util.NetUtils;
 import org.h2.util.NetworkConnectionInfo;
 import org.h2.util.SmallLRUCache;
 import org.h2.util.SmallMap;
+import org.h2.util.TimeZoneProvider;
 import org.h2.value.Transfer;
 import org.h2.value.Value;
 import org.h2.value.ValueLob;
@@ -479,6 +480,9 @@ public class TcpServerThread implements Runnable {
         }
         case SessionRemote.SESSION_SET_ID: {
             sessionId = transfer.readString();
+            if (clientVersion >= Constants.TCP_PROTOCOL_VERSION_20) {
+                session.setTimeZone(TimeZoneProvider.ofId(transfer.readString()));
+            }
             transfer.writeInt(SessionRemote.STATUS_OK);
             if (clientVersion >= Constants.TCP_PROTOCOL_VERSION_15) {
                 transfer.writeBoolean(session.getAutoCommit());

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -430,7 +430,7 @@ public final class PgServerThread implements Runnable {
                 sendErrorResponse("Portal not found: " + name);
                 break;
             }
-            int maxRows = readShort();
+            int maxRows = readInt();
             Prepared prepared = p.prep;
             CommandInterface prep = prepared.prep;
             server.trace(prepared.sql);

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -112,7 +112,7 @@ public final class PgServerThread implements Runnable {
     private CommandInterface activeRequest;
     private String clientEncoding = SysProperties.PG_DEFAULT_CLIENT_ENCODING;
     private String dateStyle = "ISO, MDY";
-    private TimeZoneProvider timeZone = TimeZoneProvider.getDefault();
+    private TimeZoneProvider timeZone = DateTimeUtils.getTimeZone();
     private final HashMap<String, Prepared> prepared =
             new CaseInsensitiveMap<>();
     private final HashMap<String, Portal> portals =

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -462,6 +462,7 @@ public final class PgServerThread implements Runnable {
         case 'Q': {
             server.trace("Query");
             String query = readString();
+            @SuppressWarnings("resource")
             ScriptReader reader = new ScriptReader(new StringReader(query));
             while (true) {
                 String s = reader.readStatement();
@@ -472,7 +473,7 @@ public final class PgServerThread implements Runnable {
                 try (CommandInterface command = session.prepareLocal(s)) {
                     setActiveRequest(command);
                     if (command.isQuery()) {
-                        try (ResultInterface result = command.executeQuery(Long.MAX_VALUE, false)) {
+                        try (ResultInterface result = command.executeQuery(0, false)) {
                             sendRowDescription(result, null);
                             while (result.next()) {
                                 sendDataRow(result, null);

--- a/h2/src/main/org/h2/tools/Csv.java
+++ b/h2/src/main/org/h2/tools/Csv.java
@@ -25,7 +25,6 @@ import java.sql.Types;
 import java.util.ArrayList;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.mvstore.DataUtils;
 import org.h2.store.fs.FileUtils;
@@ -54,7 +53,7 @@ public class Csv implements SimpleRowSource {
     private boolean preserveWhitespace;
     private boolean writeColumnHeader = true;
     private char lineComment;
-    private String lineSeparator = SysProperties.LINE_SEPARATOR;
+    private String lineSeparator = System.lineSeparator();
     private String nullString = "";
 
     private String fileName;

--- a/h2/src/main/org/h2/tools/Restore.java
+++ b/h2/src/main/org/h2/tools/Restore.java
@@ -5,6 +5,7 @@
  */
 package org.h2.tools;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -12,7 +13,6 @@ import java.sql.SQLException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.h2.engine.Constants;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
 import org.h2.util.IOUtils;
@@ -149,7 +149,7 @@ public class Restore extends Tool {
                 if (originalDbName == null) {
                     throw new IOException("No database named " + db + " found");
                 }
-                if (originalDbName.startsWith(SysProperties.FILE_SEPARATOR)) {
+                if (originalDbName.startsWith(File.separator)) {
                     originalDbName = originalDbName.substring(1);
                 }
                 originalDbLen = originalDbName.length();
@@ -163,9 +163,8 @@ public class Restore extends Tool {
                     }
                     String fileName = entry.getName();
                     // restoring windows backups on linux and vice versa
-                    fileName = fileName.replace('\\', SysProperties.FILE_SEPARATOR.charAt(0));
-                    fileName = fileName.replace('/', SysProperties.FILE_SEPARATOR.charAt(0));
-                    if (fileName.startsWith(SysProperties.FILE_SEPARATOR)) {
+                    fileName = IOUtils.nameSeparatorsToNative(fileName);
+                    if (fileName.startsWith(File.separator)) {
                         fileName = fileName.substring(1);
                     }
                     boolean copy = false;
@@ -178,8 +177,7 @@ public class Restore extends Tool {
                     if (copy) {
                         OutputStream o = null;
                         try {
-                            o = FileUtils.newOutputStream(
-                                    directory + SysProperties.FILE_SEPARATOR + fileName, false);
+                            o = FileUtils.newOutputStream(directory + File.separatorChar + fileName, false);
                             IOUtils.copy(zipIn, o);
                             o.close();
                         } finally {

--- a/h2/src/main/org/h2/tools/RunScript.java
+++ b/h2/src/main/org/h2/tools/RunScript.java
@@ -6,6 +6,7 @@
 package org.h2.tools;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -20,7 +21,6 @@ import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.engine.Constants;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
 import org.h2.util.IOUtils;
@@ -212,7 +212,7 @@ public class RunScript extends Tool {
                     startsWith("@INCLUDE")) {
                 sql = StringUtils.trimSubstring(sql, "@INCLUDE".length());
                 if (!FileUtils.isAbsolute(sql)) {
-                    sql = path + SysProperties.FILE_SEPARATOR + sql;
+                    sql = path + File.separatorChar + sql;
                 }
                 process(conn, sql, continueOnError, charset);
             } else {

--- a/h2/src/main/org/h2/util/IOUtils.java
+++ b/h2/src/main/org/h2/util/IOUtils.java
@@ -10,6 +10,7 @@ import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -411,6 +412,16 @@ public class IOUtils {
         InputStream in = FileUtils.newInputStream(original);
         OutputStream out = FileUtils.newOutputStream(copy, false);
         copyAndClose(in, out);
+    }
+
+    /**
+     * Converts / and \ name separators in path to native separators.
+     *
+     * @param path path to convert
+     * @return path with converted separators
+     */
+    public static String nameSeparatorsToNative(String path) {
+        return File.separatorChar == '/' ? path.replace('\\', '/') : path.replace('/', '\\');
     }
 
 }

--- a/h2/src/test/org/h2/test/db/TestCsv.java
+++ b/h2/src/test/org/h2/test/db/TestCsv.java
@@ -25,7 +25,6 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.api.ErrorCode;
-import org.h2.engine.SysProperties;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
@@ -182,7 +181,7 @@ public class TestCsv extends TestDb {
     private void testOptions() {
         Csv csv = new Csv();
         assertEquals(",", csv.getFieldSeparatorWrite());
-        assertEquals(SysProperties.LINE_SEPARATOR, csv.getLineSeparator());
+        assertEquals(System.lineSeparator(), csv.getLineSeparator());
         assertEquals("", csv.getNullString());
         assertEquals('\"', csv.getEscapeCharacter());
         assertEquals('"', csv.getFieldDelimiter());

--- a/h2/src/test/org/h2/test/unit/TestConnectionInfo.java
+++ b/h2/src/test/org/h2/test/unit/TestConnectionInfo.java
@@ -10,7 +10,6 @@ import java.util.Properties;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.ConnectionInfo;
-import org.h2.engine.SysProperties;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.tools.DeleteDbFiles;
@@ -41,9 +40,6 @@ public class TestConnectionInfo extends TestDb {
     }
 
     private void testImplicitRelativePath() throws Exception {
-        if (SysProperties.IMPLICIT_RELATIVE_PATH) {
-            return;
-        }
         assertThrows(ErrorCode.URL_RELATIVE_TO_CWD, this).
             getConnection("jdbc:h2:" + getTestName());
         assertThrows(ErrorCode.URL_RELATIVE_TO_CWD, this).

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -116,6 +116,7 @@ public class TestPgServer extends TestDb {
         try {
             if (getPgJdbcDriver()) {
                 testPgClient();
+                testPgClientSimple();
             }
         } finally {
             server.stop();
@@ -354,6 +355,30 @@ public class TestPgServer extends TestDb {
         assertEquals(",", rs.getString("typdelim"));
         assertEquals(PgServer.PG_TYPE_VARCHAR, rs.getInt("typelem"));
 
+        stat.setMaxRows(10);
+        rs = stat.executeQuery("select * from generate_series(0, 10)");
+        for (int i = 0; i < 10; i++) {
+            assertTrue(rs.next());
+            assertEquals(i, rs.getInt(1));
+        }
+        assertFalse(rs.next());
+        stat.setMaxRows(0);
+
+        conn.close();
+    }
+
+    private void testPgClientSimple() throws SQLException {
+        Connection conn = DriverManager.getConnection(
+                "jdbc:postgresql://localhost:5535/pgserver?preferQueryMode=simple", "sa", "sa");
+        Statement stat = conn.createStatement();
+        ResultSet rs = stat.executeQuery("select 1");
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+        assertFalse(rs.next());
+        stat.setMaxRows(0);
+        stat.execute("create table test2(int integer)");
+        stat.execute("drop table test2");
+        assertThrows(SQLException.class, stat).execute("drop table test2");
         conn.close();
     }
 

--- a/h2/src/tools/org/h2/dev/fs/FileShell.java
+++ b/h2/src/tools/org/h2/dev/fs/FileShell.java
@@ -23,7 +23,6 @@ import java.util.zip.ZipOutputStream;
 
 import org.h2.command.dml.BackupCommand;
 import org.h2.engine.Constants;
-import org.h2.engine.SysProperties;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
 import org.h2.util.IOUtils;
@@ -388,17 +387,13 @@ public class FileShell extends Tool {
                 }
                 String fileName = entry.getName();
                 // restoring windows backups on linux and vice versa
-                fileName = fileName.replace('\\',
-                        SysProperties.FILE_SEPARATOR.charAt(0));
-                fileName = fileName.replace('/',
-                        SysProperties.FILE_SEPARATOR.charAt(0));
-                if (fileName.startsWith(SysProperties.FILE_SEPARATOR)) {
+                fileName = IOUtils.nameSeparatorsToNative(fileName);
+                if (fileName.startsWith(File.separator)) {
                     fileName = fileName.substring(1);
                 }
                 OutputStream o = null;
                 try {
-                    o = FileUtils.newOutputStream(targetDir
-                            + SysProperties.FILE_SEPARATOR + fileName, false);
+                    o = FileUtils.newOutputStream(targetDir + File.separatorChar + fileName, false);
                     IOUtils.copy(zipIn, o);
                     o.close();
                 } finally {
@@ -451,7 +446,7 @@ public class FileShell extends Tool {
         }
         String unwrapped = FileUtils.unwrap(f);
         String prefix = f.substring(0, f.length() - unwrapped.length());
-        f = prefix + currentWorkingDirectory + SysProperties.FILE_SEPARATOR + unwrapped;
+        f = prefix + currentWorkingDirectory + File.separatorChar + unwrapped;
         return FileUtils.toRealPath(f);
     }
 


### PR DESCRIPTION
1. Client now sends its time zone to a server if server supports it. Closes #2888.

2. PG server now uses time zone provided by client if it is known and reports the used time zone back to client correctly, previously `CET` was reported unconditionally.

3. Incorrect schema from #2891 is now accepted during database initialization (but is not accepted by `RUNSCRIPT` command).

4. `SysProperties.FILE_SEPARATOR` and `SysProperties.LINE_SEPARATOR` are replaced with Java's own constants.

5. Unused `SysProperties.LOB_FILES_PER_DIRECTORY` is removed.

6. `SysProperties.IMPLICIT_RELATIVE_PATH` introduced in 2014 as a temporary workaround for old applications is removed.

7. Query (`'Q'`) command in `PgServerThread` is now covered by tests.

8. Execute (`'E'`) command in `PgServerThread` now reads its arguments correctly.