### PR TITLE
Assorted fixes

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3599: [2.1.214][MariaDB] DELETE query failure
+</li>
 <li>Issue #3600: NPE in MVTable.lock(), version 2.1.214
 </li>
 <li>Issue #3601: InvalidPathException when saving lock file

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3601: InvalidPathException when saving lock file
+</li>
+<li>Issue #3583: lob cleaner issue
+</li>
 <li>Issue #3585: Misuse ValueReal.DECIMAL_PRECISION when optimize typeinfo from DOUBLE to DECFLOAT
 </li>
 <li>Issue #3575: Possible syntax mismatch for json_object in MySQL compatibility mode

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3600: NPE in MVTable.lock(), version 2.1.214
+</li>
 <li>Issue #3601: InvalidPathException when saving lock file
 </li>
 <li>Issue #3583: lob cleaner issue

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1182,7 +1182,7 @@ public class Parser {
             fetch = readTerm().optimize(session);
         }
         currentPrepared = command;
-        if (!readIf(FROM) && database.getMode().getEnum() == ModeEnum.MySQL) {
+        if (!readIf(FROM) && database.getMode().deleteIdentifierFrom) {
             readIdentifierWithSchema();
             read(FROM);
         }
@@ -6047,7 +6047,7 @@ public class Parser {
         if (readIf("SELECTIVITY")) {
             column.setSelectivity(readNonNegativeInt());
         }
-        if (mode.getEnum() == ModeEnum.MySQL) {
+        if (mode.mySqlTableOptions) {
             if (readIf("CHARACTER")) {
                 readIf(SET);
                 readMySQLCharset();
@@ -8166,6 +8166,7 @@ public class Parser {
                 return command;
             }
             break;
+        case MariaDB:
         case MySQL:
             if (readIf("FOREIGN_KEY_CHECKS")) {
                 readIfEqualOrTo();
@@ -8906,7 +8907,7 @@ public class Parser {
                 break;
             case NO_NULL_CONSTRAINT_FOUND:
                 command = parseAlterTableAlterColumnType(schema, tableName, columnName, ifTableExists, false,
-                        mode.getEnum() != ModeEnum.MySQL);
+                        mode.alterTableModifyColumnPreserveNullability);
                 break;
             default:
                 throw DbException.get(ErrorCode.UNKNOWN_MODE_1,
@@ -9290,7 +9291,7 @@ public class Parser {
                 } while (readIfMore());
             }
         }
-        if (database.getMode().getEnum() == ModeEnum.MySQL) {
+        if (database.getMode().mySqlTableOptions) {
             parseCreateTableMySQLTableOptions(command);
         }
         if (readIf("ENGINE")) {

--- a/h2/src/main/org/h2/command/ddl/Analyze.java
+++ b/h2/src/main/org/h2/command/ddl/Analyze.java
@@ -169,7 +169,8 @@ public class Analyze extends DefineCommand {
      * @param manual whether the command was called by the user
      */
     public static void analyzeTable(SessionLocal session, Table table, int sample, boolean manual) {
-        if (table.getTableType() != TableType.TABLE //
+        if (!table.isValid()
+                || table.getTableType() != TableType.TABLE //
                 || table.isHidden() //
                 || session == null //
                 || !manual && (session.getDatabase().isSysTableLocked() || table.hasSelectTrigger()) //

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -286,6 +286,21 @@ public class Mode {
     public boolean alterTableModifyColumn;
 
     /**
+     * If {@code true} non-standard ALTER TABLE MODIFY COLUMN preserves nullability when changing data type.
+     */
+    public boolean alterTableModifyColumnPreserveNullability;
+
+    /**
+     * If {@code true} MySQL table and column options are allowed
+     */
+    public boolean mySqlTableOptions;
+
+    /**
+     * If {@code true} DELETE identifier FROM is allowed
+     */
+    public boolean deleteIdentifierFrom;
+
+    /**
      * If {@code true} TRUNCATE TABLE uses RESTART IDENTITY by default.
      */
     public boolean truncateTableRestartIdentity;
@@ -598,6 +613,8 @@ public class Mode {
         mode.allowUnrelatedOrderByExpressionsInDistinctQueries = true;
         mode.alterTableExtensionsMySQL = true;
         mode.alterTableModifyColumn = true;
+        mode.mySqlTableOptions = true;
+        mode.deleteIdentifierFrom = true;
         mode.truncateTableRestartIdentity = true;
         mode.allNumericTypesHavePrecision = true;
         mode.nextValueReturnsDifferentValues = true;
@@ -628,6 +645,8 @@ public class Mode {
         mode.allowUnrelatedOrderByExpressionsInDistinctQueries = true;
         mode.alterTableExtensionsMySQL = true;
         mode.alterTableModifyColumn = true;
+        mode.mySqlTableOptions = true;
+        mode.deleteIdentifierFrom = true;
         mode.truncateTableRestartIdentity = true;
         mode.allNumericTypesHavePrecision = true;
         mode.updateSequenceOnManualIdentityInsertion = true;
@@ -656,6 +675,7 @@ public class Mode {
         mode.supportedClientInfoPropertiesRegEx =
                 Pattern.compile(".*\\..*");
         mode.alterTableModifyColumn = true;
+        mode.alterTableModifyColumnPreserveNullability = true;
         mode.decimalSequences = true;
         mode.charAndByteLengthUnits = true;
         mode.nextvalAndCurrvalPseudoColumns = true;

--- a/h2/src/main/org/h2/mode/ModeFunction.java
+++ b/h2/src/main/org/h2/mode/ModeFunction.java
@@ -57,6 +57,7 @@ public abstract class ModeFunction extends FunctionN {
             return FunctionsDB2Derby.getFunction(name);
         case MSSQLServer:
             return FunctionsMSSQLServer.getFunction(name);
+        case MariaDB:
         case MySQL:
             return FunctionsMySQL.getFunction(name);
         case Oracle:

--- a/h2/src/main/org/h2/store/FileLock.java
+++ b/h2/src/main/org/h2/store/FileLock.java
@@ -15,7 +15,6 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.Paths;
 import java.util.Properties;
 import org.h2.Driver;
 import org.h2.api.ErrorCode;
@@ -24,6 +23,7 @@ import org.h2.engine.SessionRemote;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
 import org.h2.message.TraceSystem;
+import org.h2.store.fs.FilePath;
 import org.h2.store.fs.FileUtils;
 import org.h2.util.MathUtils;
 import org.h2.util.NetUtils;
@@ -210,7 +210,7 @@ public class FileLock implements Runnable {
          * cache.
          */
         try {
-            try (FileChannel f = FileChannel.open(Paths.get(fileName), FileUtils.RWS, FileUtils.NO_ATTRIBUTES);) {
+            try (FileChannel f = FilePath.get(fileName).open("rws")) {
                 ByteBuffer b = ByteBuffer.wrap(new byte[1]);
                 f.read(b);
             }

--- a/h2/src/test/org/h2/test/unit/TestFileLock.java
+++ b/h2/src/test/org/h2/test/unit/TestFileLock.java
@@ -87,12 +87,18 @@ public class TestFileLock extends TestDb implements Runnable {
     }
 
     private void testSimple() {
-        FileLock lock1 = new FileLock(new TraceSystem(null), getFile(), Constants.LOCK_SLEEP);
-        FileLock lock2 = new FileLock(new TraceSystem(null), getFile(), Constants.LOCK_SLEEP);
+        String fileName = getFile();
+        testSimple(fileName);
+        testSimple("async:" + fileName);
+    }
+
+    private void testSimple(String fileName) {
+        FileLock lock1 = new FileLock(new TraceSystem(null), fileName, Constants.LOCK_SLEEP);
+        FileLock lock2 = new FileLock(new TraceSystem(null), fileName, Constants.LOCK_SLEEP);
         lock1.lock(FileLockMethod.FILE);
         assertThrows(ErrorCode.DATABASE_ALREADY_OPEN_1, () -> lock2.lock(FileLockMethod.FILE));
         lock1.unlock();
-        FileLock lock3 = new FileLock(new TraceSystem(null), getFile(), Constants.LOCK_SLEEP);
+        FileLock lock3 = new FileLock(new TraceSystem(null), fileName, Constants.LOCK_SLEEP);
         lock3.lock(FileLockMethod.FILE);
         lock3.unlock();
     }


### PR DESCRIPTION
1. Various missing features are added to MariaDB compatibility mode. Closes #3599.
2. Automatic analyze now skips invalidated tables. Closes #3600. Unfortunately, didn't find a test case, but it is safer to have this additional conditon.
3. File locks with `async:` file system now use regular file name. Previously this prefix was incorrectly passed to OS, because our file system abstraction layer wasn't used. Closes #3601.