### PR TITLE
Stronly typed LlobStorageMap

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -1257,11 +1257,15 @@ public class MVMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V
                             K[] keys = p.createKeyStorage(keyCount);
                             V[] values = p.createValueStorage(keyCount);
                             System.arraycopy(keysBuffer, available, keys, 0, keyCount);
-                            System.arraycopy(valuesBuffer, available, values, 0, keyCount);
+                            if (valuesBuffer != null) {
+                                System.arraycopy(valuesBuffer, available, values, 0, keyCount);
+                            }
                             page = Page.createLeaf(this, keys, values, 0);
                         } else {
                             System.arraycopy(keysBuffer, available, keysBuffer, 0, keyCount);
-                            System.arraycopy(valuesBuffer, available, valuesBuffer, 0, keyCount);
+                            if (valuesBuffer != null) {
+                                System.arraycopy(valuesBuffer, available, valuesBuffer, 0, keyCount);
+                            }
                             remainingBuffer = keyCount;
                         }
                     }
@@ -1269,7 +1273,7 @@ public class MVMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V
                     tip = tip.parent;
                     page = Page.createLeaf(this,
                             Arrays.copyOf(keysBuffer, keyCount),
-                            Arrays.copyOf(valuesBuffer, keyCount),
+                            valuesBuffer == null ? null : Arrays.copyOf(valuesBuffer, keyCount),
                             0);
                 }
 
@@ -1373,7 +1377,9 @@ public class MVMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V
                     assert appendCounter < keysPerPage;
                 }
                 keysBuffer[appendCounter] = key;
-                valuesBuffer[appendCounter] = value;
+                if (valuesBuffer != null) {
+                    valuesBuffer[appendCounter] = value;
+                }
                 ++appendCounter;
             } finally {
                 unlockRoot(appendCounter);

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -1456,7 +1456,7 @@ public abstract class Page<K,V> implements Cloneable {
 
         @Override
         public V getValue(int index) {
-            return values[index];
+            return values == null ? null : values[index];
         }
 
         @Override
@@ -1617,7 +1617,7 @@ public abstract class Page<K,V> implements Cloneable {
         protected int calculateMemory() {
 //*
             return super.calculateMemory() + PAGE_LEAF_MEMORY +
-                        map.evaluateMemoryForValues(values, getKeyCount());
+                    (values == null ? 0 : map.evaluateMemoryForValues(values, getKeyCount()));
 /*/
             int keyCount = getKeyCount();
             int mem = super.calculateMemory() + PAGE_LEAF_MEMORY + keyCount * MEMORY_POINTER;

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -9,9 +9,11 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
@@ -22,6 +24,9 @@ import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.StreamStore;
+import org.h2.mvstore.WriteBuffer;
+import org.h2.mvstore.type.BasicDataType;
+import org.h2.mvstore.type.LongDataType;
 import org.h2.store.CountingReaderInputStream;
 import org.h2.store.LobStorageFrontend;
 import org.h2.store.LobStorageInterface;
@@ -32,6 +37,7 @@ import org.h2.value.Value;
 import org.h2.value.ValueBlob;
 import org.h2.value.ValueClob;
 import org.h2.value.ValueLob;
+import org.h2.value.ValueNull;
 import org.h2.value.lob.LobData;
 import org.h2.value.lob.LobDataDatabase;
 
@@ -49,13 +55,9 @@ public final class LobStorageMap implements LobStorageInterface
 
     /**
      * The lob metadata map. It contains the mapping from the lob id
-     * (which is a long) to the stream store id (which is a byte array).
-     *
-     * Key: lobId (long)
-     * Value: { streamStoreId (byte[]), tableId (int),
-     *          byteCount (long), hash (long) }.
+     * (which is a long) to the blob metadata, including stream store id (which is a byte array).
      */
-    private final MVMap<Long, Object[]> lobMap;
+    private final MVMap<Long, BlobMeta> lobMap;
 
     /**
      * The lob metadata map for temporary lobs. It contains the mapping from the lob id
@@ -70,14 +72,14 @@ public final class LobStorageMap implements LobStorageInterface
      * The reference map. It is used to remove data from the stream store: if no
      * more entries for the given streamStoreId exist, the data is removed from
      * the stream store.
-     *
-     * Key: { streamStoreId (byte[]), lobId (long) }.
-     * Value: true (boolean).
      */
-    private final MVMap<Object[], Boolean> refMap;
+    private final MVMap<BlobReference,Value> refMap;
 
     private final StreamStore streamStore;
 
+    private static MVMap<Long, BlobMeta> openLobMap(MVStore mv) {
+        return mv.openMap("lobMap", new MVMap.Builder<Long, BlobMeta>().keyType(LongDataType.INSTANCE).valueType(BlobMeta.Type.INSTANCE));
+    }
 
     public LobStorageMap(Database database) {
         this.database = database;
@@ -90,9 +92,9 @@ public final class LobStorageMap implements LobStorageInterface
         }
         MVStore.TxCounter txCounter = mvStore.registerVersionUsage();
         try {
-            lobMap = mvStore.openMap("lobMap");
+            lobMap = openLobMap(mvStore);
             tempLobMap = mvStore.openMap("tempLobMap");
-            refMap = mvStore.openMap("lobRef");
+            refMap = mvStore.openMap("lobRef", new MVMap.Builder<BlobReference,Value>().keyType(BlobReference.Type.INSTANCE).valueType(NullValueDataType.INSTANCE));
 
             /* The stream store data map.
              *
@@ -128,7 +130,6 @@ public final class LobStorageMap implements LobStorageInterface
     @Override
     public ValueBlob createBlob(InputStream in, long maxLength) {
         MVStore.TxCounter txCounter = mvStore.registerVersionUsage();
-        int type = Value.BLOB;
         try {
             if (maxLength != -1
                     && maxLength <= database.getMaxLengthInplaceLob()) {
@@ -146,7 +147,7 @@ public final class LobStorageMap implements LobStorageInterface
             if (maxLength != -1) {
                 in = new RangeInputStream(in, 0L, maxLength);
             }
-            return createBlob(in, type);
+            return createBlob(in);
         } catch (IllegalStateException e) {
             throw DbException.get(ErrorCode.OBJECT_CLOSED, e);
         } catch (IOException e) {
@@ -159,7 +160,6 @@ public final class LobStorageMap implements LobStorageInterface
     @Override
     public ValueClob createClob(Reader reader, long maxLength) {
         MVStore.TxCounter txCounter = mvStore.registerVersionUsage();
-        int type = Value.CLOB;
         try {
             // we multiple by 3 here to get the worst-case size in bytes
             if (maxLength != -1
@@ -184,7 +184,7 @@ public final class LobStorageMap implements LobStorageInterface
             }
             CountingReaderInputStream in = new CountingReaderInputStream(reader, maxLength);
             // Don't inline
-            LobData lobData = createBlob(in, type).getLobData();
+            LobData lobData = createBlob(in).getLobData();
             return new ValueClob(in.getLength(), lobData);
         } catch (IllegalStateException e) {
             throw DbException.get(ErrorCode.OBJECT_CLOSED, e);
@@ -195,7 +195,7 @@ public final class LobStorageMap implements LobStorageInterface
         }
     }
 
-    private ValueBlob createBlob(InputStream in, int type) throws IOException {
+    private ValueBlob createBlob(InputStream in) throws IOException {
         byte[] streamStoreId;
         try {
             streamStoreId = streamStore.put(in);
@@ -206,8 +206,8 @@ public final class LobStorageMap implements LobStorageInterface
         long length = streamStore.length(streamStoreId);
         final int tableId = LobStorageFrontend.TABLE_TEMP;
         tempLobMap.put(lobId, streamStoreId);
-        Object[] key = { streamStoreId, lobId };
-        refMap.put(key, Boolean.TRUE);
+        BlobReference key = new BlobReference(streamStoreId, lobId);
+        refMap.put(key, ValueNull.INSTANCE);
         ValueBlob lob =  new ValueBlob(length, new LobDataDatabase(database, tableId, lobId));
         if (TRACE) {
             trace("create " + tableId + "/" + lobId);
@@ -240,19 +240,19 @@ public final class LobStorageMap implements LobStorageInterface
             if (isTemporaryLob(lobData.getTableId())) {
                 streamStoreId = tempLobMap.get(oldLobId);
             } else {
-                Object[] value = lobMap.get(oldLobId);
-                streamStoreId = (byte[]) value[0];
+                BlobMeta value = lobMap.get(oldLobId);
+                streamStoreId = value.streamStoreId;
             }
             // create destination lob
             final long newLobId = generateLobId();
             if (isTemporaryLob(tableId)) {
                 tempLobMap.put(newLobId, streamStoreId);
             } else {
-                Object[] value = { streamStoreId, tableId, length, 0 };
+                BlobMeta value = new BlobMeta(streamStoreId, tableId, length, 0);
                 lobMap.put(newLobId, value);
             }
-            Object[] refMapKey = {streamStoreId, newLobId};
-            refMap.put(refMapKey, Boolean.TRUE);
+            BlobReference refMapKey = new BlobReference(streamStoreId, newLobId);
+            refMap.put(refMapKey, ValueNull.INSTANCE);
             LobDataDatabase newLobData = new LobDataDatabase(database, tableId, newLobId);
             ValueLob lob = type == Value.BLOB ? new ValueBlob(length, newLobData) : new ValueClob(length, newLobData);
             if (TRACE) {
@@ -272,8 +272,8 @@ public final class LobStorageMap implements LobStorageInterface
         try {
             byte[] streamStoreId = tempLobMap.get(lobId);
             if (streamStoreId == null) {
-                Object[] value = lobMap.get(lobId);
-                streamStoreId = (byte[]) value[0];
+                BlobMeta value = lobMap.get(lobId);
+                streamStoreId = value.streamStoreId;
             }
             if (streamStoreId == null) {
                 throw DbException.get(ErrorCode.LOB_CLOSED_ON_TIMEOUT_1, "" + lobId);
@@ -294,8 +294,8 @@ public final class LobStorageMap implements LobStorageInterface
             if (isTemporaryLob(tableId)) {
                 streamStoreId = tempLobMap.get(lobId);
             } else {
-                Object[] value = lobMap.get(lobId);
-                streamStoreId = (byte[]) value[0];
+                BlobMeta value = lobMap.get(lobId);
+                streamStoreId = value.streamStoreId;
             }
             if (streamStoreId == null) {
                 throw DbException.get(ErrorCode.LOB_CLOSED_ON_TIMEOUT_1, "" + lobId);
@@ -353,10 +353,9 @@ public final class LobStorageMap implements LobStorageInterface
                 // This might not be very efficient, but should only happen
                 // on DROP TABLE.
                 // To speed it up, we would need yet another map.
-                for (Entry<Long, Object[]> e : lobMap.entrySet()) {
-                    Object[] value = e.getValue();
-                    int t = (Integer) value[1];
-                    if (t == tableId) {
+                for (Entry<Long, BlobMeta> e : lobMap.entrySet()) {
+                    BlobMeta value = e.getValue();
+                    if (value.tableId == tableId) {
                         list.add(e.getKey());
                     }
                 }
@@ -394,24 +393,24 @@ public final class LobStorageMap implements LobStorageInterface
                 return;
             }
         } else {
-            Object[] value = lobMap.remove(lobId);
+            BlobMeta value = lobMap.remove(lobId);
             if (value == null) {
                 // already removed
                 return;
             }
-            streamStoreId = (byte[]) value[0];
+            streamStoreId = value.streamStoreId;
         }
-        Object[] key = {streamStoreId, lobId };
+        BlobReference key = new BlobReference(streamStoreId, lobId);
         refMap.remove(key);
         // check if there are more entries for this streamStoreId
-        key[1] = 0L;
-        Object[] value = refMap.ceilingKey(key);
+        key = new BlobReference(streamStoreId, 0L);
+        BlobReference value = refMap.ceilingKey(key);
         boolean hasMoreEntries = false;
         if (value != null) {
-            byte[] s2 = (byte[]) value[0];
+            byte[] s2 = value.streamStoreId;
             if (Arrays.equals(streamStoreId, s2)) {
                 if (TRACE) {
-                    trace("  stream still needed in lob " + value[1]);
+                    trace("  stream still needed in lob " + value.lobId);
                 }
                 hasMoreEntries = true;
             }
@@ -433,4 +432,119 @@ public final class LobStorageMap implements LobStorageInterface
         System.out.println("[" + Thread.currentThread().getName() + "] LOB " + op);
     }
 
+
+    public static final class BlobReference implements Comparable<BlobReference>
+    {
+        public final byte[] streamStoreId;
+        public final long lobId;
+
+        public BlobReference(byte[] streamStoreId, long lobId) {
+            this.streamStoreId = streamStoreId;
+            this.lobId = lobId;
+        }
+
+        @Override
+        public int compareTo(BlobReference other) {
+            int res = Integer.compare(streamStoreId.length, other.streamStoreId.length);
+            if (res == 0) {
+                for (int i = 0; res == 0 && i < streamStoreId.length; i++) {
+                    res = Byte.compare(streamStoreId[i], other.streamStoreId[i]);
+                }
+                if (res == 0) {
+                    res = Long.compare(lobId, other.lobId);
+                }
+            }
+            return res;
+        }
+
+        static final class Type extends BasicDataType<BlobReference> implements Comparator<BlobReference>
+        {
+            public static final Type INSTANCE = new Type();
+
+            private Type() {}
+
+            @Override
+            public int getMemory(BlobReference blobReference) {
+                return blobReference.streamStoreId.length + 8;
+            }
+
+            @Override
+            public int compare(BlobReference one, BlobReference two) {
+                return one == two ? 0 : one == null ? 1 : two == null ? -1 : one.compareTo(two);
+            }
+
+            @Override
+            public void write(WriteBuffer buff, BlobReference blobReference) {
+                buff.putVarInt(blobReference.streamStoreId.length);
+                buff.put(blobReference.streamStoreId);
+                buff.putVarLong(blobReference.lobId);
+            }
+
+            @Override
+            public BlobReference read(ByteBuffer buff) {
+                int len = DataUtils.readVarInt(buff);
+                byte[] streamStroreId = new byte[len];
+                buff.get(streamStroreId);
+                long blobId = DataUtils.readVarLong(buff);
+                return new BlobReference(streamStroreId, blobId);
+            }
+
+            @Override
+            public BlobReference[] createStorage(int size) {
+                return new BlobReference[size];
+            }
+        }
+    }
+
+    public static final class BlobMeta
+    {
+        public final byte[] streamStoreId;
+        public final int tableId;
+        public final long byteCount;
+        public final long hash;
+
+        public BlobMeta(byte[] streamStoreId, int tableId, long byteCount, long hash) {
+            this.streamStoreId = streamStoreId;
+            this.tableId = tableId;
+            this.byteCount = byteCount;
+            this.hash = hash;
+        }
+
+        public static final class Type extends BasicDataType<BlobMeta> {
+            public static final Type INSTANCE = new Type();
+
+            private Type() {
+            }
+
+            @Override
+            public int getMemory(BlobMeta blobMeta) {
+                return blobMeta.streamStoreId.length + 20;
+            }
+
+            @Override
+            public void write(WriteBuffer buff, BlobMeta blobMeta) {
+                buff.putVarInt(blobMeta.streamStoreId.length);
+                buff.put(blobMeta.streamStoreId);
+                buff.putVarInt(blobMeta.tableId);
+                buff.putVarLong(blobMeta.byteCount);
+                buff.putLong(blobMeta.hash);
+            }
+
+            @Override
+            public BlobMeta read(ByteBuffer buff) {
+                int len = DataUtils.readVarInt(buff);
+                byte[] streamStroreId = new byte[len];
+                buff.get(streamStroreId);
+                int tableId = DataUtils.readVarInt(buff);
+                long byteCount = DataUtils.readVarLong(buff);
+                long hash = buff.getLong();
+                return new BlobMeta(streamStroreId, tableId, byteCount, hash);
+            }
+
+            @Override
+            public BlobMeta[] createStorage(int size) {
+                return new BlobMeta[size];
+            }
+        }
+    }
 }

--- a/h2/src/main/org/h2/mvstore/db/NullValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/NullValueDataType.java
@@ -53,6 +53,7 @@ public final class NullValueDataType implements DataType<Value> {
 
     @Override
     public void write(WriteBuffer buff, Object storage, int len) {
+        assert storage == null;
     }
 
     @Override
@@ -62,12 +63,12 @@ public final class NullValueDataType implements DataType<Value> {
 
     @Override
     public void read(ByteBuffer buff, Object storage, int len) {
-        Arrays.fill((Value[]) storage, 0, len, ValueNull.INSTANCE);
+        assert storage == null;
     }
 
     @Override
     public Value[] createStorage(int size) {
-        return new Value[size];
+        return null;
     }
 
 }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -453,7 +453,7 @@ public final class Transaction {
     public <K, V> TransactionMap<K, V> openMap(String name,
                                                 DataType<K> keyType,
                                                 DataType<V> valueType) {
-        MVMap<K, VersionedValue<V>> map = store.openMap(name, keyType, valueType);
+        MVMap<K, VersionedValue<V>> map = store.openVersionedMap(name, keyType, valueType);
         return openMapX(map);
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -547,12 +547,14 @@ public class TransactionStore {
      * @param valueType the value type
      * @return the map
      */
-    <K,V> MVMap<K, VersionedValue<V>> openMap(String name, DataType<K> keyType, DataType<V> valueType) {
+    <K,V> MVMap<K, VersionedValue<V>> openVersionedMap(String name, DataType<K> keyType, DataType<V> valueType) {
         VersionedValueType<V,?> vt = valueType == null ? null : new VersionedValueType<>(valueType);
-        MVMap.Builder<K, VersionedValue<V>> builder = new TxMapBuilder<K,VersionedValue<V>>(typeRegistry, dataType)
-                .keyType(keyType).valueType(vt);
-        MVMap<K, VersionedValue<V>> map = store.openMap(name, builder);
-        return map;
+        return openMap(name, keyType, vt);
+    }
+
+    public <K,V> MVMap<K, V> openMap(String name, DataType<K> keyType, DataType<V> valueType) {
+        return store.openMap(name, new TxMapBuilder<K, V>(typeRegistry, dataType)
+                                            .keyType(keyType).valueType(valueType));
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/type/ByteArrayDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/ByteArrayDataType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2004-2021 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.mvstore.type;
+
+import org.h2.mvstore.DataUtils;
+import org.h2.mvstore.WriteBuffer;
+import java.nio.ByteBuffer;
+
+/**
+ * Class ByteArrayDataType.
+ *
+ * @author <a href='mailto:andrei.tokar@gmail.com'>Andrei Tokar</a>
+ */
+public final class ByteArrayDataType extends BasicDataType<byte[]>
+{
+    public static final ByteArrayDataType INSTANCE = new ByteArrayDataType();
+
+    private ByteArrayDataType() {}
+
+    @Override
+    public int getMemory(byte[] data) {
+        return data.length;
+    }
+
+    @Override
+    public void write(WriteBuffer buff, byte[] data) {
+        buff.putVarInt(data.length);
+        buff.put(data);
+    }
+
+    @Override
+    public byte[] read(ByteBuffer buff) {
+        int size = DataUtils.readVarInt(buff);
+        byte[] data = new byte[size];
+        buff.get(data);
+        return data;
+    }
+
+    @Override
+    public byte[][] createStorage(int size) {
+        return new byte[size][];
+    }
+}

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -662,9 +662,10 @@ public class Recover extends Tool implements DataHandler {
         if (!lobMaps) {
             return;
         }
-        MVMap<Long, byte[]> lobData = LobStorageMap.openLobDataMap(mv);
+        TransactionStore txStore = new TransactionStore(mv);
+        MVMap<Long, byte[]> lobData = LobStorageMap.openLobDataMap(txStore);
         StreamStore streamStore = new StreamStore(lobData);
-        MVMap<Long, LobStorageMap.BlobMeta> lobMap = LobStorageMap.openLobMap(mv);
+        MVMap<Long, LobStorageMap.BlobMeta> lobMap = LobStorageMap.openLobMap(txStore);
         writer.println("-- LOB");
         writer.println("CREATE TABLE IF NOT EXISTS " +
                 "INFORMATION_SCHEMA.LOB_BLOCKS(" +

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -47,7 +47,6 @@ import org.h2.mvstore.db.ValueDataType;
 import org.h2.mvstore.tx.TransactionMap;
 import org.h2.mvstore.tx.TransactionStore;
 import org.h2.mvstore.type.DataType;
-import org.h2.mvstore.type.LongDataType;
 import org.h2.mvstore.type.MetaType;
 import org.h2.mvstore.type.StringDataType;
 import org.h2.pagestore.Page;
@@ -663,9 +662,9 @@ public class Recover extends Tool implements DataHandler {
         if (!lobMaps) {
             return;
         }
-        MVMap<Long, byte[]> lobData = mv.openMap("lobData");
+        MVMap<Long, byte[]> lobData = LobStorageMap.openLobDataMap(mv);
         StreamStore streamStore = new StreamStore(lobData);
-        MVMap<Long, LobStorageMap.BlobMeta> lobMap = mv.openMap("lobMap", new MVMap.Builder<Long, LobStorageMap.BlobMeta>().keyType(LongDataType.INSTANCE).valueType(LobStorageMap.BlobMeta.Type.INSTANCE));
+        MVMap<Long, LobStorageMap.BlobMeta> lobMap = LobStorageMap.openLobMap(mv);
         writer.println("-- LOB");
         writer.println("CREATE TABLE IF NOT EXISTS " +
                 "INFORMATION_SCHEMA.LOB_BLOCKS(" +

--- a/h2/src/test/org/h2/test/store/TestMVTableEngine.java
+++ b/h2/src/test/org/h2/test/store/TestMVTableEngine.java
@@ -28,6 +28,7 @@ import org.h2.engine.Database;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
+import org.h2.mvstore.db.LobStorageMap;
 import org.h2.mvstore.tx.TransactionStore;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
@@ -37,6 +38,7 @@ import org.h2.tools.Restore;
 import org.h2.util.IOUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.Task;
+import org.h2.value.Value;
 
 /**
  * Tests the MVStore in a database.
@@ -456,10 +458,10 @@ public class TestMVTableEngine extends TestDb {
             MVMap<Long, byte[]> lobData = s.openMap("lobData");
             assertEquals(0, lobData.sizeAsLong());
             assertTrue(s.hasMap("lobMap"));
-            MVMap<Long, byte[]> lobMap = s.openMap("lobMap");
+            MVMap<Long, LobStorageMap.BlobMeta> lobMap = s.openMap("lobMap");
             assertEquals(0, lobMap.sizeAsLong());
             assertTrue(s.hasMap("lobRef"));
-            MVMap<Long, byte[]> lobRef = s.openMap("lobRef");
+            MVMap<LobStorageMap.BlobReference, Value> lobRef = s.openMap("lobRef");
             assertEquals(0, lobRef.sizeAsLong());
         }
     }


### PR DESCRIPTION
Replace generic Object[] with specific types in LobStorageMap.
This should be a little more frugal with memory and disk space (especially with "lobRef" and "lobMap" internal maps) and also will not transfer blob values from buffer byte-by-byte.
Also eliminate any memory storage for NullValue type (affects blob storage and secondary indexes).
