### PR TITLE
Unlock meta during query execution in CREATE TABLE AS query

### DIFF
--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -16,6 +16,7 @@ import org.h2.api.ErrorCode;
 import org.h2.command.Prepared;
 import org.h2.command.query.AllColumnsForPlan;
 import org.h2.constraint.Constraint;
+import org.h2.constraint.Constraint.Type;
 import org.h2.engine.CastDataProvider;
 import org.h2.engine.Constants;
 import org.h2.engine.DbObject;
@@ -1234,12 +1235,13 @@ public abstract class Table extends SchemaObject {
      * @param checkExisting true if existing rows must be checked during this
      *            call
      */
-    public void setCheckForeignKeyConstraints(SessionLocal session, boolean enabled,
-            boolean checkExisting) {
+    public void setCheckForeignKeyConstraints(SessionLocal session, boolean enabled, boolean checkExisting) {
         if (enabled && checkExisting) {
             if (constraints != null) {
                 for (Constraint c : constraints) {
-                    c.checkExistingData(session);
+                    if (c.getConstraintType() == Type.REFERENTIAL) {
+                        c.checkExistingData(session);
+                    }
                 }
             }
         }


### PR DESCRIPTION
1. `CREATE TABLE … AS query` without `WITH NO DATA` now unlocks meta before actual execution of a query. If table has identity columns they aren't flushed during query execution, but they are flushed after it under a new short-time meta lock. Fixes #3006 (I hope).
2. `setCheckForeignKeyConstraints()` method doesn't check unrelated constraints any more. It toggles only referential constraints, so the `CHECK` clause should validate only them.