### PR TITLE
Remove meta table entries even during startup.

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -828,7 +828,7 @@ public final class Database implements DataHandler, CastDataProvider {
      * @param id the id of the object to remove
      */
     public void removeMeta(SessionLocal session, int id) {
-        if (id > 0 && !starting) {
+        if (id > 0) {
             SearchRow r = meta.getRowFactory().createRow();
             r.setValue(0, ValueInteger.get(id));
             boolean wasLocked = lockMeta(session);


### PR DESCRIPTION
This is necessary since commit https://github.com/h2database/h2database/commit/74b1b25d71e78bfa986510cf5ed774c403c4bf2c changes the behavior of `addMeta()` in the same way.

Fixes h2database/h2database#3301.