### PR TITLE
Change nested classes to static nested classes where possible

### DIFF
--- a/h2/src/main/org/h2/expression/condition/UniquePredicate.java
+++ b/h2/src/main/org/h2/expression/condition/UniquePredicate.java
@@ -22,7 +22,7 @@ import org.h2.value.ValueNull;
  */
 public class UniquePredicate extends PredicateWithSubquery {
 
-    private final class Target implements ResultTarget {
+    private static final class Target implements ResultTarget {
 
         private final int columnCount;
 

--- a/h2/src/main/org/h2/jdbc/JdbcLob.java
+++ b/h2/src/main/org/h2/jdbc/JdbcLob.java
@@ -26,7 +26,7 @@ import org.h2.value.Value;
  */
 public abstract class JdbcLob extends TraceObject {
 
-    final class LobPipedOutputStream extends PipedOutputStream {
+    static final class LobPipedOutputStream extends PipedOutputStream {
         private final Task task;
 
         LobPipedOutputStream(PipedInputStream snk, Task task) throws IOException {

--- a/h2/src/main/org/h2/security/auth/impl/JaasCredentialsValidator.java
+++ b/h2/src/main/org/h2/security/auth/impl/JaasCredentialsValidator.java
@@ -52,7 +52,7 @@ public class JaasCredentialsValidator implements CredentialsValidator {
         appName=configProperties.getStringValue("appName",appName);
     }
 
-    class AuthenticationInfoCallbackHandler implements CallbackHandler {
+    static class AuthenticationInfoCallbackHandler implements CallbackHandler {
 
         AuthenticationInfo authenticationInfo;
 

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -206,7 +206,7 @@ public class TestIndex extends TestDb {
         stat.execute("drop table test");
     }
 
-    private class ConcurrentUpdateThread extends Thread {
+    private static class ConcurrentUpdateThread extends Thread {
         private final AtomicInteger concurrentUpdateId, concurrentUpdateValue;
 
         private final PreparedStatement psInsert, psDelete;

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -1148,7 +1148,7 @@ public class TestTools extends TestDb {
     /**
      * A simple Clob implementation.
      */
-    class SimpleClob implements Clob {
+    static class SimpleClob implements Clob {
 
         private final String data;
 
@@ -1238,7 +1238,7 @@ public class TestTools extends TestDb {
     /**
      * A simple Blob implementation.
      */
-    class SimpleBlob implements Blob {
+    static class SimpleBlob implements Blob {
 
         private final byte[] data;
 

--- a/h2/src/tools/org/h2/dev/net/PgTcpRedirect.java
+++ b/h2/src/tools/org/h2/dev/net/PgTcpRedirect.java
@@ -66,7 +66,7 @@ public class PgTcpRedirect {
     /**
      * This is the working thread of the TCP redirector.
      */
-    private class TcpRedirectThread implements Runnable {
+    private static class TcpRedirectThread implements Runnable {
 
         private static final int STATE_INIT_CLIENT = 0, STATE_REGULAR = 1;
         private final Socket read, write;


### PR DESCRIPTION
Non-static classes hold a link to their parent classes, which in many cases can be avoided.