### PR TITLE
Removal of unnecessary lock

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1005,9 +1005,6 @@ public final class Database implements DataHandler, CastDataProvider {
             try {
                 Cursor cursor = metaIdIndex.find(session, r, r);
                 if (cursor.next()) {
-                    if (lockMode != Constants.LOCK_MODE_OFF && !wasLocked) {
-                        throw DbException.getInternalError();
-                    }
                     Row found = cursor.get();
                     meta.removeRow(session, found);
                     if (SysProperties.CHECK) {

--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -405,21 +405,12 @@ public class SessionLocal extends Session implements TransactionStore.RollbackLi
      * @param table the table
      */
     public void removeLocalTempTable(Table table) {
-        // Exception thrown in org.h2.engine.Database.removeMeta if line below
-        // is missing with TestGeneralCommonTableQueries
-        boolean wasLocked = database.lockMeta(this);
-        try {
-            modificationId++;
-            if (localTempTables != null) {
-                localTempTables.remove(table.getName());
-            }
-            synchronized (database) {
-                table.removeChildrenAndResources(this);
-            }
-        } finally {
-            if (!wasLocked) {
-                database.unlockMeta(this);
-            }
+        modificationId++;
+        if (localTempTables != null) {
+            localTempTables.remove(table.getName());
+        }
+        synchronized (database) {
+            table.removeChildrenAndResources(this);
         }
     }
 


### PR DESCRIPTION
I do not think that removal of a local temp table has to be done under the global meta lock.
Creation and addition of such table is done without it.
#2884 reported time-out here, most likely a deadlock.