### PR TITLE
Improve NON_KEYWORDS and other changes

### DIFF
--- a/h2/src/docsrc/html/advanced.html
+++ b/h2/src/docsrc/html/advanced.html
@@ -529,8 +529,6 @@ The following tokens are keywords in H2:
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
 <tr><td>FETCH</td>
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
-<tr><td>FILTER</td>
-<td>CS</td><td>+</td><td>+</td><td>+</td><td>+</td><td></td><td></td></tr>
 <tr><td>FOR</td>
 <td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td><td>+</td></tr>
 <tr><td>FOREIGN</td>

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3390: "ROW" cannot be set as a non keyword in 2.x
+</li>
 <li>Issue #3448: With linked table to postgreSQL, case-sensitive column names not respected in where part
 </li>
 <li>Issue #3434: JavaTableFunction is not closing underlying ResultSet when reading column list

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4062,9 +4062,9 @@ public class Parser {
             return readSubstringFunction();
         // TRIM
         case "LTRIM":
-            return new TrimFunction(readSingleArgument(), null, TrimFunction.LEADING);
+            return new TrimFunction(readExpression(), readIfArgument(), TrimFunction.LEADING);
         case "RTRIM":
-            return new TrimFunction(readSingleArgument(), null, TrimFunction.TRAILING);
+            return new TrimFunction(readExpression(), readIfArgument(), TrimFunction.TRAILING);
         // UPPER
         case "UCASE":
             return new StringFunction1(readSingleArgument(), StringFunction1.UPPER);

--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -71,10 +71,13 @@ public class CreateTable extends CommandWithColumns {
     public long update() {
         Schema schema = getSchema();
         boolean isSessionTemporary = data.temporary && !data.globalTemporary;
-        if (!isSessionTemporary) {
+        Database db = session.getDatabase();
+        String tableEngine = data.tableEngine;
+        if (tableEngine != null || db.getSettings().defaultTableEngine != null) {
+            session.getUser().checkAdmin();
+        } else if (!isSessionTemporary) {
             session.getUser().checkSchemaOwner(schema);
         }
-        Database db = session.getDatabase();
         if (!db.isPersistent()) {
             data.persistIndexes = false;
         }

--- a/h2/src/main/org/h2/constraint/ConstraintDomain.java
+++ b/h2/src/main/org/h2/constraint/ConstraintDomain.java
@@ -76,11 +76,6 @@ public class ConstraintDomain extends Constraint {
     }
 
     @Override
-    public String getCreateSQLForCopy(Table forTable, String quotedName) {
-        throw DbException.getInternalError(toString());
-    }
-
-    @Override
     public String getCreateSQLWithoutIndexes() {
         return getCreateSQL();
     }

--- a/h2/src/main/org/h2/engine/Comment.java
+++ b/h2/src/main/org/h2/engine/Comment.java
@@ -7,7 +7,6 @@ package org.h2.engine;
 
 import org.h2.message.DbException;
 import org.h2.message.Trace;
-import org.h2.table.Table;
 import org.h2.util.StringUtils;
 
 /**
@@ -23,11 +22,6 @@ public final class Comment extends DbObject {
         super(database, id,  getKey(obj), Trace.DATABASE);
         this.objectType = obj.getType();
         this.quotedObjectName = obj.getSQL(DEFAULT_SQL_FLAGS);
-    }
-
-    @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
     }
 
     private static String getTypeName(int type) {

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -1699,10 +1699,13 @@ public final class Database implements DataHandler, CastDataProvider {
      * @return a unique name
      */
     public synchronized String getTempTableName(String baseName, SessionLocal session) {
+        int maxBaseLength = Constants.MAX_IDENTIFIER_LENGTH - (7 + ValueInteger.DISPLAY_SIZE * 2);
+        if (baseName.length() > maxBaseLength) {
+            baseName = baseName.substring(0, maxBaseLength);
+        }
         String tempName;
         do {
-            tempName = baseName + "_COPY_" + session.getId() +
-                    "_" + nextTempTableId++;
+            tempName = baseName + "_COPY_" + session.getId() + '_' + nextTempTableId++;
         } while (mainSchema.findTableOrView(session, tempName) != null);
         return tempName;
     }

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -54,7 +54,6 @@ import org.h2.store.FileLock;
 import org.h2.store.FileLockMethod;
 import org.h2.store.FileStore;
 import org.h2.store.InDoubtTransaction;
-import org.h2.store.LobStorageFrontend;
 import org.h2.store.LobStorageInterface;
 import org.h2.store.fs.FileUtils;
 import org.h2.store.fs.encrypt.FileEncrypt;

--- a/h2/src/main/org/h2/engine/DbObject.java
+++ b/h2/src/main/org/h2/engine/DbObject.java
@@ -228,7 +228,9 @@ public abstract class DbObject implements HasSQL {
      * @param quotedName the quoted name
      * @return the SQL statement
      */
-    public abstract String getCreateSQLForCopy(Table table, String quotedName);
+    public String getCreateSQLForCopy(Table table, String quotedName) {
+        throw DbException.getInternalError(toString());
+    }
 
     /**
      * Construct the CREATE ... SQL statement for this object for meta table.

--- a/h2/src/main/org/h2/engine/Role.java
+++ b/h2/src/main/org/h2/engine/Role.java
@@ -7,10 +7,8 @@ package org.h2.engine;
 
 import java.util.ArrayList;
 
-import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.schema.Schema;
-import org.h2.table.Table;
 
 /**
  * Represents a role. Roles can be granted to users, and to other roles.
@@ -22,11 +20,6 @@ public final class Role extends RightOwner {
     public Role(Database database, int id, String roleName, boolean system) {
         super(database, id, roleName, Trace.USER);
         this.system = system;
-    }
-
-    @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
     }
 
     /**

--- a/h2/src/main/org/h2/engine/Setting.java
+++ b/h2/src/main/org/h2/engine/Setting.java
@@ -7,7 +7,6 @@ package org.h2.engine;
 
 import org.h2.message.DbException;
 import org.h2.message.Trace;
-import org.h2.table.Table;
 
 /**
  * A persistent database setting.
@@ -45,11 +44,6 @@ public final class Setting extends DbObject {
 
     public String getStringValue() {
         return stringValue;
-    }
-
-    @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
     }
 
     @Override

--- a/h2/src/main/org/h2/engine/User.java
+++ b/h2/src/main/org/h2/engine/User.java
@@ -75,11 +75,6 @@ public final class User extends RightOwner {
     }
 
     @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
-    }
-
-    @Override
     public String getCreateSQL() {
         return getCreateSQL(true);
     }

--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -125,8 +125,10 @@ public class FileStore {
      *            used
      */
     public void open(String fileName, boolean readOnly, char[] encryptionKey) {
-        open(fileName, readOnly, encryptionKey == null ? null :
-                fileChannel ->  new FileEncrypt(fileName, FilePathEncrypt.getPasswordBytes(encryptionKey), fileChannel));
+        open(fileName, readOnly,
+                encryptionKey == null ? null
+                        : fileChannel -> new FileEncrypt(fileName, FilePathEncrypt.getPasswordBytes(encryptionKey),
+                                fileChannel));
     }
 
     public FileStore open(String fileName, boolean readOnly) {

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -58,7 +58,7 @@ public final class LobStorageMap implements LobStorageInterface
     private static final boolean TRACE = false;
 
     private final Database database;
-    private final MVStore mvStore;
+    final MVStore mvStore;
     private final AtomicLong nextLobId = new AtomicLong(0);
     private final ThreadPoolExecutor cleanupExecutor;
 

--- a/h2/src/main/org/h2/mvstore/db/MVTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTempResult.java
@@ -178,7 +178,8 @@ public abstract class MVTempResult implements ResultExternal {
             String fileName = FileUtils.createTempFile("h2tmp", Constants.SUFFIX_TEMP_FILE, true);
 
             FileStore fileStore = database.getStore().getMvStore().getFileStore().open(fileName, false);
-            MVStore.Builder builder = new MVStore.Builder().adoptFileStore(fileStore).cacheSize(0).autoCommitDisabled();
+            MVStore.Builder builder = new MVStore.Builder().adoptFileStore(fileStore).cacheSize(0)
+                    .autoCommitDisabled();
             store = builder.open();
             this.expressions = expressions;
             this.visibleColumnCount = visibleColumnCount;

--- a/h2/src/main/org/h2/mvstore/db/MVTempResult.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTempResult.java
@@ -15,7 +15,6 @@ import org.h2.expression.Expression;
 import org.h2.message.DbException;
 import org.h2.mvstore.FileStore;
 import org.h2.mvstore.MVStore;
-import org.h2.mvstore.MVStore.Builder;
 import org.h2.result.ResultExternal;
 import org.h2.result.SortOrder;
 import org.h2.store.fs.FileUtils;

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -69,7 +69,7 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
         return new ContainsRTreeCursor<>(getRootPage(), x, keyType);
     }
 
-    private boolean contains(Page<Spatial,V> p, int index, Object key) {
+    private boolean contains(Page<Spatial,V> p, int index, Spatial key) {
         return keyType.contains(p.getKey(index), key);
     }
 
@@ -236,7 +236,7 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
             // a new entry, we don't know where to add yet
             float min = Float.MAX_VALUE;
             for (int i = 0; i < p.getKeyCount(); i++) {
-                Object k = p.getKey(i);
+                Spatial k = p.getKey(i);
                 float areaIncrease = keyType.getAreaIncrease(k, key);
                 if (areaIncrease < min) {
                     index = i;
@@ -308,7 +308,7 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
 
     private Page<Spatial,V> splitLinear(Page<Spatial,V> p) {
         int keyCount = p.getKeyCount();
-        ArrayList<Object> keys = new ArrayList<>(keyCount);
+        ArrayList<Spatial> keys = new ArrayList<>(keyCount);
         for (int i = 0; i < keyCount; i++) {
             keys.add(p.getKey(i));
         }
@@ -323,10 +323,10 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
             extremes[1]--;
         }
         move(p, splitB, extremes[1]);
-        Object boundsA = keyType.createBoundingBox(splitA.getKey(0));
-        Object boundsB = keyType.createBoundingBox(splitB.getKey(0));
+        Spatial boundsA = keyType.createBoundingBox(splitA.getKey(0));
+        Spatial boundsB = keyType.createBoundingBox(splitB.getKey(0));
         while (p.getKeyCount() > 0) {
-            Object o = p.getKey(0);
+            Spatial o = p.getKey(0);
             float a = keyType.getAreaIncrease(boundsA, o);
             float b = keyType.getAreaIncrease(boundsB, o);
             if (a < b) {
@@ -350,12 +350,12 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
         int ia = 0, ib = 0;
         int keyCount = p.getKeyCount();
         for (int a = 0; a < keyCount; a++) {
-            Object objA = p.getKey(a);
+            Spatial objA = p.getKey(a);
             for (int b = 0; b < keyCount; b++) {
                 if (a == b) {
                     continue;
                 }
-                Object objB = p.getKey(b);
+                Spatial objB = p.getKey(b);
                 float area = keyType.getCombinedArea(objA, objB);
                 if (area > largest) {
                     largest = area;
@@ -369,14 +369,14 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
             ib--;
         }
         move(p, splitB, ib);
-        Object boundsA = keyType.createBoundingBox(splitA.getKey(0));
-        Object boundsB = keyType.createBoundingBox(splitB.getKey(0));
+        Spatial boundsA = keyType.createBoundingBox(splitA.getKey(0));
+        Spatial boundsB = keyType.createBoundingBox(splitB.getKey(0));
         while (p.getKeyCount() > 0) {
             float diff = 0, bestA = 0, bestB = 0;
             int best = 0;
             keyCount = p.getKeyCount();
             for (int i = 0; i < keyCount; i++) {
-                Object o = p.getKey(i);
+                Spatial o = p.getKey(i);
                 float incA = keyType.getAreaIncrease(boundsA, o);
                 float incB = keyType.getAreaIncrease(boundsB, o);
                 float d = Math.abs(incA - incB);

--- a/h2/src/main/org/h2/mvstore/rtree/SpatialDataType.java
+++ b/h2/src/main/org/h2/mvstore/rtree/SpatialDataType.java
@@ -68,15 +68,13 @@ public class SpatialDataType extends BasicDataType<Spatial> {
      * @param b the second value
      * @return true if they are equal
      */
-    public boolean equals(Object a, Object b) {
+    public boolean equals(Spatial a, Spatial b) {
         if (a == b) {
             return true;
         } else if (a == null || b == null) {
             return false;
         }
-        long la = ((Spatial) a).getId();
-        long lb = ((Spatial) b).getId();
-        return la == lb;
+        return a.getId() == b.getId();
     }
 
     @Override
@@ -155,20 +153,18 @@ public class SpatialDataType extends BasicDataType<Spatial> {
      * @param bounds the bounds (may be modified)
      * @param add the value
      */
-    public void increaseBounds(Object bounds, Object add) {
-        Spatial a = (Spatial) add;
-        Spatial b = (Spatial) bounds;
-        if (a.isNull() || b.isNull()) {
+    public void increaseBounds(Spatial bounds, Spatial add) {
+        if (add.isNull() || bounds.isNull()) {
             return;
         }
         for (int i = 0; i < dimensions; i++) {
-            float v = a.min(i);
-            if (v < b.min(i)) {
-                b.setMin(i, v);
+            float v = add.min(i);
+            if (v < bounds.min(i)) {
+                bounds.setMin(i, v);
             }
-            v = a.max(i);
-            if (v > b.max(i)) {
-                b.setMax(i, v);
+            v = add.max(i);
+            if (v > bounds.max(i)) {
+                bounds.setMax(i, v);
             }
         }
     }
@@ -176,28 +172,26 @@ public class SpatialDataType extends BasicDataType<Spatial> {
     /**
      * Get the area increase by extending a to contain b.
      *
-     * @param objA the bounding box
-     * @param objB the object
+     * @param bounds the bounding box
+     * @param add the object
      * @return the area
      */
-    public float getAreaIncrease(Object objA, Object objB) {
-        Spatial b = (Spatial) objB;
-        Spatial a = (Spatial) objA;
-        if (a.isNull() || b.isNull()) {
+    public float getAreaIncrease(Spatial bounds, Spatial add) {
+        if (bounds.isNull() || add.isNull()) {
             return 0;
         }
-        float min = a.min(0);
-        float max = a.max(0);
+        float min = bounds.min(0);
+        float max = bounds.max(0);
         float areaOld = max - min;
-        min = Math.min(min,  b.min(0));
-        max = Math.max(max,  b.max(0));
+        min = Math.min(min,  add.min(0));
+        max = Math.max(max,  add.max(0));
         float areaNew = max - min;
         for (int i = 1; i < dimensions; i++) {
-            min = a.min(i);
-            max = a.max(i);
+            min = bounds.min(i);
+            max = bounds.max(i);
             areaOld *= max - min;
-            min = Math.min(min,  b.min(i));
-            max = Math.max(max,  b.max(i));
+            min = Math.min(min,  add.min(i));
+            max = Math.max(max,  add.max(i));
             areaNew *= max - min;
         }
         return areaNew - areaOld;
@@ -206,13 +200,11 @@ public class SpatialDataType extends BasicDataType<Spatial> {
     /**
      * Get the combined area of both objects.
      *
-     * @param objA the first object
-     * @param objB the second object
+     * @param a the first object
+     * @param b the second object
      * @return the area
      */
-    float getCombinedArea(Object objA, Object objB) {
-        Spatial a = (Spatial) objA;
-        Spatial b = (Spatial) objB;
+    float getCombinedArea(Spatial a, Spatial b) {
         if (a.isNull()) {
             return getArea(b);
         } else if (b.isNull()) {
@@ -239,20 +231,18 @@ public class SpatialDataType extends BasicDataType<Spatial> {
     }
 
     /**
-     * Check whether a contains b.
+     * Check whether bounds contains object.
      *
-     * @param objA the bounding box
-     * @param objB the object
+     * @param bounds the bounding box
+     * @param object the object
      * @return the area
      */
-    public boolean contains(Object objA, Object objB) {
-        Spatial a = (Spatial) objA;
-        Spatial b = (Spatial) objB;
-        if (a.isNull() || b.isNull()) {
+    public boolean contains(Spatial bounds, Spatial object) {
+        if (bounds.isNull() || object.isNull()) {
             return false;
         }
         for (int i = 0; i < dimensions; i++) {
-            if (a.min(i) > b.min(i) || a.max(i) < b.max(i)) {
+            if (bounds.min(i) > object.min(i) || bounds.max(i) < object.max(i)) {
                 return false;
             }
         }
@@ -260,21 +250,18 @@ public class SpatialDataType extends BasicDataType<Spatial> {
     }
 
     /**
-     * Check whether a is completely inside b and does not touch the
-     * given bound.
+     * Check whether object is completely inside bounds and does not touch them.
      *
-     * @param objA the object to check
-     * @param objB the bounds
+     * @param object the object to check
+     * @param bounds the bounds
      * @return true if a is completely inside b
      */
-    public boolean isInside(Object objA, Object objB) {
-        Spatial a = (Spatial) objA;
-        Spatial b = (Spatial) objB;
-        if (a.isNull() || b.isNull()) {
+    public boolean isInside(Spatial object, Spatial bounds) {
+        if (object.isNull() || bounds.isNull()) {
             return false;
         }
         for (int i = 0; i < dimensions; i++) {
-            if (a.min(i) <= b.min(i) || a.max(i) >= b.max(i)) {
+            if (object.min(i) <= bounds.min(i) || object.max(i) >= bounds.max(i)) {
                 return false;
             }
         }
@@ -284,15 +271,14 @@ public class SpatialDataType extends BasicDataType<Spatial> {
     /**
      * Create a bounding box starting with the given object.
      *
-     * @param objA the object
+     * @param object the object
      * @return the bounding box
      */
-    Spatial createBoundingBox(Object objA) {
-        Spatial a = (Spatial) objA;
-        if (a.isNull()) {
-            return a;
+    Spatial createBoundingBox(Spatial object) {
+        if (object.isNull()) {
+            return object;
         }
-        return a.clone(0);
+        return object.clone(0);
     }
 
     /**
@@ -303,7 +289,7 @@ public class SpatialDataType extends BasicDataType<Spatial> {
      * @param list the objects
      * @return the indexes of the extremes
      */
-    public int[] getExtremes(ArrayList<Object> list) {
+    public int[] getExtremes(ArrayList<Spatial> list) {
         list = getNotNull(list);
         if (list.isEmpty()) {
             return null;
@@ -315,7 +301,7 @@ public class SpatialDataType extends BasicDataType<Spatial> {
             boundsInner.setMin(i, boundsInner.max(i));
             boundsInner.setMax(i, t);
         }
-        for (Object o : list) {
+        for (Spatial o : list) {
             increaseBounds(bounds, o);
             increaseMaxInnerBounds(boundsInner, o);
         }
@@ -341,7 +327,7 @@ public class SpatialDataType extends BasicDataType<Spatial> {
         int firstIndex = -1, lastIndex = -1;
         for (int i = 0; i < list.size() &&
                 (firstIndex < 0 || lastIndex < 0); i++) {
-            Spatial o = (Spatial) list.get(i);
+            Spatial o = list.get(i);
             if (firstIndex < 0 && o.max(bestDim) == min) {
                 firstIndex = i;
             } else if (lastIndex < 0 && o.min(bestDim) == max) {
@@ -351,11 +337,10 @@ public class SpatialDataType extends BasicDataType<Spatial> {
         return new int[] { firstIndex, lastIndex };
     }
 
-    private static ArrayList<Object> getNotNull(ArrayList<Object> list) {
+    private static ArrayList<Spatial> getNotNull(ArrayList<Spatial> list) {
         boolean foundNull = false;
-        for (Object o : list) {
-            Spatial a = (Spatial) o;
-            if (a.isNull()) {
+        for (Spatial o : list) {
+            if (o.isNull()) {
                 foundNull = true;
                 break;
             }
@@ -363,22 +348,19 @@ public class SpatialDataType extends BasicDataType<Spatial> {
         if (!foundNull) {
             return list;
         }
-        ArrayList<Object> result = new ArrayList<>();
-        for (Object o : list) {
-            Spatial a = (Spatial) o;
-            if (!a.isNull()) {
-                result.add(a);
+        ArrayList<Spatial> result = new ArrayList<>();
+        for (Spatial o : list) {
+            if (!o.isNull()) {
+                result.add(o);
             }
         }
         return result;
     }
 
-    private void increaseMaxInnerBounds(Object bounds, Object add) {
-        Spatial b = (Spatial) bounds;
-        Spatial a = (Spatial) add;
+    private void increaseMaxInnerBounds(Spatial bounds, Spatial add) {
         for (int i = 0; i < dimensions; i++) {
-            b.setMin(i, Math.min(b.min(i), a.max(i)));
-            b.setMax(i, Math.max(b.max(i), a.min(i)));
+            bounds.setMin(i, Math.min(bounds.min(i), add.max(i)));
+            bounds.setMax(i, Math.max(bounds.max(i), add.min(i)));
         }
     }
 

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -5126,19 +5126,6 @@ This method returns value of the same type as argument, but with adjusted precis
 ROUND(N, 2)
 "
 
-"Functions (Numeric)","ROUNDMAGIC","
-@h2@ ROUNDMAGIC(numeric)
-","
-This function rounds numbers in a good way, but it is slow.
-It has a special handling for numbers around 0.
-Only numbers smaller or equal +/-1000000000000 are supported.
-The value is converted to a String internally, and then the last 4 characters are checked.
-'000x' becomes '0000' and '999x' becomes '999999', which is rounded automatically.
-This method returns a double.
-","
-ROUNDMAGIC(N/3*3)
-"
-
 "Functions (Numeric)","SECURE_RAND","
 @h2@ SECURE_RAND(int)
 ","

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -961,6 +961,10 @@ TABLE @h2@ [ IF NOT EXISTS ] [schemaName.]tableName
 [ AS ( query ) [ WITH [ NO ] DATA ] ]","
 Creates a new table.
 
+Admin rights are required to execute this command
+if and only if ENGINE option is used or custom default table engine is configured in the database.
+Schema owner rights or ALTER ANY SCHEMA rights are required for creation of regular tables and GLOBAL TEMPORARY tables.
+
 Cached tables (the default for regular tables) are persistent,
 and the number of rows is not limited by the main memory.
 Memory tables (the default for temporary tables) are persistent,

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -5411,9 +5411,9 @@ RPAD(TEXT, 10, '-')
 "
 
 "Functions (String)","LTRIM","
-@c@ LTRIM(string)
+@c@ LTRIM(string [, characterToTrimString])
 ","
-Removes all leading spaces from a string.
+Removes all leading spaces or other specified characters from a string.
 
 This function is deprecated, use [TRIM](https://h2database.com/html/functions.html#trim) instead of it.
 ","
@@ -5421,9 +5421,9 @@ LTRIM(NAME)
 "
 
 "Functions (String)","RTRIM","
-@c@ RTRIM(string)
+@c@ RTRIM(string [, characterToTrimString])
 ","
-Removes all trailing spaces from a string.
+Removes all trailing spaces or other specified characters from a string.
 
 This function is deprecated, use [TRIM](https://h2database.com/html/functions.html#trim) instead of it.
 ","

--- a/h2/src/main/org/h2/schema/Constant.java
+++ b/h2/src/main/org/h2/schema/Constant.java
@@ -8,9 +8,7 @@ package org.h2.schema;
 import org.h2.engine.DbObject;
 import org.h2.engine.SessionLocal;
 import org.h2.expression.ValueExpression;
-import org.h2.message.DbException;
 import org.h2.message.Trace;
-import org.h2.table.Table;
 import org.h2.value.Value;
 
 /**
@@ -24,11 +22,6 @@ public final class Constant extends SchemaObject {
 
     public Constant(Schema schema, int id, String name) {
         super(schema, id, name, Trace.SCHEMA);
-    }
-
-    @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
     }
 
     @Override

--- a/h2/src/main/org/h2/schema/Domain.java
+++ b/h2/src/main/org/h2/schema/Domain.java
@@ -12,10 +12,8 @@ import org.h2.engine.DbObject;
 import org.h2.engine.SessionLocal;
 import org.h2.expression.Expression;
 import org.h2.expression.ValueExpression;
-import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.table.ColumnTemplate;
-import org.h2.table.Table;
 import org.h2.util.Utils;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
@@ -40,11 +38,6 @@ public final class Domain extends SchemaObject implements ColumnTemplate {
 
     public Domain(Schema schema, int id, String name) {
         super(schema, id, name, Trace.SCHEMA);
-    }
-
-    @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
     }
 
     @Override

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -93,11 +93,6 @@ public class Schema extends DbObject {
     }
 
     @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
-    }
-
-    @Override
     public String getCreateSQL() {
         if (system) {
             return null;

--- a/h2/src/main/org/h2/schema/Sequence.java
+++ b/h2/src/main/org/h2/schema/Sequence.java
@@ -11,7 +11,6 @@ import org.h2.engine.DbObject;
 import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
-import org.h2.table.Table;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
 import org.h2.value.ValueBigint;
@@ -348,11 +347,6 @@ public final class Sequence extends SchemaObject {
         }
         StringBuilder builder = new StringBuilder("DROP SEQUENCE IF EXISTS ");
         return getSQL(builder, DEFAULT_SQL_FLAGS).toString();
-    }
-
-    @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
     }
 
     @Override

--- a/h2/src/main/org/h2/schema/UserDefinedFunction.java
+++ b/h2/src/main/org/h2/schema/UserDefinedFunction.java
@@ -6,7 +6,6 @@
 package org.h2.schema;
 
 import org.h2.message.DbException;
-import org.h2.table.Table;
 
 /**
  * User-defined Java function or aggregate function.
@@ -17,11 +16,6 @@ public abstract class UserDefinedFunction extends SchemaObject {
 
     UserDefinedFunction(Schema newSchema, int id, String name, int traceModuleId) {
         super(newSchema, id, name, traceModuleId);
-    }
-
-    @Override
-    public final String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
     }
 
     @Override

--- a/h2/src/main/org/h2/server/web/WebThread.java
+++ b/h2/src/main/org/h2/server/web/WebThread.java
@@ -9,7 +9,6 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.UnknownHostException;

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -401,11 +401,6 @@ public abstract class Table extends SchemaObject {
         return null;
     }
 
-    @Override
-    public String getCreateSQLForCopy(Table table, String quotedName) {
-        throw DbException.getInternalError(toString());
-    }
-
     /**
      * Check whether the table (or view) contains no columns that prevent index
      * conditions to be used. For example, a view that contains the ROWNUM()

--- a/h2/src/main/org/h2/util/ParserUtil.java
+++ b/h2/src/main/org/h2/util/ParserUtil.java
@@ -573,7 +573,6 @@ public class ParserUtil {
         map.put("_ROWID_", _ROWID_);
         // Additional keywords
         map.put("BOTH", KEYWORD);
-        map.put("FILTER", KEYWORD);
         map.put("GROUPS", KEYWORD);
         map.put("ILIKE", KEYWORD);
         map.put("LEADING", KEYWORD);

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -76,7 +76,7 @@ public class TestTableEngines extends TestDb {
         Statement stat = conn.createStatement();
         stat.execute("CREATE USER U PASSWORD '1'");
         stat.execute("GRANT ALTER ANY SCHEMA TO U");
-        Connection connUser = getConnection("tableEngine", "U", "1");
+        Connection connUser = getConnection("tableEngine", "U", getPassword("1"));
         Statement statUser = connUser.createStatement();
         assertThrows(ErrorCode.ADMIN_RIGHTS_REQUIRED, statUser)
                 .execute("CREATE TABLE T(ID INT, NAME VARCHAR) ENGINE \"" + EndlessTableEngine.class.getName() + '"');

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.h2.api.ErrorCode;
 import org.h2.api.TableEngine;
 import org.h2.command.ddl.CreateTableData;
 import org.h2.command.query.AllColumnsForPlan;
@@ -60,12 +61,28 @@ public class TestTableEngines extends TestDb {
 
     @Override
     public void test() throws Exception {
+        testAdminPrivileges();
         testQueryExpressionFlag();
         testSubQueryInfo();
         testEngineParams();
         testSchemaEngineParams();
         testSimpleQuery();
         testMultiColumnTreeSetIndex();
+    }
+
+    private void testAdminPrivileges() throws SQLException {
+        deleteDb("tableEngine");
+        Connection conn = getConnection("tableEngine");
+        Statement stat = conn.createStatement();
+        stat.execute("CREATE USER U PASSWORD '1'");
+        stat.execute("GRANT ALTER ANY SCHEMA TO U");
+        Connection connUser = getConnection("tableEngine", "U", "1");
+        Statement statUser = connUser.createStatement();
+        assertThrows(ErrorCode.ADMIN_RIGHTS_REQUIRED, statUser)
+                .execute("CREATE TABLE T(ID INT, NAME VARCHAR) ENGINE \"" + EndlessTableEngine.class.getName() + '"');
+        connUser.close();
+        conn.close();
+        deleteDb("tableEngine");
     }
 
     private void testEngineParams() throws SQLException {

--- a/h2/src/test/org/h2/test/scripts/functions/string/ltrim.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/ltrim.sql
@@ -8,3 +8,6 @@ select ltrim(null) en, '>' || ltrim('a') || '<' ea, '>' || ltrim(' a ') || '<' e
 > ---- --- ----
 > null >a< >a <
 > rows: 1
+
+VALUES LTRIM('__A__', '_');
+>> A__

--- a/h2/src/test/org/h2/test/scripts/functions/string/rtrim.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/rtrim.sql
@@ -11,3 +11,6 @@ select rtrim(null) en, '>' || rtrim('a') || '<' ea, '>' || rtrim(' a ') || '<' e
 
 select rtrim() from dual;
 > exception SYNTAX_ERROR_2
+
+VALUES RTRIM('__A__', '_');
+>> __A

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -849,4 +849,4 @@ entirely skeleton discouraged pearson coefficient squares covariance mytab debug
 filestore backstop tie breaker lockable lobtx btx waiter accounted aiobe spf resolvers generators
 abandoned accidental approximately cited competitive configuring drastically happier hasn interactions journal
 journaling ldt occasional odt officially pragma ration recognising rnrn rough seemed sonatype supplementary subtree ver
-wal wbr worse xerial won
+wal wbr worse xerial won symlink respected adopted


### PR DESCRIPTION
1. `NON_KEYWORDS` setting now works in more cases, for example, `ROW` now can be used as a column name with `NON_KEYWORDS=ROW`. Closes #3390.
2. `FILTER` is removed from the list of context-sensitive keywords, because now only `FILTER (WHERE` has special meaning.
3. Arguments of methods in `SpatialDataType` are changed from `Object` to `Spatial` to reduce number of casts. `Spatial` is an interface from `MVStore`, so it can be used here without introduction of unwanted dependencies. `Object` was needed a long time ago to avoid usage of `SpatialKey` from H2.
4. `DbObject.getCreateSQLForCopy()` now has default implementation that throws an exception to significantly reduce number of its implementations, most of them also need to throw an exception.
5. `Database.getTempTableName()` now truncates too long names of identifiers.
6. Tables with custom table engines now can be only created by an user with `ADMIN` privileges like any other DDL operations with user-provided classes.