### PR TITLE
Add support of TINYINT and DECFLOAT to TO_CHAR

### DIFF
--- a/h2/src/main/org/h2/expression/function/ToCharFunction.java
+++ b/h2/src/main/org/h2/expression/function/ToCharFunction.java
@@ -1087,19 +1087,22 @@ public final class ToCharFunction extends FunctionN {
     @Override
     public Value getValue(SessionLocal session, Value v1, Value v2, Value v3) {
         switch (v1.getValueType()) {
-        case Value.TIME:
         case Value.DATE:
+        case Value.TIME:
+        case Value.TIME_TZ:
         case Value.TIMESTAMP:
         case Value.TIMESTAMP_TZ:
             v1 = ValueVarchar.get(toCharDateTime(session, v1, v2 == null ? null : v2.getString(),
                     v3 == null ? null : v3.getString()), session);
             break;
+        case Value.TINYINT:
         case Value.SMALLINT:
         case Value.INTEGER:
         case Value.BIGINT:
         case Value.NUMERIC:
-        case Value.DOUBLE:
         case Value.REAL:
+        case Value.DOUBLE:
+        case Value.DECFLOAT:
             v1 = ValueVarchar.get(toChar(v1.getBigDecimal(), v2 == null ? null : v2.getString(),
                     v3 == null ? null : v3.getString()), session);
             break;

--- a/h2/src/test/org/h2/test/scripts/functions/string/to-char.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/string/to-char.sql
@@ -2,3 +2,9 @@
 -- and the EPL 1.0 (https://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+VALUES '*' || TO_CHAR(CAST(-1 AS TINYINT), '999.99');
+>> * -1.00
+
+VALUES '*' || TO_CHAR(-11E-1, '999.99');
+>> * -1.10


### PR DESCRIPTION
A fix for issue from the mailing list:
https://groups.google.com/g/h2-database/c/kiwdQi2cR7I

I also noticed a difference in number of leading spaces between H2 and Oracle, but this difference isn't corrected here.