### PR TITLE
Move blob storage cleanup to a dedicated executor

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1192,7 +1192,7 @@ public final class Database implements DataHandler, CastDataProvider {
                         for (Schema schema : schemas.values()) {
                             for (Table table : schema.getAllTablesAndViews(null)) {
                                 if (table.isGlobalTemporary()) {
-                                    table.removeChildrenAndResources(systemSession);
+                                    removeSchemaObject(systemSession, table);
                                 } else {
                                     table.close(systemSession);
                                 }
@@ -1219,6 +1219,7 @@ public final class Database implements DataHandler, CastDataProvider {
                     }
                 }
             } catch (DbException e) {
+                e.printStackTrace();
                 trace.error(e, "close");
             }
             tempFileDeleter.deleteAll();

--- a/h2/src/main/org/h2/store/LobStorageInterface.java
+++ b/h2/src/main/org/h2/store/LobStorageInterface.java
@@ -86,4 +86,9 @@ public interface LobStorageInterface {
      * @return true if yes
      */
     boolean isReadOnly();
+
+    /**
+     * Close LobStorage and release all resources
+     */
+    default void close() {}
 }


### PR DESCRIPTION
Hopefully it will fix issue  #3484.
 
Also fixed issue with removal (on database closure) of the global temp table with identity column. 
Issue was created by when expression visitor to collect dependencies was introduced. Now internal sequence related to identity column can not be removed before table removed first, which is not the case currently.