### PR TITLE
Eliminate use of interrupt in executor shutdown

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1842,6 +1842,10 @@ public class MVStore implements AutoCloseable {
         return retentionTime < 0 || chunk.time + retentionTime <= time;
     }
 
+    private boolean isDeadChunk(Chunk chunk, long time) {
+        return retentionTime < 0 || chunk.unused + retentionTime <= time;
+    }
+
     private long getTimeSinceCreation() {
         return Math.max(0, getTimeAbsolute() - creationTime);
     }
@@ -3641,7 +3645,7 @@ public class MVStore implements AutoCloseable {
             try {
                 Chunk chunk;
                 while ((chunk = deadChunks.poll()) != null &&
-                        (isSeasonedChunk(chunk, time) && canOverwriteChunk(chunk, oldestVersionToKeep) ||
+                        (isDeadChunk(chunk, time) && canOverwriteChunk(chunk, oldestVersionToKeep) ||
                                 // if chunk is not ready yet, put it back and exit
                                 // since this deque is unbounded, offerFirst() always return true
                                 !deadChunks.offerFirst(chunk))) {

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -768,7 +768,7 @@ public class Utils {
      * Makes sure that all currently submitted tasks are processed before this method returns.
      * It is assumed that there will be no new submissions to this executor, once this method has started.
      * It is assumed that executor is single-threaded, and flush is done by submitting a dummy task
-     * and waiting for it's completion.
+     * and waiting for its completion.
      * @param executor to flush
      */
     public static void flushExecutor(ThreadPoolExecutor executor) {
@@ -788,11 +788,8 @@ public class Utils {
         if (executor != null) {
             executor.shutdown();
             try {
-                if (executor.awaitTermination(10, TimeUnit.SECONDS)) {
-                    return;
-                }
+                executor.awaitTermination(1, TimeUnit.DAYS);
             } catch (InterruptedException ignore) {/**/}
-            executor.shutdownNow();
         }
     }
 


### PR DESCRIPTION
This PR fix #3583 