### PR TITLE
Add experimental configuration for GraalVM's native-image tool

### DIFF
--- a/h2/MAVEN.md
+++ b/h2/MAVEN.md
@@ -44,7 +44,8 @@ or
 ```
 
 Please note that jar generated with Maven is larger than official one and it does not include OSGi attributes.
-Use build script with `jar` target instead if you need a compatible jar.
+Its configuration for native-image tool is also incomplete.
+Use build script with `jar` target instead if you need a jar compatible with official builds.
 
 ### Testing
 

--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -27,6 +27,8 @@ Build
     Building the Software</a><br />
 <a href="#maven2">
     Using Maven 2</a><br />
+<a href="#native_image">
+    Native Image</a><br />
 <a href="#using_eclipse">
     Using Eclipse</a><br />
 <a href="#translating">
@@ -48,6 +50,8 @@ This database is written in Java and therefore works on many platforms.
 <h2 id="environment">Environment</h2>
 <p>
 To run this database, a Java Runtime Environment (JRE) version 8 or higher is required.
+It it also possible to compile a standalone executable with
+experimental <a href="#native_image">native image</a> build.
 </p>
 <p>
 To create the database executables, the following software stack was used.
@@ -147,6 +151,34 @@ Afterwards, you can include the database in your Maven 2 project as a dependency
     &lt;version&gt;1.0-SNAPSHOT&lt;/version&gt;
 &lt;/dependency&gt;
 </pre>
+
+<h2 id="native_image">Native Image</h2>
+
+<p>
+There is an experimental support for compilation of native executables with native-image tool.
+To build an executable with H2 install GraalVM and use its updater to get the native-image tool:
+</p>
+<pre>
+gu install native-image
+</pre>
+This tool can be used for compilation of native executables:
+<pre>
+native-image --no-fallback -jar h2-VERSION.jar h2
+</pre>
+
+<p>Known limitations:</p>
+<ul><li>
+If <code>--no-fallback</code> parameter was specified, system tray icon may not appear
+even if <code>-Djava.awt.headless=false</code> parameter of native-image tool was used,
+because native-image doesn't add all necessary configuration for working GUI.
+</li><li>
+If <code>--no-fallback</code> parameter was specified,
+user-defined functions and triggers need an additional configuration.
+</li><li>
+JAVA_OBJECT data type wasn't tested and may not work at all.
+</li><li>
+Third-party loggers, ICU4J collators, and fulltext search weren't tested.
+</li></ul>
 
 <h2 id="using_eclipse">Using Eclipse</h2>
 <p>

--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3606: Support for GraalVMs native-image
+</li>
 <li>Issue #3607: [MySQL] UNIX_TIMESTAMP should return NULL
 </li>
 <li>Issue #3604: Improper FROM_1X implementation corrupts some BLOBs during migration

--- a/h2/src/main/META-INF/native-image/reflect-config.json
+++ b/h2/src/main/META-INF/native-image/reflect-config.json
@@ -1,0 +1,530 @@
+[
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.mem.FilePathMem"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.mem.FilePathMemLZF"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.niomem.FilePathNioMem"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.niomem.FilePathNioMemLZF"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.split.FilePathSplit"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.niomapped.FilePathNioMapped"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.async.FilePathAsync"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.zip.FilePathZip"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.store.fs.FilePath"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.store.fs.retry.FilePathRetryOnInterrupt"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.mvstore.type.MetaType"
+		},
+		"fields": [
+			{
+				"name": "INSTANCE"
+			}
+		],
+		"name": "org.h2.mvstore.type.ByteArrayDataType"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.mvstore.type.MetaType"
+		},
+		"fields": [
+			{
+				"name": "INSTANCE"
+			}
+		],
+		"name": "org.h2.mvstore.type.LongDataType"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.mvstore.type.MetaType"
+		},
+		"fields": [
+			{
+				"name": "INSTANCE"
+			}
+		],
+		"name": "org.h2.mvstore.type.StringDataType"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.mvstore.type.MetaType"
+		},
+		"fields": [
+			{
+				"name": "INSTANCE"
+			}
+		],
+		"name": "org.h2.mvstore.db.NullValueDataType"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.mvstore.type.MetaType"
+		},
+		"fields": [
+			{
+				"name": "INSTANCE"
+			}
+		],
+		"name": "org.h2.mvstore.db.LobStorageMap$BlobReference$Type"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.mvstore.type.MetaType"
+		},
+		"fields": [
+			{
+				"name": "INSTANCE"
+			}
+		],
+		"name": "org.h2.mvstore.db.LobStorageMap$BlobMeta$Type"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.mvstore.type.MetaType"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.mvstore.tx.VersionedValueType$Factory"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.mvstore.type.MetaType"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.mvstore.db.RowDataType$Factory"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.server.TcpServer"
+		},
+		"methods": [
+			{
+				"name": "stopServer",
+				"parameterTypes": [
+					"int",
+					"java.lang.String",
+					"int"
+				]
+			}
+		],
+		"name": "org.h2.server.TcpServer"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.util.MathUtils"
+		},
+		"methods": [
+			{
+				"name": "getAddress",
+				"parameterTypes": []
+			},
+			{
+				"name": "getAllByName",
+				"parameterTypes": [
+					"java.lang.String"
+				]
+			},
+			{
+				"name": "getHostName",
+				"parameterTypes": []
+			},
+			{
+				"name": "getLocalHost",
+				"parameterTypes": []
+			}
+		],
+		"name": "java.net.InetAddress"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.util.MemoryUnmapper"
+		},
+		"fields": [
+			{
+				"name": "theUnsafe"
+			}
+		],
+		"methods": [
+			{
+				"name": "invokeCleaner",
+				"parameterTypes": [
+					"java.nio.ByteBuffer"
+				]
+			}
+		],
+		"name": "sun.misc.Unsafe"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.engine.Database"
+		},
+		"methods": [
+			{
+				"name": "createIndex",
+				"parameterTypes": [
+					"java.sql.Connection",
+					"java.lang.String",
+					"java.lang.String",
+					"java.lang.String"
+				]
+			},
+			{
+				"name": "dropAll",
+				"parameterTypes": [
+					"java.sql.Connection"
+				]
+			},
+			{
+				"name": "dropIndex",
+				"parameterTypes": [
+					"java.sql.Connection",
+					"java.lang.String",
+					"java.lang.String"
+				]
+			},
+			{
+				"name": "init",
+				"parameterTypes": [
+					"java.sql.Connection"
+				]
+			},
+			{
+				"name": "reindex",
+				"parameterTypes": [
+					"java.sql.Connection"
+				]
+			},
+			{
+				"name": "search",
+				"parameterTypes": [
+					"java.sql.Connection",
+					"java.lang.String",
+					"int",
+					"int"
+				]
+			},
+			{
+				"name": "searchData",
+				"parameterTypes": [
+					"java.sql.Connection",
+					"java.lang.String",
+					"int",
+					"int"
+				]
+			}
+		],
+		"name": "org.h2.fulltext.FullText"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.fulltext.FullText"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.fulltext.FullText$FullTextTrigger"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.engine.Database"
+		},
+		"methods": [
+			{
+				"name": "createIndex",
+				"parameterTypes": [
+					"java.sql.Connection",
+					"java.lang.String",
+					"java.lang.String",
+					"java.lang.String"
+				]
+			},
+			{
+				"name": "dropAll",
+				"parameterTypes": [
+					"java.sql.Connection"
+				]
+			},
+			{
+				"name": "dropIndex",
+				"parameterTypes": [
+					"java.sql.Connection",
+					"java.lang.String",
+					"java.lang.String"
+				]
+			},
+			{
+				"name": "init",
+				"parameterTypes": [
+					"java.sql.Connection"
+				]
+			},
+			{
+				"name": "reindex",
+				"parameterTypes": [
+					"java.sql.Connection"
+				]
+			},
+			{
+				"name": "search",
+				"parameterTypes": [
+					"java.sql.Connection",
+					"java.lang.String",
+					"int",
+					"int"
+				]
+			},
+			{
+				"name": "searchData",
+				"parameterTypes": [
+					"java.sql.Connection",
+					"java.lang.String",
+					"int",
+					"int"
+				]
+			}
+		],
+		"name": "org.h2.fulltext.FullTextLucene"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.fulltext.FullTextLucene"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.fulltext.FullTextLucene$FullTextTrigger"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.slf4j.Logger"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.message.TraceWriterAdapter"
+	},
+	{
+		"condition": {
+			"typeReachable": "com.ibm.icu.text.Collator"
+		},
+		"methods": [
+			{
+				"name": "getAvailableLocales",
+				"parameterTypes": []
+			},
+			{
+				"name": "getInstance",
+				"parameterTypes": [
+					"java.util.Locale"
+				]
+			},
+			{
+				"name": "setStrength",
+				"parameterTypes": [
+					"int"
+				]
+			}
+		],
+		"name": "com.ibm.icu.text.Collator"
+	},
+	{
+		"condition": {
+			"typeReachable": "org.h2.tools.Server"
+		},
+		"methods": [
+			{
+				"name": "browse",
+				"parameterTypes": [
+					"java.net.URI"
+				]
+			},
+			{
+				"name": "getDesktop",
+				"parameterTypes": []
+			},
+			{
+				"name": "isDesktopSupported",
+				"parameterTypes": []
+			}
+		],
+		"name": "java.awt.Desktop"
+	},
+	{
+		"condition": {
+			"typeReachable": "java.awt.SystemTray"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": []
+			}
+		],
+		"name": "org.h2.tools.GUIConsole"
+	},
+	{
+		"condition": {
+			"typeReachable": "java.awt.SystemTray"
+		},
+		"methods": [
+			{
+				"name": "add",
+				"parameterTypes": [
+					"java.awt.TrayIcon"
+				]
+			},
+			{
+				"name": "getSystemTray",
+				"parameterTypes": []
+			},
+			{
+				"name": "getTrayIconSize",
+				"parameterTypes": []
+			},
+			{
+				"name": "isSupported",
+				"parameterTypes": []
+			},
+			{
+				"name": "remove",
+				"parameterTypes": [
+					"java.awt.TrayIcon"
+				]
+			}
+		],
+		"name": "java.awt.SystemTray"
+	},
+	{
+		"condition": {
+			"typeReachable": "java.awt.SystemTray"
+		},
+		"methods": [
+			{
+				"name": "<init>",
+				"parameterTypes": [
+					"java.awt.Image",
+					"java.lang.String"
+				]
+			},
+			{
+				"name": "addMouseListener",
+				"parameterTypes": [
+					"java.awt.event.MouseListener"
+				]
+			}
+		],
+		"name": "java.awt.TrayIcon"
+	}
+]

--- a/h2/src/main/META-INF/native-image/resource-config.json
+++ b/h2/src/main/META-INF/native-image/resource-config.json
@@ -1,0 +1,12 @@
+{
+	"resources": {
+		"includes": [
+			{
+				"condition": {
+					"typeReachable": "org.h2.util.Utils"
+				},
+				"pattern": "org/h2/util/data.zip"
+			}
+		]
+	}
+}

--- a/h2/src/main/org/h2/api/ErrorCode.java
+++ b/h2/src/main/org/h2/api/ErrorCode.java
@@ -230,7 +230,7 @@ public class ErrorCode {
      * Example:
      * <pre>
      * CREATE TABLE TEST(A INTEGER ARRAY) AS VALUES NULL;
-     * UDPDATE TEST SET A[1] = 2;
+     * UPDATE TEST SET A[1] = 2;
      * </pre>
      */
     public static final int NULL_VALUE_IN_ARRAY_TARGET = 22035;

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -171,7 +171,8 @@ public class Build extends BuildBase {
         }
         javac(args, files);
 
-        files = files("src/main/META-INF/services");
+        files = files("src/main/META-INF/native-image");
+        files.addAll(files("src/main/META-INF/services"));
         copy("temp", files, "src/main");
 
         files = files("src/test");

--- a/h2/src/tools/org/h2/build/code/CheckTextFiles.java
+++ b/h2/src/tools/org/h2/build/code/CheckTextFiles.java
@@ -36,7 +36,7 @@ public class CheckTextFiles {
             "Driver", "Processor", "prefs" };
     private static final String[] SUFFIX_IGNORE = { "gif", "png", "odg", "ico",
             "sxd", "layout", "res", "win", "jar", "task", "svg", "MF", "mf",
-            "sh", "DS_Store", "prop", "class" };
+            "sh", "DS_Store", "prop", "class", "json" };
     private static final String[] SUFFIX_CRLF = { "bat" };
 
     private static final boolean ALLOW_TAB = false;

--- a/h2/src/tools/org/h2/build/doc/SpellChecker.java
+++ b/h2/src/tools/org/h2/build/doc/SpellChecker.java
@@ -33,7 +33,7 @@ public class SpellChecker {
             "properties", "task", "MF", "mf", "sh", "" };
     private static final String[] IGNORE = { "dev", "nsi", "gif", "png", "odg",
             "ico", "sxd", "zip", "bz2", "rc", "layout", "res", "dll", "jar",
-            "svg", "prefs", "prop", "iml", "class" };
+            "svg", "prefs", "prop", "iml", "class", "json" };
     private static final String DELIMITERS =
             " \n.();-\"=,*/{}_<>+\r:'@[]&\\!#|?$^%~`\t";
     private static final String PREFIX_IGNORE = "abc";

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -849,4 +849,4 @@ entirely skeleton discouraged pearson coefficient squares covariance mytab debug
 filestore backstop tie breaker lockable lobtx btx waiter accounted aiobe spf resolvers generators
 abandoned accidental approximately cited competitive configuring drastically happier hasn interactions journal
 journaling ldt occasional odt officially pragma ration recognising rnrn rough seemed sonatype supplementary subtree ver
-wal wbr worse xerial won symlink respected adopted
+wal wbr worse xerial won symlink respected adopted graal weren typeinfo loggers nullability ioe


### PR DESCRIPTION
An initial experimental support of native image generation with `native-image` tool for GraalVM.

Unlike configuration from `graalvm-reachability-metadata` repository, this configuration covers all or almost all components of H2. It is possible to launch Web and TCP servers, for example.

`native-image` from GraalVM has significant problems with AWT if fallback JDK isn't used, it is unusable or nearly unusable. System tray icon doesn't appear without fallback JDK. There are alternative third-party distributions with improved GUI support, but I didn't test them.

Native images aren't covered by unit tests here and our test system may require significant changes for them.