### PR TITLE
Remove useless StringBuilder.toString() call

### DIFF
--- a/h2/src/main/org/h2/jdbcx/JdbcXAConnection.java
+++ b/h2/src/main/org/h2/jdbcx/JdbcXAConnection.java
@@ -426,7 +426,7 @@ public final class JdbcXAConnection extends TraceObject implements XAConnection,
         if (buff.length() == 0) {
             buff.append("|XAResource.TMNOFLAGS");
         }
-        return buff.toString().substring(1);
+        return buff.substring(1);
     }
 
     private void checkOpen() throws XAException {

--- a/h2/src/main/org/h2/util/NetUtils.java
+++ b/h2/src/main/org/h2/util/NetUtils.java
@@ -345,7 +345,7 @@ public class NetUtils {
                     .append(address[0] & 0xff).append('.') //
                     .append(address[1] & 0xff).append('.') //
                     .append(address[2] & 0xff).append('.') //
-                    .append(address[3] & 0xff).toString();
+                    .append(address[3] & 0xff);
             break;
         case 16:
             short[] a = new short[8];


### PR DESCRIPTION
Found by IDEA inspection 'Result of method call ignored'