### PR TITLE
Fix numeric regressions

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,16 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3266: Oracle compatibility NUMBER without precision and scale should have variable scale
+</li>
+<li>Issue #3263: Unable to store BigDecimal with negative scale in NUMERIC(19,6) column
+</li>
+<li>PR #3261: Small optimization for MIN and MAX
+</li>
+<li>Issue #3258 / PR #3259: Prevent incorrect optimization of COUNT(*) and other changes
+</li>
+<li>PR #3255: Throw proper exception when type of argument isn't known
+</li>
 <li>Issue #3249: Multi-column assignment with subquery throws exception when subquery doesn't return any rows
 </li>
 <li>PR #3248: Remove redundant uniqueness check, correct version in pom

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -7235,6 +7235,11 @@ public class Parser {
                 original = "NCHAR LARGE OBJECT";
             }
             break;
+        case "NUMBER":
+            if (!isToken(OPEN_PAREN)) {
+                return TypeInfo.getTypeInfo(Value.DECFLOAT, 40, -1, null);
+            }
+            //$FALL-THROUGH$
         case "NUMERIC":
             return parseNumericType(false);
         case "SMALLDATETIME":

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -7236,6 +7236,9 @@ public class Parser {
             }
             break;
         case "NUMBER":
+            if (database.getMode().disallowedTypes.contains("NUMBER")) {
+                throw DbException.get(ErrorCode.UNKNOWN_DATA_TYPE_1, "NUMBER");
+            }
             if (!isToken(OPEN_PAREN)) {
                 return TypeInfo.getTypeInfo(Value.DECFLOAT, 40, -1, null);
             }

--- a/h2/src/main/org/h2/fulltext/FullText.java
+++ b/h2/src/main/org/h2/fulltext/FullText.java
@@ -871,7 +871,6 @@ public class FullText {
         private FullTextSettings          setting;
         private IndexInfo                 index;
         private int[]                     columnTypes;
-        private final PreparedStatement[] prepStatements = new PreparedStatement[SQL.length];
 
         private static final int INSERT_WORD = 0;
         private static final int INSERT_ROW  = 1;
@@ -1140,7 +1139,7 @@ public class FullText {
             return builder.toString();
         }
 
-        private PreparedStatement getStatement(Connection conn, int index) throws SQLException {
+        private static PreparedStatement getStatement(Connection conn, int index) throws SQLException {
             return conn.prepareStatement(SQL[index], Statement.RETURN_GENERATED_KEYS);
         }
 

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -394,7 +394,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
             if (isDebugEnabled()) {
                 debugCode("setBigDecimal(" + parameterIndex + ", " + quoteBigDecimal(x) + ')');
             }
-            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueNumeric.get(x));
+            setParameter(parameterIndex, x == null ? ValueNull.INSTANCE : ValueNumeric.getAnyScale(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/jdbc/JdbcResultSet.java
+++ b/h2/src/main/org/h2/jdbc/JdbcResultSet.java
@@ -1800,8 +1800,7 @@ public final class JdbcResultSet extends TraceObject implements ResultSet {
             if (isDebugEnabled()) {
                 debugCode("updateBigDecimal(" + columnIndex + ", " + quoteBigDecimal(x) + ')');
             }
-            update(checkColumnIndex(columnIndex), x == null ? ValueNull.INSTANCE
-            : ValueNumeric.get(x));
+            update(checkColumnIndex(columnIndex), x == null ? ValueNull.INSTANCE : ValueNumeric.getAnyScale(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1820,7 +1819,7 @@ public final class JdbcResultSet extends TraceObject implements ResultSet {
             if (isDebugEnabled()) {
                 debugCode("updateBigDecimal(" + quote(columnLabel) + ", " + quoteBigDecimal(x) + ')');
             }
-            update(getColumnIndex(columnLabel), x == null ? ValueNull.INSTANCE : ValueNumeric.get(x));
+            update(getColumnIndex(columnLabel), x == null ? ValueNull.INSTANCE : ValueNumeric.getAnyScale(x));
         } catch (Exception e) {
             throw logAndConvert(e);
         }

--- a/h2/src/main/org/h2/jdbc/JdbcSQLXML.java
+++ b/h2/src/main/org/h2/jdbc/JdbcSQLXML.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.transform.Result;
@@ -48,7 +49,6 @@ import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
-import org.xml.sax.helpers.XMLReaderFactory;
 
 /**
  * Represents a SQLXML value.
@@ -147,12 +147,13 @@ public final class JdbcSQLXML extends JdbcLob implements SQLXML {
                 db.setEntityResolver(NOOP_ENTITY_RESOLVER);
                 return (T) new DOMSource(db.parse(new InputSource(value.getInputStream())));
             } else if (sourceClass == SAXSource.class) {
-                XMLReader reader = XMLReaderFactory.createXMLReader();
+                SAXParserFactory spf = SAXParserFactory.newInstance();
                 for (Map.Entry<String,Boolean> entry : secureFeatureMap.entrySet()) {
                     try {
-                        reader.setFeature(entry.getKey(), entry.getValue());
+                        spf.setFeature(entry.getKey(), entry.getValue());
                     } catch (Exception ignore) {/**/}
                 }
+                XMLReader reader = spf.newSAXParser().getXMLReader();
                 reader.setEntityResolver(NOOP_ENTITY_RESOLVER);
                 return (T) new SAXSource(reader, new InputSource(value.getInputStream()));
             } else if (sourceClass == StAXSource.class) {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -334,7 +334,6 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
     }
 
     private V set(Object key, TxDecisionMaker<K,V> decisionMaker) {
-        TransactionStore store = transaction.store;
         Transaction blockingTransaction;
         VersionedValue<V> result;
         String mapName = null;

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -4113,7 +4113,7 @@ BIGINT
 "
 
 "Data Types","NUMERIC Type","
-{ NUMERIC | DECIMAL | DEC | @c@ { NUMBER } } [ ( precisionInt [ , scaleInt ] ) ]
+{ NUMERIC | DECIMAL | DEC } [ ( precisionInt [ , scaleInt ] ) ]
 ","
 Data type with fixed decimal precision and scale.
 This data type is recommended for storing currency values.

--- a/h2/src/main/org/h2/value/DataType.java
+++ b/h2/src/main/org/h2/value/DataType.java
@@ -150,7 +150,7 @@ public class DataType {
         dataType.params = "PRECISION,SCALE";
         dataType.supportsPrecision = true;
         dataType.supportsScale = true;
-        add(Value.NUMERIC, Types.NUMERIC, dataType, "NUMERIC", "DECIMAL", "DEC", "NUMBER");
+        add(Value.NUMERIC, Types.NUMERIC, dataType, "NUMERIC", "DECIMAL", "DEC");
         add(Value.REAL, Types.REAL, createNumeric(ValueReal.PRECISION, 0), "REAL", "FLOAT4");
         add(Value.DOUBLE, Types.DOUBLE, createNumeric(ValueDouble.PRECISION, 0),
                 "DOUBLE PRECISION", "DOUBLE", "FLOAT8");

--- a/h2/src/main/org/h2/value/ValueNumeric.java
+++ b/h2/src/main/org/h2/value/ValueNumeric.java
@@ -172,6 +172,21 @@ public final class ValueNumeric extends ValueBigDecimalBase {
     }
 
     /**
+     * Get or create a NUMERIC value for the given big decimal with possibly
+     * negative scale. If scale is negative, it is normalized to 0.
+     *
+     * @param dec
+     *            the big decimal
+     * @return the value
+     */
+    public static ValueNumeric getAnyScale(BigDecimal dec) {
+        if (dec.scale() < 0) {
+            dec = dec.setScale(0, RoundingMode.UNNECESSARY);
+        }
+        return get(dec);
+    }
+
+    /**
      * Get or create a NUMERIC value for the given big integer.
      *
      * @param bigInteger the big integer

--- a/h2/src/main/org/h2/value/ValueToObjectConverter.java
+++ b/h2/src/main/org/h2/value/ValueToObjectConverter.java
@@ -145,7 +145,7 @@ public final class ValueToObjectConverter extends TraceObject {
         } else if (x instanceof BigInteger) {
             return ValueNumeric.get((BigInteger) x);
         } else if (x instanceof BigDecimal) {
-            return ValueNumeric.get((BigDecimal) x);
+            return ValueNumeric.getAnyScale((BigDecimal) x);
         } else {
             return otherToValue(session, x);
         }

--- a/h2/src/main/org/h2/value/ValueToObjectConverter2.java
+++ b/h2/src/main/org/h2/value/ValueToObjectConverter2.java
@@ -229,7 +229,7 @@ public final class ValueToObjectConverter2 extends TraceObject {
         }
         case Value.NUMERIC: {
             BigDecimal value = rs.getBigDecimal(columnIndex);
-            v = value == null ? ValueNull.INSTANCE : ValueNumeric.get(value);
+            v = value == null ? ValueNull.INSTANCE : ValueNumeric.getAnyScale(value);
             break;
         }
         case Value.REAL: {

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.net.URL;
 import java.sql.Array;
 import java.sql.Connection;
@@ -88,6 +89,7 @@ public class TestPreparedStatement extends TestDb {
         testCancelReuse(conn);
         testCoalesce(conn);
         testPreparedStatementMetaData(conn);
+        testBigDecimal(conn);
         testDate(conn);
         testDate8(conn);
         testTime8(conn);
@@ -646,6 +648,21 @@ public class TestPreparedStatement extends TestDb {
         case 6:
             prep.setObject(1, value, H2Type.INTEGER, 0);
         }
+    }
+
+    private void testBigDecimal(Connection conn) throws SQLException {
+        PreparedStatement prep = conn.prepareStatement("SELECT ?, ?");
+        BigDecimal bd = new BigDecimal("12300").setScale(-2, RoundingMode.UNNECESSARY);
+        prep.setBigDecimal(1, bd);
+        prep.setObject(2, bd);
+        ResultSet rs = prep.executeQuery();
+        rs.next();
+        bd = rs.getBigDecimal(1);
+        assertEquals(12300, bd.intValue());
+        assertEquals(0, bd.scale());
+        bd = rs.getBigDecimal(2);
+        assertEquals(12300, bd.intValue());
+        assertEquals(0, bd.scale());
     }
 
     private void testDate(Connection conn) throws SQLException {

--- a/h2/src/test/org/h2/test/scripts/datatypes/decfloat.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/decfloat.sql
@@ -3,16 +3,16 @@
 -- Initial Developer: H2 Group
 --
 
-CREATE MEMORY TABLE TEST(D1 DECFLOAT, D2 DECFLOAT(5), D3 DECFLOAT(10));
+CREATE MEMORY TABLE TEST(D1 DECFLOAT, D2 DECFLOAT(5), D3 DECFLOAT(10), X NUMBER);
 > ok
 
-INSERT INTO TEST VALUES(1, 1, 9999999999);
+INSERT INTO TEST VALUES(1, 1, 9999999999, 1.23);
 > update count: 1
 
 TABLE TEST;
-> D1 D2 D3
-> -- -- ----------
-> 1  1  9999999999
+> D1 D2 D3         X
+> -- -- ---------- ----
+> 1  1  9999999999 1.23
 > rows: 1
 
 SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE,
@@ -23,7 +23,8 @@ SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMER
 > D1          DECFLOAT  100000            10                      null          DECFLOAT           null                       null
 > D2          DECFLOAT  5                 10                      null          DECFLOAT           5                          null
 > D3          DECFLOAT  10                10                      null          DECFLOAT           10                         null
-> rows (ordered): 3
+> X           DECFLOAT  40                10                      null          DECFLOAT           40                         null
+> rows (ordered): 4
 
 SELECT D2 + D3 A, D2 - D3 S, D2 * D3 M, D2 / D3 D FROM TEST;
 > A     S           M          D

--- a/h2/src/test/org/h2/test/scripts/datatypes/numeric.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/numeric.sql
@@ -6,7 +6,7 @@
 CREATE MEMORY TABLE TEST(
     N1 NUMERIC, N2 NUMERIC(10), N3 NUMERIC(10, 0), N4 NUMERIC(10, 2),
     D1 DECIMAL, D2 DECIMAL(10), D3 DECIMAL(10, 0), D4 DECIMAL(10, 2), D5 DEC,
-    X1 NUMBER);
+    X1 NUMBER(10), X2 NUMBER(10, 2));
 > ok
 
 SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE,
@@ -23,8 +23,9 @@ SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMER
 > D3          NUMERIC   10                10                      0             DECIMAL            10                         0
 > D4          NUMERIC   10                10                      2             DECIMAL            10                         2
 > D5          NUMERIC   100000            10                      0             DECIMAL            null                       null
-> X1          NUMERIC   100000            10                      0             NUMERIC            null                       null
-> rows (ordered): 10
+> X1          NUMERIC   10                10                      0             NUMERIC            10                         null
+> X2          NUMERIC   10                10                      2             NUMERIC            10                         2
+> rows (ordered): 11
 
 DROP TABLE TEST;
 > ok


### PR DESCRIPTION
1. `BigDecimal` values with negative scale now create `NUMERIC` values with scale 0 instead of being rejected. Closes #3263.
2. Oracle compatibility `NUMBER` without parameters is now treated as `DECFLOAT(40)`, it cannot be emulated with standard-compliant implementation of `NUMERIC`. Closes #3266.
3. `SAXParserFactory` is now used instead of deprecated since Java 9 `XMLReaderFactory`. It accepts the same configuration parameters as reader created by the deprecated factory and passes them to `SAXParser` and its `XMLReader`.