### PR TITLE
In-memory mode: MVStore.removeMap() fail to drop MVMap object

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -480,7 +480,9 @@ public class MVMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V
                         continue;
                     }
                 }
-                store.registerUnsavedMemory(rootPage.removeAllRecursive(version));
+                if (isPersistent()) {
+                    store.registerUnsavedMemory(rootPage.removeAllRecursive(version));
+                }
                 rootPage = emptyRootPage;
                 return rootReference;
             } finally {
@@ -1870,7 +1872,9 @@ public class MVMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V
                         continue;
                     }
                 }
-                store.registerUnsavedMemory(unsavedMemoryHolder.value + tip.processRemovalInfo(version));
+                if (isPersistent()) {
+                    store.registerUnsavedMemory(unsavedMemoryHolder.value + tip.processRemovalInfo(version));
+                }
                 return result;
             } finally {
                 if(locked) {

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -2733,6 +2733,14 @@ public class MVStore implements AutoCloseable {
     }
 
     /**
+     * Indicates whether store versions are rolling.
+     * @return true if versions are rolling, false otherwise
+     */
+    public boolean isVersioningRequired() {
+        return fileStore != null || versionsToKeep > 0;
+    }
+
+    /**
      * How many versions to retain for in-memory stores. If not set, 5 old
      * versions are retained.
      *
@@ -3159,6 +3167,11 @@ public class MVStore implements AutoCloseable {
             }
             if (meta.remove(DataUtils.META_NAME + name) != null) {
                 markMetaChanged();
+            }
+            // normally actual map removal is delayed, up until this current version go out os scope,
+            // but for in-memory case, when versions rolling is turned off, do it now
+            if (!isVersioningRequired()) {
+                maps.remove(id);
             }
         } finally {
             storeLock.unlock();

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -169,7 +169,9 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
                                 unsavedMemory += page.removePage(version);
                             }
                         }
-                        store.registerUnsavedMemory(unsavedMemory);
+                        if (isPersistent()) {
+                            store.registerUnsavedMemory(unsavedMemory);
+                        }
                     } finally {
                         unlockRoot(p);
                     }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -330,7 +330,7 @@ public final class Transaction {
     @SuppressWarnings({"unchecked","rawtypes"})
     public void markStatementStart(HashSet<MVMap<Object,VersionedValue<Object>>> maps) {
         markStatementEnd();
-        if (txCounter == null) {
+        if (txCounter == null && store.store.isVersioningRequired()) {
             txCounter = store.store.registerVersionUsage();
         }
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -628,7 +628,7 @@ public class TransactionStore {
                 preparedTransactions.remove(txId);
             }
 
-            if (store.getFileStore() != null) {
+            if (store.isVersioningRequired()) {
                 if (wasStored || store.getAutoCommitDelay() == 0) {
                     store.commit();
                 } else {


### PR DESCRIPTION
Fixes #3473 