### PR TITLE
Only attempt to create tempDir (and parents) when the last level of it is not a symlink

### DIFF
--- a/h2/src/main/org/h2/store/fs/disk/FilePathDisk.java
+++ b/h2/src/main/org/h2/store/fs/disk/FilePathDisk.java
@@ -446,7 +446,7 @@ public class FilePathDisk extends FilePath {
         String prefix = file.getFileName().toString();
         if (inTempDir) {
             final Path tempDir = Paths.get(System.getProperty("java.io.tmpdir", "."));
-            if (!Files.isSymbolicLink(tempDir)) {
+            if (!Files.isDirectory(tempDir)) {
                 Files.createDirectories(tempDir);
             }
             file = Files.createTempFile(prefix, suffix);

--- a/h2/src/main/org/h2/store/fs/disk/FilePathDisk.java
+++ b/h2/src/main/org/h2/store/fs/disk/FilePathDisk.java
@@ -445,7 +445,10 @@ public class FilePathDisk extends FilePath {
         Path file = Paths.get(name + '.').toAbsolutePath();
         String prefix = file.getFileName().toString();
         if (inTempDir) {
-            Files.createDirectories(Paths.get(System.getProperty("java.io.tmpdir", ".")));
+            final Path tempDir = Paths.get(System.getProperty("java.io.tmpdir", "."));
+            if (!Files.isSymbolicLink(tempDir)) {
+                Files.createDirectories(tempDir);
+            }
             file = Files.createTempFile(prefix, suffix);
         } else {
             Path dir = file.getParent();


### PR DESCRIPTION
First check whether the java.io.tmpdir is a symlink before trying to create the directory structure including any missing parents as [by design ](https://bugs.openjdk.java.net/browse/JDK-8130464) Files.createDirectories() will throw a FileAlreadyExistsException when the last level of the path is a symlink.

Fixes #3510 