### PR TITLE
CacheLongKeyLIRS concurrency improvements

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1897,6 +1897,10 @@ public final class Database implements DataHandler, CastDataProvider {
         return traceSystem;
     }
 
+    public int getCacheSize() {
+        return cacheSize;
+    }
+
     public synchronized void setCacheSize(int kb) {
         if (starting) {
             int max = MathUtils.convertLongToInt(Utils.getMemoryMax()) / 2;

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -8,6 +8,7 @@ package org.h2.engine;
 import java.util.HashMap;
 
 import org.h2.api.ErrorCode;
+import org.h2.util.Utils;
 import org.h2.message.DbException;
 
 /**
@@ -305,6 +306,26 @@ public class DbSettings extends SettingsBase {
      * Compress data when storing.
      */
     public final boolean compressData = get("COMPRESS", false);
+
+    /**
+     * Database setting <code>CACHE_CONCURRENCY</code>
+     * (default: 16).<br />
+     * Set the read cache concurrency.
+     */
+    public final int cacheConcurrency = get("CACHE_CONCURRENCY", 16);
+
+    /**
+     * Database setting <code>AUTO_COMMIT_BUFFER_SIZE_KB</code>
+     * (default: depends on max heap).<br />
+     * Set the size of the write buffer, in KB disk space (for file-based
+     * stores). Unless auto-commit is disabled, changes are automatically
+     * saved if there are more than this amount of changes.
+     *
+     * When the value is set to 0 or lower, data is not automatically
+     * stored.
+     */
+    public final int autoCommitBufferSize = get("AUTO_COMMIT_BUFFER_SIZE_KB",
+        Math.max(1, Math.min(19, Utils.scaleForAvailableMemory(64))) * 1024);
 
     /**
      * Database setting <code>IGNORE_CATALOGS</code>

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -8,6 +8,7 @@ package org.h2.mvstore.cache;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -64,7 +64,7 @@ public class CacheLongKeyLIRS<V> {
     /*
      * Used as null value for ConcurrentSkipListSet
      */
-    private static final Entry<V> ENTRY_NULL = new Entry<>();
+    private final Entry<V> ENTRY_NULL = new Entry<>();
 
     /**
      * Create a new cache with the given memory size.

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -733,7 +733,8 @@ public class CacheLongKeyLIRS<V> {
         V get(Entry<V> e) {
             V value = e == null ? null : e.getValue();
             if (!l.tryLock()) {
-                concAccess.add(value == null ? ENTRY_NULL : e);
+                Entry<V> e2 = value == null ? ENTRY_NULL : e;
+                concAccess.add(e2);
                 return value;
             }
             try {

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -496,7 +496,7 @@ public class CacheLongKeyLIRS<V> {
     public void trimNonResidentQueue() {
         for (Segment<V> s : segments) {
             s.withLock(() -> {
-                s.trimNonResidentQueue();
+                return s.trimNonResidentQueue();
             });
         }
     }
@@ -664,7 +664,7 @@ public class CacheLongKeyLIRS<V> {
             this(old.maxMemory, old.stackMoveDistance, len,
                     old.nonResidentQueueSize, old.nonResidentQueueSizeHigh);
             hits = old.hits;
-            misses.set(old.misses);
+            misses.set(old.misses.get());
             Entry<V> s = old.stack.stackPrev;
             while (s != old.stack) {
                 Entry<V> e = new Entry<>(s);

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -6,6 +6,7 @@
 package org.h2.mvstore.cache;
 
 import java.lang.ref.WeakReference;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.atomic.AtomicLong;

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -6,6 +6,8 @@
 package org.h2.mvstore.cache;
 
 import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,6 +60,11 @@ public class CacheLongKeyLIRS<V> {
     private final int stackMoveDistance;
     private final int nonResidentQueueSize;
     private final int nonResidentQueueSizeHigh;
+
+    /*
+     * Used as null value for ConcurrentSkipListSet
+     */
+    private static final Entry<V> ENTRY_NULL = new Entry<>();
 
     /**
      * Create a new cache with the given memory size.
@@ -602,6 +609,16 @@ public class CacheLongKeyLIRS<V> {
          */
         private int stackMoveCounter;
 
+        /*
+         * Holds entries that were concurrently get()
+         */
+        private final ConcurrentSkipListSet<Entry<V>> concAccess;
+
+        /*
+         * Serialize access to this segments
+         */
+        private final ReentrantLock l;
+
         /**
          * Create a new cache segment.
          *  @param maxMemory the maximum memory to use
@@ -632,6 +649,9 @@ public class CacheLongKeyLIRS<V> {
             @SuppressWarnings("unchecked")
             Entry<V>[] e = new Entry[len];
             entries = e;
+
+            concAccess = new ConcurrentSkipListSet<>();
+            l = new ReentrantLock();
         }
 
         /**
@@ -710,17 +730,41 @@ public class CacheLongKeyLIRS<V> {
          * @param e the entry
          * @return the value, or null if there is no resident entry
          */
-        synchronized V get(Entry<V> e) {
+        V get(Entry<V> e) {
             V value = e == null ? null : e.getValue();
-            if (value == null) {
-                // the entry was not found
-                // or it was a non-resident entry
-                misses++;
-            } else {
-                access(e);
-                hits++;
+            if (!l.tryLock()) {
+                concAccess.add(value == null ? ENTRY_NULL : e);
+                return value;
             }
-            return value;
+            try {
+                if (value == null) {
+                    // the entry was not found
+                    // or it was a non-resident entry
+                    misses++;
+                } else {
+                    access(e);
+                    hits++;
+                }
+
+                // process entries that were accessed concurrently
+                while (true) {
+                    Entry<V> p = concAccess.pollFirst();
+                    if (p == null) {
+                        break;
+                    }
+                    if (p == ENTRY_NULL) {
+                        misses++;
+                    } else {
+                        access(p);
+                        hits++;
+                    }
+                }
+
+                return value;
+            }
+            finally {
+                l.unlock();
+            }
         }
 
         /**
@@ -749,9 +793,8 @@ public class CacheLongKeyLIRS<V> {
                 V v = e.getValue();
                 if (v != null) {
                     removeFromQueue(e);
-                    if (e.reference != null) {
+                    if (e.value == null) {
                         e.value = v;
-                        e.reference = null;
                         usedMemory += e.memory;
                     }
                     if (e.stackNext != null) {
@@ -787,7 +830,17 @@ public class CacheLongKeyLIRS<V> {
          * @param memory the memory used for the given entry
          * @return the old value, or null if there was no resident entry
          */
-        synchronized V put(long key, int hash, V value, int memory) {
+        V put(long key, int hash, V value, int memory) {
+            l.lock();
+            try {
+                return putUnlocked(key, hash, value, memory);
+            }
+            finally {
+                l.unlock();
+            }
+        }
+
+        private V putUnlocked(long key, int hash, V value, int memory) {
             Entry<V> e = find(key, hash);
             boolean existed = e != null;
             V old = null;
@@ -832,7 +885,17 @@ public class CacheLongKeyLIRS<V> {
          * @param hash the hash
          * @return the old value, or null if there was no resident entry
          */
-        synchronized V remove(long key, int hash) {
+        V remove(long key, int hash) {
+            l.lock();
+            try {
+                return removeUnlocked(key, hash);
+            }
+            finally {
+                l.unlock();
+            }
+        }
+
+        private V removeUnlocked(long key, int hash) {
             int index = hash & mask;
             Entry<V> e = entries[index];
             if (e == null) {
@@ -897,7 +960,6 @@ public class CacheLongKeyLIRS<V> {
                 Entry<V> e = queue.queuePrev;
                 usedMemory -= e.memory;
                 removeFromQueue(e);
-                e.reference = new WeakReference<>(e.value);
                 e.value = null;
                 addToQueue(queue2, e);
                 // the size of the non-resident-cold entries needs to be limited
@@ -1031,7 +1093,17 @@ public class CacheLongKeyLIRS<V> {
          * @param nonResident true for non-resident entries
          * @return the key list
          */
-        synchronized List<Long> keys(boolean cold, boolean nonResident) {
+        List<Long> keys(boolean cold, boolean nonResident) {
+            l.lock();
+            try {
+                return keysUnlocked(cold, nonResident);
+            }
+            finally {
+                l.unlock();
+            }
+        }
+
+        private List<Long> keysUnlocked(boolean cold, boolean nonResident) {
             ArrayList<Long> keys = new ArrayList<>();
             if (cold) {
                 Entry<V> start = nonResident ? queue2 : queue;
@@ -1053,7 +1125,17 @@ public class CacheLongKeyLIRS<V> {
          *
          * @return the set of keys
          */
-        synchronized Set<Long> keySet() {
+        Set<Long> keySet() {
+            l.lock();
+            try {
+                return keySetUnlocked();
+            }
+            finally {
+                l.unlock();
+            }
+        }
+
+        private Set<Long> keySetUnlocked() {
             HashSet<Long> set = new HashSet<>();
             for (Entry<V> e = stack.stackNext; e != stack; e = e.stackNext) {
                 set.add(e.key);
@@ -1086,7 +1168,7 @@ public class CacheLongKeyLIRS<V> {
      *
      * @param <V> the value type
      */
-    static class Entry<V> {
+    static class Entry<V> implements Comparable<Entry<V>> {
 
         /**
          * The key.
@@ -1148,10 +1230,15 @@ public class CacheLongKeyLIRS<V> {
             this.key = key;
             this.memory = memory;
             this.value = value;
+            if (value != null) {
+                this.reference = new WeakReference<>(value);
+            }
         }
 
         Entry(Entry<V> old) {
-            this(old.key, old.value, old.memory);
+            this.key = old.key;
+            this.memory = old.memory;
+            this.value = old.value;
             this.reference = old.reference;
             this.topMove = old.topMove;
         }
@@ -1166,11 +1253,16 @@ public class CacheLongKeyLIRS<V> {
         }
 
         V getValue() {
-            return value == null ? reference.get() : value;
+            final V v = value;
+            return v == null ? reference.get() : v;
         }
 
         int getMemory() {
             return value == null ? 0 : memory;
+        }
+
+        public int compareTo(Entry<V> tgt) {
+            return key == tgt.key ? 0 : key < tgt.key ? -1 : 1;
         }
     }
 

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -1140,7 +1140,7 @@ public class CacheLongKeyLIRS<V> {
         }
         
         
-        T withLock(Callable<T> c) {
+        <T> T withLock(Callable<T> c) {
             l.lock();
             try {
                 return c.call();

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -167,8 +167,8 @@ public class CacheLongKeyLIRS<V> {
         // from the old segment)
         s.l.lock();
         try {
-            s = resizeIfNeeded(s, segmentIndex);
-            return s.put(key, hash, value, memory);
+            Segment<V> s2 = s = resizeIfNeeded(s, segmentIndex);
+            return s2.put(key, hash, value, memory);
         }
         finally {
             s.l.unlock();
@@ -218,8 +218,8 @@ public class CacheLongKeyLIRS<V> {
         // from the old segment)
         s.l.lock();
         try {
-            s = resizeIfNeeded(s, segmentIndex);
-            return s.remove(key, hash);
+            Segment<V> s2 = resizeIfNeeded(s, segmentIndex);
+            return s2.remove(key, hash);
         }
         finally {
             s.l.unlock();

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -167,7 +167,7 @@ public class CacheLongKeyLIRS<V> {
         // from the old segment)
         s.l.lock();
         try {
-            s = resizeIfNeeded(s, segmentIndex)
+            s = resizeIfNeeded(s, segmentIndex);
             return s.put(key, hash, value, memory);
         }
         finally {
@@ -218,7 +218,7 @@ public class CacheLongKeyLIRS<V> {
         // from the old segment)
         s.l.lock();
         try {
-            s = resizeIfNeeded(s, segmentIndex)
+            s = resizeIfNeeded(s, segmentIndex);
             return s.remove(key, hash);
         }
         finally {

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -61,11 +61,6 @@ public class CacheLongKeyLIRS<V> {
     private final int nonResidentQueueSize;
     private final int nonResidentQueueSizeHigh;
 
-    /*
-     * Used as null value for ConcurrentSkipListSet
-     */
-    private final Entry<V> ENTRY_NULL = new Entry<>();
-
     /**
      * Create a new cache with the given memory size.
      *
@@ -618,6 +613,11 @@ public class CacheLongKeyLIRS<V> {
          * Serialize access to this segments
          */
         private final ReentrantLock l;
+
+        /*
+         * Used as null value for ConcurrentSkipListSet
+         */
+        private final Entry<V> ENTRY_NULL = new Entry<>();
 
         /**
          * Create a new cache segment.

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -496,7 +496,8 @@ public class CacheLongKeyLIRS<V> {
     public void trimNonResidentQueue() {
         for (Segment<V> s : segments) {
             s.withLock(() -> {
-                return s.trimNonResidentQueue();
+                s.trimNonResidentQueue();
+                return null;
             });
         }
     }

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -6,10 +6,10 @@
 package org.h2.mvstore.cache;
 
 import java.lang.ref.WeakReference;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -166,8 +166,7 @@ public class CacheLongKeyLIRS<V> {
         // concurrent resizes (concurrent reads read
         // from the old segment)
         return s.withLock(() -> {
-            s = resizeIfNeeded(s, segmentIndex);
-            return s.put(key, hash, value, memory);
+            return resizeIfNeeded(s, segmentIndex).put(key, hash, value, memory);
         });
     }
 
@@ -213,8 +212,7 @@ public class CacheLongKeyLIRS<V> {
         // concurrent resizes (concurrent reads read
         // from the old segment)
         return s.withLock(() -> {
-            s = resizeIfNeeded(s, segmentIndex);
-            return s.remove(key, hash);
+            return resizeIfNeeded(s, segmentIndex).remove(key, hash);
         });
     }
 
@@ -1141,10 +1139,10 @@ public class CacheLongKeyLIRS<V> {
         }
         
         
-        <T> T withLock(Callable<T> c) {
+        <T> T withLock(Supplier<T> c) {
             l.lock();
             try {
-                return c.call();
+                return c.get();
             }
             finally {
                 l.unlock();

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -166,7 +166,7 @@ public class CacheLongKeyLIRS<V> {
         return s.withLock(() -> {
             s = resizeIfNeeded(s, segmentIndex);
             return s.put(key, hash, value, memory);
-        })
+        });
     }
 
     private Segment<V> resizeIfNeeded(Segment<V> s, int segmentIndex) {
@@ -213,7 +213,7 @@ public class CacheLongKeyLIRS<V> {
         return s.withLock(() -> {
             s = resizeIfNeeded(s, segmentIndex);
             return s.remove(key, hash);
-        })
+        });
     }
 
     /**
@@ -495,7 +495,7 @@ public class CacheLongKeyLIRS<V> {
         for (Segment<V> s : segments) {
             s.withLock(() -> {
                 s.trimNonResidentQueue();
-            })
+            });
         }
     }
 

--- a/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
+++ b/h2/src/main/org/h2/mvstore/cache/CacheLongKeyLIRS.java
@@ -167,7 +167,7 @@ public class CacheLongKeyLIRS<V> {
         // from the old segment)
         s.l.lock();
         try {
-            Segment<V> s2 = s = resizeIfNeeded(s, segmentIndex);
+            Segment<V> s2 = resizeIfNeeded(s, segmentIndex);
             return s2.put(key, hash, value, memory);
         }
         finally {

--- a/h2/src/main/org/h2/mvstore/db/Store.java
+++ b/h2/src/main/org/h2/mvstore/db/Store.java
@@ -126,6 +126,7 @@ public final class Store {
 
             builder.cacheConcurrency(db.getSettings().cacheConcurrency);
             builder.autoCommitBufferSize(db.getSettings().autoCommitBufferSize);
+            builder.cacheSize(db.getCacheSize());
         }
         this.encrypted = encrypted;
         try {

--- a/h2/src/main/org/h2/mvstore/db/Store.java
+++ b/h2/src/main/org/h2/mvstore/db/Store.java
@@ -123,6 +123,9 @@ public final class Store {
             // otherwise background thread would compete for store lock
             // with maps opening procedure
             builder.autoCommitDisabled();
+
+            builder.cacheConcurrency(db.getSettings().cacheConcurrency);
+            builder.autoCommitBufferSize(db.getSettings().autoCommitBufferSize);
         }
         this.encrypted = encrypted;
         try {


### PR DESCRIPTION
We've strike into significant concurrency limitation in a condition with large number of threads (60 threads) + empty database. 

Looks like it happens because all threads read the same index which is small. And most of the time threads were blocked on CacheLongKeyLIRS.Segment.get() method (since is synchronized). 

This degradation persists until this index is small and slowly improved with db growth (several hours in our case).