### PR TITLE
Fix NPE when closing cloned JdbcConnection

### DIFF
--- a/h2/src/main/org/h2/util/CloseWatcher.java
+++ b/h2/src/main/org/h2/util/CloseWatcher.java
@@ -97,6 +97,9 @@ public class CloseWatcher extends PhantomReference<Object> {
      * @param w the reference
      */
     public static void unregister(CloseWatcher w) {
+        if (null == w) {
+            return;
+        }
         w.closeable = null;
         refs.remove(w);
     }


### PR DESCRIPTION

closing a cloned JdbcConnection (by calling the copy constructor) results in an NPE:
```fortran
org.h2.jdbc.JdbcSQLNonTransientException: General error: "java.lang.NullPointerException" [50000-210]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:573)
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:496)
	at org.h2.message.DbException.get(DbException.java:216)
	at org.h2.message.DbException.convert(DbException.java:414)
	at org.h2.message.DbException.toSQLException(DbException.java:386)
	at org.h2.message.TraceObject.logAndConvert(TraceObject.java:365)
	at org.h2.jdbc.JdbcConnection.close(JdbcConnection.java:368)
Caused by: java.lang.NullPointerException
	at org.h2.util.CloseWatcher.unregister(CloseWatcher.java:100)
	at org.h2.jdbc.JdbcConnection.close(JdbcConnection.java:334)
	... 2 more
```
This is because the clone nulls out the watcher field of the cloned object, which I believe is by design:
https://github.com/h2database/h2database/blob/465399f886c0ede2b70d3c14de1d7187665b494a/h2/src/main/org/h2/jdbc/JdbcConnection.java#L154

Circumvented with a simple null check which I propose as a small fix.