### PR TITLE
Alternative fix for #1808

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #1808: Occasional NPE in concurrent update of LOB
+</li>
 <li>Issue #3439: Cannot use enum values in JSON without explicit casts
 </li>
 <li>Issue #3426: Regression: BIT(1) is not accepted in MySQL compatibility mode

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2789,7 +2789,7 @@ public class MVStore implements AutoCloseable {
     }
 
     private void notifyAboutOldestVersion(long oldestVersionToKeep) {
-        if (cleaner != null && cleaner.needCleanup()) {
+        if (cleaner != null && cleaner.needCleanup() && bufferSaveExecutor != null) {
             Runnable blobCleaner = () -> {
                 notifyCleaner(oldestVersionToKeep);
             };

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -365,7 +365,7 @@ public class MVStore implements AutoCloseable {
     private long nonLeafCount;
 
     /**
-     * Callback for maintance after some unused store versions were dropped
+     * Callback for maintenance after some unused store versions were dropped
      */
     private Cleaner cleaner;
 

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -405,7 +405,8 @@ public final class LobStorageMap implements LobStorageInterface
                 pendingLobRemovals.offer(lobRemovalInfo);
             }
         } finally {
-            mvStore.deregisterVersionUsage(txCounter);
+            // we can not call deregisterVersionUsage() due to a possible infinite recursion
+            mvStore.decrementVersionUsageCounter(txCounter);
         }
     }
 

--- a/h2/src/main/org/h2/value/lob/LobDataDatabase.java
+++ b/h2/src/main/org/h2/value/lob/LobDataDatabase.java
@@ -17,7 +17,7 @@ import org.h2.value.ValueLob;
  */
 public final class LobDataDatabase extends LobData {
 
-    private DataHandler handler;
+    private final DataHandler handler;
 
     /**
      * If the LOB is managed by the one the LobStorageBackend classes, these are
@@ -26,11 +26,6 @@ public final class LobDataDatabase extends LobData {
     private final int tableId;
 
     private final long lobId;
-
-    /**
-     * Fix for recovery tool.
-     */
-    private boolean isRecoveryReference;
 
     public LobDataDatabase(DataHandler handler, int tableId, long lobId) {
         this.handler = handler;
@@ -87,13 +82,4 @@ public final class LobDataDatabase extends LobData {
     public String toString() {
         return "lob-table: table: " + tableId + " id: " + lobId;
     }
-
-    public void setRecoveryReference(boolean isRecoveryReference) {
-        this.isRecoveryReference = isRecoveryReference;
-    }
-
-    public boolean isRecoveryReference() {
-        return isRecoveryReference;
-    }
-
 }

--- a/h2/src/test/org/h2/test/db/TestLob.java
+++ b/h2/src/test/org/h2/test/db/TestLob.java
@@ -1583,49 +1583,44 @@ public class TestLob extends TestDb {
     
     public void testConcurrentSelectAndUpdate() throws SQLException, InterruptedException {
         deleteDb("lob");
-        final JdbcConnection conn1 = (JdbcConnection) getConnection("lob");
-        final JdbcConnection conn2 = (JdbcConnection) getConnection("lob");
+        try (JdbcConnection conn1 = (JdbcConnection) getConnection("lob")) {
+            try (JdbcConnection conn2 = (JdbcConnection) getConnection("lob")) {
 
-        try (Statement st = conn1.createStatement()) {
-            final String createTable = "create table t1 (id int, ver bigint, data text, primary key (id));";
-            st.execute(createTable);
-//            st.execute("SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ");
-        }
-
-        final String insert = "insert into t1 (id, ver, data) values (1, 0, ?)";
-        try (final PreparedStatement insertStmt = conn1.prepareStatement(insert)) {
-            final String largeData = org.h2.util.StringUtils.pad("", 512, "x", false);
-            insertStmt.setString(1, largeData);
-            insertStmt.executeUpdate();
-        }
-
-        final long startTime_ms = System.currentTimeMillis();
-        final long endTime_ms = startTime_ms + 10_000; // 10 seconds
-
-        final Thread thread1 = new Thread() {
-            @Override
-            public void run() {
-                try {
-                    final String update = "update t1 set ver = ver + 1 where id = 1";
-                    try (PreparedStatement ps = conn2.prepareStatement(update)) {
-                        while (!Thread.currentThread().isInterrupted() && System.currentTimeMillis() < endTime_ms) {
-                            ps.executeUpdate();
-                        }
-                    }
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
+                try (Statement st = conn1.createStatement()) {
+                    String createTable = "create table t1 (id int, ver bigint, data text, primary key (id));";
+                    st.execute(createTable);
                 }
-            }
-        };
-        thread1.start();
 
-        try (final PreparedStatement st = conn1.prepareStatement("select * from t1 where id = 1")) {
-            while (System.currentTimeMillis() < endTime_ms) {
-                st.executeQuery();
+                String insert = "insert into t1 (id, ver, data) values (1, 0, ?)";
+                try (PreparedStatement insertStmt = conn1.prepareStatement(insert)) {
+                    String largeData = org.h2.util.StringUtils.pad("", 512, "x", false);
+                    insertStmt.setString(1, largeData);
+                    insertStmt.executeUpdate();
+                }
+
+                long startTimeNs = System.nanoTime();
+
+                Thread thread1 = new Thread(() -> {
+                    try {
+                        String update = "update t1 set ver = ver + 1 where id = 1";
+                        try (PreparedStatement ps = conn2.prepareStatement(update)) {
+                            while (!Thread.currentThread().isInterrupted() && System.nanoTime() - startTimeNs < 10_000_000_000L) {
+                                ps.executeUpdate();
+                            }
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                thread1.start();
+
+                try (PreparedStatement st = conn1.prepareStatement("select * from t1 where id = 1")) {
+                    while (System.nanoTime() - startTimeNs  < 10_000_000_000L) {
+                        st.executeQuery();
+                    }
+                }
+                thread1.join();
             }
         }
-        thread1.join();
-        conn1.close();
-        conn2.close();
     }
 }


### PR DESCRIPTION
This PR is an alternative to PR #3451 attempt to fix issue #1808
It uses the same idea - to postpone LOB removal until a such time, when it's known not to be used.
In existing code, call for removal is issued when LOB is no longer used by the current version of the database (actually underlying store).
This still give the possibility for a concurrent transaction, which may use some previous version of the database, to access a dangling reference to now removed LOB, hence NPE.

Unlike alternative PR, which attempts to track possible LOB usage at transaction level (wait until all transactions, open at the moment of BLOB deletion, are closed), here we choose appropriate moment, based on the fact that version, current at the moment of BLOB deletion goes out of scope (is dropped by the store, because there are no more open transactions use it).
This is the same machinery, that is used by MVStore to determine when storage chunk is safe to reuse.
It looks much less invasive than #3451, because it's not trying to put additional restrictions on SQL engine code path, depending on whether LOBs are involved.
