### PR TITLE
src/main/org/h2/engine/Engine.java

### DIFF
--- a/h2/.vscode/settings.json
+++ b/h2/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "maven.view": "hierarchical"
+}

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -8,6 +8,9 @@ package org.h2.engine;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import javax.management.monitor.Monitor;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.command.dml.SetTypes;
@@ -367,7 +370,8 @@ public final class Engine {
                     // an attacker can't know how long it will be
                     delay = MathUtils.secureRandomInt((int) delay);
                     try {
-                        Thread.sleep(delay);
+//                        Thread.sleep(delay);
+                    	Engine.class.wait(delay);
                     } catch (InterruptedException e) {
                         // ignore
                     }
@@ -391,7 +395,8 @@ public final class Engine {
                     // a bit more to protect against timing attacks
                     delay += Math.abs(MathUtils.secureRandomLong() % 100);
                     try {
-                        Thread.sleep(delay);
+//                        Thread.sleep(delay);
+                        Engine.class.wait(delay);
                     } catch (InterruptedException e) {
                         // ignore
                     }


### PR DESCRIPTION
I have replaced the call to "Thread.sleep(...)" with a call to "wait(...)" due to the fact that this instruction was inside a synchronised block and therefore an object.wait(x) is needed instead of the Thread.sleep(x).
It has been replaced twice inside the Engine.java class.