### PR TITLE
Lazy construction / calculation of the current_timestamp

### DIFF
--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -127,9 +127,16 @@ public class DateTimeUtils {
      * @return current timestamp
      */
     public static ValueTimestampTimeZone currentTimestamp(TimeZoneProvider timeZone) {
-        Instant now = Instant.now();
-        long second = now.getEpochSecond();
-        int nano = now.getNano();
+        return timestampWithTimeZone(Instant.now(), timeZone);
+    }
+
+    public static ValueTimestampTimeZone timestampWithTimeZone(long millis, TimeZoneProvider timeZone) {
+        return timestampWithTimeZone(Instant.ofEpochMilli(millis), timeZone);
+    }
+
+    public static ValueTimestampTimeZone timestampWithTimeZone(Instant instant, TimeZoneProvider timeZone) {
+        long second = instant.getEpochSecond();
+        int nano = instant.getNano();
         /*
          * This code intentionally does not support properly dates before UNIX
          * epoch because such support is not required for current dates.


### PR DESCRIPTION
SessionLocal.transactionStart  and SessionLocal.commandStartOrEnd are only used by metadata table and by current_timestamp function for a consistent reference within a transaction / statement. Most of the time it has no use, nevertheless it's initialization as timestamp with timezone is quite expensive.
TestPerformance / TestScalabiliti figures show some tangible performance gains (5-10%), although your actual mileage may and will vary, of course.
