### PR TITLE
SHUTDOWN DEFRAG: carry over store current version

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1131,6 +1131,11 @@ public class MVStore implements AutoCloseable {
         return false;
     }
 
+    void adoptMetaFrom(MVStore source) {
+        currentVersion = source.currentVersion;
+        lastMapId.set(source.lastMapId.get());
+    }
+
     private void setLastChunk(Chunk last) {
         chunks.clear();
         lastChunk = last;

--- a/h2/src/main/org/h2/mvstore/MVStoreTool.java
+++ b/h2/src/main/org/h2/mvstore/MVStoreTool.java
@@ -508,6 +508,7 @@ public class MVStoreTool {
      * @param target the target store
      */
     public static void compact(MVStore source, MVStore target) {
+        target.adoptMetaFrom(source);
         int autoCommitDelay = target.getAutoCommitDelay();
         boolean reuseSpace = target.getReuseSpace();
         try {


### PR DESCRIPTION
Bug fix for PR #3471 
Last version saved in the store was not propagated into the new store, created by SHUTDOWN DEFRAG, unlike version at which particular map was created. Those two versions are compared later in save procedure to filter out maps which where created after it's start. As a result it could lead to a store corruption.