### PR TITLE
Regression in 2.x - Can't call SELECT USER() with empty username

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2338,7 +2338,7 @@ public final class Database implements DataHandler, CastDataProvider {
     private static boolean isUpperSysIdentifier(String upperName) {
         int l = upperName.length();
         if (l == 0) {
-            return false;
+            return true;
         }
         for (int i = 0; i < l; i++) {
             int ch = upperName.charAt(i);

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2342,7 +2342,7 @@ public final class Database implements DataHandler, CastDataProvider {
         }
         for (int i = 0; i < l; i++) {
             int ch = upperName.charAt(i);
-            if (ch < 'A' || ch > 'Z' && ch != '_') {
+            if ((ch < 'A' || ch > 'Z') && ch != '_' && !Character.isDigit(ch)) {
                 return false;
             }
         }

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -115,6 +115,8 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         testDeterministic();
         testTransactionId();
         testPrecision();
+        testUser();
+        testUserEmptyUsernameAndPassword();
         testVarArgs();
         testAggregate();
         testAggregateType();
@@ -483,6 +485,24 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         assertEquals(1, rs.getMetaData().getScale(2));
         assertEquals(ValueNumeric.MAXIMUM_SCALE / 2, rs.getMetaData().getScale(1));
         stat.executeQuery("select * from information_schema.routines");
+        conn.close();
+    }
+
+    private void testUser() throws SQLException {
+        Connection conn = getConnection("functions");
+        PreparedStatement prep = conn.prepareStatement("select user()");
+        ResultSet rs = prep.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("SA", rs.getString(1));
+        conn.close();
+    }
+
+    private void testUserEmptyUsernameAndPassword() throws SQLException {
+        Connection conn = getConnection("functions_empty_un", "", "");
+        PreparedStatement prep = conn.prepareStatement("select user()");
+        ResultSet rs = prep.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("", rs.getString(1));
         conn.close();
     }
 

--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -117,6 +117,7 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         testPrecision();
         testUser();
         testUserEmptyUsernameAndPassword();
+        testUserUsernameContainingDigits();
         testVarArgs();
         testAggregate();
         testAggregateType();
@@ -503,6 +504,15 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         ResultSet rs = prep.executeQuery();
         assertTrue(rs.next());
         assertEquals("", rs.getString(1));
+        conn.close();
+    }
+
+    private void testUserUsernameContainingDigits() throws SQLException {
+        Connection conn = getConnection("functions_un_with_digits", "abc123", "");
+        PreparedStatement prep = conn.prepareStatement("select user()");
+        ResultSet rs = prep.executeQuery();
+        assertTrue(rs.next());
+        assertEquals("ABC123", rs.getString(1));
         conn.close();
     }
 


### PR DESCRIPTION
In H2 1.x, if a database was created with an empty username (""), it was possible to call the function `SELECT USER()` and you would get back a row with an empty string as the result.

In H2 2.x this function currently fails with a cryptic general error due to an assertion. This could prevent people from migrating to the new versions of H2. I tripped over this because Flyway starts its session off by calling `SELECT USER()`.