### PR TITLE
Allow ROLLING_BACK -> ROLLED_BACK tx transition

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -233,7 +233,8 @@ public final class Transaction {
                     break;
                 case STATUS_ROLLED_BACK:
                     valid = currentStatus == STATUS_OPEN ||
-                            currentStatus == STATUS_PREPARED;
+                            currentStatus == STATUS_PREPARED ||
+                            currentStatus == STATUS_ROLLING_BACK;
                     break;
                 case STATUS_CLOSED:
                     valid = currentStatus == STATUS_COMMITTED ||


### PR DESCRIPTION
Fix for #2911 
There is no reason for disallowing such transition. While it should not happen under normal circumstances, when transaction is used by only one thread at a time, it can legitimately happen when session is forcibly closed by a concurrent thread.
It may prevent database from doing a proper shutdown.