### PR TITLE
improve shutdown perf with lots of LOBs

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -314,8 +314,8 @@ public final class LobStorageMap implements LobStorageInterface
         MVStore.TxCounter txCounter = mvStore.registerVersionUsage();
         try {
             ArrayList<Long> list = new ArrayList<>();
-            Long startKey = Long.valueOf(tableId << 48);
-            Long endKey = Long.valueOf((tableId + 1) << 48);
+            long startKey = ((long)tableId) << 48;
+            long endKey = ((long)(tableId + 1)) << 48;
             final Cursor<Long, byte[]> cursor = lobMap.cursor(startKey, endKey, false);
             while (cursor.hasNext()) {
                 Long lobId = cursor.next();

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -110,7 +110,7 @@ public final class LobStorageMap implements LobStorageInterface
                             trace("lob " + tableIdAndlobId + " lastUsedKey=" + lastUsedKey);
                         }
                     }
-                    long lobId = Math.abs(maxLobUniqueId & 0xffffffffffffL); // remove the tableId in the top 16-bits
+                    long lobId = Math.abs(tableIdAndlobId & 0xffffffffffffL); // remove the tableId in the top 16-bits
                     maxLobUniqueId = Math.max(lobId, maxLobUniqueId);
                 }
                 nextLobUniqueId.set(maxLobUniqueId + 1);

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -661,17 +661,16 @@ public class Recover extends Tool implements DataHandler {
         }
         MVMap<Long, byte[]> lobData = mv.openMap("lobData");
         StreamStore streamStore = new StreamStore(lobData);
-        MVMap<Long, Object[]> lobMap = mv.openMap("lobMap");
+        MVMap<Long, byte[]> lobMap = mv.openMap("lobMap");
         writer.println("-- LOB");
         writer.println("CREATE TABLE IF NOT EXISTS " +
                 "INFORMATION_SCHEMA.LOB_BLOCKS(" +
                 "LOB_ID BIGINT, SEQ INT, DATA VARBINARY, " +
                 "PRIMARY KEY(LOB_ID, SEQ));");
         boolean hasErrors = false;
-        for (Entry<Long, Object[]> e : lobMap.entrySet()) {
+        for (Entry<Long, byte[]> e : lobMap.entrySet()) {
             long lobId = e.getKey();
-            Object[] value = e.getValue();
-            byte[] streamStoreId = (byte[]) value[0];
+            byte[] streamStoreId = e.getValue();
             InputStream in = streamStore.get(streamStoreId);
             int len = 8 * 1024;
             byte[] block = new byte[len];
@@ -699,8 +698,7 @@ public class Recover extends Tool implements DataHandler {
         if (hasErrors) {
             writer.println("-- lobMap");
             for (Long k : lobMap.keyList()) {
-                Object[] value = lobMap.get(k);
-                byte[] streamStoreId = (byte[]) value[0];
+                byte[] streamStoreId = lobMap.get(k);
                 writer.println("--     " + k + " " + StreamStore.toString(streamStoreId));
             }
             writer.println("-- lobData");

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -61,9 +61,8 @@ public class TestLob extends TestDb {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-//        test.config.big = true;
-        test.config.mvStore = true;
-        test.config.memory = false;
+        test.config.big = true;
+        test.config.mvStore = false;
         test.testFromMain();
     }
 

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -61,8 +61,9 @@ public class TestLob extends TestDb {
      */
     public static void main(String... a) throws Exception {
         TestBase test = TestBase.createCaller().init();
-        test.config.big = true;
-        test.config.mvStore = false;
+//        test.config.big = true;
+        test.config.mvStore = true;
+        test.config.memory = false;
         test.testFromMain();
     }
 


### PR DESCRIPTION
by changing the structure of the lobMap, and encoding the tableId in the lobId.
This lets us perform a very limited range scan when we need to do cleanup.

This is related to
  Very high DB opening/closing times (#3066)