### PR TITLE
Remove duplicate method IOUtils.getBufferedReader

### DIFF
--- a/h2/src/main/org/h2/tools/ConvertTraceFile.java
+++ b/h2/src/main/org/h2/tools/ConvertTraceFile.java
@@ -107,7 +107,7 @@ public class ConvertTraceFile extends Tool {
     private void convertFile(String traceFileName, String javaClassName,
             String script) throws IOException {
         LineNumberReader reader = new LineNumberReader(
-                IOUtils.getBufferedReader(
+                IOUtils.getReader(
                 FileUtils.newInputStream(traceFileName)));
         PrintWriter javaWriter = new PrintWriter(
                 IOUtils.getBufferedWriter(

--- a/h2/src/main/org/h2/util/IOUtils.java
+++ b/h2/src/main/org/h2/util/IOUtils.java
@@ -323,20 +323,6 @@ public class IOUtils {
     }
 
     /**
-     * Create a buffered reader to read from an input stream using the UTF-8
-     * format. If the input stream is null, this method returns null. The
-     * InputStreamReader that is used here is not exact, that means it may read
-     * some additional bytes when buffering.
-     *
-     * @param in the input stream or null
-     * @return the reader
-     */
-    public static Reader getBufferedReader(InputStream in) {
-        return in == null ? null : new BufferedReader(
-                new InputStreamReader(in, StandardCharsets.UTF_8));
-    }
-
-    /**
      * Create a reader to read from an input stream using the UTF-8 format. If
      * the input stream is null, this method returns null. The InputStreamReader
      * that is used here is not exact, that means it may read some additional

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -267,7 +267,7 @@ public abstract class ValueLob extends Value {
 
     @Override
     public Reader getReader() {
-        return IOUtils.getBufferedReader(getInputStream());
+        return IOUtils.getReader(getInputStream());
     }
 
     @Override

--- a/h2/src/test/org/h2/test/unit/TestReader.java
+++ b/h2/src/test/org/h2/test/unit/TestReader.java
@@ -35,7 +35,7 @@ public class TestReader extends TestBase {
         InputStream in = new ReaderInputStream(r);
         byte[] buff = IOUtils.readBytesAndClose(in, 0);
         InputStream in2 = new ByteArrayInputStream(buff);
-        Reader r2 = IOUtils.getBufferedReader(in2);
+        Reader r2 = IOUtils.getReader(in2);
         String s2 = IOUtils.readStringAndClose(r2, Integer.MAX_VALUE);
         assertEquals(s, s2);
     }


### PR DESCRIPTION
IOUtils.getReader and IOUtils.getBufferedReader have the same implementation
Delete getBufferedReader in favor of shorter getReader