### PR TITLE
Fix issues with Path.toRealPath()

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,7 +21,11 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
-<li>Nothing yet ...
+<li>Issue #3493: org.h2.tools.DeleteDbFiles won't delete files under certain circumstances
+</li>
+<li>Issue #3486: FilePathDisk.newDirectoryStream() may fail on remote drive on Windows due to AccessDeniedException in Path.toRealPath()
+</li>
+<li>Issue #3484: LOB issue
 </li>
 </ul>
 

--- a/h2/src/main/org/h2/store/FileLister.java
+++ b/h2/src/main/org/h2/store/FileLister.java
@@ -86,10 +86,10 @@ public class FileLister {
     public static ArrayList<String> getDatabaseFiles(String dir, String db,
             boolean all) {
         ArrayList<String> files = new ArrayList<>();
-        // for Windows, File.getCanonicalPath("...b.") returns just "...b"
-        String start = db == null ? null : (FileUtils.toRealPath(dir + "/" + db) + ".");
-        for (String f : FileUtils.newDirectoryStream(dir)) {
+        String start = db == null ? null : db + '.';
+        for (FilePath path : FilePath.get(dir).newDirectoryStream()) {
             boolean ok = false;
+            String f = path.toString();
             if (f.endsWith(Constants.SUFFIX_MV_FILE)) {
                 ok = true;
             } else if (all) {
@@ -102,7 +102,7 @@ public class FileLister {
                 }
             }
             if (ok) {
-                if (db == null || f.startsWith(start)) {
+                if (db == null || path.getName().startsWith(start)) {
                     files.add(f);
                 }
             }


### PR DESCRIPTION
1. Our usual workaround for `toRealPath()` is used for `newDirectoryStream()` too. Closes #3486.
2. `FileLister.getDatabaseFiles()` doesn't call `toRealPath()` by itself anymore. It was needed only because `FilePath.newDirectoryStream()` returns real names, but `toRealPath()` was called with a fake name. If such file or directory exists with different case of characters on case-insensitive file system a wrong prefix for test was generated. With the new implementation `FilePath.getName()` is used for filtration. Closes #3493.