### PR TITLE
Do not call MVStore.store() for in-memory case

### DIFF
--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -1131,18 +1131,14 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
                 rollback();
             }
         } else {
-            ArrayList<InDoubtTransaction> list = database
-                    .getInDoubtTransactions();
-            int state = commit ? InDoubtTransaction.COMMIT
-                    : InDoubtTransaction.ROLLBACK;
+            ArrayList<InDoubtTransaction> list = database.getInDoubtTransactions();
+            int state = commit ? InDoubtTransaction.COMMIT : InDoubtTransaction.ROLLBACK;
             boolean found = false;
-            if (list != null) {
-                for (InDoubtTransaction p: list) {
-                    if (p.getTransactionName().equals(transactionName)) {
-                        p.setState(state);
-                        found = true;
-                        break;
-                    }
+            for (InDoubtTransaction p: list) {
+                if (p.getTransactionName().equals(transactionName)) {
+                    p.setState(state);
+                    found = true;
+                    break;
                 }
             }
             if (!found) {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -617,18 +617,20 @@ public class TransactionStore {
                 preparedTransactions.remove(txId);
             }
 
-            if (wasStored || store.getAutoCommitDelay() == 0) {
-                store.commit();
-            } else {
-                if (isUndoEmpty()) {
-                    // to avoid having to store the transaction log,
-                    // if there is no open transaction,
-                    // and if there have been many changes, store them now
-                    int unsaved = store.getUnsavedMemory();
-                    int max = store.getAutoCommitMemory();
-                    // save at 3/4 capacity
-                    if (unsaved * 4 > max * 3) {
-                        store.tryCommit();
+            if (store.getFileStore() != null) {
+                if (wasStored || store.getAutoCommitDelay() == 0) {
+                    store.commit();
+                } else {
+                    if (isUndoEmpty()) {
+                        // to avoid having to store the transaction log,
+                        // if there is no open transaction,
+                        // and if there have been many changes, store them now
+                        int unsaved = store.getUnsavedMemory();
+                        int max = store.getAutoCommitMemory();
+                        // save at 3/4 capacity
+                        if (unsaved * 4 > max * 3) {
+                            store.tryCommit();
+                        }
                     }
                 }
             }

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -2862,7 +2862,7 @@ public final class InformationSchemaTable extends MetaTable {
                 // EXECUTING_STATEMENT_START
                 command == null ? null : s.getCommandStartOrEnd(),
                 // CONTAINS_UNCOMMITTED
-                ValueBoolean.get(s.containsUncommitted()),
+                ValueBoolean.get(s.hasPendingTransaction()),
                 // SESSION_STATE
                 String.valueOf(s.getState()),
                 // BLOCKER_ID

--- a/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTableLegacy.java
@@ -1928,7 +1928,7 @@ public final class InformationSchemaTableLegacy extends MetaTable {
                             // STATEMENT_START
                             command == null ? null : s.getCommandStartOrEnd(),
                             // CONTAINS_UNCOMMITTED
-                            ValueBoolean.get(s.containsUncommitted()),
+                            ValueBoolean.get(s.hasPendingTransaction()),
                             // STATE
                             String.valueOf(s.getState()),
                             // BLOCKER_ID


### PR DESCRIPTION
I have no idea why LocalSession.hasPendingTransaction() always return false, but it does not look right.
This PR also avoid call to  MVStore.store() for in-memory case, which might be a boost in performance and scalability.
