### PR TITLE
Fixed negative Page memory.

### DIFF
--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -849,6 +849,9 @@ public abstract class Page<K,V> implements Cloneable {
      */
     final void addMemory(int mem) {
         memory += mem;
+        if (memory < 0) {
+            recalculateMemory();
+        }
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
@@ -1528,7 +1528,7 @@ public class ObjectDataType extends BasicDataType<Object> {
      */
     static class SerializedObjectType extends AutoDetectDataType<Object> {
 
-        private long averageSize = 10_000;
+        private int averageSize = 10_000;
 
         SerializedObjectType(ObjectDataType base) {
             super(base, TYPE_SERIALIZED_OBJECT);
@@ -1574,7 +1574,7 @@ public class ObjectDataType extends BasicDataType<Object> {
         public int getMemory(Object obj) {
             DataType<Object> t = getType(obj);
             if (t == this) {
-                return (int) averageSize;
+                return averageSize;
             }
             return t.getMemory(obj);
         }
@@ -1592,7 +1592,7 @@ public class ObjectDataType extends BasicDataType<Object> {
             int size = data.length * 2;
             // adjust the average size
             // using an exponential moving average
-            averageSize = (size + 15 * averageSize) / 16;
+            averageSize = (int) ((size + 15L * averageSize) / 16);
             buff.put((byte) TYPE_SERIALIZED_OBJECT).putVarInt(data.length)
                     .put(data);
         }
@@ -1609,7 +1609,7 @@ public class ObjectDataType extends BasicDataType<Object> {
             int size = data.length * 2;
             // adjust the average size
             // using an exponential moving average
-            averageSize = (size + 15 * averageSize) / 16;
+            averageSize = (int) ((size + 15L * averageSize) / 16);
             buff.get(data);
             return deserialize(data);
         }

--- a/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/ObjectDataType.java
@@ -1528,7 +1528,7 @@ public class ObjectDataType extends BasicDataType<Object> {
      */
     static class SerializedObjectType extends AutoDetectDataType<Object> {
 
-        private int averageSize = 10_000;
+        private long averageSize = 10_000;
 
         SerializedObjectType(ObjectDataType base) {
             super(base, TYPE_SERIALIZED_OBJECT);
@@ -1574,7 +1574,7 @@ public class ObjectDataType extends BasicDataType<Object> {
         public int getMemory(Object obj) {
             DataType<Object> t = getType(obj);
             if (t == this) {
-                return averageSize;
+                return (int) averageSize;
             }
             return t.getMemory(obj);
         }


### PR DESCRIPTION
In some cases with serialized objects the Page memory could be negative, what led to a memory leak.

See the issue:
https://github.com/h2database/h2database/issues/2972