### PR TITLE
Throw proper exception when type of argument isn't known

### DIFF
--- a/h2/src/main/org/h2/expression/ArrayElementReference.java
+++ b/h2/src/main/org/h2/expression/ArrayElementReference.java
@@ -59,7 +59,7 @@ public final class ArrayElementReference extends Operation2 {
             }
             break;
         default:
-            throw DbException.getInvalidValueException("Array", leftType.getTraceSQL());
+            throw DbException.getInvalidExpressionTypeException("Array", left);
         }
         return this;
     }

--- a/h2/src/main/org/h2/expression/FieldReference.java
+++ b/h2/src/main/org/h2/expression/FieldReference.java
@@ -50,7 +50,7 @@ public final class FieldReference extends Operation1 {
         arg = arg.optimize(session);
         TypeInfo type = arg.getType();
         if (type.getValueType() != Value.ROW) {
-            throw DbException.getInvalidValueException("ROW", type.getTraceSQL());
+            throw DbException.getInvalidExpressionTypeException("ROW", arg);
         }
         int ordinal = 0;
         for (Entry<String, TypeInfo> entry : ((ExtTypeInfoRow) type.getExtTypeInfo()).getFields()) {

--- a/h2/src/main/org/h2/expression/function/ArrayFunction.java
+++ b/h2/src/main/org/h2/expression/function/ArrayFunction.java
@@ -148,10 +148,11 @@ public final class ArrayFunction extends FunctionN {
         switch (function) {
         case TRIM_ARRAY:
         case ARRAY_SLICE: {
-            type = args[0].getType();
+            Expression arg = args[0];
+            type = arg.getType();
             int t = type.getValueType();
             if (t != Value.ARRAY && t != Value.NULL) {
-                throw DbException.getInvalidValueException(getName() + " array argument", type.getTraceSQL());
+                throw DbException.getInvalidExpressionTypeException(getName() + " array argument", arg);
             }
             break;
         }

--- a/h2/src/main/org/h2/expression/function/BitFunction.java
+++ b/h2/src/main/org/h2/expression/function/BitFunction.java
@@ -713,7 +713,7 @@ public final class BitFunction extends Function1_2 {
         case Value.BIGINT:
             return t;
         }
-        throw DbException.getInvalidValueException("bit function parameter", t.getTraceSQL());
+        throw DbException.getInvalidExpressionTypeException("bit function argument", arg);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/function/DateTimeFunction.java
+++ b/h2/src/main/org/h2/expression/function/DateTimeFunction.java
@@ -973,7 +973,7 @@ public final class DateTimeFunction extends Function1_2 {
             int valueType = type.getValueType();
             // TODO set scale when possible
             if (!DataType.isDateTimeType(valueType)) {
-                throw DbException.getInvalidValueException("DATE_TRUNC datetime argument", type.getTraceSQL());
+                throw DbException.getInvalidExpressionTypeException("DATE_TRUNC datetime argument", left);
             } else if (session.getMode().getEnum() == ModeEnum.PostgreSQL && valueType == Value.DATE) {
                 type = TypeInfo.TYPE_TIMESTAMP_TZ;
             }

--- a/h2/src/main/org/h2/expression/function/MathFunction.java
+++ b/h2/src/main/org/h2/expression/function/MathFunction.java
@@ -238,7 +238,8 @@ public final class MathFunction extends Function1_2 {
             if (valueType == Value.NULL) {
                 commonType = TypeInfo.TYPE_BIGINT;
             } else if (!DataType.isNumericType(valueType)) {
-                throw DbException.getInvalidValueException("numeric", commonType.getTraceSQL());
+                throw DbException.getInvalidExpressionTypeException("MOD argument",
+                        DataType.isNumericType(left.getType().getValueType()) ? right : left);
             }
             type = DataType.isNumericType(divisorType.getValueType()) ? divisorType : commonType;
             break;
@@ -377,7 +378,7 @@ public final class MathFunction extends Function1_2 {
             break;
         }
         default:
-            throw DbException.getInvalidValueException("numeric", leftType.getTraceSQL());
+            throw DbException.getInvalidExpressionTypeException(getName() + " argument", left);
         }
         if (scaleIsNull) {
             return TypedValueExpression.get(ValueNull.INSTANCE, type);

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -33,9 +33,13 @@ import org.h2.jdbc.JdbcSQLSyntaxErrorException;
 import org.h2.jdbc.JdbcSQLTimeoutException;
 import org.h2.jdbc.JdbcSQLTransactionRollbackException;
 import org.h2.jdbc.JdbcSQLTransientException;
+import org.h2.util.HasSQL;
 import org.h2.util.SortedProperties;
 import org.h2.util.StringUtils;
 import org.h2.util.Utils;
+import org.h2.value.TypeInfo;
+import org.h2.value.Typed;
+import org.h2.value.Value;
 
 /**
  * This exception wraps a checked exception.
@@ -296,6 +300,21 @@ public class DbException extends RuntimeException {
      */
     public static DbException getInvalidValueException(String param, Object value) {
         return get(INVALID_VALUE_2, value == null ? "null" : value.toString(), param);
+    }
+
+    /**
+     * Gets a SQL exception meaning the type of expression is invalid or unknown.
+     *
+     * @param param the name of the parameter
+     * @param e the expression
+     * @return the exception
+     */
+    public static DbException getInvalidExpressionTypeException(String param, Typed e) {
+        TypeInfo type = e.getType();
+        if (type.getValueType() == Value.UNKNOWN) {
+            return get(UNKNOWN_DATA_TYPE_1, (e instanceof HasSQL ? (HasSQL) e : type).getTraceSQL());
+        }
+        return get(INVALID_VALUE_2, type.getTraceSQL(), param);
     }
 
     /**

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -352,6 +352,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL, Typ
     };
 
     private static final String NAMES[] = {
+            "UNKNOWN",
             "NULL", //
             "CHARACTER", "CHARACTER VARYING", "CHARACTER LARGE OBJECT", "VARCHAR_IGNORECASE", //
             "BINARY", "BINARY VARYING", "BINARY LARGE OBJECT", //
@@ -408,7 +409,7 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL, Typ
      * @return the name
      */
     public static String getTypeName(int valueType) {
-        return NAMES[valueType];
+        return NAMES[valueType + 1];
     }
 
     /**

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -393,6 +393,8 @@ public class TestPreparedStatement extends TestDb {
     private void testUnknownDataType(Connection conn) throws SQLException {
         assertThrows(ErrorCode.UNKNOWN_DATA_TYPE_1, conn).
             prepareStatement("SELECT * FROM (SELECT ? FROM DUAL)");
+        assertThrows(ErrorCode.UNKNOWN_DATA_TYPE_1, conn).
+            prepareStatement("VALUES BITAND(?, ?)");
         PreparedStatement prep = conn.prepareStatement("SELECT -?");
         prep.setInt(1, 1);
         execute(prep);


### PR DESCRIPTION
`UNKNOWN_DATA_TYPE_1` is now thrown instead of general error caused by AIOOBE when some function cannot be 
initialized because type of its argument isn't known because it is a JDBC parameter without a cast.