### PR TITLE
MVStore.registerVersionUsage() in "non-transactional" DDL flow

### DIFF
--- a/h2/src/main/org/h2/command/ddl/CreateIndex.java
+++ b/h2/src/main/org/h2/command/ddl/CreateIndex.java
@@ -57,9 +57,7 @@ public class CreateIndex extends SchemaCommand {
 
     @Override
     public long update() {
-        if (!transactional) {
-            session.commit(true);
-        }
+        commitIfNonTransactional();
         Database db = session.getDatabase();
         boolean persistent = db.isPersistent();
         Table table = getSchema().findTableOrView(session, tableName);

--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -75,9 +75,7 @@ public class CreateTable extends CommandWithColumns {
         if (!isSessionTemporary) {
             session.getUser().checkSchemaOwner(schema);
         }
-        if (!transactional) {
-            session.commit(true);
-        }
+        commitIfNonTransactional();
         Database db = session.getDatabase();
         if (!db.isPersistent()) {
             data.persistIndexes = false;
@@ -176,9 +174,7 @@ public class CreateTable extends CommandWithColumns {
             try {
                 db.checkPowerOff();
                 db.removeSchemaObject(session, table);
-                if (!transactional) {
-                    session.commit(true);
-                }
+                commitIfNonTransactional();
             } catch (Throwable ex) {
                 e.addSuppressed(ex);
             }

--- a/h2/src/main/org/h2/command/ddl/SchemaCommand.java
+++ b/h2/src/main/org/h2/command/ddl/SchemaCommand.java
@@ -35,4 +35,10 @@ public abstract class SchemaCommand extends DefineCommand {
         return schema;
     }
 
+    protected final void commitIfNonTransactional() {
+        if (!transactional) {
+            session.commit(true);
+            session.startStatementWithinTransaction(null);
+        }
+    }
 }

--- a/h2/src/main/org/h2/command/ddl/SchemaOwnerCommand.java
+++ b/h2/src/main/org/h2/command/ddl/SchemaOwnerCommand.java
@@ -30,9 +30,7 @@ abstract class SchemaOwnerCommand extends SchemaCommand {
     public final long update() {
         Schema schema = getSchema();
         session.getUser().checkSchemaOwner(schema);
-        if (!transactional) {
-            session.commit(true);
-        }
+        commitIfNonTransactional();
         return update(schema);
     }
 


### PR DESCRIPTION
This should fix #2590 
Issue MVStore.registerVersionUsage() right after commit() in "non-transactional" DDL flow.

The problem is that the index re-build (and few others "non-transactional" commands) is running "outside" of normal statement execution path, because those commands do commit() (and therefore MVStore.deregisterVersionUsage()) before they start, but after SessionLocal.startStatementWithinTransaction(). Subsequent updates appear like they do not belong to the statement, and they are not protected with MVStore.registerVersionUsage()/deregisterVersionUsage() pair, which makes them vulnerable.
