### PR TITLE
Add implementation of DatabaseMetaData.getPseudoColumns()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1022: JdbcDatabaseMetaData.getPseudoColumns() should be implemented
+</li>
 <li>Issue #2914: (T1.A = T2.B) OR (T1.A = T2.C) should be optimized to T1.A IN(T2.B, T2.C) to allow index conditions
 </li>
 <li>PR #2903: Assorted changes

--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -299,7 +299,7 @@ otherwise they are not parsed correctly. If in doubt, add <code>;</code> before 
             @attributes, @best_row_identifier, @catalogs, @columns,
             @column_privileges, @cross_references, @exported_keys,
             @imported_keys, @index_info,  @primary_keys, @procedures,
-            @procedure_columns, @schemas, @super_tables, @super_types,
+            @procedure_columns, @pseudo_columns, @schemas, @super_tables, @super_types,
             @tables, @table_privileges, @table_types, @type_info, @udts,
             @version_columns
             </code>

--- a/h2/src/main/org/h2/expression/condition/Comparison.java
+++ b/h2/src/main/org/h2/expression/condition/Comparison.java
@@ -548,11 +548,10 @@ public final class Comparison extends Condition {
         if (compareType == EQUAL && other.compareType == EQUAL) {
             Expression left2 = other.left;
             Expression right2 = other.right;
-            String l = left.getSQL(DEFAULT_SQL_FLAGS);
             String l2 = left2.getSQL(DEFAULT_SQL_FLAGS);
-            String r = right.getSQL(DEFAULT_SQL_FLAGS);
             String r2 = right2.getSQL(DEFAULT_SQL_FLAGS);
             if (left.isEverything(ExpressionVisitor.DETERMINISTIC_VISITOR)) {
+                String l = left.getSQL(DEFAULT_SQL_FLAGS);
                 if (l.equals(l2)) {
                     return getConditionIn(session, left, right, right2);
                 } else if (l.equals(r2)) {
@@ -560,6 +559,7 @@ public final class Comparison extends Condition {
                 }
             }
             if (right.isEverything(ExpressionVisitor.DETERMINISTIC_VISITOR)) {
+                String r = right.getSQL(DEFAULT_SQL_FLAGS);
                 if (r.equals(l2)) {
                     return getConditionIn(session, right, left, right2);
                 } else if (r.equals(r2)) {

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -169,13 +169,13 @@ public final class JdbcDatabaseMetaData extends TraceObject
      * <li>TABLE_SCHEM (String) table schema</li>
      * <li>TABLE_NAME (String) table name</li>
      * <li>COLUMN_NAME (String) column name</li>
-     * <li>DATA_TYPE (short) data type (see java.sql.Types)</li>
+     * <li>DATA_TYPE (int) data type (see java.sql.Types)</li>
      * <li>TYPE_NAME (String) data type name ("INTEGER", "VARCHAR",...)</li>
      * <li>COLUMN_SIZE (int) precision
      *         (values larger than 2 GB are returned as 2 GB)</li>
      * <li>BUFFER_LENGTH (int) unused</li>
      * <li>DECIMAL_DIGITS (int) scale (0 for INTEGER and VARCHAR)</li>
-     * <li>NUM_PREC_RADIX (int) radix (always 10)</li>
+     * <li>NUM_PREC_RADIX (int) radix</li>
      * <li>NULLABLE (int) columnNoNulls or columnNullable</li>
      * <li>REMARKS (String) comment</li>
      * <li>COLUMN_DEF (String) default value</li>
@@ -506,7 +506,7 @@ public final class JdbcDatabaseMetaData extends TraceObject
      * <li>PRECISION (int) precision</li>
      * <li>LENGTH (int) length</li>
      * <li>SCALE (short) scale</li>
-     * <li>RADIX (int) always 10</li>
+     * <li>RADIX (int)</li>
      * <li>NULLABLE (short) nullable
      * (DatabaseMetaData.columnNoNulls for primitive data types,
      * DatabaseMetaData.columnNullable otherwise)</li>
@@ -2736,7 +2736,26 @@ public final class JdbcDatabaseMetaData extends TraceObject
     }
 
     /**
-     * [Not supported]
+     * Gets the list of pseudo and invisible columns. The result set is sorted
+     * by TABLE_SCHEM, TABLE_NAME, and COLUMN_NAME.
+     *
+     * <ol>
+     * <li>TABLE_CAT (String) table catalog</li>
+     * <li>TABLE_SCHEM (String) table schema</li>
+     * <li>TABLE_NAME (String) table name</li>
+     * <li>COLUMN_NAME (String) column name</li>
+     * <li>DATA_TYPE (int) data type (see java.sql.Types)</li>
+     * <li>COLUMN_SIZE (int) precision
+     *         (values larger than 2 GB are returned as 2 GB)</li>
+     * <li>DECIMAL_DIGITS (int) scale (0 for INTEGER and VARCHAR)</li>
+     * <li>NUM_PREC_RADIX (int) radix</li>
+     * <li>COLUMN_USAGE (String) he allowed usage for the column,
+     *         see {@link java.sql.PseudoColumnUsage}</li>
+     * <li>REMARKS (String) comment</li>
+     * <li>CHAR_OCTET_LENGTH (int) for char types the
+     *         maximum number of bytes in the column</li>
+     * <li>IS_NULLABLE (String) "NO" or "YES"</li>
+     * </ol>
      *
      * @param catalog null (to get all objects) or the catalog name
      * @param schemaPattern null (to get all objects) or a schema name
@@ -2745,6 +2764,7 @@ public final class JdbcDatabaseMetaData extends TraceObject
      *            (uppercase for unquoted names)
      * @param columnNamePattern null (to get all objects) or a column name
      *            (uppercase for unquoted names)
+     * @return the list of pseudo and invisible columns
      */
     @Override
     public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern,

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLegacy.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLegacy.java
@@ -651,6 +651,12 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 BACKSLASH);
     }
 
+    @Override
+    public ResultInterface getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern,
+            String columnNamePattern) {
+        return getPseudoColumnsResult();
+    }
+
     private ResultInterface executeQuery(String sql, Value... args) {
         checkClosed();
         synchronized (session) {

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocalBase.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLocalBase.java
@@ -150,9 +150,7 @@ abstract class DatabaseMetaLocalBase extends DatabaseMeta {
         return result;
     }
 
-    @Override
-    public final ResultInterface getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern,
-            String columnNamePattern) {
+    final SimpleResult getPseudoColumnsResult() {
         checkClosed();
         SimpleResult result = new SimpleResult();
         result.addColumn("TABLE_CAT", TypeInfo.TYPE_VARCHAR);

--- a/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcConnectionPool.java
@@ -317,23 +317,33 @@ public final class JdbcConnectionPool
     }
 
     /**
-     * [Not supported] Return an object of this class if possible.
+     * Return an object of this class if possible.
      *
      * @param iface the class
+     * @return this
      */
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw DbException.getUnsupportedException("unwrap");
+        try {
+            if (isWrapperFor(iface)) {
+                return (T) this;
+            }
+            throw DbException.getInvalidValueException("iface", iface);
+        } catch (Exception e) {
+            throw DbException.toSQLException(e);
+        }
     }
 
     /**
-     * [Not supported] Checks if unwrap can return an object of this class.
+     * Checks if unwrap can return an object of this class.
      *
      * @param iface the class
+     * @return whether or not the interface is assignable from this class
      */
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw DbException.getUnsupportedException("isWrapperFor");
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /**

--- a/h2/src/main/org/h2/table/RegularTable.java
+++ b/h2/src/main/org/h2/table/RegularTable.java
@@ -226,6 +226,7 @@ public abstract class RegularTable extends TableBase {
         if (rowIdColumn == null) {
             rowIdColumn = new Column(Column.ROWID, TypeInfo.TYPE_BIGINT, this, SearchRow.ROWID_INDEX);
             rowIdColumn.setRowId(true);
+            rowIdColumn.setNullable(false);
         }
         return rowIdColumn;
     }

--- a/h2/src/main/org/h2/tools/SimpleResultSet.java
+++ b/h2/src/main/org/h2/tools/SimpleResultSet.java
@@ -2316,19 +2316,33 @@ public class SimpleResultSet implements ResultSet, ResultSetMetaData {
     }
 
     /**
-     * INTERNAL
+     * Return an object of this class if possible.
+     *
+     * @param iface the class
+     * @return this
      */
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw getUnsupportedException();
+        try {
+            if (isWrapperFor(iface)) {
+                return (T) this;
+            }
+            throw DbException.getInvalidValueException("iface", iface);
+        } catch (Exception e) {
+            throw DbException.toSQLException(e);
+        }
     }
 
     /**
-     * INTERNAL
+     * Checks if unwrap can return an object of this class.
+     *
+     * @param iface the class
+     * @return whether or not the interface is assignable from this class
      */
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw getUnsupportedException();
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /**

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -708,6 +708,9 @@ public class JdbcUtils {
         } else if (isBuiltIn(sql, "@super_types")) {
             String[] p = split(sql);
             return meta.getSuperTypes(p[1], p[2], p[3]);
+        } else if (isBuiltIn(sql, "@pseudo_columns")) {
+            String[] p = split(sql);
+            return meta.getPseudoColumns(p[1], p[2], p[3], p[4]);
         }
         return null;
     }

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -51,6 +51,7 @@ public class TestMetaData extends TestDb {
         testColumnPrecision();
         testColumnDefault();
         testColumnGenerated();
+        testHiddenColumn();
         testCrossReferences();
         testProcedureColumns();
         testTypeInfo();
@@ -203,6 +204,28 @@ public class TestMetaData extends TestDb {
         rs.next();
         assertEquals("B", rs.getString("COLUMN_NAME"));
         assertEquals("YES", rs.getString("IS_GENERATEDCOLUMN"));
+        assertFalse(rs.next());
+        stat.execute("DROP TABLE TEST");
+        conn.close();
+    }
+
+    private void testHiddenColumn() throws SQLException {
+        Connection conn = getConnection("metaData");
+        DatabaseMetaData meta = conn.getMetaData();
+        ResultSet rs;
+        Statement stat = conn.createStatement();
+        stat.execute("CREATE TABLE TEST(A INT, B INT INVISIBLE)");
+        rs = meta.getColumns(null, null, "TEST", null);
+        assertTrue(rs.next());
+        assertEquals("A", rs.getString("COLUMN_NAME"));
+        assertFalse(rs.next());
+        rs = meta.getPseudoColumns(null, null, "TEST", null);
+        assertTrue(rs.next());
+        assertEquals("B", rs.getString("COLUMN_NAME"));
+        assertEquals("YES", rs.getString("IS_NULLABLE"));
+        assertTrue(rs.next());
+        assertEquals("_ROWID_", rs.getString("COLUMN_NAME"));
+        assertEquals("NO", rs.getString("IS_NULLABLE"));
         assertFalse(rs.next());
         stat.execute("DROP TABLE TEST");
         conn.close();

--- a/h2/src/test/org/h2/test/jdbcx/TestConnectionPool.java
+++ b/h2/src/test/org/h2/test/jdbcx/TestConnectionPool.java
@@ -48,6 +48,7 @@ public class TestConnectionPool extends TestDb {
         testKeepOpen();
         testConnect();
         testThreads();
+        testUnwrap();
         deleteDb("connectionPool");
         deleteDb("connectionPool2");
     }
@@ -251,6 +252,18 @@ public class TestConnectionPool extends TestDb {
                 getConnection();
         assertThrows(UnsupportedOperationException.class, ds).
                 getConnection(null, null);
+    }
+
+    private void testUnwrap() throws SQLException {
+        JdbcConnectionPool pool = JdbcConnectionPool.create(new JdbcDataSource());
+        assertTrue(pool.isWrapperFor(Object.class));
+        assertTrue(pool.isWrapperFor(DataSource.class));
+        assertTrue(pool.isWrapperFor(pool.getClass()));
+        assertFalse(pool.isWrapperFor(Integer.class));
+        assertTrue(pool == pool.unwrap(Object.class));
+        assertTrue(pool == pool.unwrap(DataSource.class));
+        assertTrue(pool == pool.unwrap(pool.getClass()));
+        assertThrows(ErrorCode.INVALID_VALUE_2, () -> pool.unwrap(Integer.class));
     }
 
 }

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -509,6 +509,16 @@ public class TestTools extends TestDb {
         rs.next();
         assertEquals(uuid, rs.getObject(1));
         assertEquals(uuid, ValueUuid.get(rs.getBytes(1)).getUuid());
+
+        assertTrue(rs.isWrapperFor(Object.class));
+        assertTrue(rs.isWrapperFor(ResultSet.class));
+        assertTrue(rs.isWrapperFor(rs.getClass()));
+        assertFalse(rs.isWrapperFor(Integer.class));
+        assertTrue(rs == rs.unwrap(Object.class));
+        assertTrue(rs == rs.unwrap(ResultSet.class));
+        assertTrue(rs == rs.unwrap(rs.getClass()));
+        SimpleResultSet rs2 = rs;
+        assertThrows(ErrorCode.INVALID_VALUE_2, () -> rs2.unwrap(Integer.class));
     }
 
     private void testJdbcDriverUtils() {


### PR DESCRIPTION
1. `DatabaseMetaData.getPseudoColumns()` is now implemented. Closes #1022. It returns `_ROWID_` and invisible columns, as required by its documentation from Java. Oracle also returns its own system columns and invisible columns in this method (invisible columns came to H2 from Oracle).

2. `JdbcConnectionPool` and `SimpleResultSet` now have real implementations of `Wrapper` interface.