### PR TITLE
Fix ResultSetMetaData.getSchemaName() for aliased columns

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,7 +21,7 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
-<li>Nothing yet...
+<li>Issue #3186: ResultSetMetaData.getSchemaName() returns empty string for aliased columns
 </li>
 </ul>
 

--- a/h2/src/main/org/h2/expression/Alias.java
+++ b/h2/src/main/org/h2/expression/Alias.java
@@ -100,6 +100,14 @@ public final class Alias extends Expression {
     }
 
     @Override
+    public String getSchemaName() {
+        if (aliasColumnName) {
+            return null;
+        }
+        return expr.getSchemaName();
+    }
+
+    @Override
     public String getTableName() {
         if (aliasColumnName) {
             return null;

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -148,16 +148,18 @@ public class TestCompatibility extends TestDb {
             stat.execute("SET MODE " + mode);
             ResultSet rs = stat.executeQuery("SELECT ID I FROM TEST");
             ResultSetMetaData meta = rs.getMetaData();
+            assertEquals(mode + " mode", "I", meta.getColumnLabel(1));
             String columnName = meta.getColumnName(1);
             String tableName = meta.getTableName(1);
-            if ("ID".equals(columnName) && "TEST".equals(tableName)) {
-                assertTrue(mode + " mode should not support columnAlias",
-                        columnAlias.contains(mode));
-            } else if ("I".equals(columnName) && tableName.equals("")) {
-                assertTrue(mode + " mode should support columnAlias",
-                        columnAlias.indexOf(mode) < 0);
+            String schemaName = meta.getSchemaName(1);
+            if (columnAlias.contains(mode)) {
+                assertEquals(mode + " mode", "ID", columnName);
+                assertEquals(mode + " mode", "TEST", tableName);
+                assertEquals(mode + " mode", "PUBLIC", schemaName);
             } else {
-                fail();
+                assertEquals(mode + " mode", "I", columnName);
+                assertEquals(mode + " mode", "", tableName);
+                assertEquals(mode + " mode", "", schemaName);
             }
         }
         stat.execute("DROP TABLE TEST");


### PR DESCRIPTION
Closes #3186.