### PR TITLE
Avoid AIOB exception in TestCrashAPI and in Transaction

### DIFF
--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -142,7 +142,7 @@ public class CommandContainer extends Command {
             long mod = prepared.getModificationMetaId();
             prepared.setModificationMetaId(0);
             ArrayList<Parameter> newParams = prepared.getParameters();
-            for (int i = 0, size = newParams.size(); i < size; i++) {
+            for (int i = 0, size = Math.min(newParams.size(), oldParams.size()); i < size; i++) {
                 Parameter old = oldParams.get(i);
                 if (old.isValueSet()) {
                     Value v = old.getValue(session);

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -249,7 +249,7 @@ public final class Transaction {
                 throw DataUtils.newMVStoreException(
                         DataUtils.ERROR_TRANSACTION_ILLEGAL_STATE,
                         "Transaction was illegally transitioned from {0} to {1}",
-                        STATUS_NAMES[currentStatus], STATUS_NAMES[status]);
+                        getStatusName(currentStatus), getStatusName(status));
             }
             long newState = composeState(status, logId, hasRollback(currentState));
             if (statusAndLogId.compareAndSet(currentState, newState)) {
@@ -623,7 +623,7 @@ public final class Transaction {
         if (status != STATUS_OPEN) {
             throw DataUtils.newMVStoreException(
                     DataUtils.ERROR_TRANSACTION_ILLEGAL_STATE,
-                    "Transaction {0} has status {1}, not OPEN", transactionId, STATUS_NAMES[status]);
+                    "Transaction {0} has status {1}, not OPEN", transactionId, getStatusName(status));
         }
     }
 
@@ -771,7 +771,7 @@ public final class Transaction {
     }
 
     private static String stateToString(long state) {
-        return STATUS_NAMES[getStatus(state)] + (hasRollback(state) ? "<" : "") + " " + getLogId(state);
+        return getStatusName(getStatus(state)) + (hasRollback(state) ? "<" : "") + " " + getLogId(state);
     }
 
 
@@ -799,5 +799,9 @@ public final class Transaction {
             status |= 1 << STATUS_BITS;
         }
         return ((long)status << LOG_ID_BITS1) | logId;
+    }
+
+    private static String getStatusName(int status) {
+        return status >= 0 && status < STATUS_NAMES.length ? STATUS_NAMES[status] : "UNKNOWN_STATUS_" + status;
     }
 }


### PR DESCRIPTION
First one creates undesired noise in test, while second one (on exception creation) masks actual problem