### PR TITLE
Better Page memory estimation

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1968,6 +1968,10 @@ public class MVMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V
         }
     }
 
+    final boolean isMemoryEstimationAllowed() {
+        return avgKeySize != null || avgValSize != null;
+    }
+
     final int evaluateMemoryForKeys(K[] storage, int count) {
         if (avgKeySize == null) {
             return calculateMemory(keyType, storage, count);

--- a/h2/src/main/org/h2/util/MemoryEstimator.java
+++ b/h2/src/main/org/h2/util/MemoryEstimator.java
@@ -69,7 +69,7 @@ public final class MemoryEstimator {
         if (initialized == 0 || counter-- == 0) {
             cnt = 1;
             mem = data == null ? 0 : dataType.getMemory(data);
-            long delta = (mem << WINDOW_SHIFT) - sum;
+            long delta = ((long) mem << WINDOW_SHIFT) - sum;
             if (initialized == 0) {
                 if (++counter == WINDOW_SIZE) {
                     initialized = INIT_BIT;
@@ -114,7 +114,7 @@ public final class MemoryEstimator {
                 T data = storage[index++];
                 int mem = data == null ? 0 : dataType.getMemory(data);
                 memSum += mem;
-                long delta = (mem << WINDOW_SHIFT) - sum;
+                long delta = ((long) mem << WINDOW_SHIFT) - sum;
                 if (initialized == 0) {
                     if (++counter == WINDOW_SIZE) {
                         initialized = INIT_BIT;
@@ -127,7 +127,7 @@ public final class MemoryEstimator {
                     sum += ((delta >> (MAGNITUDE_LIMIT - magnitude)) + 1) >> 1;
                     counter += ((1 << magnitude) - 1) & COUNTER_MASK;
 
-                    delta = (counter << WINDOW_SHIFT) - skipSum;
+                    delta = ((long) counter << WINDOW_SHIFT) - skipSum;
                     skipSum += (delta + WINDOW_HALF_SIZE) >> WINDOW_SHIFT;
                 }
             }
@@ -165,7 +165,7 @@ public final class MemoryEstimator {
     }
 
     private static long constructStatsData(long sum, long initialized, int skipSum, int counter) {
-        return (sum << SUM_SHIFT) | initialized | (skipSum << SKIP_SUM_SHIFT) | counter;
+        return (sum << SUM_SHIFT) | initialized | ((long) skipSum << SKIP_SUM_SHIFT) | counter;
     }
 
     private static long updateStatsData(AtomicLong stats, long statsData, long updatedStatsData,


### PR DESCRIPTION
Fix for issue #2972 
The fact that we use two different estimations for a single key and/or value - one when mapping is added and another one (later in time) when the same mapping is removed, may cause totally unrealistic, i.e. negative Page sizes.
This PR on removal uses a prorated page size instead, without any need to estimate size of the removed entry at all.
Also fix missing casts in MemoryEstimator, that (theoretically) may produce an overflow.

This is an alternative to PR #2973