### PR TITLE
Fix some compatibility issues

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3604: Improper FROM_1X implementation corrupts some BLOBs during migration
+</li>
 <li>Issue #3597: Support array element assignments in UPDATE statements
 </li>
 <li>Issue #3599: [2.1.214][MariaDB] DELETE query failure

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3607: [MySQL] UNIX_TIMESTAMP should return NULL
+</li>
 <li>Issue #3604: Improper FROM_1X implementation corrupts some BLOBs during migration
 </li>
 <li>Issue #3597: Support array element assignments in UPDATE statements

--- a/h2/src/main/org/h2/command/dml/RunScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/RunScriptCommand.java
@@ -16,6 +16,7 @@ import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
 import org.h2.result.ResultInterface;
 import org.h2.util.ScriptReader;
+import org.h2.util.StringUtils;
 
 /**
  * This class represents the statement
@@ -91,6 +92,17 @@ public class RunScriptCommand extends ScriptBase {
     private void execute(String sql) {
         if (from1X) {
             sql = sql.trim();
+            if (sql.startsWith("--")) {
+                int i = 2, l = sql.length();
+                char c;
+                do {
+                    if (i >= l) {
+                        return;
+                    }
+                    c = sql.charAt(i++);
+                } while (c != '\n' && c != '\r');
+                sql = StringUtils.trimSubstring(sql, i);
+            }
             if (sql.startsWith("INSERT INTO SYSTEM_LOB_STREAM VALUES(")) {
                 int idx = sql.indexOf(", NULL, '");
                 if (idx >= 0) {

--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -40,10 +40,10 @@ public final class FunctionsMySQL extends ModeFunction {
 
     static {
         FUNCTIONS.put("UNIX_TIMESTAMP",
-                new FunctionInfo("UNIX_TIMESTAMP", UNIX_TIMESTAMP, VAR_ARGS, Value.INTEGER, false, false));
+                new FunctionInfo("UNIX_TIMESTAMP", UNIX_TIMESTAMP, VAR_ARGS, Value.INTEGER, true, false));
         FUNCTIONS.put("FROM_UNIXTIME",
-                new FunctionInfo("FROM_UNIXTIME", FROM_UNIXTIME, VAR_ARGS, Value.VARCHAR, false, true));
-        FUNCTIONS.put("DATE", new FunctionInfo("DATE", DATE, 1, Value.DATE, false, true));
+                new FunctionInfo("FROM_UNIXTIME", FROM_UNIXTIME, VAR_ARGS, Value.VARCHAR, true, true));
+        FUNCTIONS.put("DATE", new FunctionInfo("DATE", DATE, 1, Value.DATE, true, true));
         FUNCTIONS.put("LAST_INSERT_ID",
                 new FunctionInfo("LAST_INSERT_ID", LAST_INSERT_ID, VAR_ARGS, Value.BIGINT, false, false));
     }
@@ -201,7 +201,10 @@ public final class FunctionsMySQL extends ModeFunction {
 
     @Override
     public Value getValue(SessionLocal session) {
-        Value[] values = new Value[args.length];
+        Value[] values = getArgumentsValues(session, args);
+        if (values == null) {
+            return ValueNull.INSTANCE;
+        }
         Value v0 = getNullOrValue(session, args, values, 0);
         Value v1 = getNullOrValue(session, args, values, 1);
         Value result;
@@ -215,7 +218,6 @@ public final class FunctionsMySQL extends ModeFunction {
             break;
         case DATE:
             switch (v0.getValueType()) {
-            case Value.NULL:
             case Value.DATE:
                 result = v0;
                 break;

--- a/h2/src/main/org/h2/store/fs/FilePath.java
+++ b/h2/src/main/org/h2/store/fs/FilePath.java
@@ -40,10 +40,12 @@ public abstract class FilePath {
     public String name;
 
     static {
-        FilePath def = null;
         ConcurrentHashMap<String, FilePath> map = new ConcurrentHashMap<>();
+        FilePath p = new FilePathDisk();
+        map.put(p.getScheme(), p);
+        map.put("nio", p);
+        defaultProvider = p;
         for (String c : new String[] {
-                "org.h2.store.fs.disk.FilePathDisk",
                 "org.h2.store.fs.mem.FilePathMem",
                 "org.h2.store.fs.mem.FilePathMemLZF",
                 "org.h2.store.fs.niomem.FilePathNioMem",
@@ -55,19 +57,12 @@ public abstract class FilePath {
                 "org.h2.store.fs.retry.FilePathRetryOnInterrupt"
         }) {
             try {
-                FilePath p = (FilePath) Class.forName(c).getDeclaredConstructor().newInstance();
+                p = (FilePath) Class.forName(c).getDeclaredConstructor().newInstance();
                 map.put(p.getScheme(), p);
-                if (p.getClass() == FilePathDisk.class) {
-                    map.put("nio", p);
-                }
-                if (def == null) {
-                    def = p;
-                }
             } catch (Exception e) {
                 // ignore - the files may be excluded in purpose
             }
         }
-        defaultProvider = def;
         providers = map;
     }
 

--- a/h2/src/test/org/h2/test/db/TestCompatibility.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibility.java
@@ -320,6 +320,7 @@ public class TestCompatibility extends TestDb {
         stat.execute("DROP TABLE IF EXISTS TEST");
         stat.execute("CREATE TABLE `TEST`(ID INT PRIMARY KEY, NAME VARCHAR)");
         stat.execute("INSERT INTO TEST VALUES(1, 'Hello'), (2, 'World')");
+        assertResult(null, stat, "SELECT UNIX_TIMESTAMP(NULL)");
         assertResult("0", stat, "SELECT UNIX_TIMESTAMP('1970-01-01 00:00:00Z')");
         assertResult("1196418619", stat, "SELECT UNIX_TIMESTAMP('2007-11-30 10:30:19Z')");
         assertResult("1196418619", stat, "SELECT UNIX_TIMESTAMP(FROM_UNIXTIME(1196418619))");


### PR DESCRIPTION
1. LOB import with `RUNSCRIPT … FROM_1X` is fixed. Closes #3604.
2. MySQL compatibility functions now handle `NULL` arguments properly. Closes #3607.
3. Registration of `FilePathDisk` doesn't use reflection any more. This default implementation is expected to be always available.