### PR TITLE
Blob space reclamation on rollback of in-doubt transactions

### DIFF
--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -728,7 +728,6 @@ public class SessionLocal extends Session implements TransactionStore.RollbackLi
     }
 
     private void removeTemporaryLobs(boolean onTimeout) {
-        assert this != database.getLobSession() || Thread.holdsLock(this) || Thread.holdsLock(database);
         if (temporaryLobs != null) {
             for (ValueLob v : temporaryLobs) {
                 if (!v.isLinkedToTable()) {
@@ -1917,7 +1916,6 @@ public class SessionLocal extends Session implements TransactionStore.RollbackLi
         Row result;
         if(value instanceof Row) {
             result = (Row) value;
-            assert result.getKey() == recKey : result.getKey() + " != " + recKey;
         } else {
             result = table.createRow(((ValueArray) value).getList(), 0, recKey);
         }

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -175,12 +175,16 @@ public class TransactionStore {
         return store.openMap(TYPE_REGISTRY_NAME, typeRegistryBuilder);
     }
 
+    public void init() {
+        init(ROLLBACK_LISTENER_NONE);
+    }
+
     /**
      * Initialize the store. This is needed before a transaction can be opened.
      * If the transaction store is corrupt, this method can throw an exception,
      * in which case the store can only be used for reading.
      */
-    public void init() {
+    public void init(RollbackListener listener) {
         if (!init) {
             for (String mapName : store.getMapNames()) {
                 if (mapName.startsWith(UNDO_LOG_NAME_PREFIX)) {
@@ -225,7 +229,7 @@ public class TransactionStore {
                                     logId = lastUndoKey == null ? 0 : getLogId(lastUndoKey) + 1;
                                 }
                                 registerTransaction(transactionId, status, name, logId, timeoutMillis, 0,
-                                        IsolationLevel.READ_COMMITTED, ROLLBACK_LISTENER_NONE);
+                                        IsolationLevel.READ_COMMITTED, listener);
                                 continue;
                             }
                         }

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -134,7 +134,7 @@ public class TestLob extends TestDb {
     }
 
     private void testReclamationOnInDoubtRollback() throws Exception {
-        if (config.memory) {
+        if (config.memory || config.cipher != null) {
             return;
         }
         deleteDb("lob");


### PR DESCRIPTION
Fixes #3036 
Because in-doubt transactions are not owned by any particular session, which usually takes care of a blob space reclamation during rollback, space leak was occurring in such scenario.
This PR assigns those transactions to a dedicated blobSession.