### PR TITLE
Add performance tests for SQLite

### DIFF
--- a/h2/src/docsrc/html/performance.html
+++ b/h2/src/docsrc/html/performance.html
@@ -158,9 +158,16 @@ The memory usage number is incorrect, because only the memory usage of the JDBC 
 
 <h4>SQLite</h4>
 <p>
-SQLite 3.36.0.2 was tested, but the results are not published currently,
-because it's about 50 times slower than H2 in embedded mode.
-Any tips on how to configure SQLite for higher performance are welcome.
+SQLite 3.36.0.3, configured to use <a href="https://sqlite.org/wal.html">WAL</a> and with
+<a href="https://sqlite.org/pragma.html#pragma_synchronous"><code>synchronous=NORMAL</code></a> was tested in a
+separate, less reliable run. A rough estimate is that SQLite performs approximately 2-5x worse in the simple benchmarks,
+which perform simple work in the database, resulting in a low work-per-transaction ration. SQLite becomes competitive as
+the complexity of the database interactions increases. The results seemed to vary drastically across machine, and more
+reliable results should be obtained. Benchmark on your production hardware.
+</p>
+<p>
+The benchmarks used include multi-threaded scenarios, and we were not able to get the SQLite JDBC driver we used to work
+with them. Help with configuring the driver for multi-threaded usage is welcome.
 </p>
 
 <h4>Firebird</h4>

--- a/h2/src/test/org/h2/test/bench/test.properties
+++ b/h2/src/test/org/h2/test/bench/test.properties
@@ -8,6 +8,7 @@ db1 = H2, org.h2.Driver, jdbc:h2:./data/test, sa, sa
 
 db2 = HSQLDB, org.hsqldb.jdbc.JDBCDriver, jdbc:hsqldb:file:./data/test;hsqldb.default_table_type=cached;hsqldb.write_delay_millis=1000;shutdown=true, sa
 db3 = Derby, org.apache.derby.jdbc.AutoloadedDriver, jdbc:derby:data/derby;create=true, sa, sa
+db9 = SQLite, org.sqlite.JDBC, jdbc:sqlite:data/testSQLite.db, sa, sa
 
 db4 = H2 (C/S), org.h2.Driver, jdbc:h2:tcp://localhost/./data/testServer, sa, sa
 db5 = HSQLDB (C/S), org.hsqldb.jdbcDriver, jdbc:hsqldb:hsql://localhost/xdb, sa
@@ -15,12 +16,11 @@ db6 = Derby (C/S), org.apache.derby.jdbc.ClientDriver, jdbc:derby://localhost/da
 db7 = PG (C/S), org.postgresql.Driver, jdbc:postgresql://localhost:5432/test, sa, sa
 db8 = MySQL (C/S), com.mysql.cj.jdbc.Driver, jdbc:mysql://localhost:3306/test, sa, sa
 
-#db9 = MSSQLServer, com.microsoft.jdbc.sqlserver.SQLServerDriver, jdbc:microsoft:sqlserver://127.0.0.1:1433;DatabaseName=test, test, test
-#db9 = Oracle, oracle.jdbc.driver.OracleDriver, jdbc:oracle:thin:@localhost:1521:XE, client, client
-#db9 = Firebird, org.firebirdsql.jdbc.FBDriver, jdbc:firebirdsql:localhost:test?encoding=UTF8, sa, sa
-#db9 = DB2, COM.ibm.db2.jdbc.net.DB2Driver, jdbc:db2://localhost/test, test, test
-#db9 = OneDollarDB, in.co.daffodil.db.jdbc.DaffodilDBDriver, jdbc:daffodilDB_embedded:school;path=C:/temp;create=true, sa
-#db9 = SQLite, org.sqlite.JDBC, jdbc:sqlite:data/testSQLite.db, sa, sa
+#db10 = MSSQLServer, com.microsoft.jdbc.sqlserver.SQLServerDriver, jdbc:microsoft:sqlserver://127.0.0.1:1433;DatabaseName=test, test, test
+#db10 = Oracle, oracle.jdbc.driver.OracleDriver, jdbc:oracle:thin:@localhost:1521:XE, client, client
+#db10 = Firebird, org.firebirdsql.jdbc.FBDriver, jdbc:firebirdsql:localhost:test?encoding=UTF8, sa, sa
+#db10 = DB2, COM.ibm.db2.jdbc.net.DB2Driver, jdbc:db2://localhost/test, test, test
+#db10 = OneDollarDB, in.co.daffodil.db.jdbc.DaffodilDBDriver, jdbc:daffodilDB_embedded:school;path=C:/temp;create=true, sa
 
 db11 = H2 (mem), org.h2.Driver, jdbc:h2:mem:test;LOCK_MODE=0, sa, sa
 db12 = HSQLDB (mem), org.hsqldb.jdbcDriver, jdbc:hsqldb:mem:data/test;hsqldb.tx=mvcc;shutdown=true, sa

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -65,6 +65,8 @@ public class Build extends BuildBase {
 
     private static final String APIGUARDIAN_VERSION = "1.1.0";
 
+    private static final String SQLITE_VERSION = "3.36.0.3";
+
     private boolean filesMissing;
 
     /**
@@ -101,6 +103,8 @@ public class Build extends BuildBase {
         downloadUsingMaven("ext/mysql-connector-java-" + MYSQL_CONNECTOR_VERSION + ".jar",
                 "mysql", "mysql-connector-java", MYSQL_CONNECTOR_VERSION,
                 "f1da9f10a3de6348725a413304aab6d0aa04f923");
+        downloadUsingMaven("ext/sqlite-" + SQLITE_VERSION + ".jar",
+            "org.xerial", "sqlite-jdbc", SQLITE_VERSION, "7fa71c4dfab806490cb909714fb41373ec552c29");
         compile();
 
         String cp = "temp" +
@@ -111,7 +115,8 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/derbynet-" + DERBY_VERSION + ".jar" +
 //                File.pathSeparator + "ext/derbyshared-" + DERBY_VERSION + ".jar" +
                 File.pathSeparator + "ext/postgresql-" + PGJDBC_VERSION + ".jar" +
-                File.pathSeparator + "ext/mysql-connector-java-" + MYSQL_CONNECTOR_VERSION + ".jar";
+                File.pathSeparator + "ext/mysql-connector-java-" + MYSQL_CONNECTOR_VERSION + ".jar" +
+                File.pathSeparator + "ext/sqlite-" + SQLITE_VERSION + ".jar";
         StringList args = args("-Xmx128m",
                 "-cp", cp, "-Dderby.system.durability=test", "org.h2.test.bench.TestPerformance");
         execJava(args.plus("-init", "-db", "1"));
@@ -122,6 +127,8 @@ public class Build extends BuildBase {
         execJava(args.plus("-db", "6"));
         execJava(args.plus("-db", "7"));
         execJava(args.plus("-db", "8", "-out", "ps.html"));
+        // Disable SQLite because it doesn't work with multi-threaded benchmark, BenchB
+        // execJava(args.plus("-db", "9"));
     }
 
     /**


### PR DESCRIPTION
Configure SQLite to run in a mode comparable to H2.

The performance docs are updated with approximations of SQLite performance on these tests, but not with detailed numbers.

---

Anecdotal results collected off my laptop (not a reliable benchmark) for reference. Strangely, the `BenchB` test executes 24,088 fewer statements in the SQLite run than H2, but there are no exceptions or other indicators in the run output.
<table><tr><th>Test Case</th><th>Unit</th><th>H2</th><th>SQLite</th></tr>
<tr><td>Simple: Init</td><td>ms</td><td>813</td><td>520</td></tr>
<tr><td>Simple: Query (random)</td><td>ms</td><td>487</td><td>274</td></tr>
<tr><td>Simple: Query (sequential)</td><td>ms</td><td>777</td><td>1829</td></tr>
<tr><td>Simple: Update (sequential)</td><td>ms</td><td>934</td><td>2241</td></tr>
<tr><td>Simple: Delete (sequential)</td><td>ms</td><td>950</td><td>3282</td></tr>
<tr><td>Simple: Memory Usage</td><td>MB</td><td>19</td><td>2</td></tr>
<tr><td>BenchA: Init</td><td>ms</td><td>572</td><td>563</td></tr>
<tr><td>BenchA: Transactions</td><td>ms</td><td>588</td><td>2399</td></tr>
<tr><td>BenchA: Memory Usage</td><td>MB</td><td>13</td><td>2</td></tr>
<tr><td>BenchB: Init</td><td>ms</td><td>661</td><td>576</td></tr>
<tr><td>BenchB: Transactions</td><td>ms</td><td>167</td><td>80</td></tr>
<tr><td>BenchB: Memory Usage</td><td>MB</td><td>19</td><td>2</td></tr>
<tr><td>BenchC: Init</td><td>ms</td><td>1537</td><td>1262</td></tr>
<tr><td>BenchC: Transactions</td><td>ms</td><td>860</td><td>648</td></tr>
<tr><td>BenchC: Memory Usage</td><td>MB</td><td>20</td><td>3</td></tr>
<tr><td>Executed statements</td><td>#</td><td>2222032</td><td>2197724</td></tr>
<tr><td>Total time</td><td>ms</td><td>8346</td><td>13674</td></tr>
<tr><td>Statements per second</td><td>#/s</td><td>266239</td><td>160722</td></tr></table>
