### PR TITLE
Small optimization for MIN and MAX

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -25,7 +25,7 @@ Change Log
 </li>
 <li>PR #3248: Remove redundant uniqueness check, correct version in pom
 </li>
-<li>PR #3247: Avoid AIOB exception in TestCrashAPI and in Transaction
+<li>PR #3247: Avoid AIOBE exception in TestCrashAPI and in Transaction
 </li>
 <li>Issue #3241: ResultSetMetaData::getColumnTypeName should produce the correct ARRAY type
 </li>

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -5,7 +5,6 @@
  */
 package org.h2.mvstore.db;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
@@ -21,6 +20,7 @@ import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStoreException;
 import org.h2.mvstore.tx.Transaction;
 import org.h2.mvstore.tx.TransactionMap;
+import org.h2.mvstore.tx.TransactionMap.TMIterator;
 import org.h2.mvstore.type.LongDataType;
 import org.h2.result.Row;
 import org.h2.result.SearchRow;
@@ -406,11 +406,11 @@ public class MVPrimaryIndex extends MVIndex<Long, SearchRow> {
      */
     static final class MVStoreCursor implements Cursor {
 
-        private final Iterator<Entry<Long,SearchRow>> it;
-        private Entry<Long,SearchRow> current;
+        private final TMIterator<Long, SearchRow, Entry<Long, SearchRow>> it;
+        private Entry<Long, SearchRow> current;
         private Row row;
 
-        public MVStoreCursor(Iterator<Entry<Long,SearchRow>> it) {
+        public MVStoreCursor(TMIterator<Long, SearchRow, Entry<Long, SearchRow>> it) {
             this.it = it;
         }
 
@@ -434,7 +434,7 @@ public class MVPrimaryIndex extends MVIndex<Long, SearchRow> {
 
         @Override
         public boolean next() {
-            current = it.hasNext() ? it.next() : null;
+            current = it.fetchNext();
             row = null;
             return current != null;
         }

--- a/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVPrimaryIndex.java
@@ -314,13 +314,9 @@ public class MVPrimaryIndex extends MVIndex<Long, SearchRow> {
 
     @Override
     public Cursor findFirstOrLast(SessionLocal session, boolean first) {
-        TransactionMap<Long,SearchRow> map = getMap(session);
-        Long rowId = first ? map.firstKey() : map.lastKey();
-        Row row = null;
-        if (rowId != null) {
-            row = setRowKey((Row) map.getFromSnapshot(rowId), rowId);
-        }
-        return new SingleRowCursor(row);
+        TransactionMap<Long, SearchRow> map = getMap(session);
+        Entry<Long, SearchRow> entry = first ? map.firstEntry() : map.lastEntry();
+        return new SingleRowCursor(entry != null ? setRowKey((Row) entry.getValue(), entry.getKey()) : null);
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -330,17 +330,15 @@ public final class MVSecondaryIndex extends MVIndex<SearchRow, Value> {
 
     @Override
     public Cursor findFirstOrLast(SessionLocal session, boolean first) {
-        TransactionMap<SearchRow,Value> map = getMap(session);
-        SearchRow key = first ? map.firstKey() : map.lastKey();
-        while (true) {
-            if (key == null) {
-                return new SingleRowCursor(null);
-            }
+        TransactionMap<SearchRow, Value> map = getMap(session);
+        Iterator<SearchRow> iter = map.keyIterator(null, !first);
+        while (iter.hasNext()) {
+            SearchRow key = iter.next();
             if (key.getValue(columnIds[0]) != ValueNull.INSTANCE) {
                 return new SingleRowCursor(mvTable.getRow(session, key.getKey()));
             }
-            key = first ? map.higherKey(key) : map.lowerKey(key);
         }
+        return new SingleRowCursor(null);
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -205,7 +205,7 @@ public final class MVSecondaryIndex extends MVIndex<SearchRow, Value> {
         to.setKey(Long.MAX_VALUE);
         if (repeatableRead) {
             // In order to guarantee repeatable reads, snapshot taken at the beginning of the statement or transaction
-            // need to be checked additionaly, because existence of the key should be accounted for,
+            // need to be checked additionally, because existence of the key should be accounted for,
             // even if since then, it was already deleted by another (possibly committed) transaction.
             Iterator<SearchRow> it = map.keyIterator(from, to);
             while (it.hasNext()) {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -664,11 +664,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @return the result
      */
     public K higherKey(K key) {
-        RootReference<K,VersionedValue<V>> rootReference = getSnapshot().root;
-        do {
-            key = map.higherKey(rootReference, key);
-        } while (key != null && getFromSnapshot(key) == null);
-        return key;
+        return higherLowerKey(key, false);
     }
 
     /**
@@ -701,11 +697,17 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @return the result
      */
     public K lowerKey(K key) {
-        RootReference<K,VersionedValue<V>> rootReference = getSnapshot().root;
-        do {
-            key = map.lowerKey(rootReference, key);
-        } while (key != null && getFromSnapshot(key) == null);
-        return key;
+        return higherLowerKey(key, true);
+    }
+
+    private K higherLowerKey(K key, boolean lower) {
+        TMIterator<K, V, K> it = chooseIterator(key, null, lower, false);
+        K result = it.current;
+        if (result != null && map.getKeyType().compare(key, result) == 0) {
+            it.next();
+            result = it.current;
+        }
+        return result;
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -790,13 +790,13 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
     }
 
     /**
-     * Iterate over keys in the specified order
+     * Iterate over keys in the specified order.
      *
      * @param from the first key to return
      * @param reverse if true, iterate in reverse (descending) order
      * @return the iterator
      */
-    public Iterator<K> keyIterator(K from, boolean reverse) {
+    public TMIterator<K, V, K> keyIterator(K from, boolean reverse) {
         return chooseIterator(from, null, reverse, false);
     }
 
@@ -807,7 +807,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @param to the last key to return or null if there is no limit
      * @return the iterator
      */
-    public Iterator<K> keyIterator(K from, K to) {
+    public TMIterator<K, V, K> keyIterator(K from, K to) {
         return chooseIterator(from, to, false, false);
     }
 
@@ -818,7 +818,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @param to the last key to return or null if there is no limit
      * @return the iterator
      */
-    public Iterator<K> keyIteratorUncommitted(K from, K to) {
+    public TMIterator<K, V, K> keyIteratorUncommitted(K from, K to) {
         return new ValidationIterator<>(this, from, to);
     }
 
@@ -829,7 +829,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @param to the last key to return
      * @return the iterator
      */
-    public Iterator<Map.Entry<K, V>> entryIterator(final K from, final K to) {
+    public TMIterator<K, V, Map.Entry<K, V>> entryIterator(final K from, final K to) {
         return chooseIterator(from, to, false, true);
     }
 
@@ -878,7 +878,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
         }
 
         @Override
-        final X fetchNext() {
+        public final X fetchNext() {
             while (cursor.hasNext()) {
                 K key = cursor.next();
                 VersionedValue<?> data = cursor.getValue();
@@ -933,7 +933,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
         }
 
         @Override
-        X fetchNext() {
+        public X fetchNext() {
             while (cursor.hasNext()) {
                 K key = cursor.next();
                 VersionedValue<?> data = cursor.getValue();
@@ -992,7 +992,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
         }
 
         @Override
-        X fetchNext() {
+        public X fetchNext() {
             X next = null;
             do {
                 if (snapshotKey == null) {
@@ -1066,7 +1066,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
         }
     }
 
-    private abstract static class TMIterator<K,V,X> implements Iterator<X> {
+    public abstract static class TMIterator<K,V,X> implements Iterator<X> {
         final int transactionId;
 
         final BitSet committingTransactions;
@@ -1091,7 +1091,15 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
             return (X) (forEntries ? new AbstractMap.SimpleImmutableEntry<>(key, value) : key);
         }
 
-        abstract X fetchNext();
+        /**
+         * Fetches a next entry.
+         *
+         * This method cannot be used together with {@link #hasNext()} and
+         * {@link #next()}.
+         *
+         * @return the next entry or {@code null}
+         */
+        public abstract X fetchNext();
 
         @Override
         public final boolean hasNext() {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -639,6 +639,15 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
     }
 
     /**
+     * Get the first entry.
+     *
+     * @return the first entry, or null if empty
+     */
+    public Entry<K,V> firstEntry() {
+        return this.<Entry<K,V>>chooseIterator(null, null, false, true).current;
+    }
+
+    /**
      * Get the first key.
      *
      * @return the first key, or null if empty
@@ -648,12 +657,32 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
     }
 
     /**
+     * Get the last entry.
+     *
+     * @return the last entry, or null if empty
+     */
+    public Entry<K,V> lastEntry() {
+        return this.<Entry<K,V>>chooseIterator(null, null, true, true).current;
+    }
+
+    /**
      * Get the last key.
      *
      * @return the last key, or null if empty
      */
     public K lastKey() {
         return this.<K>chooseIterator(null, null, true, false).current;
+    }
+
+    /**
+     * Get the entry with smallest key that is larger than the given key, or null if no
+     * such key exists.
+     *
+     * @param key the key (may not be null)
+     * @return the result
+     */
+    public Entry<K,V> higherEntry(K key) {
+        return higherLowerEntry(key, false);
     }
 
     /**
@@ -668,6 +697,17 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
     }
 
     /**
+     * Get the entry with smallest key that is larger than or equal to this key,
+     * or null if no such key exists.
+     *
+     * @param key the key (may not be null)
+     * @return the result
+     */
+    public Entry<K,V> ceilingEntry(K key) {
+        return this.<Entry<K, V>>chooseIterator(key, null, false, true).current;
+    }
+
+    /**
      * Get the smallest key that is larger than or equal to this key,
      * or null if no such key exists.
      *
@@ -676,6 +716,17 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      */
     public K ceilingKey(K key) {
         return this.<K>chooseIterator(key, null, false, false).current;
+    }
+
+    /**
+     * Get the entry with largest key that is smaller than or equal to this key,
+     * or null if no such key exists.
+     *
+     * @param key the key (may not be null)
+     * @return the result
+     */
+    public Entry<K,V> floorEntry(K key) {
+        return this.<Entry<K, V>>chooseIterator(key, null, true, true).current;
     }
 
     /**
@@ -690,6 +741,17 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
     }
 
     /**
+     * Get the entry with largest key that is smaller than the given key, or null if no
+     * such key exists.
+     *
+     * @param key the key (may not be null)
+     * @return the result
+     */
+    public Entry<K,V> lowerEntry(K key) {
+        return higherLowerEntry(key, true);
+    }
+
+    /**
      * Get the largest key that is smaller than the given key, or null if no
      * such key exists.
      *
@@ -698,6 +760,16 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      */
     public K lowerKey(K key) {
         return higherLowerKey(key, true);
+    }
+
+    private Entry<K, V> higherLowerEntry(K key, boolean lower) {
+        TMIterator<K, V, Entry<K, V>> it = chooseIterator(key, null, lower, true);
+        Entry<K, V> result = it.current;
+        if (result != null && map.getKeyType().compare(key, result.getKey()) == 0) {
+            it.next();
+            result = it.current;
+        }
+        return result;
     }
 
     private K higherLowerKey(K key, boolean lower) {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -128,7 +128,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
     public long sizeAsLong() {
         IsolationLevel isolationLevel = transaction.getIsolationLevel();
         if (!isolationLevel.allowNonRepeatableRead() && hasChanges) {
-            return sizeAsLongSlow();
+            return sizeAsLongRepeatableReadWithChanges();
         }
         // getting coherent picture of the map, committing transactions, and undo logs
         // either from values stored in transaction (never loops in that case),
@@ -223,9 +223,9 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
         return v == null;
     }
 
-    private long sizeAsLongSlow() {
+    private long sizeAsLongRepeatableReadWithChanges() {
         long count = 0L;
-        Iterator<K> iterator = keyIterator(null, null);
+        RepeatableIterator<K, V, K> iterator = new RepeatableIterator<>(this, null, null, false, false);
         while (iterator.hasNext()) {
             iterator.next();
             count++;

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -790,6 +790,17 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
     }
 
     /**
+     * Iterate over keys in the specified order
+     *
+     * @param from the first key to return
+     * @param reverse if true, iterate in reverse (descending) order
+     * @return the iterator
+     */
+    public Iterator<K> keyIterator(K from, boolean reverse) {
+        return chooseIterator(from, null, reverse, false);
+    }
+
+    /**
      * Iterate over keys.
      *
      * @param from the first key to return

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -644,8 +644,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @return the first key, or null if empty
      */
     public K firstKey() {
-        Iterator<K> it = keyIterator(null);
-        return it.hasNext() ? it.next() : null;
+        return this.<K>chooseIterator(null, null, false, false).current;
     }
 
     /**
@@ -654,8 +653,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @return the last key, or null if empty
      */
     public K lastKey() {
-        Iterator<K> it = keyIteratorReverse(null);
-        return it.hasNext() ? it.next() : null;
+        return this.<K>chooseIterator(null, null, true, false).current;
     }
 
     /**
@@ -681,8 +679,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @return the result
      */
     public K ceilingKey(K key) {
-        Iterator<K> it = keyIterator(key);
-        return it.hasNext() ? it.next() : null;
+        return this.<K>chooseIterator(key, null, false, false).current;
     }
 
     /**
@@ -693,8 +690,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @return the result
      */
     public K floorKey(K key) {
-        Iterator<K> it = keyIteratorReverse(key);
-        return it.hasNext() ? it.next() : null;
+        return this.<K>chooseIterator(key, null, true, false).current;
     }
 
     /**
@@ -720,10 +716,6 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      */
     public Iterator<K> keyIterator(K from) {
         return chooseIterator(from, null, false, false);
-    }
-
-    private Iterator<K> keyIteratorReverse(K from) {
-        return chooseIterator(from, null, true, false);
     }
 
     /**
@@ -759,7 +751,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
         return chooseIterator(from, to, false, true);
     }
 
-    private <X> Iterator<X> chooseIterator(K from, K to, boolean reverse, boolean forEntries) {
+    private <X> TMIterator<K, V, X> chooseIterator(K from, K to, boolean reverse, boolean forEntries) {
         switch (transaction.isolationLevel) {
             case READ_UNCOMMITTED:
                 return new UncommittedIterator<>(this, from, to, reverse, forEntries);

--- a/h2/src/test/org/h2/test/db/TestTransaction.java
+++ b/h2/src/test/org/h2/test/db/TestTransaction.java
@@ -1256,7 +1256,7 @@ public class TestTransaction extends TestDb {
             stat2.executeUpdate("INSERT INTO TEST VALUES (104, 2)");
             conn1.commit();
             // Transaction was started with concurrent uncommitted change
-            testIsolationLevelCountAggregate2(prep, 
+            testIsolationLevelCountAggregate2(prep,
                     isolationLevel == Connection.TRANSACTION_READ_UNCOMMITTED ? 98L : 97L);
         }
     }

--- a/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
+++ b/h2/src/test/org/h2/test/jdbc/TestTransactionIsolation.java
@@ -90,14 +90,15 @@ public class TestTransactionIsolation extends TestDb {
         testDirtyRead(Connection.TRANSACTION_SERIALIZABLE, 4, false, false);
     }
 
-    private void testDirtyRead(int isolationLevel, int value, boolean dirtyVisible, boolean commitedVisible) throws SQLException {
+    private void testDirtyRead(int isolationLevel, int value, boolean dirtyVisible, boolean committedVisible)
+            throws SQLException {
         conn1.setTransactionIsolation(isolationLevel);
         assertSingleValue(conn1.createStatement(), "SELECT * FROM TEST", value);
         int newValue = value + 1;
         conn2.createStatement().executeUpdate("UPDATE TEST SET ID=" + newValue);
         assertSingleValue(conn1.createStatement(), "SELECT * FROM TEST", dirtyVisible ? newValue  : value);
         conn2.commit();
-        assertSingleValue(conn1.createStatement(), "SELECT * FROM TEST", commitedVisible ? newValue : value);
+        assertSingleValue(conn1.createStatement(), "SELECT * FROM TEST", committedVisible ? newValue : value);
     }
 
     private void testRowLocks(int isolationLevel) throws SQLException {

--- a/h2/src/test/org/h2/test/store/TestTransactionStore.java
+++ b/h2/src/test/org/h2/test/store/TestTransactionStore.java
@@ -10,6 +10,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -75,9 +76,11 @@ public class TestTransactionStore extends TestBase {
             Transaction t = ts.begin();
             LongDataType keyType = LongDataType.INSTANCE;
             TransactionMap<Long, Long> map = t.openMap("test", keyType, keyType);
-            // firstKey()
+            // firstEntry() & firstKey()
+            assertNull(map.firstEntry());
             assertNull(map.firstKey());
-            // lastKey()
+            // lastEntry() & lastKey()
+            assertNull(map.lastEntry());
             assertNull(map.lastKey());
             map.put(10L, 100L);
             map.put(20L, 200L);
@@ -88,28 +91,50 @@ public class TestTransactionStore extends TestBase {
             map = t.openMap("test", keyType, keyType);
             map.put(15L, 150L);
             // The same transaction
+            assertEquals(new SimpleImmutableEntry<>(15L, 150L), map.higherEntry(10L));
             assertEquals((Object) 15L, map.higherKey(10L));
             t = ts.begin();
             map = t.openMap("test", keyType, keyType);
             // Another transaction
-            // higherKey()
+            // firstEntry() & firstKey()
+            assertEquals(new SimpleImmutableEntry<>(10L, 100L), map.firstEntry());
+            assertEquals((Object) 10L, map.firstKey());
+            // lastEntry() & lastKey()
+            assertEquals(new SimpleImmutableEntry<>(40L, 400L),map.lastEntry());
+            assertEquals((Object) 40L, map.lastKey());
+            // higherEntry() & higherKey()
+            assertEquals(new SimpleImmutableEntry<>(20L, 200L), map.higherEntry(10L));
             assertEquals((Object) 20L, map.higherKey(10L));
+            assertEquals(new SimpleImmutableEntry<>(20L, 200L), map.higherEntry(15L));
             assertEquals((Object) 20L, map.higherKey(15L));
+            assertNull(map.higherEntry(40L));
             assertNull(map.higherKey(40L));
-            // ceilingKey()
+            // ceilingEntry() & ceilingKey()
+            assertEquals(new SimpleImmutableEntry<>(10L, 100L), map.ceilingEntry(10L));
             assertEquals((Object) 10L, map.ceilingKey(10L));
+            assertEquals(new SimpleImmutableEntry<>(20L, 200L), map.ceilingEntry(15L));
             assertEquals((Object) 20L, map.ceilingKey(15L));
+            assertEquals(new SimpleImmutableEntry<>(40L, 400L), map.ceilingEntry(40L));
             assertEquals((Object) 40L, map.ceilingKey(40L));
+            assertNull(map.higherEntry(45L));
             assertNull(map.higherKey(45L));
-            // lowerKey()
+            // lowerEntry() & lowerKey()
+            assertNull(map.lowerEntry(10L));
             assertNull(map.lowerKey(10L));
+            assertEquals(new SimpleImmutableEntry<>(10L, 100L), map.lowerEntry(15L));
             assertEquals((Object) 10L, map.lowerKey(15L));
+            assertEquals(new SimpleImmutableEntry<>(10L, 100L), map.lowerEntry(20L));
             assertEquals((Object) 10L, map.lowerKey(20L));
+            assertEquals(new SimpleImmutableEntry<>(20L, 200L), map.lowerEntry(25L));
             assertEquals((Object) 20L, map.lowerKey(25L));
-            // floorKey()
+            // floorEntry() & floorKey()
+            assertNull(map.floorEntry(5L));
             assertNull(map.floorKey(5L));
+            assertEquals(new SimpleImmutableEntry<>(10L, 100L), map.floorEntry(10L));
             assertEquals((Object) 10L, map.floorKey(10L));
+            assertEquals(new SimpleImmutableEntry<>(10L, 100L), map.floorEntry(15L));
             assertEquals((Object) 10L, map.floorKey(15L));
+            assertEquals(new SimpleImmutableEntry<>(30L, 300L), map.floorEntry(35L));
             assertEquals((Object) 30L, map.floorKey(35L));
         }
     }

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -846,4 +846,4 @@ deref corr asensitive sqlexception avgy avgx lateral rollup syy reseved specific
 ptf overlay precedes regr slope sqlerror multiset submultiset inout sxx sxy intercept sqlwarning tablesample preorder
 orientation eternal consideration erased fedc npgsql powers fffd uencode ampersand noversion ude considerable intro
 entirely skeleton discouraged pearson coefficient squares covariance mytab debuggers fonts glyphs
-filestore backstop tie breaker lockable lobtx btx waiter
+filestore backstop tie breaker lockable lobtx btx waiter accounted aiobe


### PR DESCRIPTION
1. Iterators of `TransactionMap` don't prefetch next entry any more. There are many cases when we don't need all rows, such as `MIN()` and `MAX()` aggregate functions, `FETCH` clause, `EXISTS`, etc. For in-memory database with single session on default isolation level and all committed rows `MIN` and `MAX` over primary key with delegated index are now faster by about 8% in test with 1 to 1,000,000 rows, `MIN` and `MAX` over other indexed column are faster by about 2.5%. For higher isolation levels and invisible uncommitted rows before or after visible rows difference in performance is expected to be larger.

2. `TransactionMap` now implements additional methods from (still unimplemented) `NavigableMap` interface: `firstEntry()`, `lastEntry()`, `higherEntry()`, `ceilingEntry()`, `floorEntry()`, and `lowerEntry()`.