### PR TITLE
Fix WebApp.addTableOrView() for DBMS without INFORMATION_SCHEMA.VIEWS

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3615: H2 Console connecting to Oracle DB will not show the list of tables
+</li>
+<li>PR #3613: Fix infinite loop in Tokenizer when special whitespace character is used
+</li>
 <li>Issue #3606: Support for GraalVMs native-image
 </li>
 <li>Issue #3607: [MySQL] UNIX_TIMESTAMP should return NULL

--- a/h2/src/main/org/h2/server/web/WebApp.java
+++ b/h2/src/main/org/h2/server/web/WebApp.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.h2.api.ErrorCode;
 import org.h2.bnf.Bnf;
@@ -679,11 +680,12 @@ public class WebApp {
             if (prep != null) {
                 prep.setString(1, schema.name);
             }
+            AtomicReference<PreparedStatement> prepRef = new AtomicReference<>(prep);
             if (schema.isSystem) {
                 Arrays.sort(tables, SYSTEM_SCHEMA_COMPARATOR);
                 for (DbTableOrView table : tables) {
                     treeIndex = addTableOrView(schema, mainSchema, builder, treeIndex, meta, false, indentation,
-                            isOracle, notManyTables, table, table.isView(), prep, indentNode);
+                            isOracle, notManyTables, table, table.isView(), prepRef, indentNode);
                 }
             } else {
                 for (DbTableOrView table : tables) {
@@ -698,7 +700,7 @@ public class WebApp {
                         continue;
                     }
                     treeIndex = addTableOrView(schema, mainSchema, builder, treeIndex, meta, showColumns, indentation,
-                            isOracle, notManyTables, table, true, prep, indentNode);
+                            isOracle, notManyTables, table, true, prepRef, indentNode);
                 }
             }
         }
@@ -719,7 +721,8 @@ public class WebApp {
 
     private static int addTableOrView(DbSchema schema, boolean mainSchema, StringBuilder builder, int treeIndex,
             DatabaseMetaData meta, boolean showColumns, String indentation, boolean isOracle, boolean notManyTables,
-            DbTableOrView table, boolean isView, PreparedStatement prep, String indentNode) throws SQLException {
+            DbTableOrView table, boolean isView, AtomicReference<PreparedStatement> prepRef, String indentNode)
+                    throws SQLException {
         int tableId = treeIndex;
         String tab = table.getQuotedName();
         if (!mainSchema) {
@@ -735,6 +738,7 @@ public class WebApp {
             StringBuilder columnsBuilder = new StringBuilder();
             treeIndex = addColumns(mainSchema, table, builder, treeIndex, notManyTables, columnsBuilder);
             if (isView) {
+                PreparedStatement prep = prepRef.get();
                 if (prep != null) {
                     prep.setString(2, table.getName());
                     try (ResultSet rs = prep.executeQuery()) {
@@ -746,6 +750,8 @@ public class WebApp {
                                 treeIndex++;
                             }
                         }
+                    } catch (SQLException e) {
+                        prepRef.set(null);
                     }
                 }
             } else if (!isOracle && notManyTables) {


### PR DESCRIPTION
Many JDBC drivers check SQL of prepared statements only in `execute*()` methods. An additional `try`-`catch` is added here to ignore missing `INFORMATION_SCHEMA.VIEWS` table. This table is used when available to get definitions of views.

Closes #3615.