### PR TITLE
Pevent "Chunk not found" on LOB operations

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -416,7 +416,6 @@ public final class Database implements DataHandler, CastDataProvider {
                 }
             }
             lobStorage = dbSettings.mvStore ? new LobStorageMap(this) : new LobStorageBackend(this);
-            lobStorage.init();
             systemSession.commit(true);
             trace.info("opened {0}", databaseName);
             if (persistent) {

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -32,7 +32,6 @@ import org.h2.value.Value;
 import org.h2.value.ValueLob;
 import org.h2.value.ValueLobDatabase;
 import org.h2.value.ValueLobInMemory;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * This class stores LOB objects in the database, in maps. This is the back-end

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -320,6 +320,16 @@ public final class LobStorageMap implements LobStorageInterface
                         deregisterVersionUsage(txCounter);
                     }
                 }
+
+                @Override
+                public int read() throws IOException {
+                    MVStore.TxCounter txCounter = initialize();
+                    try {
+                        return super.read();
+                    } finally {
+                        deregisterVersionUsage(txCounter);
+                    }
+                }
             };
         } finally {
             deregisterVersionUsage(txCounter);

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -313,7 +313,7 @@ public final class LobStorageMap implements LobStorageInterface
             InputStream inputStream = streamStore.get(streamStoreId);
             return new FilterInputStream(inputStream) {
                 @Override
-                public int read(@NotNull byte[] b, int off, int len) throws IOException {
+                public int read(byte[] b, int off, int len) throws IOException {
                     MVStore.TxCounter txCounter = initialize();
                     try {
                         return super.read(b, off, len);

--- a/h2/src/main/org/h2/store/LobStorageFrontend.java
+++ b/h2/src/main/org/h2/store/LobStorageFrontend.java
@@ -88,10 +88,4 @@ public class LobStorageFrontend implements LobStorageInterface {
         // to read a block while writing something)
         return ValueLobFile.createTempClob(reader, maxLength, sessionRemote);
     }
-
-    @Override
-    public void init() {
-        // nothing to do
-    }
-
 }

--- a/h2/src/main/org/h2/store/LobStorageInterface.java
+++ b/h2/src/main/org/h2/store/LobStorageInterface.java
@@ -68,15 +68,9 @@ public interface LobStorageInterface {
     void removeAllForTable(int tableId);
 
     /**
-     * Initialize the lob storage.
-     */
-    void init();
-
-    /**
      * Whether the storage is read-only
      *
      * @return true if yes
      */
     boolean isReadOnly();
-
 }

--- a/h2/src/test/org/h2/test/unit/TestValueMemory.java
+++ b/h2/src/test/org/h2/test/unit/TestValueMemory.java
@@ -418,12 +418,5 @@ public class TestValueMemory extends TestBase implements DataHandler {
             // to read a block while writing something)
             return ValueLobFile.createTempClob(reader, maxLength, TestValueMemory.this);
         }
-
-        @Override
-        public void init() {
-            // nothing to do
-        }
-
     }
-
 }


### PR DESCRIPTION
Because LOB operations are performed outside of a transaction framework, they require their own MVStore.registerVersionUsage() / deregisterVersionUsage() calls to protect the acted upon version of MVStore from being garbage-collected.
It suppose to fix #2907.
There is no change to a transactional aspect of LobStorageMap behaviour, this PR just ensure physical integrity of the underlying MVStore.
