### PR TITLE
Properly return row with NULL values from subqueries with cardinality 0

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3249: Multi-column assignment with subquery throws exception when subquery doesn't return any rows
+</li>
+<li>PR #3248: Remove redundant uniqueness check, correct version in pom
+</li>
+<li>PR #3247: Avoid AIOB exception in TestCrashAPI and in Transaction
+</li>
 <li>Issue #3241: ResultSetMetaData::getColumnTypeName should produce the correct ARRAY type
 </li>
 <li>Issue #3204: H2 Tools Web Console: Unicode 32

--- a/h2/src/main/org/h2/api/JavaObjectSerializer.java
+++ b/h2/src/main/org/h2/api/JavaObjectSerializer.java
@@ -5,8 +5,6 @@
  */
 package org.h2.api;
 
-import java.sql.SQLException;
-
 /**
  * Custom serialization mechanism for java objects being stored in column of
  * type OTHER.

--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -47,24 +47,6 @@ public class Constants {
     public static final String BUILD_VENDOR_AND_VERSION = null;
 
     /**
-     * The TCP protocol version number 14.
-     * @since 1.3.176 (2014-04-05)
-     */
-    public static final int TCP_PROTOCOL_VERSION_14 = 14;
-
-    /**
-     * The TCP protocol version number 15.
-     * @since 1.4.178 Beta (2014-05-02)
-     */
-    public static final int TCP_PROTOCOL_VERSION_15 = 15;
-
-    /**
-     * The TCP protocol version number 16.
-     * @since 1.4.194 (2017-03-10)
-     */
-    public static final int TCP_PROTOCOL_VERSION_16 = 16;
-
-    /**
      * The TCP protocol version number 17.
      * @since 1.4.197 (2018-03-18)
      */
@@ -91,7 +73,7 @@ public class Constants {
     /**
      * Minimum supported version of TCP protocol.
      */
-    public static final int TCP_PROTOCOL_VERSION_MIN_SUPPORTED = TCP_PROTOCOL_VERSION_14;
+    public static final int TCP_PROTOCOL_VERSION_MIN_SUPPORTED = TCP_PROTOCOL_VERSION_17;
 
     /**
      * Maximum supported version of TCP protocol.

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -202,14 +202,6 @@ public abstract class Session implements CastDataProvider, AutoCloseable {
     public abstract String getCurrentSchemaName();
 
     /**
-     * Returns is this session supports generated keys.
-     *
-     * @return {@code true} if generated keys are supported, {@code false} if only
-     *         {@code SCOPE_IDENTITY()} is supported
-     */
-    public abstract boolean isSupportsGeneratedKeys();
-
-    /**
      * Sets the network connection information if possible.
      *
      * @param networkConnectionInfo the network connection information

--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -1842,11 +1842,6 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
 
     }
 
-    @Override
-    public boolean isSupportsGeneratedKeys() {
-        return true;
-    }
-
     /**
      * Returns the network connection information, or {@code null}.
      *

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -64,7 +64,7 @@ public final class SessionRemote extends Session implements DataHandler {
     public static final int COMMAND_COMMIT = 8;
     public static final int CHANGE_ID = 9;
     public static final int COMMAND_GET_META_DATA = 10;
-    public static final int SESSION_PREPARE_READ_PARAMS = 11;
+    // 11 was used for SESSION_PREPARE_READ_PARAMS
     public static final int SESSION_SET_ID = 12;
     public static final int SESSION_CANCEL_STATEMENT = 13;
     public static final int SESSION_CHECK_KEY = 14;
@@ -161,11 +161,7 @@ public final class SessionRemote extends Session implements DataHandler {
                 trans.writeString(timeZone.getId());
             }
             done(trans);
-            if (clientVersion >= Constants.TCP_PROTOCOL_VERSION_15) {
-                autoCommit = trans.readBoolean();
-            } else {
-                autoCommit = true;
-            }
+            autoCommit = trans.readBoolean();
             return trans;
         } catch (DbException e) {
             trans.close();
@@ -822,11 +818,6 @@ public final class SessionRemote extends Session implements DataHandler {
             command.executeUpdate(null);
             currentSchemaName = schema;
         }
-    }
-
-    @Override
-    public boolean isSupportsGeneratedKeys() {
-        return clientVersion >= Constants.TCP_PROTOCOL_VERSION_17;
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/ParameterRemote.java
+++ b/h2/src/main/org/h2/expression/ParameterRemote.java
@@ -7,7 +7,6 @@ package org.h2.expression;
 
 import java.io.IOException;
 import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
 
 import org.h2.api.ErrorCode;
 import org.h2.message.DbException;

--- a/h2/src/main/org/h2/fulltext/FullTextLucene.java
+++ b/h2/src/main/org/h2/fulltext/FullTextLucene.java
@@ -612,7 +612,7 @@ public class FullTextLucene extends FullText {
          * @param commitIndex whether to commit the changes to the Lucene index
          * @throws SQLException on failure
          */
-        private void insert(Object[] row, boolean commitIndex) throws SQLException {
+        void insert(Object[] row, boolean commitIndex) throws SQLException {
             String query = getQuery(row);
             Document doc = new Document();
             doc.add(new Field(LUCENE_FIELD_QUERY, query, DOC_ID_FIELD_TYPE));

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -890,12 +890,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
             }
             checkClosed();
             if (generatedKeys == null) {
-                if (session.isSupportsGeneratedKeys()) {
-                    generatedKeys = new JdbcResultSet(conn, this, null, new SimpleResult(), id, true, false);
-                } else {
-                    // Old server, use SCOPE_IDENTITY()
-                    generatedKeys = conn.getGeneratedKeys(this, id);
-                }
+                generatedKeys = new JdbcResultSet(conn, this, null, new SimpleResult(), id, true, false);
             }
             return generatedKeys;
         } catch (Exception e) {

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLegacy.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLegacy.java
@@ -13,7 +13,6 @@ import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.engine.Constants;
 import org.h2.engine.Session;
-import org.h2.engine.SessionRemote;
 import org.h2.expression.ParameterInterface;
 import org.h2.message.DbException;
 import org.h2.mode.DefaultNullOrdering;
@@ -181,7 +180,7 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
     @Override
     public ResultInterface getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types) {
         int typesLength = types != null ? types.length : 0;
-        boolean includeSynonyms = hasSynonyms() && (types == null || Arrays.asList(types).contains("SYNONYM"));
+        boolean includeSynonyms = types == null || Arrays.asList(types).contains("SYNONYM");
         // (1024 - 16) is enough for the most cases
         StringBuilder select = new StringBuilder(1008);
         if (includeSynonyms) {
@@ -282,72 +281,67 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
     @Override
     public ResultInterface getColumns(String catalog, String schemaPattern, String tableNamePattern,
             String columnNamePattern) {
-        boolean includeSynonyms = hasSynonyms();
-        StringBuilder select = new StringBuilder(2432);
-        if (includeSynonyms) {
-            select.append("SELECT " //
-                    + "TABLE_CAT, " //
-                    + "TABLE_SCHEM, " //
-                    + "TABLE_NAME, " //
-                    + "COLUMN_NAME, " //
-                    + "DATA_TYPE, " //
-                    + "TYPE_NAME, " //
-                    + "COLUMN_SIZE, " //
-                    + "BUFFER_LENGTH, " //
-                    + "DECIMAL_DIGITS, " //
-                    + "NUM_PREC_RADIX, " //
-                    + "NULLABLE, " //
-                    + "REMARKS, " //
-                    + "COLUMN_DEF, " //
-                    + "SQL_DATA_TYPE, " //
-                    + "SQL_DATETIME_SUB, " //
-                    + "CHAR_OCTET_LENGTH, " //
-                    + "ORDINAL_POSITION, " //
-                    + "IS_NULLABLE, " //
-                    + "SCOPE_CATALOG, " //
-                    + "SCOPE_SCHEMA, " //
-                    + "SCOPE_TABLE, " //
-                    + "SOURCE_DATA_TYPE, " //
-                    + "IS_AUTOINCREMENT, " //
-                    + "IS_GENERATEDCOLUMN " //
-                    + "FROM (" //
-                    + "SELECT " //
-                    + "s.SYNONYM_CATALOG TABLE_CAT, " //
-                    + "s.SYNONYM_SCHEMA TABLE_SCHEM, " //
-                    + "s.SYNONYM_NAME TABLE_NAME, " //
-                    + "c.COLUMN_NAME, " //
-                    + "c.DATA_TYPE, " //
-                    + "c.TYPE_NAME, " //
-                    + "c.CHARACTER_MAXIMUM_LENGTH COLUMN_SIZE, " //
-                    + "c.CHARACTER_MAXIMUM_LENGTH BUFFER_LENGTH, " //
-                    + "c.NUMERIC_SCALE DECIMAL_DIGITS, " //
-                    + "c.NUMERIC_PRECISION_RADIX NUM_PREC_RADIX, " //
-                    + "c.NULLABLE, " //
-                    + "c.REMARKS, " //
-                    + "c.COLUMN_DEFAULT COLUMN_DEF, " //
-                    + "c.DATA_TYPE SQL_DATA_TYPE, " //
-                    + "ZERO() SQL_DATETIME_SUB, " //
-                    + "c.CHARACTER_OCTET_LENGTH CHAR_OCTET_LENGTH, " //
-                    + "c.ORDINAL_POSITION, " //
-                    + "c.IS_NULLABLE IS_NULLABLE, " //
-                    + "CAST(c.SOURCE_DATA_TYPE AS VARCHAR) SCOPE_CATALOG, " //
-                    + "CAST(c.SOURCE_DATA_TYPE AS VARCHAR) SCOPE_SCHEMA, " //
-                    + "CAST(c.SOURCE_DATA_TYPE AS VARCHAR) SCOPE_TABLE, " //
-                    + "c.SOURCE_DATA_TYPE, " //
-                    + "CASE WHEN c.SEQUENCE_NAME IS NULL THEN " //
-                    + "CAST(?1 AS VARCHAR) ELSE CAST(?2 AS VARCHAR) END IS_AUTOINCREMENT, " //
-                    + "CASE WHEN c.IS_COMPUTED THEN " //
-                    + "CAST(?2 AS VARCHAR) ELSE CAST(?1 AS VARCHAR) END IS_GENERATEDCOLUMN " //
-                    + "FROM INFORMATION_SCHEMA.COLUMNS c JOIN INFORMATION_SCHEMA.SYNONYMS s ON " //
-                    + "s.SYNONYM_FOR = c.TABLE_NAME " //
-                    + "AND s.SYNONYM_FOR_SCHEMA = c.TABLE_SCHEMA " //
-                    + "WHERE s.SYNONYM_CATALOG LIKE ?3 ESCAPE ?7 " //
-                    + "AND s.SYNONYM_SCHEMA LIKE ?4 ESCAPE ?7 " //
-                    + "AND s.SYNONYM_NAME LIKE ?5 ESCAPE ?7 " //
-                    + "AND c.COLUMN_NAME LIKE ?6 ESCAPE ?7 " //
-                    + "UNION ");
-        }
-        select.append("SELECT " //
+        return executeQuery("SELECT " //
+                + "TABLE_CAT, " //
+                + "TABLE_SCHEM, " //
+                + "TABLE_NAME, " //
+                + "COLUMN_NAME, " //
+                + "DATA_TYPE, " //
+                + "TYPE_NAME, " //
+                + "COLUMN_SIZE, " //
+                + "BUFFER_LENGTH, " //
+                + "DECIMAL_DIGITS, " //
+                + "NUM_PREC_RADIX, " //
+                + "NULLABLE, " //
+                + "REMARKS, " //
+                + "COLUMN_DEF, " //
+                + "SQL_DATA_TYPE, " //
+                + "SQL_DATETIME_SUB, " //
+                + "CHAR_OCTET_LENGTH, " //
+                + "ORDINAL_POSITION, " //
+                + "IS_NULLABLE, " //
+                + "SCOPE_CATALOG, " //
+                + "SCOPE_SCHEMA, " //
+                + "SCOPE_TABLE, " //
+                + "SOURCE_DATA_TYPE, " //
+                + "IS_AUTOINCREMENT, " //
+                + "IS_GENERATEDCOLUMN " //
+                + "FROM (" //
+                + "SELECT " //
+                + "s.SYNONYM_CATALOG TABLE_CAT, " //
+                + "s.SYNONYM_SCHEMA TABLE_SCHEM, " //
+                + "s.SYNONYM_NAME TABLE_NAME, " //
+                + "c.COLUMN_NAME, " //
+                + "c.DATA_TYPE, " //
+                + "c.TYPE_NAME, " //
+                + "c.CHARACTER_MAXIMUM_LENGTH COLUMN_SIZE, " //
+                + "c.CHARACTER_MAXIMUM_LENGTH BUFFER_LENGTH, " //
+                + "c.NUMERIC_SCALE DECIMAL_DIGITS, " //
+                + "c.NUMERIC_PRECISION_RADIX NUM_PREC_RADIX, " //
+                + "c.NULLABLE, " //
+                + "c.REMARKS, " //
+                + "c.COLUMN_DEFAULT COLUMN_DEF, " //
+                + "c.DATA_TYPE SQL_DATA_TYPE, " //
+                + "ZERO() SQL_DATETIME_SUB, " //
+                + "c.CHARACTER_OCTET_LENGTH CHAR_OCTET_LENGTH, " //
+                + "c.ORDINAL_POSITION, " //
+                + "c.IS_NULLABLE IS_NULLABLE, " //
+                + "CAST(c.SOURCE_DATA_TYPE AS VARCHAR) SCOPE_CATALOG, " //
+                + "CAST(c.SOURCE_DATA_TYPE AS VARCHAR) SCOPE_SCHEMA, " //
+                + "CAST(c.SOURCE_DATA_TYPE AS VARCHAR) SCOPE_TABLE, " //
+                + "c.SOURCE_DATA_TYPE, " //
+                + "CASE WHEN c.SEQUENCE_NAME IS NULL THEN " //
+                + "CAST(?1 AS VARCHAR) ELSE CAST(?2 AS VARCHAR) END IS_AUTOINCREMENT, " //
+                + "CASE WHEN c.IS_COMPUTED THEN " //
+                + "CAST(?2 AS VARCHAR) ELSE CAST(?1 AS VARCHAR) END IS_GENERATEDCOLUMN " //
+                + "FROM INFORMATION_SCHEMA.COLUMNS c JOIN INFORMATION_SCHEMA.SYNONYMS s ON " //
+                + "s.SYNONYM_FOR = c.TABLE_NAME " //
+                + "AND s.SYNONYM_FOR_SCHEMA = c.TABLE_SCHEMA " //
+                + "WHERE s.SYNONYM_CATALOG LIKE ?3 ESCAPE ?7 " //
+                + "AND s.SYNONYM_SCHEMA LIKE ?4 ESCAPE ?7 " //
+                + "AND s.SYNONYM_NAME LIKE ?5 ESCAPE ?7 " //
+                + "AND c.COLUMN_NAME LIKE ?6 ESCAPE ?7 " //
+                + "UNION SELECT " //
                 + "TABLE_CATALOG TABLE_CAT, " //
                 + "TABLE_SCHEMA TABLE_SCHEM, " //
                 + "TABLE_NAME, " //
@@ -378,11 +372,8 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
                 + "WHERE TABLE_CATALOG LIKE ?3 ESCAPE ?7 " //
                 + "AND TABLE_SCHEMA LIKE ?4 ESCAPE ?7 " //
                 + "AND TABLE_NAME LIKE ?5 ESCAPE ?7 " //
-                + "AND COLUMN_NAME LIKE ?6 ESCAPE ?7");
-        if (includeSynonyms) {
-            select.append(')');
-        }
-        return executeQuery(select.append(" ORDER BY TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION").toString(), //
+                + "AND COLUMN_NAME LIKE ?6 ESCAPE ?7) " //
+                + "ORDER BY TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION", //
                 NO, //
                 YES, //
                 getCatalogPattern(catalog), //
@@ -679,11 +670,6 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
         if (session.isClosed()) {
             throw DbException.get(ErrorCode.DATABASE_CALLED_AT_SHUTDOWN);
         }
-    }
-
-    private boolean hasSynonyms() {
-        return !(session instanceof SessionRemote)
-                || ((SessionRemote) session).getClientVersion() >= Constants.TCP_PROTOCOL_VERSION_17;
     }
 
     private Value getString(String string) {

--- a/h2/src/main/org/h2/result/UpdatableRow.java
+++ b/h2/src/main/org/h2/result/UpdatableRow.java
@@ -5,7 +5,6 @@
  */
 package org.h2.result;
 
-import java.io.IOException;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;

--- a/h2/src/main/org/h2/store/DataReader.java
+++ b/h2/src/main/org/h2/store/DataReader.java
@@ -9,7 +9,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.sql.SQLException;
 import org.h2.util.IOUtils;
 
 /**

--- a/h2/src/main/org/h2/store/fs/FileUtils.java
+++ b/h2/src/main/org/h2/store/fs/FileUtils.java
@@ -15,7 +15,6 @@ import java.nio.channels.FileChannel;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;

--- a/h2/src/main/org/h2/util/NetUtils.java
+++ b/h2/src/main/org/h2/util/NetUtils.java
@@ -13,7 +13,6 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
-import java.sql.SQLException;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.SysProperties;

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -14,7 +14,6 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;

--- a/h2/src/main/org/h2/value/Transfer.java
+++ b/h2/src/main/org/h2/value/Transfer.java
@@ -14,7 +14,6 @@ import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/h2/src/main/org/h2/value/ValueBytesBase.java
+++ b/h2/src/main/org/h2/value/ValueBytesBase.java
@@ -8,8 +8,6 @@ package org.h2.value;
 import java.util.Arrays;
 
 import org.h2.engine.CastDataProvider;
-import org.h2.engine.Constants;
-import org.h2.message.DbException;
 import org.h2.util.Bits;
 import org.h2.util.StringUtils;
 import org.h2.util.Utils;

--- a/h2/src/main/org/h2/value/lob/LobDataFile.java
+++ b/h2/src/main/org/h2/value/lob/LobDataFile.java
@@ -6,7 +6,6 @@
 package org.h2.value.lob;
 
 import java.io.BufferedInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 import org.h2.engine.Constants;
@@ -15,7 +14,6 @@ import org.h2.store.DataHandler;
 import org.h2.store.FileStore;
 import org.h2.store.FileStoreInputStream;
 import org.h2.store.fs.FileUtils;
-import org.h2.util.MathUtils;
 import org.h2.value.ValueLob;
 
 /**

--- a/h2/src/test/org/h2/samples/FileFunctions.java
+++ b/h2/src/test/org/h2/samples/FileFunctions.java
@@ -10,7 +10,6 @@ import java.io.RandomAccessFile;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 
 /**

--- a/h2/src/test/org/h2/samples/HelloWorld.java
+++ b/h2/src/test/org/h2/samples/HelloWorld.java
@@ -8,7 +8,6 @@ package org.h2.samples;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.tools.DeleteDbFiles;
 

--- a/h2/src/test/org/h2/samples/InitDatabaseFromJar.java
+++ b/h2/src/test/org/h2/samples/InitDatabaseFromJar.java
@@ -10,7 +10,6 @@ import java.io.InputStreamReader;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.h2.tools.RunScript;

--- a/h2/src/test/org/h2/samples/Newsfeed.java
+++ b/h2/src/test/org/h2/samples/Newsfeed.java
@@ -14,7 +14,6 @@ import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 
 import org.h2.tools.RunScript;
 import org.h2.util.StringUtils;

--- a/h2/src/test/org/h2/samples/ReadOnlyDatabaseInZip.java
+++ b/h2/src/test/org/h2/samples/ReadOnlyDatabaseInZip.java
@@ -7,7 +7,6 @@ package org.h2.samples;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.store.fs.FileUtils;
 import org.h2.tools.Backup;

--- a/h2/src/test/org/h2/samples/SecurePassword.java
+++ b/h2/src/test/org/h2/samples/SecurePassword.java
@@ -9,7 +9,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 

--- a/h2/src/test/org/h2/test/bench/BenchB.java
+++ b/h2/src/test/org/h2/test/bench/BenchB.java
@@ -7,7 +7,6 @@ package org.h2.test.bench;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Random;
 

--- a/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
+++ b/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
@@ -6,7 +6,6 @@
 package org.h2.test.jdbc;
 
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.h2.api.ErrorCode;

--- a/h2/src/test/org/h2/test/scripts/dml/update.sql
+++ b/h2/src/test/org/h2/test/scripts/dml/update.sql
@@ -318,3 +318,28 @@ UPDATE FOO SET BAR.VAL = FOO.VAL FROM BAR WHERE FOO.ID = BAR.ID;
 
 SET MODE Regular;
 > ok
+
+CREATE TABLE DEST(ID INT, X INT, Y INT);
+> ok
+
+INSERT INTO DEST VALUES (1, 10, 11), (2, 20, 21);
+> update count: 2
+
+CREATE TABLE SRC(ID INT, X INT, Y INT);
+> ok
+
+INSERT INTO SRC VALUES (1, 100, 101);
+> update count: 1
+
+UPDATE DEST SET (X, Y) = (SELECT X, Y FROM SRC WHERE SRC.ID = DEST.ID);
+> update count: 2
+
+TABLE DEST;
+> ID X    Y
+> -- ---- ----
+> 1  100  101
+> 2  null null
+> rows: 2
+
+DROP TABLE SRC, DEST;
+> ok

--- a/h2/src/tools/org/h2/build/doclet/Doclet.java
+++ b/h2/src/tools/org/h2/build/doclet/Doclet.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;

--- a/h2/src/tools/org/h2/build/doclet/ResourceDoclet.java
+++ b/h2/src/tools/org/h2/build/doclet/ResourceDoclet.java
@@ -6,7 +6,6 @@
 package org.h2.build.doclet;
 
 import java.io.IOException;
-import java.sql.SQLException;
 import org.h2.build.doc.XMLParser;
 import org.h2.build.indexer.HtmlConverter;
 import org.h2.util.SortedProperties;

--- a/h2/src/tools/org/h2/build/indexer/Indexer.java
+++ b/h2/src/tools/org/h2/build/indexer/Indexer.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/h2/src/tools/org/h2/jcr/Railroads.java
+++ b/h2/src/tools/org/h2/jcr/Railroads.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
1. Subquery with degree greater than one is fixed for queries without rows. Closes #3249.

2. Old versions of TCP protocol for H2 1.4.196 and older versions are removed, because some operations in them are broken and I think nobody wants to fix them. Actually even H2 1.4.197 has interoperability problems with 1.4.196 and older versions.