### PR TITLE
Fix NPE in DROP SCHEMA caused by linked constraints

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,7 +21,11 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #2894: NPE in DROP SCHEMA when unique constraint is removed before linked referential constraint
+</li>
 <li>Issue #2888: H2 should pass time zone of client to the server
+</li>
+<li>PR #2890: Fixed possible eternal wait(0)
 </li>
 <li>Issue #2846: GRANT SELECT, INSERT, UPDATE, DELETE incorrectly gives privileges to drop a table
 </li>

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -184,9 +184,16 @@ public class Schema extends DbObject {
     private void removeChildrenFromMap(SessionLocal session, ConcurrentHashMap<String, ? extends SchemaObject> map) {
         if (!map.isEmpty()) {
             for (SchemaObject obj : map.values()) {
-                // Database.removeSchemaObject() removes the object from
-                // the map too, but it is safe for ConcurrentHashMap.
-                database.removeSchemaObject(session, obj);
+                /*
+                 * Referential constraints are dropped when unique or PK
+                 * constraint is dropped, but iterator may return already
+                 * removed objects in some cases.
+                 */
+                if (obj.isValid()) {
+                    // Database.removeSchemaObject() removes the object from
+                    // the map too, but it is safe for ConcurrentHashMap.
+                    database.removeSchemaObject(session, obj);
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #2894.

Unfortunately, I didn't find any simple test case, but I placed a comment before the new condition with description why it is needed.