### PR TITLE
Prevent endless regeneration of Recursive CTE views when there are subqueries

### DIFF
--- a/h2/src/main/org/h2/command/query/Select.java
+++ b/h2/src/main/org/h2/command/query/Select.java
@@ -1372,7 +1372,7 @@ public class Select extends Query {
             TableView tableView = t instanceof TableView ? (TableView) t : null;
             if (tableView != null && tableView.isRecursive() && tableView.isTableExpression()) {
 
-                if (!tableView.isTemporary()) {
+                if (tableView.isTemporary()) {
                     // skip the generation of plan SQL for this already recursive persistent CTEs,
                     // since using a with statement will re-create the common table expression
                     // views.


### PR DESCRIPTION
Currently, this query from the documentation works:
```
WITH RECURSIVE T(N) AS (
    SELECT 1
    UNION ALL
    SELECT N+1 FROM T WHERE N<10
)
SELECT * FROM T;
```
but
```
WITH RECURSIVE T(N) AS (
    SELECT 1
    UNION ALL
    SELECT * FROM (SELECT N+1 FROM T WHERE N<10)
)
SELECT * FROM T;
```
never finishes. This occurs because the existing code attempts to regenerate the entire T inside the recursive call rather than using the most recent T. This is precisely the problem that this if/else is designed to avoid, the boolean is just switched. Making this switch expands the experimental CTE features to work for a much larger set of recursive queries. 

It's a small issue, but this was just a nasty amount of debugging for me to get my set of recursive queries to work. Hope it helps