### PR TITLE
#3441 fix EXTERNAL_NAME column result for NULL value

### DIFF
--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -1975,9 +1975,15 @@ public final class InformationSchemaTable extends MetaTable {
                         } else {
                             routineType = "FUNCTION";
                         }
+                        String externalName = null;
+                        String javaClassName = alias.getJavaClassName();
+                        String javaMethodName = alias.getJavaMethodName();
+                        if (javaClassName != null && javaMethodName != null) {
+                            externalName = javaClassName + '.' + javaMethodName;
+                        }
                         routines(session, rows, catalog, mainSchemaName, collation, schemaName, name,
                                 name + '_' + (i + 1), routineType, admin ? alias.getSource() : null,
-                                alias.getJavaClassName() + '.' + alias.getJavaMethodName(), typeInfo,
+                                externalName, typeInfo,
                                 alias.isDeterministic(), alias.getComment());
                     }
                 } else {


### PR DESCRIPTION
The original issue is https://github.com/h2database/h2database/issues/3441.

I hope this PR will help return NULL instead of the "null.null" value in the INFORMATION_SCHEMA.ROUTINES view.