### PR TITLE
Assorted minor changes

### DIFF
--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3493,7 +3493,7 @@ VALUES (1, 2), (3, 4);
 
 "Other Grammar","Quoted Name","
 ""anythingExceptDoubleQuote""
-    | U&'anythingExceptDoubleQuote' [ UESCAPE 'singleCharacter' ]
+    | U&""anythingExceptDoubleQuote"" [ UESCAPE 'singleCharacter' ]
 ","
 Case of characters in quoted names is preserved as is. Such names can contain spaces.
 The maximum name length is 256 characters.

--- a/h2/src/docsrc/help/help.csv
+++ b/h2/src/docsrc/help/help.csv
@@ -3416,7 +3416,7 @@ UPDATE SET setClauseList | DELETE
 ","
 WHEN MATCHED clause for MERGE USING command.
 ","
-WHEN MATCHED THEN UPDATE SET VALUE = S.VALUE
+WHEN MATCHED THEN UPDATE SET NAME = S.NAME
 WHEN MATCHED THEN DELETE
 "
 
@@ -3587,7 +3587,7 @@ wildcardExpression | expression [ [ AS ] columnAlias ]
 ","
 An expression in a SELECT statement.
 ","
-ID AS VALUE
+ID AS DOCUMENT_ID
 "
 
 "Other Grammar","Sequence value expression","
@@ -3695,7 +3695,7 @@ NO CACHE
 ","
 List of SET clauses.
 ","
-NAME = 'Test', VALUE = 2
+NAME = 'Test', PRICE = 2
 (A, B) = (1, 2)
 (A, B) = (1, 2), C = 3
 (A, B) = (SELECT X, Y FROM OTHER T2 WHERE T1.ID = T2.ID)
@@ -4679,8 +4679,8 @@ ABS(-2147483648) should be 2147483648, but this value is not allowed for this da
 It leads to an exception.
 To avoid it cast argument of this function to a higher data type.
 ","
-ABS(VALUE)
-ABS(CAST(VALUE AS BIGINT))
+ABS(I)
+ABS(CAST(I AS BIGINT))
 "
 
 "Functions (Numeric)","ACOS","
@@ -5145,7 +5145,7 @@ RANDOM_UUID()
 Rounds to a number of fractional digits.
 This method returns a double, float, or numeric value depending on type of the argument.
 ","
-ROUND(VALUE, 2)
+ROUND(N, 2)
 "
 
 "Functions (Numeric)","ROUNDMAGIC","
@@ -5158,7 +5158,7 @@ The value is converted to a String internally, and then the last 4 characters ar
 '000x' becomes '0000' and '999x' becomes '999999', which is rounded automatically.
 This method returns a double.
 ","
-ROUNDMAGIC(VALUE/3*3)
+ROUNDMAGIC(N/3*3)
 "
 
 "Functions (Numeric)","SECURE_RAND","
@@ -5175,7 +5175,7 @@ CALL SECURE_RAND(16)
 ","
 Returns -1 if the value is smaller than 0, 0 if zero or NaN, and otherwise 1.
 ","
-SIGN(VALUE)
+SIGN(N)
 "
 
 "Functions (Numeric)","ENCRYPT","
@@ -5237,7 +5237,7 @@ When used with a date, returns a timestamp at start of this date.
 When used with a timestamp as string, truncates the timestamp to a date (day) value
 and returns a timestamp without time zone.
 ","
-TRUNCATE(VALUE, 2)
+TRUNCATE(N, 2)
 "
 
 "Functions (Numeric)","COMPRESS","
@@ -6682,7 +6682,7 @@ SELECT * FROM LINK_SCHEMA('TEST2', '', 'jdbc:h2:./test2', 'sa', 'sa', 'PUBLIC');
 ","
 Returns the result set. TABLE_DISTINCT removes duplicate rows.
 ","
-SELECT * FROM TABLE(VALUE INT = ARRAY[1, 2]);
+SELECT * FROM TABLE(V INT = ARRAY[1, 2]);
 SELECT * FROM TABLE(ID INT=(1, 2), NAME VARCHAR=('Hello', 'World'));
 "
 

--- a/h2/src/docsrc/help/information_schema.csv
+++ b/h2/src/docsrc/help/information_schema.csv
@@ -420,7 +420,7 @@ Whether identity values are cycled ('YES' or 'NO') for identity columns.
 "
 
 "COLUMNS","IS_GENERATED","
-Whether column is an generated column ('YES' or 'NO')
+Whether column is an generated column ('ALWAYS' or 'NEVER')
 "
 
 "COLUMNS","GENERATION_EXPRESSION","

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -67,8 +67,8 @@ Features
     Read Only Databases</a><br />
 <a href="#database_in_zip">
     Read Only Databases in Zip or Jar File</a><br />
-<a href="#computed_columns">
-    Computed Columns / Function Based Index</a><br />
+<a href="#generated_columns">
+    Generated Columns (Computed Columns) / Function Based Index</a><br />
 <a href="#multi_dimensional">
     Multi-Dimensional Indexes</a><br />
 <a href="#user_defined_functions">
@@ -116,7 +116,7 @@ Features
 </li><li>Triggers and Java functions / stored procedures
 </li><li>Many built-in functions, including XML and lossless data compression
 </li><li>Wide range of data types including large objects (BLOB/CLOB) and arrays
-</li><li>Sequence and autoincrement columns, computed columns (can be used for function based indexes)
+</li><li>Sequence and autoincrement columns, generated columns (can be used for function based indexes)
 </li><li>ORDER BY, GROUP BY, HAVING, UNION, OFFSET / FETCH (including PERCENT and WITH TIES), LIMIT, TOP,
     DISTINCT / DISTINCT ON (...)
 </li><li>Window functions
@@ -1272,9 +1272,10 @@ is corrupted, then the database can be opened by specifying a database event lis
 The exceptions are logged, but opening the database will continue.
 </p>
 
-<h2 id="computed_columns">Computed Columns / Function Based Index</h2>
+<h2 id="generated_columns">Generated Columns (Computed Columns) / Function Based Index</h2>
 <p>
-A computed column is a column whose value is calculated before storing.
+Each column is either a base column or a generated column.
+A generated column is a column whose value is calculated before storing and cannot be assigned directly.
 The formula is evaluated when the row is inserted, and re-evaluated every time the row is updated.
 One use case is to automatically update the last-modification time:
 </p>
@@ -1282,20 +1283,21 @@ One use case is to automatically update the last-modification time:
 CREATE TABLE TEST(
     ID INT,
     NAME VARCHAR,
-    LAST_MOD TIMESTAMP WITH TIME ZONE AS CURRENT_TIMESTAMP
+    LAST_MOD TIMESTAMP WITH TIME ZONE
+        GENERATED ALWAYS AS CURRENT_TIMESTAMP
 );
 </pre>
 <p>
 Function indexes are not directly supported by this database, but they can be emulated
-by using computed columns. For example, if an index on the upper-case version of
-a column is required, create a computed column with the upper-case version of the original column,
+by using generated columns. For example, if an index on the upper-case version of
+a column is required, create a generated column with the upper-case version of the original column,
 and create an index for this column:
 </p>
 <pre>
 CREATE TABLE ADDRESS(
     ID INT PRIMARY KEY,
     NAME VARCHAR,
-    UPPER_NAME VARCHAR AS UPPER(NAME)
+    UPPER_NAME VARCHAR GENERATED ALWAYS AS UPPER(NAME)
 );
 CREATE INDEX IDX_U_NAME ON ADDRESS(UPPER_NAME);
 </pre>
@@ -1320,7 +1322,7 @@ This value specifies the location on a space-filling curve.
 Currently, Z-order (also called N-order or Morton-order) is used;
 Hilbert curve could also be used, but the implementation is more complex.
 The algorithm to convert the multi-dimensional value is called bit-interleaving.
-The scalar value is indexed using a B-Tree index (usually using a computed column).
+The scalar value is indexed using a B-Tree index (usually using a generated column).
 </p><p>
 The method can result in a drastic performance improvement
 over just using an index on the first column. Depending on the

--- a/h2/src/docsrc/html/performance.html
+++ b/h2/src/docsrc/html/performance.html
@@ -749,7 +749,8 @@ The data is stored in the database as follows:
 </table>
 <p>
 Access by row id is fast because the data is sorted by this key.
-Please note the row id is not available until after the row was added (that means, it can not be used in computed columns or constraints).
+Please note the row id is not available until after the row was added
+(that means, it can not be used in generated columns or constraints).
 If the query condition does not contain the row id (and if no other index can be used), then all rows of the table are scanned.
 A table scan iterates over all rows in the table, in the order of the row id.
 To find out what strategy the database uses to retrieve the data, use <code>EXPLAIN SELECT</code>:

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -604,20 +603,21 @@ public final class Database implements DataHandler, CastDataProvider {
 
     private String parseDatabaseShortName() {
         String n = databaseName;
-        if (n.endsWith(":")) {
-            n = null;
-        }
-        if (n != null) {
-            StringTokenizer tokenizer = new StringTokenizer(n, "/\\:,;");
-            while (tokenizer.hasMoreTokens()) {
-                n = tokenizer.nextToken();
+        int l = n.length(), i = l;
+        loop: while (--i >= 0) {
+            char ch = n.charAt(i);
+            switch (ch) {
+            case '/':
+            case ':':
+            case '\\':
+                break loop;
             }
         }
-        if (n == null || n.isEmpty()) {
-            n = "unnamed";
-        }
-        return dbSettings.databaseToUpper ? StringUtils.toUpperEnglish(n)
-                : dbSettings.databaseToLower ? StringUtils.toLowerEnglish(n) : n;
+        n = ++i == l ? "UNNAMED" : n.substring(i);
+        return StringUtils.truncateString(
+                dbSettings.databaseToUpper ? StringUtils.toUpperEnglish(n)
+                        : dbSettings.databaseToLower ? StringUtils.toLowerEnglish(n) : n,
+                Constants.MAX_IDENTIFIER_LENGTH);
     }
 
     private CreateTableData createSysTableData() {

--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -994,6 +994,29 @@ public class StringUtils {
     }
 
     /**
+     * Truncates the specified string to the specified length. This method,
+     * unlike {@link String#substring(int, int)}, doesn't break Unicode code
+     * points. If the specified length in characters breaks a valid pair of
+     * surrogates, the whole pair is not included into result.
+     *
+     * @param s
+     *            the string to truncate
+     * @param maximumLength
+     *            the maximum length in characters
+     * @return the specified string if it isn't longer than the specified
+     *         maximum length, and the truncated string otherwise
+     */
+    public static String truncateString(String s, int maximumLength) {
+        if (s.length() > maximumLength) {
+            s = maximumLength > 0 ? s.substring(0,
+                    Character.isSurrogatePair(s.charAt(maximumLength - 1), s.charAt(maximumLength)) ? maximumLength - 1
+                            : maximumLength)
+                    : "";
+        }
+        return s;
+    }
+
+    /**
      * Get the string from the cache if possible. If the string has not been
      * found, it is added to the cache. If there is such a string in the cache,
      * that one is returned.

--- a/h2/src/test/org/h2/test/unit/TestStringUtils.java
+++ b/h2/src/test/org/h2/test/unit/TestStringUtils.java
@@ -42,6 +42,7 @@ public class TestStringUtils extends TestBase {
         testReplaceAll();
         testTrim();
         testTrimSubstring();
+        testTruncateString();
     }
 
     private void testParseUInt31() {
@@ -286,6 +287,14 @@ public class TestStringUtils extends TestBase {
         assertEquals(expected, StringUtils.trimSubstring(string, startIndex, endIndex));
         assertEquals(expected, StringUtils
                 .trimSubstring(new StringBuilder(endIndex - startIndex), string, startIndex, endIndex).toString());
+    }
+
+    private void testTruncateString() {
+        assertEquals("", StringUtils.truncateString("", 1));
+        assertEquals("", StringUtils.truncateString("a", 0));
+        assertEquals("_\ud83d\ude00", StringUtils.truncateString("_\ud83d\ude00", 3));
+        assertEquals("_", StringUtils.truncateString("_\ud83d\ude00", 2));
+        assertEquals("_\ud83d", StringUtils.truncateString("_\ud83d_", 2));
     }
 
 }

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -843,4 +843,4 @@ submissions explaining cycled assigns separation aimed ababab quotation cleanly 
 xnor bitnand bitcount nand bitnor bitxnor ulshift urshift rotates rotation rotateleft rotateright leaking incomparable
 deref corr asensitive sqlexception avgy avgx lateral rollup syy reseved specifictype classifier sqlcode covar uescape
 ptf overlay precedes regr slope sqlerror multiset submultiset inout sxx sxy intercept sqlwarning tablesample preorder
-orientation eternal consideration erased fedc npgsql powers fffd uencode ampersand noversion
+orientation eternal consideration erased fedc npgsql powers fffd uencode ampersand noversion ude


### PR DESCRIPTION
1. `CURRENT_CATALOG` is now ensured to be not longer than the allowed length of identifiers.

2. `VALUE` is a keyword, but it was used as identifier in documentation somewhere, now non-keywords are used.

3. “Generated columns” term is now used in the documentation everywhere and “computed columns” term is only used as another secondary name.

4. BNF of quoted name is fixed in `help.csv`.

5. Documentation of `INFORMATION_SCHEMA.COLUMNS.IS_GENERATED` is fixed.