### PR TITLE
Store octet length in CLOBs

### DIFF
--- a/h2/src/main/org/h2/jmx/DatabaseInfo.java
+++ b/h2/src/main/org/h2/jmx/DatabaseInfo.java
@@ -18,7 +18,6 @@ import org.h2.engine.ConnectionInfo;
 import org.h2.engine.Constants;
 import org.h2.engine.Database;
 import org.h2.engine.SessionLocal;
-import org.h2.mvstore.db.Store;
 import org.h2.table.Table;
 import org.h2.util.NetworkConnectionInfo;
 

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -186,7 +186,7 @@ public final class LobStorageMap implements LobStorageInterface
             CountingReaderInputStream in = new CountingReaderInputStream(reader, maxLength);
             // Don't inline
             LobData lobData = createBlob(in).getLobData();
-            return new ValueClob(in.getLength(), lobData);
+            return new ValueClob(lobData, in.getLength());
         } catch (IllegalStateException e) {
             throw DbException.get(ErrorCode.OBJECT_CLOSED, e);
         } catch (IOException e) {
@@ -209,7 +209,7 @@ public final class LobStorageMap implements LobStorageInterface
         tempLobMap.put(lobId, streamStoreId);
         BlobReference key = new BlobReference(streamStoreId, lobId);
         refMap.put(key, ValueNull.INSTANCE);
-        ValueBlob lob =  new ValueBlob(length, new LobDataDatabase(database, tableId, lobId));
+        ValueBlob lob =  new ValueBlob(new LobDataDatabase(database, tableId, lobId), length);
         if (TRACE) {
             trace("create " + tableId + "/" + lobId);
         }
@@ -255,7 +255,7 @@ public final class LobStorageMap implements LobStorageInterface
             BlobReference refMapKey = new BlobReference(streamStoreId, newLobId);
             refMap.put(refMapKey, ValueNull.INSTANCE);
             LobDataDatabase newLobData = new LobDataDatabase(database, tableId, newLobId);
-            ValueLob lob = type == Value.BLOB ? new ValueBlob(length, newLobData) : new ValueClob(length, newLobData);
+            ValueLob lob = type == Value.BLOB ? new ValueBlob(newLobData, length) : new ValueClob(newLobData, length);
             if (TRACE) {
                 trace("copy " + lobData.getTableId() + "/" + lobData.getLobId() +
                         " > " + tableId + "/" + newLobId);

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -232,7 +232,7 @@ public final class LobStorageMap implements LobStorageInterface
             final LobDataDatabase lobData = (LobDataDatabase) old.getLobData();
             final int type = old.getValueType();
             final long oldLobId = lobData.getLobId();
-            final long oldLength = old.getPrecision();
+            final long oldLength = type == Value.CLOB ? old.charLength() : old.octetLength();
             if (oldLength != length) {
                 throw DbException.getInternalError("Length is different");
             }

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -178,7 +178,7 @@ public final class LobStorageMap implements LobStorageInterface
                             "len > maxinplace, " + utf8.length + " > "
                                     + database.getMaxLengthInplaceLob());
                 }
-                return ValueClob.createSmall(utf8);
+                return ValueClob.createSmall(utf8, len);
             }
             if (maxLength < 0) {
                 maxLength = Long.MAX_VALUE;

--- a/h2/src/main/org/h2/mvstore/db/ValueDataType.java
+++ b/h2/src/main/org/h2/mvstore/db/ValueDataType.java
@@ -54,7 +54,6 @@ import org.h2.value.ValueInteger;
 import org.h2.value.ValueInterval;
 import org.h2.value.ValueJavaObject;
 import org.h2.value.ValueJson;
-import org.h2.value.ValueLob;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueNumeric;
 import org.h2.value.ValueReal;
@@ -451,17 +450,33 @@ public final class ValueDataType extends BasicDataType<Value> implements Statefu
             }
             break;
         }
-        case Value.BLOB:
-        case Value.CLOB: {
-            buff.put(type == Value.BLOB ? BLOB : CLOB);
-            ValueLob lob = (ValueLob) v;
+        case Value.BLOB: {
+            buff.put(BLOB);
+            ValueBlob lob = (ValueBlob) v;
             LobData lobData = lob.getLobData();
             if (lobData instanceof LobDataDatabase) {
                 LobDataDatabase lobDataDatabase = (LobDataDatabase) lobData;
                 buff.putVarInt(-3).
                     putVarInt(lobDataDatabase.getTableId()).
                     putVarLong(lobDataDatabase.getLobId()).
-                    putVarLong(lob.getPrecision());
+                    putVarLong(lob.octetLength());
+            } else {
+                byte[] small = ((LobDataInMemory) lobData).getSmall();
+                buff.putVarInt(small.length).
+                    put(small);
+            }
+            break;
+        }
+        case Value.CLOB: {
+            buff.put(CLOB);
+            ValueClob lob = (ValueClob) v;
+            LobData lobData = lob.getLobData();
+            if (lobData instanceof LobDataDatabase) {
+                LobDataDatabase lobDataDatabase = (LobDataDatabase) lobData;
+                buff.putVarInt(-3).
+                    putVarInt(lobDataDatabase.getTableId()).
+                    putVarLong(lobDataDatabase.getLobId()).
+                    putVarLong(lob.charLength());
             } else {
                 byte[] small = ((LobDataInMemory) lobData).getSmall();
                 buff.putVarInt(small.length).

--- a/h2/src/main/org/h2/store/LobStorageFrontend.java
+++ b/h2/src/main/org/h2/store/LobStorageFrontend.java
@@ -65,7 +65,7 @@ public class LobStorageFrontend implements LobStorageInterface {
     }
 
     @Override
-    public ValueLob copyLob(ValueLob old, int tableId, long length) {
+    public ValueLob copyLob(ValueLob old, int tableId) {
         throw new UnsupportedOperationException();
     }
 

--- a/h2/src/main/org/h2/store/LobStorageInterface.java
+++ b/h2/src/main/org/h2/store/LobStorageInterface.java
@@ -41,10 +41,9 @@ public interface LobStorageInterface {
      *
      * @param old the old lob
      * @param tableId the new table id
-     * @param length the length
      * @return the new lob
      */
-    ValueLob copyLob(ValueLob old, int tableId, long length);
+    ValueLob copyLob(ValueLob old, int tableId);
 
     /**
      * Get the input stream for the given lob, only called on server side of a TCP connection.

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -26,11 +26,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.DbObject;
 import org.h2.engine.MetaRecord;
-import org.h2.jdbc.JdbcConnection;
 import org.h2.message.DbException;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
@@ -58,8 +56,6 @@ import org.h2.util.TempFileDeleter;
 import org.h2.util.Tool;
 import org.h2.value.CompareMode;
 import org.h2.value.Value;
-import org.h2.value.ValueBlob;
-import org.h2.value.ValueClob;
 import org.h2.value.ValueCollectionBase;
 import org.h2.value.ValueLob;
 import org.h2.value.lob.LobData;
@@ -81,7 +77,6 @@ public class Recover extends Tool implements DataHandler {
     private HashSet<Integer> objectIdSet;
     private HashMap<Integer, String> tableMap;
     private HashMap<String, String> columnTypeMap;
-    private boolean remove;
     private boolean lobMaps;
 
     /**
@@ -128,8 +123,6 @@ public class Recover extends Tool implements DataHandler {
                 dir = args[++i];
             } else if ("-db".equals(arg)) {
                 db = args[++i];
-            } else if ("-removePassword".equals(arg)) {
-                remove = true;
             } else if ("-trace".equals(arg)) {
                 trace = true;
             } else if (arg.equals("-help") || arg.equals("-?")) {
@@ -140,36 +133,6 @@ public class Recover extends Tool implements DataHandler {
             }
         }
         process(dir, db);
-    }
-
-    /**
-     * INTERNAL
-     */
-    public static ValueBlob readBlobDb(Connection conn, long lobId, long precision) {
-        DataHandler h = ((JdbcConnection) conn).getSession().getDataHandler();
-        verifyPageStore(h);
-        LobDataDatabase lobData = new LobDataDatabase(h, LobStorageFrontend.TABLE_TEMP, lobId);
-        lobData.setRecoveryReference(true);
-        return new ValueBlob(lobData, precision);
-    }
-
-    private static void verifyPageStore(DataHandler h) {
-        if (h.getLobStorage() instanceof LobStorageMap) {
-            throw DbException.get(ErrorCode.FEATURE_NOT_SUPPORTED_1,
-                    "Restore page store recovery SQL script " +
-                    "can only be restored to a PageStore file");
-        }
-    }
-
-    /**
-     * INTERNAL
-     */
-    public static ValueClob readClobDb(Connection conn, long lobId, long precision) {
-        DataHandler h = ((JdbcConnection) conn).getSession().getDataHandler();
-        verifyPageStore(h);
-        LobDataDatabase lobData = new LobDataDatabase(h, LobStorageFrontend.TABLE_TEMP, lobId);
-        lobData.setRecoveryReference(true);
-        return new ValueClob(lobData, precision);
     }
 
     /**

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -294,12 +294,14 @@ public class Recover extends Tool implements DataHandler {
                 LobDataDatabase lobDataDatabase = (LobDataDatabase) lobData;
                 int type = v.getValueType();
                 long id = lobDataDatabase.getLobId();
-                long precision = lob.getPrecision();
+                long precision;
                 String columnType;
                 if (type == Value.BLOB) {
+                    precision = lob.octetLength();
                     columnType = "BLOB";
                     builder.append("READ_BLOB");
                 } else {
+                    precision = lob.charLength();
                     columnType = "CLOB";
                     builder.append("READ_CLOB");
                 }

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -150,7 +150,7 @@ public class Recover extends Tool implements DataHandler {
         verifyPageStore(h);
         LobDataDatabase lobData = new LobDataDatabase(h, LobStorageFrontend.TABLE_TEMP, lobId);
         lobData.setRecoveryReference(true);
-        return new ValueBlob(precision, lobData);
+        return new ValueBlob(lobData, precision);
     }
 
     private static void verifyPageStore(DataHandler h) {
@@ -169,7 +169,7 @@ public class Recover extends Tool implements DataHandler {
         verifyPageStore(h);
         LobDataDatabase lobData = new LobDataDatabase(h, LobStorageFrontend.TABLE_TEMP, lobId);
         lobData.setRecoveryReference(true);
-        return new ValueClob(precision, lobData);
+        return new ValueClob(lobData, precision);
     }
 
     /**

--- a/h2/src/main/org/h2/util/JdbcUtils.java
+++ b/h2/src/main/org/h2/util/JdbcUtils.java
@@ -596,14 +596,12 @@ public class JdbcUtils {
     }
 
     private static void setLob(PreparedStatement prep, int parameterIndex, ValueLob value) throws SQLException {
-        long p = value.getPrecision();
-        if (p > Integer.MAX_VALUE) {
-            p = -1;
-        }
         if (value.getValueType() == Value.BLOB) {
-            prep.setBinaryStream(parameterIndex, value.getInputStream(), (int) p);
+            long p = value.octetLength();
+            prep.setBinaryStream(parameterIndex, value.getInputStream(), p > Integer.MAX_VALUE ? -1 : (int) p);
         } else {
-            prep.setCharacterStream(parameterIndex, value.getReader(), (int) p);
+            long p = value.charLength();
+            prep.setCharacterStream(parameterIndex, value.getReader(), p > Integer.MAX_VALUE ? -1 : (int) p);
         }
     }
 

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -874,16 +874,16 @@ public final class Transfer {
             writeInt(BLOB);
             ValueBlob lob = (ValueBlob) v;
             LobData lobData = lob.getLobData();
+            long length = lob.octetLength();
             if (lobData instanceof LobDataDatabase) {
                 LobDataDatabase lobDataDatabase = (LobDataDatabase) lobData;
                 writeLong(-1);
                 writeInt(lobDataDatabase.getTableId());
                 writeLong(lobDataDatabase.getLobId());
                 writeBytes(calculateLobMac(lobDataDatabase.getLobId()));
-                writeLong(lob.getPrecision());
+                writeLong(length);
                 break;
             }
-            long length = lob.getPrecision();
             if (length < 0) {
                 throw DbException.get(
                         ErrorCode.CONNECTION_BROKEN_1, "length=" + length);
@@ -901,16 +901,16 @@ public final class Transfer {
             writeInt(CLOB);
             ValueClob lob = (ValueClob) v;
             LobData lobData = lob.getLobData();
+            long length = lob.charLength();
             if (lobData instanceof LobDataDatabase) {
                 LobDataDatabase lobDataDatabase = (LobDataDatabase) lobData;
                 writeLong(-1);
                 writeInt(lobDataDatabase.getTableId());
                 writeLong(lobDataDatabase.getLobId());
                 writeBytes(calculateLobMac(lobDataDatabase.getLobId()));
-                writeLong(lob.getPrecision());
+                writeLong(length);
                 break;
             }
-            long length = lob.getPrecision();
             if (length < 0) {
                 throw DbException.get(
                         ErrorCode.CONNECTION_BROKEN_1, "length=" + length);

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -1081,7 +1081,7 @@ public final class Transfer {
                 long id = readLong();
                 byte[] hmac = readBytes();
                 long precision = readLong();
-                return new ValueBlob(precision, new LobDataFetchOnDemand(session.getDataHandler(), tableId, id, hmac));
+                return new ValueBlob(new LobDataFetchOnDemand(session.getDataHandler(), tableId, id, hmac), precision);
             }
             Value v = session.getDataHandler().getLobStorage().createBlob(in, length);
             int magic = readInt();
@@ -1099,7 +1099,7 @@ public final class Transfer {
                 long id = readLong();
                 byte[] hmac = readBytes();
                 long precision = readLong();
-                return new ValueClob(precision, new LobDataFetchOnDemand(session.getDataHandler(), tableId, id, hmac));
+                return new ValueClob(new LobDataFetchOnDemand(session.getDataHandler(), tableId, id, hmac), precision);
             }
             if (length < 0) {
                 throw DbException.get(

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -1380,7 +1380,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL, Typ
             v = (ValueBlob) this;
             break;
         case CLOB:
-            DataHandler handler = ((ValueLob) this).getDataHandler();
+            DataHandler handler = ((ValueLob) this).lobData.getDataHandler();
             if (handler != null) {
                 v = handler.getLobStorage().createBlob(getInputStream(), -1);
                 break;

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -1296,7 +1296,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL, Typ
         if (conversionMode != CONVERT_TO) {
             if (conversionMode == CAST_TO) {
                 v = v.convertPrecision(targetType.getPrecision());
-            } else if (v.getPrecision() > targetType.getPrecision()) {
+            } else if (v.charLength() > targetType.getPrecision()) {
                 throw v.getValueTooLongException(targetType, column);
             }
         }
@@ -1400,7 +1400,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL, Typ
         if (conversionMode != CONVERT_TO) {
             if (conversionMode == CAST_TO) {
                 v = v.convertPrecision(targetType.getPrecision());
-            } else if (v.getPrecision() > targetType.getPrecision()) {
+            } else if (v.octetLength() > targetType.getPrecision()) {
                 throw v.getValueTooLongException(targetType, column);
             }
         }

--- a/h2/src/main/org/h2/value/ValueBlob.java
+++ b/h2/src/main/org/h2/value/ValueBlob.java
@@ -48,7 +48,7 @@ public final class ValueBlob extends ValueLob {
      * @return the BLOB
      */
     public static ValueBlob create(long precision, DataHandler handler, int tableId, long lobId) {
-        return new ValueBlob(precision, new LobDataDatabase(handler, tableId, lobId));
+        return new ValueBlob(new LobDataDatabase(handler, tableId, lobId), precision);
     }
 
     /**
@@ -59,7 +59,7 @@ public final class ValueBlob extends ValueLob {
      * @return the BLOB
      */
     public static ValueBlob createSmall(byte[] data) {
-        return new ValueBlob(data.length, new LobDataInMemory(data));
+        return new ValueBlob(new LobDataInMemory(data), data.length);
     }
 
     /**
@@ -121,11 +121,11 @@ public final class ValueBlob extends ValueLob {
                 }
             }
         }
-        return new ValueBlob(tmpPrecision, new LobDataFile(handler, fileName, tempFile));
+        return new ValueBlob(new LobDataFile(handler, fileName, tempFile), tmpPrecision);
     }
 
-    public ValueBlob(long precision, LobData lobData) {
-        super(precision, lobData);
+    public ValueBlob(LobData lobData, long octetLength) {
+        super(lobData, octetLength, -1L);
     }
 
     @Override
@@ -135,7 +135,7 @@ public final class ValueBlob extends ValueLob {
 
     @Override
     public String getString() {
-        long p = otherPrecision;
+        long p = charLength;
         if (p >= 0L) {
             if (p > Constants.MAX_STRING_LENGTH) {
                 throw getStringTooLong(p);
@@ -143,7 +143,7 @@ public final class ValueBlob extends ValueLob {
             return readString((int) p);
         }
         // 1 Java character may be encoded with up to 3 bytes
-        if (precision > Constants.MAX_STRING_LENGTH * 3) {
+        if (octetLength > Constants.MAX_STRING_LENGTH * 3) {
             throw getStringTooLong(charLength());
         }
         String s;
@@ -152,7 +152,7 @@ public final class ValueBlob extends ValueLob {
         } else {
             s = readString(Integer.MAX_VALUE);
         }
-        otherPrecision = p = s.length();
+        charLength = p = s.length();
         if (p > Constants.MAX_STRING_LENGTH) {
             throw getStringTooLong(p);
         }
@@ -161,20 +161,20 @@ public final class ValueBlob extends ValueLob {
 
     @Override
     byte[] getBytesInternal() {
-        if (precision > Constants.MAX_STRING_LENGTH) {
-            throw getBinaryTooLong(precision);
+        if (octetLength > Constants.MAX_STRING_LENGTH) {
+            throw getBinaryTooLong(octetLength);
         }
-        return readBytes((int) precision);
+        return readBytes((int) octetLength);
     }
 
     @Override
     public InputStream getInputStream() {
-        return lobData.getInputStream(precision);
+        return lobData.getInputStream(octetLength);
     }
 
     @Override
     public InputStream getInputStream(long oneBasedOffset, long length) {
-        long p = precision;
+        long p = octetLength;
         return rangeInputStream(lobData.getInputStream(p), oneBasedOffset, length, p);
     }
 
@@ -217,7 +217,7 @@ public final class ValueBlob extends ValueLob {
      * @return result of comparison
      */
     private static int compare(ValueBlob v1, ValueBlob v2) {
-        long minPrec = Math.min(v1.precision, v2.precision);
+        long minPrec = Math.min(v1.octetLength, v2.octetLength);
         try (InputStream is1 = v1.getInputStream(); InputStream is2 = v2.getInputStream()) {
             byte[] buf1 = new byte[BLOCK_COMPARISON_SIZE];
             byte[] buf2 = new byte[BLOCK_COMPARISON_SIZE];
@@ -251,8 +251,8 @@ public final class ValueBlob extends ValueLob {
     @Override
     public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
         if ((sqlFlags & REPLACE_LOBS_FOR_TRACE) != 0
-                && (!(lobData instanceof LobDataInMemory) || precision > SysProperties.MAX_TRACE_DATA_LENGTH)) {
-            builder.append("CAST(REPEAT(CHAR(0), ").append(precision).append(") AS BINARY VARYING");
+                && (!(lobData instanceof LobDataInMemory) || octetLength > SysProperties.MAX_TRACE_DATA_LENGTH)) {
+            builder.append("CAST(REPEAT(CHAR(0), ").append(octetLength).append(") AS BINARY VARYING");
             LobDataDatabase lobDb = (LobDataDatabase) lobData;
             builder.append(" /* table: ").append(lobDb.getTableId()).append(" id: ").append(lobDb.getLobId())
                     .append(" */)");
@@ -260,7 +260,7 @@ public final class ValueBlob extends ValueLob {
             if ((sqlFlags & (REPLACE_LOBS_FOR_TRACE | NO_CASTS)) == 0) {
                 builder.append("CAST(X'");
                 StringUtils.convertBytesToHex(builder, getBytesNoCopy()).append("' AS BINARY LARGE OBJECT(")
-                        .append(precision).append("))");
+                        .append(octetLength).append("))");
             } else {
                 builder.append("X'");
                 StringUtils.convertBytesToHex(builder, getBytesNoCopy()).append('\'');
@@ -277,7 +277,7 @@ public final class ValueBlob extends ValueLob {
      * @return the truncated or this value
      */
     ValueBlob convertPrecision(long precision) {
-        if (this.precision <= precision) {
+        if (this.octetLength <= precision) {
             return this;
         }
         ValueBlob lob;
@@ -300,14 +300,14 @@ public final class ValueBlob extends ValueLob {
             byte[] small = ((LobDataInMemory) lobData).getSmall();
             if (small.length > database.getMaxLengthInplaceLob()) {
                 LobStorageInterface s = database.getLobStorage();
-                ValueBlob v = s.createBlob(getInputStream(), precision);
+                ValueBlob v = s.createBlob(getInputStream(), octetLength);
                 ValueLob v2 = v.copy(database, tableId);
                 v.remove();
                 return v2;
             }
             return this;
         } else if (lobData instanceof LobDataDatabase) {
-            return database.getLobStorage().copyLob(this, tableId, precision);
+            return database.getLobStorage().copyLob(this, tableId, octetLength);
         } else {
             throw new UnsupportedOperationException();
         }
@@ -315,7 +315,7 @@ public final class ValueBlob extends ValueLob {
 
     @Override
     public long charLength() {
-        long p = otherPrecision;
+        long p = charLength;
         if (p < 0L) {
             if (lobData instanceof LobDataInMemory) {
                 p = new String(((LobDataInMemory) lobData).getSmall(), StandardCharsets.UTF_8).length();
@@ -333,14 +333,14 @@ public final class ValueBlob extends ValueLob {
                     throw DbException.convertIOException(e, null);
                 }
             }
-            otherPrecision = p;
+            charLength = p;
         }
         return p;
     }
 
     @Override
     public long octetLength() {
-        return precision;
+        return octetLength;
     }
 
 }

--- a/h2/src/main/org/h2/value/ValueBlob.java
+++ b/h2/src/main/org/h2/value/ValueBlob.java
@@ -290,7 +290,7 @@ public final class ValueBlob extends ValueLob {
             }
             return this;
         } else if (lobData instanceof LobDataDatabase) {
-            return database.getLobStorage().copyLob(this, tableId, octetLength);
+            return database.getLobStorage().copyLob(this, tableId);
         } else {
             throw new UnsupportedOperationException();
         }

--- a/h2/src/main/org/h2/value/ValueBlob.java
+++ b/h2/src/main/org/h2/value/ValueBlob.java
@@ -35,23 +35,6 @@ import org.h2.value.lob.LobDataInMemory;
 public final class ValueBlob extends ValueLob {
 
     /**
-     * Creates a reference to the BLOB data persisted in the database.
-     *
-     * @param precision
-     *            the precision (count of bytes)
-     * @param handler
-     *            the data handler
-     * @param tableId
-     *            the table identifier
-     * @param lobId
-     *            the LOB identifier
-     * @return the BLOB
-     */
-    public static ValueBlob create(long precision, DataHandler handler, int tableId, long lobId) {
-        return new ValueBlob(new LobDataDatabase(handler, tableId, lobId), precision);
-    }
-
-    /**
      * Creates a small BLOB value that can be stored in the row directly.
      *
      * @param data

--- a/h2/src/main/org/h2/value/ValueClob.java
+++ b/h2/src/main/org/h2/value/ValueClob.java
@@ -49,7 +49,7 @@ public final class ValueClob extends ValueLob {
      * @return the CLOB
      */
     public static ValueClob create(long precision, DataHandler handler, int tableId, long lobId) {
-        return new ValueClob(precision, new LobDataDatabase(handler, tableId, lobId));
+        return new ValueClob(new LobDataDatabase(handler, tableId, lobId), precision);
     }
 
     /**
@@ -60,7 +60,7 @@ public final class ValueClob extends ValueLob {
      * @return the CLOB
      */
     public static ValueClob createSmall(byte[] data) {
-        return new ValueClob(new String(data, StandardCharsets.UTF_8).length(), new LobDataInMemory(data));
+        return new ValueClob(new LobDataInMemory(data), new String(data, StandardCharsets.UTF_8).length());
     }
 
     /**
@@ -74,7 +74,7 @@ public final class ValueClob extends ValueLob {
      * @return the CLOB
      */
     public static ValueClob createSmall(byte[] data, long precision) {
-        return new ValueClob(precision, new LobDataInMemory(data));
+        return new ValueClob(new LobDataInMemory(data), precision);
     }
 
     /**
@@ -85,7 +85,7 @@ public final class ValueClob extends ValueLob {
      * @return the CLOB
      */
     public static ValueClob createSmall(String string) {
-        return new ValueClob(string.length(), new LobDataInMemory(string.getBytes(StandardCharsets.UTF_8)));
+        return new ValueClob(new LobDataInMemory(string.getBytes(StandardCharsets.UTF_8)), string.length());
     }
 
     /**
@@ -164,11 +164,11 @@ public final class ValueClob extends ValueLob {
                 tmpPrecision += len;
             }
         }
-        return new ValueClob(tmpPrecision, new LobDataFile(handler, fileName, tempFile));
+        return new ValueClob(new LobDataFile(handler, fileName, tempFile), tmpPrecision);
     }
 
-    public ValueClob(long precision, LobData lobData) {
-        super(precision, lobData);
+    public ValueClob(LobData lobData, long charLength) {
+        super(lobData, -1L, charLength);
     }
 
     @Override
@@ -178,29 +178,29 @@ public final class ValueClob extends ValueLob {
 
     @Override
     public String getString() {
-        if (precision > Constants.MAX_STRING_LENGTH) {
-            throw getStringTooLong(precision);
+        if (charLength > Constants.MAX_STRING_LENGTH) {
+            throw getStringTooLong(charLength);
         }
         if (lobData instanceof LobDataInMemory) {
             return new String(((LobDataInMemory) lobData).getSmall(), StandardCharsets.UTF_8);
         }
-        return readString((int) precision);
+        return readString((int) charLength);
     }
 
     @Override
     byte[] getBytesInternal() {
-        long p = otherPrecision;
+        long p = octetLength;
         if (p >= 0L) {
             if (p > Constants.MAX_STRING_LENGTH) {
                 throw getBinaryTooLong(p);
             }
             return readBytes((int) p);
         }
-        if (precision > Constants.MAX_STRING_LENGTH) {
+        if (octetLength > Constants.MAX_STRING_LENGTH) {
             throw getBinaryTooLong(octetLength());
         }
         byte[] b = readBytes(Integer.MAX_VALUE);
-        otherPrecision = p = b.length;
+        octetLength = p = b.length;
         if (p > Constants.MAX_STRING_LENGTH) {
             throw getBinaryTooLong(p);
         }
@@ -219,7 +219,7 @@ public final class ValueClob extends ValueLob {
 
     @Override
     public Reader getReader(long oneBasedOffset, long length) {
-        return rangeReader(getReader(), oneBasedOffset, length, precision);
+        return rangeReader(getReader(), oneBasedOffset, length, charLength);
     }
 
     @Override
@@ -255,7 +255,7 @@ public final class ValueClob extends ValueLob {
      * @return result of comparison
      */
     private static int compare(ValueClob v1, ValueClob v2) {
-        long minPrec = Math.min(v1.precision, v2.precision);
+        long minPrec = Math.min(v1.charLength, v2.charLength);
         try (Reader reader1 = v1.getReader(); Reader reader2 = v2.getReader()) {
             char[] buf1 = new char[BLOCK_COMPARISON_SIZE];
             char[] buf2 = new char[BLOCK_COMPARISON_SIZE];
@@ -289,15 +289,15 @@ public final class ValueClob extends ValueLob {
     @Override
     public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
         if ((sqlFlags & REPLACE_LOBS_FOR_TRACE) != 0
-                && (!(lobData instanceof LobDataInMemory) || precision > SysProperties.MAX_TRACE_DATA_LENGTH)) {
-            builder.append("SPACE(").append(precision);
+                && (!(lobData instanceof LobDataInMemory) || charLength > SysProperties.MAX_TRACE_DATA_LENGTH)) {
+            builder.append("SPACE(").append(charLength);
             LobDataDatabase lobDb = (LobDataDatabase) lobData;
             builder.append(" /* table: ").append(lobDb.getTableId()).append(" id: ").append(lobDb.getLobId())
                     .append(" */)");
         } else {
             if ((sqlFlags & (REPLACE_LOBS_FOR_TRACE | NO_CASTS)) == 0) {
                 StringUtils.quoteStringSQL(builder.append("CAST("), getString()).append(" AS CHARACTER LARGE OBJECT(")
-                        .append(precision).append("))");
+                        .append(charLength).append("))");
             } else {
                 StringUtils.quoteStringSQL(builder, getString());
             }
@@ -313,7 +313,7 @@ public final class ValueClob extends ValueLob {
      * @return the truncated or this value
      */
     ValueClob convertPrecision(long precision) {
-        if (this.precision <= precision) {
+        if (this.charLength <= precision) {
             return this;
         }
         ValueClob lob;
@@ -336,14 +336,14 @@ public final class ValueClob extends ValueLob {
             byte[] small = ((LobDataInMemory) lobData).getSmall();
             if (small.length > database.getMaxLengthInplaceLob()) {
                 LobStorageInterface s = database.getLobStorage();
-                ValueClob v = s.createClob(getReader(), precision);
+                ValueClob v = s.createClob(getReader(), charLength);
                 ValueLob v2 = v.copy(database, tableId);
                 v.remove();
                 return v2;
             }
             return this;
         } else if (lobData instanceof LobDataDatabase) {
-            return database.getLobStorage().copyLob(this, tableId, precision);
+            return database.getLobStorage().copyLob(this, tableId, charLength);
         } else {
             throw new UnsupportedOperationException();
         }
@@ -351,12 +351,12 @@ public final class ValueClob extends ValueLob {
 
     @Override
     public long charLength() {
-        return precision;
+        return charLength;
     }
 
     @Override
     public long octetLength() {
-        long p = otherPrecision;
+        long p = octetLength;
         if (p < 0L) {
             if (lobData instanceof LobDataInMemory) {
                 p = ((LobDataInMemory) lobData).getSmall().length;
@@ -374,7 +374,7 @@ public final class ValueClob extends ValueLob {
                     throw DbException.convertIOException(e, null);
                 }
             }
-            otherPrecision = p;
+            octetLength = p;
         }
         return p;
     }

--- a/h2/src/main/org/h2/value/ValueClob.java
+++ b/h2/src/main/org/h2/value/ValueClob.java
@@ -330,7 +330,7 @@ public final class ValueClob extends ValueLob {
             }
             return this;
         } else if (lobData instanceof LobDataDatabase) {
-            return database.getLobStorage().copyLob(this, tableId, charLength);
+            return database.getLobStorage().copyLob(this, tableId);
         } else {
             throw new UnsupportedOperationException();
         }

--- a/h2/src/main/org/h2/value/ValueClob.java
+++ b/h2/src/main/org/h2/value/ValueClob.java
@@ -68,13 +68,13 @@ public final class ValueClob extends ValueLob {
      *
      * @param data
      *            the data in UTF-8 encoding
-     * @param precision
+     * @param charLength
      *            the count of characters, must be exactly the same as count of
      *            characters in the data
      * @return the CLOB
      */
-    public static ValueClob createSmall(byte[] data, long precision) {
-        return new ValueClob(new LobDataInMemory(data), precision);
+    public static ValueClob createSmall(byte[] data, long charLength) {
+        return new ValueClob(new LobDataInMemory(data), charLength);
     }
 
     /**

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -249,8 +249,7 @@ public abstract class ValueLob extends Value {
         if (lobData instanceof LobDataDatabase) {
             LobStorageInterface s = lobData.getDataHandler().getLobStorage();
             if (!s.isReadOnly()) {
-                int valueType = getValueType();
-                return s.copyLob(this, LobStorageFrontend.TABLE_RESULT, valueType == CLOB ? charLength : octetLength);
+                return s.copyLob(this, LobStorageFrontend.TABLE_RESULT);
             }
         }
         return this;

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -88,28 +88,27 @@ public abstract class ValueLob extends Value {
 
     private TypeInfo type;
 
-    /**
-     * Length in characters for character large objects or length in bytes for
-     * binary large objects.
-     */
-    protected long precision;
-
     final LobData lobData;
 
     /**
-     * Length in characters for binary large objects or length in bytes for
-     * character large objects.
+     * Length in bytes.
      */
-    volatile long otherPrecision = -1L;
+    long octetLength;
+
+    /**
+     * Length in characters.
+     */
+    long charLength;
 
     /**
      * Cache the hashCode because it can be expensive to compute.
      */
     private int hash;
 
-    ValueLob(long precision, LobData lobData) {
-        this.precision = precision;
+    ValueLob(LobData lobData, long octetLength, long charLength) {
         this.lobData = lobData;
+        this.octetLength = octetLength;
+        this.charLength = charLength;
     }
 
     /**
@@ -144,7 +143,8 @@ public abstract class ValueLob extends Value {
     public TypeInfo getType() {
         TypeInfo type = this.type;
         if (type == null) {
-            this.type = type = new TypeInfo(getValueType(), precision, 0, null);
+            int valueType = getValueType();
+            this.type = type = new TypeInfo(valueType, valueType == CLOB ? charLength : octetLength, 0, null);
         }
         return type;
     }
@@ -209,10 +209,12 @@ public abstract class ValueLob extends Value {
     @Override
     public int hashCode() {
         if (hash == 0) {
-            if (precision > 4096) {
+            int valueType = getValueType();
+            long length = valueType == Value.CLOB ? charLength : octetLength;
+            if (length > 4096) {
                 // TODO: should calculate the hash code when saving, and store
                 // it in the database file
-                return (int) (precision ^ (precision >>> 32));
+                return (int) (length ^ (length >>> 32));
             }
             hash = Utils.getByteArrayHash(getBytesNoCopy());
         }
@@ -247,7 +249,8 @@ public abstract class ValueLob extends Value {
         if (lobData instanceof LobDataDatabase) {
             LobStorageInterface s = lobData.getDataHandler().getLobStorage();
             if (!s.isReadOnly()) {
-                return s.copyLob(this, LobStorageFrontend.TABLE_RESULT, precision);
+                int valueType = getValueType();
+                return s.copyLob(this, LobStorageFrontend.TABLE_RESULT, valueType == CLOB ? charLength : octetLength);
             }
         }
         return this;

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -243,15 +243,6 @@ public abstract class ValueLob extends Value {
         return lobData.getMemory();
     }
 
-    /**
-     * Returns the data handler.
-     *
-     * @return the data handler, or {@code null}
-     */
-    public DataHandler getDataHandler() {
-        return lobData.getDataHandler();
-    }
-
     public LobData getLobData() {
         return lobData;
     }

--- a/h2/src/main/org/h2/value/ValueLob.java
+++ b/h2/src/main/org/h2/value/ValueLob.java
@@ -219,15 +219,6 @@ public abstract class ValueLob extends Value {
         return hash;
     }
 
-    /**
-     * Returns the precision.
-     *
-     * @return the precision
-     */
-    public long getPrecision() {
-        return precision;
-    }
-
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof ValueLob))

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -757,8 +757,7 @@ public class TestTools extends TestDb {
 
     private void testTraceFile(String url) throws SQLException {
         Connection conn;
-        Recover.main("-removePassword", "-dir", getBaseDir(), "-db",
-                "toolsConvertTraceFile");
+        Recover.main("-dir", getBaseDir(), "-db", "toolsConvertTraceFile");
         conn = getConnection(url, "sa", "");
         Statement stat = conn.createStatement();
         ResultSet rs;

--- a/h2/src/test/org/h2/test/unit/TestValueMemory.java
+++ b/h2/src/test/org/h2/test/unit/TestValueMemory.java
@@ -390,7 +390,7 @@ public class TestValueMemory extends TestBase implements DataHandler {
         }
 
         @Override
-        public ValueLob copyLob(ValueLob old, int tableId, long length) {
+        public ValueLob copyLob(ValueLob old, int tableId) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
1. Octet length (length in bytes) is now stored in `CHARACTER LARGE OBJECT` values. Note: on-disk format is slightly changed in incompatible way.

2. Length fields and code in `ValueLob`, `ValueBlob` and `ValueClob` are refactored and prepared for the LOB-based JSON and geometry values (this PR doesn't contain changes for these data types, they aren't ready yet).

3. Unused PageStore-specific code is removed from `Recover`.