### PR TITLE
Replace NUMERIC without parameters with DECFLOAT in PostgreSQL compatibility mode

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -44,7 +44,7 @@
     <junit.version>5.6.2</junit.version>
     <lucene.version>8.5.2</lucene.version>
     <osgi.version>5.0.0</osgi.version>
-    <pgjdbc.version>42.3.2</pgjdbc.version>
+    <pgjdbc.version>42.4.0</pgjdbc.version>
     <javax.servlet.version>4.0.1</javax.servlet.version>
     <jakarta.servlet.version>5.0.0</jakarta.servlet.version>
     <slf4j.version>1.7.30</slf4j.version>

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3538: In Postgres compatibility mode the NUMERIC type w/o scale should not default to 0
+</li>
 <li>Issue #3534: Subquery has incorrect empty parameters since 2.1.210 that breaks sameResultAsLast()
 </li>
 <li>Issue #3390: "ROW" cannot be set as a non keyword in 2.x

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -1089,6 +1089,7 @@ Do not change value of DATABASE_TO_LOWER after creation of database.
 </li><li>ON CONFLICT DO NOTHING is supported in INSERT statements.
 </li><li>Spaces are trimmed from the right side of CHAR values, but CHAR values in result sets are right-padded with
     spaces to the declared length.
+</li><li>NUMERIC and DECIMAL/DEC data types without parameters are treated like DECFLOAT data type.
 </li><li>MONEY data type is treated like NUMERIC(19, 2) data type.
 </li><li>Datetime value functions return the same value within a transaction.
 </li><li>ARRAY_SLICE() out of bounds parameters are silently corrected.

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6164,6 +6164,9 @@ public class Parser {
                 original = "CHARACTER LARGE OBJECT";
             }
             break;
+        case "DATE":
+            return database.getMode().dateIsTimestamp0 ? TypeInfo.getTypeInfo(Value.TIMESTAMP, -1L, 0, null)
+                    : TypeInfo.TYPE_DATE;
         case "DATETIME":
         case "DATETIME2":
             return parseDateTimeType(false);
@@ -6370,6 +6373,8 @@ public class Parser {
                 }
             }
             read(CLOSE_PAREN);
+        } else if (database.getMode().numericIsDecfloat) {
+            return TypeInfo.TYPE_DECFLOAT;
         }
         return TypeInfo.getTypeInfo(Value.NUMERIC, precision, scale, decimal ? ExtTypeInfoNumeric.DECIMAL : null);
     }

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -424,6 +424,16 @@ public class Mode {
     public boolean autoIncrementClause;
 
     /**
+     * Whether DATE data type is parsed as TIMESTAMP(0).
+     */
+    public boolean dateIsTimestamp0;
+
+    /**
+     * Whether NUMERIC and DECIMAL/DEC without parameters are parsed as DECFLOAT.
+     */
+    public boolean numericIsDecfloat;
+
+    /**
      * An optional Set of hidden/disallowed column types.
      * Certain DBMSs don't support all column types provided by H2, such as
      * "NUMBER" when using PostgreSQL mode.
@@ -646,13 +656,9 @@ public class Mode {
         mode.minusIsExcept = true;
         mode.expressionNames = ExpressionNames.ORIGINAL_SQL;
         mode.viewExpressionNames = ViewExpressionNames.EXCEPTION;
+        mode.dateIsTimestamp0 = true;
         mode.typeByNameMap.put("BINARY_FLOAT", DataType.getDataType(Value.REAL));
         mode.typeByNameMap.put("BINARY_DOUBLE", DataType.getDataType(Value.DOUBLE));
-        dt = DataType.createDate(/* 2001-01-01 23:59:59 */ 19, 19, "DATE", false, 0, 0);
-        dt.type = Value.TIMESTAMP;
-        dt.sqlType = Types.TIMESTAMP;
-        dt.specialPrecisionScale = true;
-        mode.typeByNameMap.put("DATE", dt);
         add(mode);
 
         mode = new Mode(ModeEnum.PostgreSQL);
@@ -673,6 +679,7 @@ public class Mode {
         mode.allowUsingFromClauseInUpdateStatement = true;
         mode.limit = true;
         mode.serialDataTypes = true;
+        mode.numericIsDecfloat = true;
         // Enumerate all H2 types NOT supported by PostgreSQL:
         Set<String> disallowedTypes = new java.util.HashSet<>();
         disallowedTypes.add("NUMBER");

--- a/h2/src/test/org/h2/test/scripts/datatypes/numeric.sql
+++ b/h2/src/test/org/h2/test/scripts/datatypes/numeric.sql
@@ -184,5 +184,25 @@ INSERT INTO TEST VALUES CAST(20 AS NUMERIC(2));
 DROP TABLE TEST;
 > ok
 
+SET MODE PostgreSQL;
+> ok
+
+CREATE TABLE TEST(A NUMERIC, B DECIMAL, C DEC, D NUMERIC(1));
+> ok
+
+SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE,
+    DECLARED_DATA_TYPE, DECLARED_NUMERIC_PRECISION, DECLARED_NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'TEST' ORDER BY ORDINAL_POSITION;
+> COLUMN_NAME DATA_TYPE NUMERIC_PRECISION NUMERIC_PRECISION_RADIX NUMERIC_SCALE DECLARED_DATA_TYPE DECLARED_NUMERIC_PRECISION DECLARED_NUMERIC_SCALE
+> ----------- --------- ----------------- ----------------------- ------------- ------------------ -------------------------- ----------------------
+> A           DECFLOAT  100000            10                      null          DECFLOAT           null                       null
+> B           DECFLOAT  100000            10                      null          DECFLOAT           null                       null
+> C           DECFLOAT  100000            10                      null          DECFLOAT           null                       null
+> D           NUMERIC   1                 10                      0             NUMERIC            1                          null
+> rows (ordered): 4
+
+DROP TABLE TEST;
+> ok
+
 SET MODE Regular;
 > ok

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -53,9 +53,9 @@ public class Build extends BuildBase {
 
     private static final String OSGI_VERSION = "5.0.0";
 
-    private static final String PGJDBC_VERSION = "42.3.2";
+    private static final String PGJDBC_VERSION = "42.4.0";
 
-    private static final String PGJDBC_HASH = "8fd7a20f008a58b97b26ba5c5084ee61602203aa";
+    private static final String PGJDBC_HASH = "21ff952426bbfe4a041c175407333d4a07c70931";
 
     private static final String JAVAX_SERVLET_VERSION = "4.0.1";
 


### PR DESCRIPTION
1. `NUMERIC`, `DECIMAL`, and `DEC` without parameters are now replaced with `DECFLOAT` in PostgreSQL compatibility mode. Closes #3538.
2. PgJDBC driver is upgraded to 42.4.0 to silence warnings about vulnerable dependency.