### PR TITLE
Fix OOME with nested derived tables

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3410: OOME with nested derived tables
+</li>
 <li>Issue #3405: Enhance SCRIPT to support operations on STDOUT
 </li>
 <li>Issue #3406 / PR #3407: FunctionMultiReturn.polar2CartesianArray result set iteration throws ClassCastException

--- a/h2/src/main/org/h2/command/ddl/AlterTableAlterColumn.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAlterColumn.java
@@ -625,7 +625,7 @@ public class AlterTableAlterColumn extends CommandWithColumns {
     private void checkViewsAreValid(DbObject tableOrView) {
         for (DbObject view : tableOrView.getChildren()) {
             if (view instanceof TableView) {
-                String sql = ((TableView) view).getQuery();
+                String sql = ((TableView) view).getQuerySQL();
                 // check if the query is still valid
                 // do not execute, not even with limit 1, because that could
                 // have side effects or take a very long time

--- a/h2/src/main/org/h2/command/ddl/CreateView.java
+++ b/h2/src/main/org/h2/command/ddl/CreateView.java
@@ -121,7 +121,7 @@ public class CreateView extends SchemaOwnerCommand {
                         false/*isTemporary*/, db);
             } else {
                 view = new TableView(schema, id, viewName, querySQL, null, columnTemplatesAsUnknowns, session,
-                        false, false, isTableExpression, false, false);
+                        false, false, isTableExpression, false);
             }
         } else {
             // TODO support isTableExpression in replace function...

--- a/h2/src/main/org/h2/command/query/Query.java
+++ b/h2/src/main/org/h2/command/query/Query.java
@@ -31,9 +31,9 @@ import org.h2.result.ResultTarget;
 import org.h2.result.SortOrder;
 import org.h2.table.Column;
 import org.h2.table.ColumnResolver;
+import org.h2.table.DerivedTable;
 import org.h2.table.Table;
 import org.h2.table.TableFilter;
-import org.h2.table.TableView;
 import org.h2.util.Utils;
 import org.h2.value.ExtTypeInfoRow;
 import org.h2.value.TypeInfo;
@@ -149,7 +149,7 @@ public abstract class Query extends Prepared {
 
     boolean checkInit;
 
-    private boolean isPrepared;
+    boolean isPrepared;
 
     Query(SessionLocal session) {
         super(session);
@@ -215,11 +215,13 @@ public abstract class Query extends Prepared {
         if (isPrepared) {
             return;
         }
-        doPrepare();
-        isPrepared = true;
+        prepareExpressions();
+        preparePlan();
     }
 
-    abstract void doPrepare();
+    public abstract void prepareExpressions();
+
+    public abstract void preparePlan();
 
     /**
      * The the list of select expressions.
@@ -997,9 +999,8 @@ public abstract class Query extends Prepared {
         if (!checkInit) {
             init();
         }
-        prepare();
-        return TableView.createTempView(forCreateView ? session.getDatabase().getSystemSession() : session,
-                session.getUser(), alias, columnTemplates, this, topQuery);
+        return new DerivedTable(forCreateView ? session.getDatabase().getSystemSession() : session, alias,
+                columnTemplates, this, topQuery);
     }
 
     @Override

--- a/h2/src/main/org/h2/command/query/Select.java
+++ b/h2/src/main/org/h2/command/query/Select.java
@@ -37,7 +37,7 @@ import org.h2.expression.condition.ConditionLocalAndGlobal;
 import org.h2.expression.function.CoalesceFunction;
 import org.h2.index.Cursor;
 import org.h2.index.Index;
-import org.h2.index.ViewIndex;
+import org.h2.index.QueryExpressionIndex;
 import org.h2.message.DbException;
 import org.h2.mode.DefaultNullOrdering;
 import org.h2.result.LazyResult;
@@ -857,7 +857,7 @@ public class Select extends Query {
         if (session.isLazyQueryExecution()) {
             top.visit(f -> {
                 if (f != top && f.getTable().getTableType() == TableType.VIEW) {
-                    ViewIndex idx = (ViewIndex) f.getIndex();
+                    QueryExpressionIndex idx = (QueryExpressionIndex) f.getIndex();
                     if (idx != null && idx.getQuery() != null) {
                         idx.getQuery().setNeverLazy(true);
                     }
@@ -1158,7 +1158,7 @@ public class Select extends Query {
     }
 
     @Override
-    void doPrepare() {
+    public void prepareExpressions() {
         if (orderList != null) {
             prepareOrder(orderList, expressions.size());
         }
@@ -1175,24 +1175,29 @@ public class Select extends Query {
         }
         if (condition != null) {
             condition = condition.optimizeCondition(session);
-            if (condition != null) {
-                for (TableFilter f : filters) {
-                    // outer joins: must not add index conditions such as
-                    // "c is null" - example:
-                    // create table parent(p int primary key) as select 1;
-                    // create table child(c int primary key, pc int);
-                    // insert into child values(2, 1);
-                    // select p, c from parent
-                    // left outer join child on p = pc where c is null;
-                    if (!f.isJoinOuter() && !f.isJoinOuterIndirect()) {
-                        condition.createIndexConditions(session, f);
-                    }
-                }
-            }
         }
         if (isGroupQuery && groupIndex == null && havingIndex < 0 && qualifyIndex < 0 && condition == null
                 && filters.size() == 1) {
             isQuickAggregateQuery = isEverything(ExpressionVisitor.getOptimizableVisitor(filters.get(0).getTable()));
+        }
+        expressionArray = expressions.toArray(new Expression[0]);
+    }
+
+    @Override
+    public void preparePlan() {
+        if (condition != null) {
+            for (TableFilter f : filters) {
+                // outer joins: must not add index conditions such as
+                // "c is null" - example:
+                // create table parent(p int primary key) as select 1;
+                // create table child(c int primary key, pc int);
+                // insert into child values(2, 1);
+                // select p, c from parent
+                // left outer join child on p = pc where c is null;
+                if (!f.isJoinOuter() && !f.isJoinOuterIndirect()) {
+                    condition.createIndexConditions(session, f);
+                }
+            }
         }
         cost = preparePlan(session.isParsingCreateView());
         if (distinct && session.getDatabase().getSettings().optimizeDistinct &&
@@ -1263,7 +1268,7 @@ public class Select extends Query {
                 }
             }
         }
-        expressionArray = expressions.toArray(new Expression[0]);
+        isPrepared = true;
     }
 
     private void optimizeExpressionsAndPreserveAliases() {

--- a/h2/src/main/org/h2/command/query/SelectUnion.java
+++ b/h2/src/main/org/h2/command/query/SelectUnion.java
@@ -246,9 +246,9 @@ public class SelectUnion extends Query {
     }
 
     @Override
-    void doPrepare() {
-        left.prepare();
-        right.prepare();
+    public void prepareExpressions() {
+        left.prepareExpressions();
+        right.prepareExpressions();
         int len = left.getColumnCount();
         // set the correct expressions now
         expressions = new ArrayList<>(len);
@@ -269,6 +269,13 @@ public class SelectUnion extends Query {
         }
         resultColumnCount = expressions.size();
         expressionArray = expressions.toArray(new Expression[0]);
+    }
+
+    @Override
+    public void preparePlan() {
+        left.preparePlan();
+        right.preparePlan();
+        isPrepared = true;
     }
 
     @Override

--- a/h2/src/main/org/h2/command/query/TableValueConstructor.java
+++ b/h2/src/main/org/h2/command/query/TableValueConstructor.java
@@ -168,7 +168,7 @@ public class TableValueConstructor extends Query {
     }
 
     @Override
-    void doPrepare() {
+    public void prepareExpressions() {
         if (columnResolver == null) {
             createTable();
         }
@@ -192,6 +192,10 @@ public class TableValueConstructor extends Query {
             cleanupOrder();
         }
         expressionArray = expressions.toArray(new Expression[0]);
+    }
+
+    @Override
+    public void preparePlan() {
         double cost = 0;
         int columnCount = visibleColumnCount;
         for (ArrayList<Expression> r : rows) {
@@ -200,6 +204,7 @@ public class TableValueConstructor extends Query {
             }
         }
         this.cost = cost + rows.size();
+        isPrepared = true;
     }
 
     private void createTable() {

--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -26,9 +26,10 @@ import org.h2.command.CommandInterface;
 import org.h2.command.Parser;
 import org.h2.command.Prepared;
 import org.h2.command.ddl.Analyze;
+import org.h2.command.query.Query;
 import org.h2.constraint.Constraint;
 import org.h2.index.Index;
-import org.h2.index.ViewIndex;
+import org.h2.index.QueryExpressionIndex;
 import org.h2.jdbc.JdbcConnection;
 import org.h2.jdbc.meta.DatabaseMeta;
 import org.h2.jdbc.meta.DatabaseMetaLocal;
@@ -183,8 +184,8 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
     private SmallLRUCache<String, Command> queryCache;
     private long modificationMetaID = -1;
     private int createViewLevel;
-    private volatile SmallLRUCache<Object, ViewIndex> viewIndexCache;
-    private HashMap<Object, ViewIndex> subQueryIndexCache;
+    private volatile SmallLRUCache<Object, QueryExpressionIndex> viewIndexCache;
+    private HashMap<Object, QueryExpressionIndex> derivedTableIndexCache;
     private boolean lazyQueryExecution;
 
     private BitSet nonKeywords;
@@ -581,6 +582,21 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
     }
 
     /**
+     * Parse a query and prepare its expressions. Rights and literals must be
+     * already checked.
+     *
+     * @param sql the SQL statement
+     * @return the prepared statement
+     */
+    public Query prepareQueryExpression(String sql) {
+        Parser parser = new Parser(this);
+        parser.setRightsChecked(true);
+        parser.setLiteralsChecked(true);
+        return parser.prepareQueryExpression(sql);
+    }
+
+
+    /**
      * Parse and prepare the given SQL statement.
      * This method also checks if the connection has been closed.
      *
@@ -614,8 +630,8 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         try {
             command = parser.prepareCommand(sql);
         } finally {
-            // we can't reuse sub-query indexes, so just drop the whole cache
-            subQueryIndexCache = null;
+            // we can't reuse indexes of derived tables, so just drop the whole cache
+            derivedTableIndexCache = null;
         }
         if (queryCache != null) {
             if (command.isCacheable()) {
@@ -1485,24 +1501,25 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
     }
 
     /**
-     * Get the view cache for this session. There are two caches: the subquery
-     * cache (which is only use for a single query, has no bounds, and is
+     * Get the view cache for this session. There are two caches: the derived
+     * table cache (which is only use for a single query, has no bounds, and is
      * cleared after use), and the cache for regular views.
      *
-     * @param subQuery true to get the subquery cache
-     * @return the view cache
+     * @param derivedTable
+     *            true to get the cache of derived tables
+     * @return the view cache or derived table cache
      */
-    public Map<Object, ViewIndex> getViewIndexCache(boolean subQuery) {
-        if (subQuery) {
-            // for sub-queries we don't need to use LRU because the cache should
-            // not grow too large for a single query (we drop the whole cache in
-            // the end of prepareLocal)
-            if (subQueryIndexCache == null) {
-                subQueryIndexCache = new HashMap<>();
+    public Map<Object, QueryExpressionIndex> getViewIndexCache(boolean derivedTable) {
+        if (derivedTable) {
+            // for derived tables we don't need to use LRU because the cache
+            // should not grow too large for a single query (we drop the whole
+            // cache in this cache is dropped at the end of prepareLocal)
+            if (derivedTableIndexCache == null) {
+                derivedTableIndexCache = new HashMap<>();
             }
-            return subQueryIndexCache;
+            return derivedTableIndexCache;
         }
-        SmallLRUCache<Object, ViewIndex> cache = viewIndexCache;
+        SmallLRUCache<Object, QueryExpressionIndex> cache = viewIndexCache;
         if (cache == null) {
             viewIndexCache = cache = SmallLRUCache.newInstance(Constants.VIEW_INDEX_CACHE_SIZE);
         }

--- a/h2/src/main/org/h2/engine/User.java
+++ b/h2/src/main/org/h2/engine/User.java
@@ -18,7 +18,6 @@ import org.h2.table.MetaTable;
 import org.h2.table.RangeTable;
 import org.h2.table.Table;
 import org.h2.table.TableType;
-import org.h2.table.TableView;
 import org.h2.util.MathUtils;
 import org.h2.util.StringUtils;
 import org.h2.util.Utils;
@@ -221,15 +220,8 @@ public final class User extends RightOwner {
             return true;
         }
         TableType tableType = table.getTableType();
-        if (TableType.VIEW == tableType) {
-            TableView v = (TableView) table;
-            if (v.getOwner() == this) {
-                // the owner of a view has access:
-                // SELECT * FROM (SELECT * FROM ...)
-                return true;
-            }
-        } else if (tableType == null) {
-            // function table
+        if (tableType == null) {
+            // derived or function table
             return true;
         }
         if (table.isTemporary() && !table.isGlobalTemporary()) {

--- a/h2/src/main/org/h2/index/QueryExpressionCursor.java
+++ b/h2/src/main/org/h2/index/QueryExpressionCursor.java
@@ -14,18 +14,17 @@ import org.h2.value.Value;
 import org.h2.value.ValueNull;
 
 /**
- * The cursor implementation of a view index.
+ * The cursor implementation of a query expression index.
  */
-public class ViewCursor implements Cursor {
+public class QueryExpressionCursor implements Cursor {
 
     private final Table table;
-    private final ViewIndex index;
+    private final QueryExpressionIndex index;
     private final ResultInterface result;
     private final SearchRow first, last;
     private Row current;
 
-    public ViewCursor(ViewIndex index, ResultInterface result, SearchRow first,
-            SearchRow last) {
+    public QueryExpressionCursor(QueryExpressionIndex index, ResultInterface result, SearchRow first, SearchRow last) {
         this.table = index.getTable();
         this.index = index;
         this.result = result;

--- a/h2/src/main/org/h2/table/DerivedTable.java
+++ b/h2/src/main/org/h2/table/DerivedTable.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2004-2022 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.table;
+
+import java.util.ArrayList;
+
+import org.h2.api.ErrorCode;
+import org.h2.command.query.Query;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.ExpressionVisitor;
+import org.h2.expression.Parameter;
+import org.h2.index.QueryExpressionIndex;
+import org.h2.message.DbException;
+import org.h2.util.StringUtils;
+
+/**
+ * A derived table.
+ */
+public final class DerivedTable extends QueryExpressionTable {
+
+    private String querySQL;
+
+    private Query topQuery;
+
+    /**
+     * Create a derived table out of the given query.
+     *
+     * @param session the session
+     * @param name the view name
+     * @param columnTemplates column templates, or {@code null}
+     * @param query the initialized query
+     * @param topQuery the top level query
+     */
+    public DerivedTable(SessionLocal session, String name, Column[] columnTemplates, Query query, Query topQuery) {
+        super(session.getDatabase().getMainSchema(), 0, name);
+        setTemporary(true);
+        this.topQuery = topQuery;
+        query.prepareExpressions();
+        try {
+            this.querySQL = query.getPlanSQL(DEFAULT_SQL_FLAGS);
+            ArrayList<Parameter> params = query.getParameters();
+            index = new QueryExpressionIndex(this, querySQL, params, false);
+            tables = new ArrayList<>(query.getTables());
+            setColumns(initColumns(session, columnTemplates, query, true));
+            viewQuery = query;
+        } catch (DbException e) {
+            if (e.getErrorCode() == ErrorCode.COLUMN_ALIAS_IS_NOT_SPECIFIED_1) {
+                throw e;
+            }
+            e.addSQL(getCreateSQL());
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean isQueryComparable() {
+        if (!super.isQueryComparable()) {
+            return false;
+        }
+        if (topQuery != null && !topQuery.isEverything(ExpressionVisitor.QUERY_COMPARABLE_VISITOR)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean canDrop() {
+        return false;
+    }
+
+    @Override
+    public TableType getTableType() {
+        return null;
+    }
+
+    @Override
+    public Query getTopQuery() {
+        return topQuery;
+    }
+
+    @Override
+    public String getCreateSQL() {
+        return null;
+    }
+
+    @Override
+    public StringBuilder getSQL(StringBuilder builder, int sqlFlags) {
+        return StringUtils.indent(builder.append("(\n"), querySQL, 4, true).append(')');
+    }
+
+}

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -2403,7 +2403,7 @@ public final class InformationSchemaTable extends MetaTable {
         String viewDefinition, status = "VALID";
         if (table instanceof TableView) {
             TableView view = (TableView) table;
-            viewDefinition = view.getQuery();
+            viewDefinition = view.getQuerySQL();
             if (view.isInvalid()) {
                 status = "INVALID";
             }

--- a/h2/src/main/org/h2/table/QueryExpressionTable.java
+++ b/h2/src/main/org/h2/table/QueryExpressionTable.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2004-2022 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.table;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.h2.command.query.AllColumnsForPlan;
+import org.h2.command.query.Query;
+import org.h2.engine.DbObject;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionVisitor;
+import org.h2.expression.Parameter;
+import org.h2.index.Index;
+import org.h2.index.IndexType;
+import org.h2.index.QueryExpressionIndex;
+import org.h2.message.DbException;
+import org.h2.result.Row;
+import org.h2.result.SortOrder;
+import org.h2.schema.Schema;
+import org.h2.util.StringUtils;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+
+/**
+ * A derived table or view.
+ */
+public abstract class QueryExpressionTable extends Table {
+
+    /**
+     * The key of the index cache for views.
+     */
+    static final class CacheKey {
+
+        private final int[] masks;
+
+        private final QueryExpressionTable queryExpressionTable;
+
+        CacheKey(int[] masks, QueryExpressionTable queryExpressionTable) {
+            this.masks = masks;
+            this.queryExpressionTable = queryExpressionTable;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Arrays.hashCode(masks);
+            result = prime * result + queryExpressionTable.hashCode();
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            CacheKey other = (CacheKey) obj;
+            if (queryExpressionTable != other.queryExpressionTable) {
+                return false;
+            }
+            return Arrays.equals(masks, other.masks);
+        }
+    }
+
+    private static final long ROW_COUNT_APPROXIMATION = 100;
+
+    /**
+     * Creates a list of column templates from a query (usually from WITH query,
+     * but could be any query)
+     *
+     * @param cols
+     *            - an optional list of column names (can be specified by WITH
+     *            clause overriding usual select names)
+     * @param theQuery
+     *            - the query object we want the column list for
+     * @param querySQLOutput
+     *            - array of length 1 to receive extra 'output' field in
+     *            addition to return value - containing the SQL query of the
+     *            Query object
+     * @return a list of column object returned by withQuery
+     */
+    public static List<Column> createQueryColumnTemplateList(String[] cols, Query theQuery, String[] querySQLOutput) {
+        ArrayList<Column> columnTemplateList = new ArrayList<>();
+        theQuery.prepare();
+        // String array of length 1 is to receive extra 'output' field in
+        // addition to
+        // return value
+        querySQLOutput[0] = StringUtils.cache(theQuery.getPlanSQL(ADD_PLAN_INFORMATION));
+        SessionLocal session = theQuery.getSession();
+        ArrayList<Expression> withExpressions = theQuery.getExpressions();
+        for (int i = 0; i < withExpressions.size(); ++i) {
+            Expression columnExp = withExpressions.get(i);
+            // use the passed in column name if supplied, otherwise use alias
+            // (if found) otherwise use column name derived from column
+            // expression
+            String columnName = cols != null && cols.length > i ? cols[i] : columnExp.getColumnNameForView(session, i);
+            columnTemplateList.add(new Column(columnName, columnExp.getType()));
+        }
+        return columnTemplateList;
+    }
+
+    static int getMaxParameterIndex(ArrayList<Parameter> parameters) {
+        int result = -1;
+        for (Parameter p : parameters) {
+            if (p != null) {
+                result = Math.max(result, p.getIndex());
+            }
+        }
+        return result;
+    }
+
+    Query viewQuery;
+
+    QueryExpressionIndex index;
+
+    ArrayList<Table> tables;
+
+    private long lastModificationCheck;
+
+    private long maxDataModificationId;
+
+    QueryExpressionTable(Schema schema, int id, String name) {
+        super(schema, id, name, false, true);
+    }
+
+    Column[] initColumns(SessionLocal session, Column[] columnTemplates, Query query, boolean isDerivedTable) {
+        ArrayList<Expression> expressions = query.getExpressions();
+        final int count = query.getColumnCount();
+        ArrayList<Column> list = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            Expression expr = expressions.get(i);
+            String name = null;
+            TypeInfo type = TypeInfo.TYPE_UNKNOWN;
+            if (columnTemplates != null && columnTemplates.length > i) {
+                name = columnTemplates[i].getName();
+                type = columnTemplates[i].getType();
+            }
+            if (name == null) {
+                name = isDerivedTable ? expr.getAlias(session, i) : expr.getColumnNameForView(session, i);
+            }
+            if (type.getValueType() == Value.UNKNOWN) {
+                type = expr.getType();
+            }
+            list.add(new Column(name, type, this, i));
+        }
+        return list.toArray(new Column[0]);
+    }
+
+    public final Query getQuery() {
+        return viewQuery;
+    }
+
+    public abstract Query getTopQuery();
+
+    @Override
+    public final void close(SessionLocal session) {
+        // nothing to do
+    }
+
+    @Override
+    public final Index addIndex(SessionLocal session, String indexName, int indexId, IndexColumn[] cols,
+            int uniqueColumnCount, IndexType indexType, boolean create, String indexComment) {
+        throw DbException.getUnsupportedException(getClass().getSimpleName() + ".addIndex");
+    }
+
+    @Override
+    public final boolean isView() {
+        return true;
+    }
+
+    @Override
+    public final PlanItem getBestPlanItem(SessionLocal session, int[] masks, TableFilter[] filters, int filter,
+            SortOrder sortOrder, AllColumnsForPlan allColumnsSet) {
+        final CacheKey cacheKey = new CacheKey(masks, this);
+        Map<Object, QueryExpressionIndex> indexCache = session.getViewIndexCache(getTableType() == null);
+        QueryExpressionIndex i = indexCache.get(cacheKey);
+        if (i == null || i.isExpired()) {
+            i = new QueryExpressionIndex(this, index, session, masks, filters, filter, sortOrder);
+            indexCache.put(cacheKey, i);
+        }
+        PlanItem item = new PlanItem();
+        item.cost = i.getCost(session, masks, filters, filter, sortOrder, allColumnsSet);
+        item.setIndex(i);
+        return item;
+    }
+
+    @Override
+    public boolean isQueryComparable() {
+        for (Table t : tables) {
+            if (!t.isQueryComparable()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public final boolean isInsertable() {
+        return false;
+    }
+
+    @Override
+    public final void removeRow(SessionLocal session, Row row) {
+        throw DbException.getUnsupportedException(getClass().getSimpleName() + ".removeRow");
+    }
+
+    @Override
+    public final void addRow(SessionLocal session, Row row) {
+        throw DbException.getUnsupportedException(getClass().getSimpleName() + ".addRow");
+    }
+
+    @Override
+    public final void checkSupportAlter() {
+        throw DbException.getUnsupportedException(getClass().getSimpleName() + ".checkSupportAlter");
+    }
+
+    @Override
+    public final long truncate(SessionLocal session) {
+        throw DbException.getUnsupportedException(getClass().getSimpleName() + ".truncate");
+    }
+
+    @Override
+    public final long getRowCount(SessionLocal session) {
+        throw DbException.getInternalError(toString());
+    }
+
+    @Override
+    public final boolean canGetRowCount(SessionLocal session) {
+        // TODO could get the row count, but not that easy
+        return false;
+    }
+
+    @Override
+    public final long getRowCountApproximation(SessionLocal session) {
+        return ROW_COUNT_APPROXIMATION;
+    }
+
+    /**
+     * Get the index of the first parameter.
+     *
+     * @param additionalParameters
+     *            additional parameters
+     * @return the index of the first parameter
+     */
+    public final int getParameterOffset(ArrayList<Parameter> additionalParameters) {
+        Query topQuery = getTopQuery();
+        int result = topQuery == null ? -1 : getMaxParameterIndex(topQuery.getParameters());
+        if (additionalParameters != null) {
+            result = Math.max(result, getMaxParameterIndex(additionalParameters));
+        }
+        return result + 1;
+    }
+
+    @Override
+    public final boolean canReference() {
+        return false;
+    }
+
+    @Override
+    public final ArrayList<Index> getIndexes() {
+        return null;
+    }
+
+    @Override
+    public long getMaxDataModificationId() {
+        // if nothing was modified in the database since the last check, and the
+        // last is known, then we don't need to check again
+        // this speeds up nested views
+        long dbMod = database.getModificationDataId();
+        if (dbMod > lastModificationCheck && maxDataModificationId <= dbMod) {
+            maxDataModificationId = viewQuery.getMaxDataModificationId();
+            lastModificationCheck = dbMod;
+        }
+        return maxDataModificationId;
+    }
+
+    @Override
+    public final Index getScanIndex(SessionLocal session) {
+        return getBestPlanItem(session, null, null, -1, null, null).getIndex();
+    }
+
+    @Override
+    public Index getScanIndex(SessionLocal session, int[] masks, TableFilter[] filters, int filter, //
+            SortOrder sortOrder, AllColumnsForPlan allColumnsSet) {
+        return getBestPlanItem(session, masks, filters, filter, sortOrder, allColumnsSet).getIndex();
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return viewQuery.isEverything(ExpressionVisitor.DETERMINISTIC_VISITOR);
+    }
+
+    @Override
+    public final void addDependencies(HashSet<DbObject> dependencies) {
+        super.addDependencies(dependencies);
+        if (tables != null) {
+            for (Table t : tables) {
+                if (TableType.VIEW != t.getTableType()) {
+                    t.addDependencies(dependencies);
+                }
+            }
+        }
+    }
+
+}

--- a/h2/src/test/org/h2/test/scripts/queries/select.sql
+++ b/h2/src/test/org/h2/test/scripts/queries/select.sql
@@ -1184,3 +1184,30 @@ SELECT ((SELECT 1 X) EXCEPT (SELECT 1 Y)) T;
 > ----
 > null
 > rows: 1
+
+create table test(x0 int, x1 int);
+> ok
+
+select * from
+    (select * from
+        (select * from
+            (select * from
+                (select * from
+                    (select * from
+                        (select * from
+                            (select * from
+                                (select * from test as t399 where x0 < 1 and x0 >= x0 or null <= -1) as t398
+                            where -1 is not distinct from -1) as t397
+                        where 3 is distinct from 2) as t396
+                    where null is distinct from -1) as t395
+                where 3 is distinct from -1 or null = x1) as t394
+            where x0 is distinct from null) as t393
+        where x0 >= null and -1 <= 1 and 3 is not distinct from -1) as t392
+    where -1 >= 3) as t391
+where -1 is distinct from -1 or 2 is distinct from x0;
+> X0 X1
+> -- --
+> rows: 0
+
+drop table test;
+> ok


### PR DESCRIPTION
1. Views and derived tables now have separate implementations based on the same common implementation.

2. Immediate recompilation of derived table during initial parsing is removed.

3. When derived table is recompiled in its index and index conditions are supported, but weren't applied its additional recompilation is removed. I think it shouldn't be performed in all cases, but without it some joins return wrong results. This needs further investigation.

4. OOME with deeply nested derived tables is fixed. Closes #3410.