### PR TITLE
Use BufferedReader instead of BufferedInputStream to avoid Illegal seek exception

### DIFF
--- a/h2/src/docsrc/html/download.html
+++ b/h2/src/docsrc/html/download.html
@@ -27,10 +27,12 @@ Downloads
 <!-- sha1Zip --><br />
 </p>
 
-<h3>Version ${stableVersion} (${stableVersionDate}), Last Stable</h3>
+<h3>Version 2.0.206 (2022-01-04)</h3>
 <p>
-<a href="https://h2database.com/h2-setup-${stableVersionDate}.exe">Windows Installer</a><br />
-<a href="https://h2database.com/h2-${stableVersionDate}.zip">Platform-Independent Zip</a><br />
+<a href="https://github.com/h2database/h2database/releases/download/version-2.0.206/h2-setup-2022-01-04.exe">Windows Installer</a>
+(SHA1 checksum: 982dff9c88412b00b3ced52b6870753e0133be07)<br />
+<a href="https://github.com/h2database/h2database/releases/download/version-2.0.206/h2-2022-01-04.zip">Platform-Independent Zip</a>
+(SHA1 checksum: 85d6d8f552661c2f8e1b86c10a12ab4bb6b0d29b)<br />
 </p>
 
 <h3>Archive Downloads</h3>

--- a/h2/src/installer/release.txt
+++ b/h2/src/installer/release.txt
@@ -34,9 +34,8 @@ Update org.h2.engine.Constants.java:
         set VERSION_MAJOR / VERSION_MINOR to the new version number
     if the last TCP_PROTOCOL_VERSION_##
         doesn't have a release date set it to current BUILD_DATE
-    set BUILD_DATE_STABLE to BUILD_DATE of the latest stable release
-    set BUILD_ID_STABLE to BUILD_ID of the latest stable release
-    check prefix in VERSION_STABLE and update if necessary
+    check and update if necessary links to the latest releases in previous
+    series of releases and their checksums in download.html
 
 Update README.md.
     set version to the new version

--- a/h2/src/main/org/h2/command/dml/RunScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/RunScriptCommand.java
@@ -5,9 +5,7 @@
  */
 package org.h2.command.dml;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -51,8 +49,7 @@ public class RunScriptCommand extends ScriptBase {
         boolean oldQuirksMode = session.isQuirksMode();
         boolean oldVariableBinary = session.isVariableBinary();
         try {
-            openInput();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(in, charset));
+            openInput(charset);
             // if necessary, strip the BOM from the front of the file
             reader.mark(1);
             if (reader.read() != UTF8_BOM) {

--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -18,20 +18,10 @@ public class Constants {
     public static final String BUILD_DATE = "2021-12-21";
 
     /**
-     * The build date of the last stable release.
-     */
-    public static final String BUILD_DATE_STABLE = "2022-01-04";
-
-    /**
      * Sequential version number. Even numbers are used for official releases,
      * odd numbers are used for development builds.
      */
     public static final int BUILD_ID = 209;
-
-    /**
-     * The build id of the last stable release.
-     */
-    public static final int BUILD_ID_STABLE = 206;
 
     /**
      * Whether this is a snapshot version.
@@ -489,11 +479,6 @@ public class Constants {
      * version, and build id.
      */
     public static final String VERSION;
-
-    /**
-     * The last stable version name.
-     */
-    public static final String VERSION_STABLE = "2.0." + BUILD_ID_STABLE;
 
     /**
      * The complete version number of this database, consisting of

--- a/h2/src/main/org/h2/store/fs/FileUtils.java
+++ b/h2/src/main/org/h2/store/fs/FileUtils.java
@@ -5,13 +5,16 @@
  */
 package org.h2.store.fs;
 
+import java.io.BufferedReader;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
@@ -20,6 +23,8 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+
+import org.h2.engine.Constants;
 
 /**
  * This utility class contains utility functions that use the file system
@@ -252,21 +257,34 @@ public class FileUtils {
     /**
      * Create an input stream to read from the file.
      * This method is similar to Java 7
-     * <code>java.nio.file.Path.newInputStream</code>.
+     * <code>java.nio.file.Files.newInputStream()</code>.
      *
      * @param fileName the file name
      * @return the input stream
      * @throws IOException on failure
      */
-    public static InputStream newInputStream(String fileName)
-            throws IOException {
+    public static InputStream newInputStream(String fileName) throws IOException {
         return FilePath.get(fileName).newInputStream();
     }
 
     /**
+     * Create a buffered reader to read from the file.
+     * This method is similar to
+     * <code>java.nio.file.Files.newBufferedReader()</code>.
+     *
+     * @param fileName the file name
+     * @param charset the charset
+     * @return the buffered reader
+     * @throws IOException on failure
+     */
+    public static BufferedReader newBufferedReader(String fileName, Charset charset) throws IOException {
+        return new BufferedReader(new InputStreamReader(newInputStream(fileName), charset), Constants.IO_BUFFER_SIZE);
+    }
+
+    /**
      * Create an output stream to write into the file.
-     * This method is similar to Java 7
-     * <code>java.nio.file.Path.newOutputStream</code>.
+     * This method is similar to
+     * <code>java.nio.file.Files.newOutputStream()</code>.
      *
      * @param fileName the file name
      * @param append if true, the file will grow, if false, the file will be
@@ -274,8 +292,7 @@ public class FileUtils {
      * @return the output stream
      * @throws IOException on failure
      */
-    public static OutputStream newOutputStream(String fileName, boolean append)
-            throws IOException {
+    public static OutputStream newOutputStream(String fileName, boolean append) throws IOException {
         return FilePath.get(fileName).newOutputStream(append);
     }
 

--- a/h2/src/main/org/h2/tools/RunScript.java
+++ b/h2/src/main/org/h2/tools/RunScript.java
@@ -5,11 +5,9 @@
  */
 package org.h2.tools;
 
-import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -19,7 +17,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 
-import org.h2.engine.Constants;
 import org.h2.message.DbException;
 import org.h2.store.fs.FileUtils;
 import org.h2.util.IOUtils;
@@ -184,14 +181,11 @@ public class RunScript extends Tool {
     private void process(Connection conn, String fileName,
             boolean continueOnError, Charset charset) throws SQLException,
             IOException {
-        InputStream in = FileUtils.newInputStream(fileName);
-        String path = FileUtils.getParent(fileName);
+        BufferedReader reader = FileUtils.newBufferedReader(fileName, charset);
         try {
-            in = new BufferedInputStream(in, Constants.IO_BUFFER_SIZE);
-            Reader reader = new InputStreamReader(in, charset);
-            process(conn, continueOnError, path, reader, charset);
+            process(conn, continueOnError, FileUtils.getParent(fileName), reader, charset);
         } finally {
-            IOUtils.closeSilently(in);
+            IOUtils.closeSilently(reader);
         }
     }
 

--- a/h2/src/tools/org/h2/build/doc/GenerateDoc.java
+++ b/h2/src/tools/org/h2/build/doc/GenerateDoc.java
@@ -70,8 +70,6 @@ public class GenerateDoc {
         bnf.linkStatements();
         session.put("version", Constants.VERSION);
         session.put("versionDate", Constants.BUILD_DATE);
-        session.put("stableVersion", Constants.VERSION_STABLE);
-        session.put("stableVersionDate", Constants.BUILD_DATE_STABLE);
         session.put("downloadRoot",
                 "https://github.com/h2database/h2database/releases/download/version-" + Constants.VERSION);
         String help = "SELECT ROWNUM ID, * FROM CSVREAD('" +


### PR DESCRIPTION
1. A workaround for issue from the mailing list: https://groups.google.com/g/h2-database/c/0E3x4vxjeMM It actually looks like a bug in Java, but it will be better to avoid it anyway.
2. `BUILD_ID_STABLE` is removed. `download.html` now has links to the latest releases in each series of releases instead of outdated latest / stable sections.