### PR TITLE
Binary NUMERIC type support for Npgsql

### DIFF
--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -758,7 +758,13 @@ public final class PgServerThread implements Runnable {
         int scale = value.scale();
         int signum = value.signum();
         if (signum != 0) {
-            BigInteger[] unscaled = new BigInteger[] {value.unscaledValue()};
+            BigInteger[] unscaled = {null};
+            if (scale < 0) {
+                unscaled[0] = value.setScale(0).unscaledValue();
+                scale = 0;
+            } else {
+                unscaled[0] = value.unscaledValue();
+            }
             if (signum < 0) {
                 unscaled[0] = unscaled[0].negate();
             }
@@ -786,7 +792,8 @@ public final class PgServerThread implements Runnable {
         writeShort(groupCount);
         writeShort(groupCount + weight);
         writeShort(signum < 0 ? 16384 : 0);
-        writeShort(scale < Short.MIN_VALUE ? Short.MIN_VALUE : scale > Short.MAX_VALUE ? Short.MAX_VALUE : scale);
+        assert scale >= 0;
+        writeShort(scale > Short.MAX_VALUE ? Short.MAX_VALUE : scale);
         for (int i = groupCount - 1; i >= 0; i--) {
             writeShort(groups.get(i));
         }

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -788,12 +788,14 @@ public final class PgServerThread implements Runnable {
             }
         }
         int groupCount = groups.size();
+        if (groupCount + weight > Short.MAX_VALUE || scale > Short.MAX_VALUE) {
+            throw DbException.get(ErrorCode.NUMERIC_VALUE_OUT_OF_RANGE_1, value.toString());
+        }
         writeInt(8 + groupCount * 2);
         writeShort(groupCount);
         writeShort(groupCount + weight);
         writeShort(signum < 0 ? 16384 : 0);
-        assert scale >= 0;
-        writeShort(scale > Short.MAX_VALUE ? Short.MAX_VALUE : scale);
+        writeShort(scale);
         for (int i = groupCount - 1; i >= 0; i--) {
             writeShort(groups.get(i));
         }

--- a/h2/src/main/org/h2/server/pg/PgServerThread.java
+++ b/h2/src/main/org/h2/server/pg/PgServerThread.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.Socket;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -669,7 +671,7 @@ public final class PgServerThread implements Runnable {
             switch (pgType) {
             case PgServer.PG_TYPE_BOOL:
                 writeInt(1);
-                dataOut.writeByte(v.getBoolean() ? 't' : 'f');
+                dataOut.writeByte(v.getBoolean() ? 1 : 0);
                 break;
             case PgServer.PG_TYPE_INT2:
                 writeInt(2);
@@ -690,6 +692,9 @@ public final class PgServerThread implements Runnable {
             case PgServer.PG_TYPE_FLOAT8:
                 writeInt(8);
                 dataOut.writeDouble(v.getDouble());
+                break;
+            case PgServer.PG_TYPE_NUMERIC:
+                writeNumericBinary(v.getBigDecimal());
                 break;
             case PgServer.PG_TYPE_BYTEA: {
                 byte[] data = v.getBytesNoCopy();
@@ -734,6 +739,59 @@ public final class PgServerThread implements Runnable {
         }
     }
 
+    private static final int[] POWERS10 = {1, 10, 100, 1000, 10000};
+    private static final int MAX_GROUP_SCALE = 4;
+    private static final int MAX_GROUP_SIZE = POWERS10[4];
+
+    private static int divide(BigInteger[] unscaled, int divisor) {
+        BigInteger[] bi = unscaled[0].divideAndRemainder(BigInteger.valueOf(divisor));
+        unscaled[0] = bi[0];
+        return bi[1].intValue();
+    }
+
+    // https://www.npgsql.org/dev/types.html
+    // https://github.com/npgsql/npgsql/blob/8a479081f707784b5040747b23102c3d6371b9d3/
+    //         src/Npgsql/TypeHandlers/NumericHandlers/NumericHandler.cs#L166
+    private void writeNumericBinary(BigDecimal value) throws IOException {
+        int weight = 0;
+        List<Integer> groups = new ArrayList<>();
+        int scale = value.scale();
+        int signum = value.signum();
+        if (signum != 0) {
+            BigInteger[] unscaled = new BigInteger[] {value.unscaledValue()};
+            if (signum < 0) {
+                unscaled[0] = unscaled[0].negate();
+            }
+            weight = -scale / MAX_GROUP_SCALE - 1;
+            int remainder = 0;
+            int scaleChunk = scale % MAX_GROUP_SCALE;
+            if (scaleChunk > 0) {
+                remainder = divide(unscaled, POWERS10[scaleChunk]) * POWERS10[MAX_GROUP_SCALE - scaleChunk];
+                if (remainder != 0) {
+                    weight--;
+                }
+            }
+            if (remainder == 0) {
+                while ((remainder = divide(unscaled, MAX_GROUP_SIZE)) == 0) {
+                    weight++;
+                }
+            }
+            groups.add(remainder);
+            while (unscaled[0].signum() != 0) {
+                groups.add(divide(unscaled, MAX_GROUP_SIZE));
+            }
+        }
+        int groupCount = groups.size();
+        writeInt(8 + groupCount * 2);
+        writeShort(groupCount);
+        writeShort(groupCount + weight);
+        writeShort(signum < 0 ? 16384 : 0);
+        writeShort(scale < Short.MIN_VALUE ? Short.MIN_VALUE : scale > Short.MAX_VALUE ? Short.MAX_VALUE : scale);
+        for (int i = groupCount - 1; i >= 0; i--) {
+            writeShort(groups.get(i));
+        }
+    }
+
     private void writeTimeBinary(long m, int numBytes) throws IOException {
         writeInt(numBytes);
         if (INTEGER_DATE_TYPES) {
@@ -767,7 +825,12 @@ public final class PgServerThread implements Runnable {
 
     private void setParameter(ArrayList<? extends ParameterInterface> parameters, int pgType, int i, int[] formatCodes)
             throws IOException {
-        boolean text = (i >= formatCodes.length) || (formatCodes[i] == 0);
+        boolean text = true;
+        if (formatCodes.length == 1) {
+            text = formatCodes[0] == 0;
+        } else if (i < formatCodes.length) {
+            text = formatCodes[i] == 0;
+        }
         int paramLen = readInt();
         Value value;
         if (paramLen == -1) {

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -67,6 +67,7 @@ public class TestPgServer extends TestDb {
         testKeyAlias();
         testCancelQuery();
         testTextualAndBinaryTypes();
+        testBinaryNumeric();
         testDateTime();
         testPrepareWithUnspecifiedType();
         testOtherPgClients();
@@ -419,23 +420,27 @@ public class TestPgServer extends TestDb {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void testTextualAndBinaryTypes() throws SQLException {
-        testTextualAndBinaryTypes(false);
-        testTextualAndBinaryTypes(true);
-        Set<Integer> supportedBinaryOids;
+    private static Set<Integer> supportedBinaryOids;
+
+    static {
         try {
             Field supportedBinaryOidsField = Class
                     .forName("org.postgresql.jdbc.PgConnection")
                     .getDeclaredField("SUPPORTED_BINARY_OIDS");
             supportedBinaryOidsField.setAccessible(true);
             supportedBinaryOids = (Set<Integer>) supportedBinaryOidsField.get(null);
-            supportedBinaryOids.add(16);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private void testTextualAndBinaryTypes() throws SQLException {
+        testTextualAndBinaryTypes(false);
         testTextualAndBinaryTypes(true);
-        supportedBinaryOids.remove(16);
+        // additional support of NUMERIC for Npgsql
+        supportedBinaryOids.add(1700);
+        testTextualAndBinaryTypes(true);
+        supportedBinaryOids.remove(1700);
     }
 
     private void testTextualAndBinaryTypes(boolean binary) throws SQLException {
@@ -517,6 +522,44 @@ public class TestPgServer extends TestDb {
 
             conn.close();
         } finally {
+            server.stop();
+        }
+    }
+
+    private void testBinaryNumeric() throws SQLException {
+        if (!getPgJdbcDriver()) {
+            return;
+        }
+        Server server = createPgServer(
+                "-ifNotExists", "-pgPort", "5535", "-pgDaemon", "-key", "pgserver", "mem:pgserver");
+        supportedBinaryOids.add(1700);
+        try {
+            Properties props = new Properties();
+            props.setProperty("user", "sa");
+            props.setProperty("password", "sa");
+            // force binary
+            props.setProperty("prepareThreshold", "-1");
+
+            Connection conn = DriverManager.getConnection(
+                    "jdbc:postgresql://localhost:5535/pgserver", props);
+            Statement stat = conn.createStatement();
+
+            try (ResultSet rs = stat.executeQuery("SELECT 1E-16383, 1E-16384, 1E+1")) {
+                rs.next();
+                assertEquals(new BigDecimal("1E-16383"), rs.getBigDecimal(1));
+                for (int i = 2; i <= 3; i ++) {
+                    try {
+                        rs.getBigDecimal(i);
+                        fail();
+                    } catch (IllegalArgumentException e) {
+                        // PgJDBC doesn't support scale greater than 16383 or negative scale
+                    }
+                }
+            }
+
+            conn.close();
+        } finally {
+            supportedBinaryOids.remove(1700);
             server.stop();
         }
     }

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -544,16 +544,17 @@ public class TestPgServer extends TestDb {
                     "jdbc:postgresql://localhost:5535/pgserver", props);
             Statement stat = conn.createStatement();
 
-            try (ResultSet rs = stat.executeQuery("SELECT 1E-16383, 1E-16384, 1E+1")) {
+            try (ResultSet rs = stat.executeQuery("SELECT 1E-16383, 1E+1, 1E+89, 1E-16384")) {
                 rs.next();
                 assertEquals(new BigDecimal("1E-16383"), rs.getBigDecimal(1));
-                for (int i = 2; i <= 3; i ++) {
-                    try {
-                        rs.getBigDecimal(i);
-                        fail();
-                    } catch (IllegalArgumentException e) {
-                        // PgJDBC doesn't support scale greater than 16383 or negative scale
-                    }
+                assertEquals(new BigDecimal("10"), rs.getBigDecimal(2));
+                assertEquals(new BigDecimal("10").pow(89), rs.getBigDecimal(3));
+                // TODO `SELECT 1E+90, 1E+131071` fails due to PgJDBC issue 1935
+                try {
+                    rs.getBigDecimal(4);
+                    fail();
+                } catch (IllegalArgumentException e) {
+                    // PgJDBC doesn't support scale greater than 16383
                 }
             }
 

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -557,6 +557,16 @@ public class TestPgServer extends TestDb {
                     // PgJDBC doesn't support scale greater than 16383
                 }
             }
+            try (ResultSet rs = stat.executeQuery("SELECT 1E-32768")) {
+                fail();
+            } catch (SQLException e) {
+                assertEquals("22003", e.getSQLState());
+            }
+            try (ResultSet rs = stat.executeQuery("SELECT 1E+131072")) {
+                fail();
+            } catch (SQLException e) {
+                assertEquals("22003", e.getSQLState());
+            }
 
             conn.close();
         } finally {


### PR DESCRIPTION
PgServer supports most common types in binary format, which make it possible for C# to access PgServer via Npgsql (Npgsql uses binary format by default).  Not commonly used NUMERIC type is necessary because `SUM(BIGINT)` returns NUMERIC. Here is an example:

```
using System;
using Npgsql;

namespace sample1
{
    class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine("Testing Npgsql ...");
            var connString = "Host=localhost;Port=5432;Username=sa;Password=sa;Database=test";

            var conn = new NpgsqlConnection(connString);
            // Here we need to hack something to pass pg_type queries, either in H2 or in Npgsql
            conn.Open();

            using (var cmd = new NpgsqlCommand("DROP TABLE IF EXISTS test", conn)) {
                cmd.ExecuteNonQuery();
            }
            using (var cmd = new NpgsqlCommand(CREATE TABLE test(x1 BIGINT)", conn)) {
                cmd.ExecuteNonQuery();
            }
            using (var cmd = new NpgsqlCommand("INSERT INTO test (x1) VALUES (@p), (@q)", conn)) {
                cmd.Parameters.AddWithValue("p", 1111222233334444);
                cmd.Parameters.AddWithValue("q", 1234123412341234);
                cmd.ExecuteNonQuery();
            }

            using (var cmd = new NpgsqlCommand("SELECT SUM(x1) FROM test", conn)) {
                using (var reader = cmd.ExecuteReader()) {
                    while (reader.Read()) {
                        Console.WriteLine(reader.GetDecimal(0)); // expects 2345345645675678
                    }
                }
            }
        }
    }
}
```

btw, formatCode (text or binary) for Parameter needs to be consistent with formatCode for RowDescription: if only one formatCode, it applies to all parameters.