### PR TITLE
Don't evaluate ValueTimestampTimeZone at begin and end of each command

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -30,7 +30,6 @@ import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
 import org.h2.value.Value;
 import org.h2.value.ValueLob;
-import org.h2.value.ValueNull;
 import org.h2.value.VersionedValue;
 
 /**
@@ -362,20 +361,6 @@ public class MVPrimaryIndex extends MVIndex<Long, SearchRow> {
     @Override
     public void addBufferedRows(List<String> bufferNames) {
         throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Search for a specific row or a set of rows.
-     *
-     * @param session the session
-     * @param first the key of the first row
-     * @param last the key of the last row
-     * @return the cursor
-     */
-    Cursor find(SessionLocal session, Value first, Value last) {
-        long from = first == null || first == ValueNull.INSTANCE ? Long.MIN_VALUE : first.getLong();
-        long to = last == null || last == ValueNull.INSTANCE ? Long.MAX_VALUE : last.getLong();
-        return find(session, from, to);
     }
 
     private Cursor find(SessionLocal session, Long first, Long last) {

--- a/h2/src/main/org/h2/util/DateTimeUtils.java
+++ b/h2/src/main/org/h2/util/DateTimeUtils.java
@@ -127,17 +127,29 @@ public class DateTimeUtils {
      * @return current timestamp
      */
     public static ValueTimestampTimeZone currentTimestamp(TimeZoneProvider timeZone) {
-        Instant now = Instant.now();
-        long second = now.getEpochSecond();
-        int nano = now.getNano();
+        return currentTimestamp(timeZone, Instant.now());
+    }
+
+    /**
+     * Returns current timestamp using the specified instant for its value.
+     *
+     * @param timeZone
+     *            the time zone
+     * @param now
+     *            timestamp source, must be greater than or equal to
+     *            1970-01-01T00:00:00Z
+     * @return current timestamp
+     */
+    public static ValueTimestampTimeZone currentTimestamp(TimeZoneProvider timeZone, Instant now) {
         /*
          * This code intentionally does not support properly dates before UNIX
          * epoch because such support is not required for current dates.
          */
+        long second = now.getEpochSecond();
         int offset = timeZone.getTimeZoneOffsetUTC(second);
         second += offset;
         return ValueTimestampTimeZone.fromDateValueAndNanos(dateValueFromAbsoluteDay(second / SECONDS_PER_DAY),
-                second % SECONDS_PER_DAY * 1_000_000_000 + nano, offset);
+                second % SECONDS_PER_DAY * 1_000_000_000 + now.getNano(), offset);
     }
 
     /**


### PR DESCRIPTION
This PR addresses the same issue as #3032, but it preserves maximum available resolution of `CURRENT_TIMESTAMP`, `LOCALTIMESTAMP`, `CURRENT_TIME` and `LOCALTIME`. It is 6 or more digits depending on OS since Java 9.

All 5 datetime value functions (four mentioned + `CURRENT_DATE`) now always use new `SessionLocal.currentTimestamp` field of type `ValueTimestampTimeZone`. This field is initialized only on demand. This field is set to `null` at the end of transaction and at the end of each command if and only if compatibility mode requires that. `SET TIME ZONE` moves the value of this field, if any, to the target time zone, but preserves its absolute UTC value.

`transactionStart` is removed. This field didn't represent the real start of transaction. It was only used for these functions, so it was confusing.

`commandStartOrEnd` is converted to `java.time.Instant`. It is now set in the constructor of the session to avoid null checks in other methods; it doesn't perform additional calls because session preserves its start time in `sessionStart` anyway. It is still updated before and after execution of each command, but `Instant.now` is faster than initialization of `ValueTimestampTimeZone`. This value is now only used for JMX and meta tables. Datetime value functions don't use it any more to avoid unnecessary conditional code.

Dummy loop with `SELECT 1` in the same prepared statement and iteration over result now takes 940 nanoseconds instead of 1100 on my system. My time zone has transitions only in the past, so in some time zones with pending DST transitions this improvement should be slightly larger, because they are slower.

For real useful queries these 160 nanoseconds per call most likely will not affect execution time in any noticeable way, so this change is mostly for synthetic tests.

`commandStartOrEnd` now can be converted to `long`, but it will give much smaller performance improvements and will make this field less readable in debugger.