### PR TITLE
Fix issues with triggers

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3251: Table with GEOMETRY column can't have a TriggerAdapter-based trigger any more
+</li>
+<li>PR #3281: DateTimeFormatter-based FORMATDATETIME and PARSEDATETIME and other changes
+</li>
 <li>Issue #3246: Spatial predicates with comparison are broken in MySQL compatibility mode
 </li>
 <li>Issue #3270: org.h2.jdbc.JdbcSQLFeatureNotSupportedException: Feature not supported: "Unsafe comparison or cast"

--- a/h2/src/main/org/h2/command/dml/SetClauseList.java
+++ b/h2/src/main/org/h2/command/dml/SetClauseList.java
@@ -137,7 +137,7 @@ public final class SetClauseList implements HasSQL {
             newRow.setValue(i, newValue);
         }
         newRow.setKey(oldRow.getKey());
-        table.convertUpdateRow(session, newRow);
+        table.convertUpdateRow(session, newRow, false);
         boolean result = true;
         if (onUpdate) {
             if (!oldRow.hasSameValues(newRow)) {
@@ -150,7 +150,7 @@ public final class SetClauseList implements HasSQL {
                 }
                 // Convert on update expressions and reevaluate
                 // generated columns
-                table.convertUpdateRow(session, newRow);
+                table.convertUpdateRow(session, newRow, false);
             } else if (updateToCurrentValuesReturnsZero) {
                 result = false;
             }

--- a/h2/src/main/org/h2/jdbc/JdbcArray.java
+++ b/h2/src/main/org/h2/jdbc/JdbcArray.java
@@ -267,7 +267,7 @@ public final class JdbcArray extends TraceObject implements Array {
         for (int i = (int) index; i < index + count; i++) {
             rs.addRow(ValueBigint.get(i), values[i - 1]);
         }
-        return new JdbcResultSet(conn, null, null, rs, id, true, false);
+        return new JdbcResultSet(conn, null, null, rs, id, true, false, false);
     }
 
     private void checkClosed() {

--- a/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
+++ b/h2/src/main/org/h2/jdbc/JdbcDatabaseMetaData.java
@@ -2613,7 +2613,7 @@ public final class JdbcDatabaseMetaData extends TraceObject
         }
         int id = getNextId(TraceObject.RESULT_SET);
         debugCodeAssign("ResultSet", TraceObject.RESULT_SET, id, "getClientInfoProperties()");
-        return new JdbcResultSet(conn, null, null, result, id, true, false);
+        return new JdbcResultSet(conn, null, null, result, id, true, false, false);
     }
 
     /**
@@ -2746,7 +2746,7 @@ public final class JdbcDatabaseMetaData extends TraceObject
     }
 
     private JdbcResultSet getResultSet(ResultInterface result) {
-        return new JdbcResultSet(conn, null, null, result, getNextId(TraceObject.RESULT_SET), false, false);
+        return new JdbcResultSet(conn, null, null, result, getNextId(TraceObject.RESULT_SET), true, false, false);
     }
 
 }

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -211,7 +211,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
                 ResultInterface gk = result.getGeneratedKeys();
                 if (gk != null) {
                     int id = getNextId(TraceObject.RESULT_SET);
-                    generatedKeys = new JdbcResultSet(conn, this, command, gk, id, true, false);
+                    generatedKeys = new JdbcResultSet(conn, this, command, gk, id, true, false, false);
                 }
             } finally {
                 setExecutingStatement(null);
@@ -255,7 +255,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
                         updateCount = result.getUpdateCount();
                         ResultInterface gk = result.getGeneratedKeys();
                         if (gk != null) {
-                            generatedKeys = new JdbcResultSet(conn, this, command, gk, id, true, false);
+                            generatedKeys = new JdbcResultSet(conn, this, command, gk, id, true, false, false);
                         }
                     }
                 } finally {
@@ -1332,7 +1332,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
                 int id = getNextId(TraceObject.RESULT_SET);
                 debugCodeAssign("ResultSet", TraceObject.RESULT_SET, id, "getGeneratedKeys()");
                 checkClosed();
-                generatedKeys = new JdbcResultSet(conn, this, null, batchIdentities.getResult(), id, true, false);
+                generatedKeys = new JdbcResultSet(conn, this, null, batchIdentities.getResult(), id, true, false, false);
             } catch (Exception e) {
                 throw logAndConvert(e);
             }

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -106,7 +106,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
                 if (!lazy) {
                     command.close();
                 }
-                resultSet = new JdbcResultSet(conn, this, command, result, id, scrollable, updatable);
+                resultSet = new JdbcResultSet(conn, this, command, result, id, scrollable, updatable, false);
             }
             return resultSet;
         } catch (Exception e) {
@@ -192,7 +192,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
                 ResultInterface gk = result.getGeneratedKeys();
                 if (gk != null) {
                     int id = getNextId(TraceObject.RESULT_SET);
-                    generatedKeys = new JdbcResultSet(conn, this, command, gk, id, true, false);
+                    generatedKeys = new JdbcResultSet(conn, this, command, gk, id, true, false, false);
                 }
             } finally {
                 setExecutingStatement(null);
@@ -246,14 +246,14 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
                     boolean updatable = resultSetConcurrency == ResultSet.CONCUR_UPDATABLE;
                     ResultInterface result = command.executeQuery(maxRows, scrollable);
                     lazy = result.isLazy();
-                    resultSet = new JdbcResultSet(conn, this, command, result, id, scrollable, updatable);
+                    resultSet = new JdbcResultSet(conn, this, command, result, id, scrollable, updatable, false);
                 } else {
                     returnsResultSet = false;
                     ResultWithGeneratedKeys result = command.executeUpdate(generatedKeysRequest);
                     updateCount = result.getUpdateCount();
                     ResultInterface gk = result.getGeneratedKeys();
                     if (gk != null) {
-                        generatedKeys = new JdbcResultSet(conn, this, command, gk, id, true, false);
+                        generatedKeys = new JdbcResultSet(conn, this, command, gk, id, true, false, false);
                     }
                 }
             } finally {
@@ -890,7 +890,7 @@ public class JdbcStatement extends TraceObject implements Statement, JdbcStateme
             }
             checkClosed();
             if (generatedKeys == null) {
-                generatedKeys = new JdbcResultSet(conn, this, null, new SimpleResult(), id, true, false);
+                generatedKeys = new JdbcResultSet(conn, this, null, new SimpleResult(), id, true, false, false);
             }
             return generatedKeys;
         } catch (Exception e) {

--- a/h2/src/main/org/h2/result/SimpleResult.java
+++ b/h2/src/main/org/h2/result/SimpleResult.java
@@ -74,20 +74,38 @@ public class SimpleResult implements ResultInterface, ResultTarget {
 
     private final ArrayList<Value[]> rows;
 
+    private final String schemaName, tableName;
+
     private int rowId;
 
     /**
      * Creates new instance of simple result.
      */
     public SimpleResult() {
+        this("", "");
+    }
+
+    /**
+     * Creates new instance of simple result.
+     *
+     * @param schemaName
+     *            the name of the schema
+     * @param tableName
+     *            the name of the table
+     */
+    public SimpleResult(String schemaName, String tableName) {
         this.columns = Utils.newSmallArrayList();
         this.rows = new ArrayList<>();
+        this.schemaName = schemaName;
+        this.tableName = tableName;
         this.rowId = -1;
     }
 
-    private SimpleResult(ArrayList<Column> columns, ArrayList<Value[]> rows) {
+    private SimpleResult(ArrayList<Column> columns, ArrayList<Value[]> rows, String schemaName, String tableName) {
         this.columns = columns;
         this.rows = rows;
+        this.schemaName = schemaName;
+        this.tableName = tableName;
         this.rowId = -1;
     }
 
@@ -213,12 +231,12 @@ public class SimpleResult implements ResultInterface, ResultTarget {
 
     @Override
     public String getSchemaName(int i) {
-        return "";
+        return schemaName;
     }
 
     @Override
     public String getTableName(int i) {
-        return "";
+        return tableName;
     }
 
     @Override
@@ -263,7 +281,7 @@ public class SimpleResult implements ResultInterface, ResultTarget {
 
     @Override
     public SimpleResult createShallowCopy(Session targetSession) {
-        return new SimpleResult(columns, rows);
+        return new SimpleResult(columns, rows, schemaName, tableName);
     }
 
     @Override

--- a/h2/src/main/org/h2/schema/TriggerObject.java
+++ b/h2/src/main/org/h2/schema/TriggerObject.java
@@ -258,11 +258,16 @@ public final class TriggerObject extends SchemaObject {
                 throw getErrorExecutingTrigger(e);
             }
             if (newListBackup != null) {
+                boolean modified = false;
                 for (int i = 0; i < newList.length; i++) {
                     Object o = newList[i];
                     if (o != newListBackup[i]) {
+                        modified = true;
                         newRow.setValue(i, ValueToObjectConverter.objectToValue(session, o, Value.UNKNOWN));
                     }
+                }
+                if (modified) {
+                    table.convertUpdateRow(session, newRow, true);
                 }
             }
         } catch (Exception e) {

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -938,16 +938,20 @@ public abstract class Table extends SchemaObject {
      *
      * @param session the session
      * @param row the row
+     * @param fromTrigger {@code true} if row was modified by INSERT or UPDATE trigger
      */
-    public void convertUpdateRow(SessionLocal session, Row row) {
+    public void convertUpdateRow(SessionLocal session, Row row, boolean fromTrigger) {
         int length = columns.length, generated = 0;
         for (int i = 0; i < length; i++) {
             Value value = row.getValue(i);
             Column column = columns[i];
             if (column.isGenerated()) {
                 if (value != null) {
-                    throw DbException.get(ErrorCode.GENERATED_COLUMN_CANNOT_BE_ASSIGNED_1,
-                            column.getSQLWithTable(new StringBuilder(), TRACE_SQL_FLAGS).toString());
+                    if (!fromTrigger) {
+                        throw DbException.get(ErrorCode.GENERATED_COLUMN_CANNOT_BE_ASSIGNED_1,
+                                column.getSQLWithTable(new StringBuilder(), TRACE_SQL_FLAGS).toString());
+                    }
+                    row.setValue(i, null);
                 }
                 generated++;
                 continue;

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -671,7 +671,7 @@ public class TableLink extends Table {
     }
 
     @Override
-    public void convertUpdateRow(SessionLocal session, Row row) {
+    public void convertUpdateRow(SessionLocal session, Row row, boolean fromTrigger) {
         convertRow(session, row);
     }
 

--- a/h2/src/main/org/h2/tools/TriggerAdapter.java
+++ b/h2/src/main/org/h2/tools/TriggerAdapter.java
@@ -9,6 +9,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.h2.api.Trigger;
+import org.h2.message.DbException;
 
 /**
  * An adapter for the trigger interface that allows to use the ResultSet
@@ -43,9 +44,6 @@ public abstract class TriggerAdapter implements Trigger {
      */
     protected int type;
 
-    private SimpleResultSet oldResultSet, newResultSet;
-    private TriggerRowSource oldSource, newSource;
-
     /**
      * This method is called by the database engine once when initializing the
      * trigger. It is called when the trigger is created, as well as when the
@@ -66,20 +64,6 @@ public abstract class TriggerAdapter implements Trigger {
     public void init(Connection conn, String schemaName,
             String triggerName, String tableName,
             boolean before, int type) throws SQLException {
-        ResultSet rs = conn.getMetaData().getColumns(
-                null, schemaName, tableName, null);
-        oldSource = new TriggerRowSource();
-        newSource = new TriggerRowSource();
-        oldResultSet = new SimpleResultSet(oldSource);
-        newResultSet = new SimpleResultSet(newSource);
-        while (rs.next()) {
-            String column = rs.getString("COLUMN_NAME");
-            int dataType = rs.getInt("DATA_TYPE");
-            int precision = rs.getInt("COLUMN_SIZE");
-            int scale = rs.getInt("DECIMAL_DIGITS");
-            oldResultSet.addColumn(column, dataType, precision, scale);
-            newResultSet.addColumn(column, dataType, precision, scale);
-        }
         this.schemaName = schemaName;
         this.triggerName = triggerName;
         this.tableName = tableName;
@@ -87,67 +71,14 @@ public abstract class TriggerAdapter implements Trigger {
         this.type = type;
     }
 
-    /**
-     * A row source that allows to set the next row.
-     */
-    static class TriggerRowSource implements SimpleRowSource {
-
-        private Object[] row;
-
-        void setRow(Object[] row) {
-            this.row = row;
-        }
-
-        @Override
-        public Object[] readRow() {
-            return row;
-        }
-
-        @Override
-        public void close() {
-            // ignore
-        }
-
-        @Override
-        public void reset() {
-            // ignore
-        }
-
-    }
-
-    /**
-     * This method is called for each triggered action. The method is called
-     * immediately when the operation occurred (before it is committed). A
-     * transaction rollback will also rollback the operations that were done
-     * within the trigger, if the operations occurred within the same database.
-     * If the trigger changes state outside the database, a rollback trigger
-     * should be used.
-     * <p>
-     * The row arrays contain all columns of the table, in the same order
-     * as defined in the table.
-     * </p>
-     * <p>
-     * The default implementation calls the fire method with the ResultSet
-     * parameters.
-     * </p>
-     *
-     * @param conn a connection to the database
-     * @param oldRow the old row, or null if no old row is available (for
-     *            INSERT)
-     * @param newRow the new row, or null if no new row is available (for
-     *            DELETE)
-     * @throws SQLException if the operation must be undone
-     */
     @Override
-    public synchronized void fire(Connection conn, Object[] oldRow, Object[] newRow) throws SQLException {
-        fire(conn, wrap(oldResultSet, oldSource, oldRow), wrap(newResultSet, newSource, newRow));
+    public final void fire(Connection conn, Object[] oldRow, Object[] newRow) throws SQLException {
+        throw DbException.getInternalError();
     }
 
     /**
      * This method is called for each triggered action by the default
      * fire(Connection conn, Object[] oldRow, Object[] newRow) method.
-     * ResultSet.next does not need to be called (and calling it has no effect;
-     * it will always return true).
      * <p>
      * For "before" triggers, the new values of the new row may be changed
      * using the ResultSet.updateX methods.
@@ -162,15 +93,5 @@ public abstract class TriggerAdapter implements Trigger {
      */
     public abstract void fire(Connection conn, ResultSet oldRow,
             ResultSet newRow) throws SQLException;
-
-    private static SimpleResultSet wrap(SimpleResultSet rs,
-            TriggerRowSource source, Object[] row) throws SQLException {
-        if (row == null) {
-            return null;
-        }
-        source.setRow(row);
-        rs.next();
-        return rs;
-    }
 
 }

--- a/h2/src/main/org/h2/value/ValueToObjectConverter.java
+++ b/h2/src/main/org/h2/value/ValueToObjectConverter.java
@@ -370,7 +370,7 @@ public final class ValueToObjectConverter extends TraceObject {
             return new JdbcSQLXML(conn, value, JdbcLob.State.WITH_VALUE, getNextId(TraceObject.SQLXML));
         } else if (type == ResultSet.class) {
             return new JdbcResultSet(conn, null, null, value.convertToAnyRow().getResult(),
-                    getNextId(TraceObject.RESULT_SET), true, false);
+                    getNextId(TraceObject.RESULT_SET), true, false, false);
         } else {
             Object obj = LegacyDateTimeUtils.valueToLegacyType(type, value, conn);
             if (obj != null) {
@@ -575,7 +575,7 @@ public final class ValueToObjectConverter extends TraceObject {
         case Value.ROW:
             if (forJdbc) {
                 return new JdbcResultSet(conn, null, null, ((ValueRow) value).getResult(),
-                        getNextId(TraceObject.RESULT_SET), true, false);
+                        getNextId(TraceObject.RESULT_SET), true, false, false);
             }
             return valueToDefaultArray(value, conn, forJdbc);
         default:

--- a/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
+++ b/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
@@ -46,6 +46,7 @@ public class TestTriggersConstraints extends TestDb implements Trigger {
     @Override
     public void test() throws Exception {
         deleteDb("trigger");
+        testWrongDataType();
         testTriggerDeadlock();
         testTriggerAdapter();
         testTriggerSelectEachRow();
@@ -71,6 +72,76 @@ public class TestTriggersConstraints extends TestDb implements Trigger {
         public void fire(Connection conn, ResultSet oldRow, ResultSet newRow)
                 throws SQLException {
             conn.createStatement().execute("delete from test");
+        }
+    }
+
+    /**
+     * Trigger that sets value of the wrong data type.
+     */
+    public static class WrongTrigger implements Trigger {
+        @Override
+        public void fire(Connection conn, Object[] oldRow, Object[] newRow) throws SQLException {
+            newRow[1] = "Wrong value";
+        }
+    }
+
+    /**
+     * Trigger that sets value of the wrong data type.
+     */
+    public static class WrongTriggerAdapter extends TriggerAdapter {
+        @Override
+        public void fire(Connection conn, ResultSet oldRow, ResultSet newRow) throws SQLException {
+            newRow.updateString(2, "Wrong value");
+        }
+    }
+
+    /**
+     * Trigger that sets null value.
+     */
+    public static class NullTrigger implements Trigger {
+        @Override
+        public void fire(Connection conn, Object[] oldRow, Object[] newRow) throws SQLException {
+            newRow[1] = null;
+        }
+    }
+
+    /**
+     * Trigger that sets null value.
+     */
+    public static class NullTriggerAdapter extends TriggerAdapter {
+        @Override
+        public void fire(Connection conn, ResultSet oldRow, ResultSet newRow) throws SQLException {
+            newRow.updateNull(2);
+        }
+    }
+
+    private void testWrongDataType() throws Exception {
+        try (Connection conn = getConnection("trigger")) {
+            Statement stat = conn.createStatement();
+            stat.executeUpdate("CREATE TABLE TEST(A INTEGER, B INTEGER NOT NULL)");
+            PreparedStatement prep = conn.prepareStatement("INSERT INTO TEST VALUES (1, 2)");
+
+            stat.executeUpdate("CREATE TRIGGER TEST_TRIGGER BEFORE INSERT ON TEST FOR EACH ROW CALL '"
+                    + WrongTrigger.class.getName() + '\'');
+            assertThrows(ErrorCode.DATA_CONVERSION_ERROR_1, prep).executeUpdate();
+            stat.executeUpdate("DROP TRIGGER TEST_TRIGGER");
+
+            stat.executeUpdate("CREATE TRIGGER TEST_TRIGGER BEFORE INSERT ON TEST FOR EACH ROW CALL '"
+                    + WrongTriggerAdapter.class.getName() + '\'');
+            assertThrows(ErrorCode.DATA_CONVERSION_ERROR_1, prep).executeUpdate();
+            stat.executeUpdate("DROP TRIGGER TEST_TRIGGER");
+
+            stat.executeUpdate("CREATE TRIGGER TEST_TRIGGER BEFORE INSERT ON TEST FOR EACH ROW CALL '"
+                    + NullTrigger.class.getName() + '\'');
+            assertThrows(ErrorCode.NULL_NOT_ALLOWED, prep).executeUpdate();
+            stat.executeUpdate("DROP TRIGGER TEST_TRIGGER");
+
+            stat.executeUpdate("CREATE TRIGGER TEST_TRIGGER BEFORE INSERT ON TEST FOR EACH ROW CALL '"
+                    + NullTriggerAdapter.class.getName() + '\'');
+            assertThrows(ErrorCode.NULL_NOT_ALLOWED, prep).executeUpdate();
+            stat.executeUpdate("DROP TRIGGER TEST_TRIGGER");
+
+            stat.executeUpdate("DROP TABLE TEST");
         }
     }
 


### PR DESCRIPTION
1. Rows modified by `BEFORE` trigger are now re-validated. Before this change it was possible to insert values with wrong data type into storage, now they are converted to data types of columns; it was possible to insert `NULL` into column with `NOT NULL` constraint, now an exception in thrown. Generated columns are now re-evaluated if base columns were modified by the trigger.
2. Normal feature-reach and reliable `JdbcResultSet` with complete metadata is now passed to `TriggerAdapter`-based triggers instead of buggy `SimpleResultSet`. This also allows to skip conversion of all values to Java types, in some cases it is relatively slow.

Closes #3251. This issue was actually fixed earlier, but new implementation is far better.