### PR TITLE
fix bug in readStoreHeader()

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -937,6 +937,7 @@ public class MVStore implements AutoCloseable {
             Chunk tailChunk = discoverChunk(blocksInStore);
             if (tailChunk != null) {
                 blocksInStore = tailChunk.block; // for a possible full scan later on
+                validChunksByLocation.put(blocksInStore, tailChunk);
                 if (newest == null || tailChunk.version > newest.version) {
                     newest = tailChunk;
                 }


### PR DESCRIPTION
This bug may affect cases when full scan of a datafile is executed (open after abrupt termination or when Recovery tool is executed). Last chunk (in terms of a file location) is erroneously ignored, and therefore last store version may be thrown away, even though it is a valid one.