### PR TITLE
Clear LocalSession.database and LocalSession.User fields

### DIFF
--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -55,7 +55,7 @@ public abstract class Command implements CommandInterface {
     Command(SessionLocal session, String sql) {
         this.session = session;
         this.sql = sql;
-        trace = session.getDatabase().getTrace(Trace.COMMAND);
+        trace = getDatabase().getTrace(Trace.COMMAND);
     }
 
     /**
@@ -129,13 +129,13 @@ public abstract class Command implements CommandInterface {
      * Start the stopwatch.
      */
     void start() {
-        if (trace.isInfoEnabled() || session.getDatabase().getQueryStatistics()) {
+        if (trace.isInfoEnabled() || getDatabase().getQueryStatistics()) {
             startTimeNanos = Utils.currentNanoTime();
         }
     }
 
-    void setProgress(int state) {
-        session.getDatabase().setProgress(state, sql, 0, 0);
+    void setProgress(Database database, int state) {
+        database.setProgress(state, sql, 0, 0);
     }
 
     /**
@@ -152,9 +152,11 @@ public abstract class Command implements CommandInterface {
 
     @Override
     public void stop() {
-        commitIfNonTransactional();
-        if (isTransactional() && session.getAutoCommit()) {
-            session.commit(false);
+        if (session.isOpen()) {
+            commitIfNonTransactional();
+            if (isTransactional() && session.getAutoCommit()) {
+                session.commit(false);
+            }
         }
         if (trace.isInfoEnabled() && startTimeNanos != 0L) {
             long timeMillis = (System.nanoTime() - startTimeNanos) / 1_000_000L;
@@ -176,10 +178,9 @@ public abstract class Command implements CommandInterface {
     public ResultInterface executeQuery(long maxrows, boolean scrollable) {
         startTimeNanos = 0L;
         long start = 0L;
-        Database database = session.getDatabase();
+        Database database = getDatabase();
         session.waitIfExclusiveModeEnabled();
         boolean callStop = true;
-        //noinspection SynchronizationOnLocalVariableOrMethodParameter
         synchronized (session) {
             session.startStatementWithinTransaction(this);
             Session oldSession = session.setThreadLocalSession();
@@ -235,11 +236,10 @@ public abstract class Command implements CommandInterface {
     @Override
     public ResultWithGeneratedKeys executeUpdate(Object generatedKeysRequest) {
         long start = 0;
-        Database database = session.getDatabase();
-        session.waitIfExclusiveModeEnabled();
         boolean callStop = true;
-        //noinspection SynchronizationOnLocalVariableOrMethodParameter
         synchronized (session) {
+            Database database = getDatabase();
+            session.waitIfExclusiveModeEnabled();
             commitIfNonTransactional();
             SessionLocal.Savepoint rollback = session.setSavepoint();
             session.startStatementWithinTransaction(this);
@@ -378,4 +378,8 @@ public abstract class Command implements CommandInterface {
      * @return true if yes
      */
     protected abstract boolean isCurrentCommandADefineCommand();
+
+    protected final Database getDatabase() {
+        return session.getDatabase();
+    }
 }

--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -154,7 +154,8 @@ public class CommandContainer extends Command {
     @Override
     public ResultWithGeneratedKeys update(Object generatedKeysRequest) {
         recompileIfRequired();
-        setProgress(DatabaseEventListener.STATE_STATEMENT_START);
+        Database database = getDatabase();
+        setProgress(database, DatabaseEventListener.STATE_STATEMENT_START);
         start();
         prepared.checkParameters();
         ResultWithGeneratedKeys result;
@@ -168,14 +169,14 @@ public class CommandContainer extends Command {
         } else {
             result = ResultWithGeneratedKeys.of(prepared.update());
         }
-        prepared.trace(startTimeNanos, result.getUpdateCount());
-        setProgress(DatabaseEventListener.STATE_STATEMENT_END);
+        prepared.trace(database, startTimeNanos, result.getUpdateCount());
+        setProgress(database, DatabaseEventListener.STATE_STATEMENT_END);
         return result;
     }
 
     private ResultWithGeneratedKeys executeUpdateWithGeneratedKeys(DataChangeStatement statement,
             Object generatedKeysRequest) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Table table = statement.getTable();
         ArrayList<ExpressionColumn> expressionColumns;
         if (Boolean.TRUE.equals(generatedKeysRequest)) {
@@ -245,12 +246,13 @@ public class CommandContainer extends Command {
     @Override
     public ResultInterface query(long maxrows) {
         recompileIfRequired();
-        setProgress(DatabaseEventListener.STATE_STATEMENT_START);
+        Database database = getDatabase();
+        setProgress(database, DatabaseEventListener.STATE_STATEMENT_START);
         start();
         prepared.checkParameters();
         ResultInterface result = prepared.query(maxrows);
-        prepared.trace(startTimeNanos, result.isLazy() ? 0 : result.getRowCount());
-        setProgress(DatabaseEventListener.STATE_STATEMENT_END);
+        prepared.trace(database, startTimeNanos, result.isLazy() ? 0 : result.getRowCount());
+        setProgress(database, DatabaseEventListener.STATE_STATEMENT_END);
         return result;
     }
 

--- a/h2/src/main/org/h2/command/Prepared.java
+++ b/h2/src/main/org/h2/command/Prepared.java
@@ -83,7 +83,7 @@ public abstract class Prepared {
      */
     public Prepared(SessionLocal session) {
         this.session = session;
-        modificationMetaId = session.getDatabase().getModificationMetaId();
+        modificationMetaId = getDatabase().getModificationMetaId();
     }
 
     /**
@@ -124,7 +124,7 @@ public abstract class Prepared {
      * @return true if it must
      */
     public boolean needRecompile() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (db == null) {
             throw DbException.get(ErrorCode.CONNECTION_BROKEN_1, "database closed");
         }
@@ -307,7 +307,7 @@ public abstract class Prepared {
     protected int getObjectId() {
         int id = persistedObjectId;
         if (id == 0) {
-            id = session.getDatabase().allocateObjectId();
+            id = getDatabase().allocateObjectId();
         } else if (id < 0) {
             throw DbException.getInternalError("Prepared.getObjectId() was called before");
         }
@@ -360,11 +360,11 @@ public abstract class Prepared {
     /**
      * Print information about the statement executed if info trace level is
      * enabled.
-     *
+     * @param database to update statistics
      * @param startTimeNanos when the statement was started
      * @param rowCount the query or update row count
      */
-    void trace(long startTimeNanos, long rowCount) {
+    void trace(Database database, long startTimeNanos, long rowCount) {
         if (session.getTrace().isInfoEnabled() && startTimeNanos > 0) {
             long deltaTimeNanos = System.nanoTime() - startTimeNanos;
             String params = Trace.formatParams(parameters);
@@ -372,9 +372,9 @@ public abstract class Prepared {
         }
         // startTime_nanos can be zero for the command that actually turns on
         // statistics
-        if (session.getDatabase().getQueryStatistics() && startTimeNanos != 0) {
+        if (database != null && database.getQueryStatistics() && startTimeNanos != 0) {
             long deltaTimeNanos = System.nanoTime() - startTimeNanos;
-            session.getDatabase().getQueryStatisticsData().update(toString(), deltaTimeNanos, rowCount);
+            database.getQueryStatisticsData().update(toString(), deltaTimeNanos, rowCount);
         }
     }
 
@@ -415,7 +415,7 @@ public abstract class Prepared {
      */
     private void setProgress() {
         if ((currentRowNumber & 127) == 0) {
-            session.getDatabase().setProgress(DatabaseEventListener.STATE_STATEMENT_PROGRESS, sqlStatement,
+            getDatabase().setProgress(DatabaseEventListener.STATE_STATEMENT_PROGRESS, sqlStatement,
                     currentRowNumber, 0L);
         }
     }
@@ -448,7 +448,7 @@ public abstract class Prepared {
      * @param values the values of the row
      * @return the exception
      */
-    protected DbException setRow(DbException e, long rowId, String values) {
+    protected final DbException setRow(DbException e, long rowId, String values) {
         StringBuilder buff = new StringBuilder();
         if (sqlStatement != null) {
             buff.append(sqlStatement);
@@ -492,4 +492,7 @@ public abstract class Prepared {
      */
     public void collectDependencies(HashSet<DbObject> dependencies) {}
 
+    protected final Database getDatabase() {
+        return session.getDatabase();
+    }
 }

--- a/h2/src/main/org/h2/command/ddl/AlterDomainAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomainAddConstraint.java
@@ -61,7 +61,7 @@ public class AlterDomainAddConstraint extends AlterDomain {
             }
             throw DbException.get(ErrorCode.CONSTRAINT_ALREADY_EXISTS_1, constraintName);
         }
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         db.lockMeta(session);
 
         int id = getObjectId();

--- a/h2/src/main/org/h2/command/ddl/AlterDomainDropConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomainDropConstraint.java
@@ -41,7 +41,7 @@ public class AlterDomainDropConstraint extends AlterDomain {
                 throw DbException.get(ErrorCode.CONSTRAINT_NOT_FOUND_1, constraintName);
             }
         } else {
-            session.getDatabase().removeSchemaObject(session, constraint);
+            getDatabase().removeSchemaObject(session, constraint);
         }
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/AlterDomainExpressions.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomainExpressions.java
@@ -51,7 +51,7 @@ public class AlterDomainExpressions extends AlterDomain {
         if (expression != null) {
             forAllDependencies(session, domain, this::copyColumn, this::copyDomain, true);
         }
-        session.getDatabase().updateMeta(session, domain);
+        getDatabase().updateMeta(session, domain);
         return 0;
     }
 

--- a/h2/src/main/org/h2/command/ddl/AlterDomainRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomainRename.java
@@ -39,7 +39,7 @@ public class AlterDomainRename extends AlterDomain {
                 return 0;
             }
         }
-        session.getDatabase().renameSchemaObject(session, domain, newDomainName);
+        getDatabase().renameSchemaObject(session, domain, newDomainName);
         forAllDependencies(session, domain, null, null, false);
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/AlterDomainRenameConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterDomainRenameConstraint.java
@@ -47,7 +47,7 @@ public class AlterDomainRenameConstraint extends AlterDomain {
                 || newConstraintName.equals(constraintName)) {
             throw DbException.get(ErrorCode.CONSTRAINT_ALREADY_EXISTS_1, newConstraintName);
         }
-        session.getDatabase().renameSchemaObject(session, constraint, newConstraintName);
+        getDatabase().renameSchemaObject(session, constraint, newConstraintName);
         return 0;
     }
 

--- a/h2/src/main/org/h2/command/ddl/AlterIndexRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterIndexRename.java
@@ -47,7 +47,7 @@ public class AlterIndexRename extends DefineCommand {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Index oldIndex = oldSchema.findIndex(session, oldIndexName);
         if (oldIndex == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/AlterSchemaRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterSchemaRename.java
@@ -38,7 +38,7 @@ public class AlterSchemaRename extends DefineCommand {
     @Override
     public long update() {
         session.getUser().checkSchemaAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (!oldSchema.canDrop()) {
             throw DbException.get(ErrorCode.SCHEMA_CAN_NOT_BE_DROPPED_1, oldSchema.getName());
         }

--- a/h2/src/main/org/h2/command/ddl/AlterSequence.java
+++ b/h2/src/main/org/h2/command/ddl/AlterSequence.java
@@ -93,7 +93,7 @@ public class AlterSequence extends SchemaOwnerCommand {
         sequence.flush(session);
         if (column != null && always != null) {
             column.setSequence(sequence, always);
-            session.getDatabase().updateMeta(session, column.getTable());
+            getDatabase().updateMeta(session, column.getTable());
         }
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -74,11 +74,11 @@ public class AlterTableAddConstraint extends AlterTable {
             try {
                 if (createdUniqueConstraint != null) {
                     Index index = createdUniqueConstraint.getIndex();
-                    session.getDatabase().removeSchemaObject(session, createdUniqueConstraint);
+                    getDatabase().removeSchemaObject(session, createdUniqueConstraint);
                     createdIndexes.remove(index);
                 }
                 for (Index index : createdIndexes) {
-                    session.getDatabase().removeSchemaObject(session, index);
+                    getDatabase().removeSchemaObject(session, index);
                 }
             } catch (Throwable ex) {
                 e.addSuppressed(ex);
@@ -110,7 +110,7 @@ public class AlterTableAddConstraint extends AlterTable {
             }
             constraintName = null;
         }
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         db.lockMeta(session);
         table.lock(session, Table.EXCLUSIVE_LOCK);
         Constraint constraint;
@@ -142,7 +142,7 @@ public class AlterTableAddConstraint extends AlterTable {
                         table.isPersistIndexes(), primaryKeyHash);
                 String indexName = table.getSchema().getUniqueIndexName(
                         session, table, Constants.PREFIX_PRIMARY_KEY);
-                int indexId = session.getDatabase().allocateObjectId();
+                int indexId = getDatabase().allocateObjectId();
                 try {
                     index = table.addIndex(session, indexName, indexId, indexColumns, indexColumns.length, indexType,
                             true, null);
@@ -318,7 +318,7 @@ public class AlterTableAddConstraint extends AlterTable {
         String name;
         Schema tableSchema = table.getSchema();
         if (forForeignKey) {
-            id = session.getDatabase().allocateObjectId();
+            id = getDatabase().allocateObjectId();
             try {
                 tableSchema.reserveUniqueName(constraintName);
                 name = tableSchema.getUniqueConstraintName(session, table);
@@ -345,7 +345,7 @@ public class AlterTableAddConstraint extends AlterTable {
     }
 
     private Index createIndex(Table t, IndexColumn[] cols, boolean unique) {
-        int indexId = session.getDatabase().allocateObjectId();
+        int indexId = getDatabase().allocateObjectId();
         IndexType indexType;
         if (unique) {
             // for unique constraints

--- a/h2/src/main/org/h2/command/ddl/AlterTableAlterColumn.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAlterColumn.java
@@ -107,7 +107,7 @@ public class AlterTableAlterColumn extends CommandWithColumns {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Table table = getSchema().resolveTableOrView(session, tableName);
         if (table == null) {
             if (ifTableExists) {
@@ -300,7 +300,7 @@ public class AlterTableAlterColumn extends CommandWithColumns {
 
     private void checkClustering(Column c) {
         if (!Constants.CLUSTERING_DISABLED
-                .equals(session.getDatabase().getCluster())
+                .equals(getDatabase().getCluster())
                 && c.hasIdentityOptions()) {
             throw DbException.getUnsupportedException(
                     "CLUSTERING && identity columns");
@@ -322,7 +322,7 @@ public class AlterTableAlterColumn extends CommandWithColumns {
         if (sequence != null) {
             table.removeSequence(sequence);
             sequence.setBelongsToTable(false);
-            Database db = session.getDatabase();
+            Database db = getDatabase();
             db.removeSchemaObject(session, sequence);
         }
     }
@@ -331,7 +331,7 @@ public class AlterTableAlterColumn extends CommandWithColumns {
         if (table.isTemporary()) {
             throw DbException.getUnsupportedException("TEMP TABLE");
         }
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         String baseName = table.getName();
         String tempName = db.getTempTableName(baseName, session);
         Column[] columns = table.getColumns();

--- a/h2/src/main/org/h2/command/ddl/AlterTableDropConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableDropConstraint.java
@@ -29,7 +29,7 @@ public class AlterTableDropConstraint extends AlterTable {
     public AlterTableDropConstraint(SessionLocal session, Schema schema, boolean ifExists) {
         super(session, schema);
         this.ifExists = ifExists;
-        dropAction = session.getDatabase().getSettings().dropRestrict ?
+        dropAction = getDatabase().getSettings().dropRestrict ?
                 ConstraintActionType.RESTRICT : ConstraintActionType.CASCADE;
     }
 
@@ -69,7 +69,7 @@ public class AlterTableDropConstraint extends AlterTable {
                     }
                 }
             }
-            session.getDatabase().removeSchemaObject(session, constraint);
+            getDatabase().removeSchemaObject(session, constraint);
         }
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/AlterTableRename.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableRename.java
@@ -32,7 +32,7 @@ public class AlterTableRename extends AlterTable {
 
     @Override
     public long update(Table table) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Table t = getSchema().findTableOrView(session, newTableName);
         if (t != null && hidden && newTableName.equals(table.getName())) {
             if (!t.isHidden()) {

--- a/h2/src/main/org/h2/command/ddl/AlterTableRenameColumn.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableRenameColumn.java
@@ -49,7 +49,7 @@ public class AlterTableRenameColumn extends AlterTable {
         table.checkSupportAlter();
         table.renameColumn(column, newName);
         table.setModified();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         db.updateMeta(session, table);
 
         // if we have foreign key constraints pointing at this table, we need to update them

--- a/h2/src/main/org/h2/command/ddl/AlterTableRenameConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableRenameConstraint.java
@@ -41,7 +41,7 @@ public class AlterTableRenameConstraint extends AlterTable {
     @Override
     public long update(Table table) {
         Constraint constraint = getSchema().findConstraint(session, constraintName);
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (constraint == null || constraint.getConstraintType() == Type.DOMAIN || constraint.getTable() != table) {
             throw DbException.get(ErrorCode.CONSTRAINT_NOT_FOUND_1, constraintName);
         }

--- a/h2/src/main/org/h2/command/ddl/AlterUser.java
+++ b/h2/src/main/org/h2/command/ddl/AlterUser.java
@@ -63,7 +63,7 @@ public class AlterUser extends DefineCommand {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         switch (type) {
         case CommandInterface.ALTER_USER_SET_PASSWORD:
             if (user != session.getUser()) {

--- a/h2/src/main/org/h2/command/ddl/Analyze.java
+++ b/h2/src/main/org/h2/command/ddl/Analyze.java
@@ -137,7 +137,7 @@ public class Analyze extends DefineCommand {
 
     public Analyze(SessionLocal session) {
         super(session);
-        sampleRows = session.getDatabase().getSettings().analyzeSample;
+        sampleRows = getDatabase().getSettings().analyzeSample;
     }
 
     public void setTable(Table table) {
@@ -147,7 +147,7 @@ public class Analyze extends DefineCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (table != null) {
             analyzeTable(session, table, sampleRows, true);
         } else {

--- a/h2/src/main/org/h2/command/ddl/CommandWithColumns.java
+++ b/h2/src/main/org/h2/command/ddl/CommandWithColumns.java
@@ -99,9 +99,9 @@ public abstract class CommandWithColumns extends SchemaCommand {
         if (columns != null) {
             for (Column c : columns) {
                 if (c.hasIdentityOptions()) {
-                    int objId = session.getDatabase().allocateObjectId();
+                    int objId = getDatabase().allocateObjectId();
                     c.initializeSequence(session, getSchema(), objId, temporary);
-                    if (!Constants.CLUSTERING_DISABLED.equals(session.getDatabase().getCluster())) {
+                    if (!Constants.CLUSTERING_DISABLED.equals(getDatabase().getCluster())) {
                         throw DbException.getUnsupportedException("CLUSTERING && identity columns");
                     }
                 }

--- a/h2/src/main/org/h2/command/ddl/CreateAggregate.java
+++ b/h2/src/main/org/h2/command/ddl/CreateAggregate.java
@@ -31,7 +31,7 @@ public class CreateAggregate extends SchemaCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Schema schema = getSchema();
         if (schema.findFunctionOrAggregate(name) != null) {
             if (!ifNotExists) {

--- a/h2/src/main/org/h2/command/ddl/CreateConstant.java
+++ b/h2/src/main/org/h2/command/ddl/CreateConstant.java
@@ -35,7 +35,7 @@ public class CreateConstant extends SchemaOwnerCommand {
 
     @Override
     long update(Schema schema) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (schema.findConstant(constantName) != null) {
             if (ifNotExists) {
                 return 0;

--- a/h2/src/main/org/h2/command/ddl/CreateDomain.java
+++ b/h2/src/main/org/h2/command/ddl/CreateDomain.java
@@ -82,12 +82,12 @@ public class CreateDomain extends SchemaOwnerCommand {
             throw DbException.get(ErrorCode.DOMAIN_ALREADY_EXISTS_1, typeName);
         }
         if (typeName.indexOf(' ') < 0) {
-            DataType builtIn = DataType.getTypeByName(typeName, session.getDatabase().getMode());
+            DataType builtIn = DataType.getTypeByName(typeName, getDatabase().getMode());
             if (builtIn != null) {
-                if (session.getDatabase().equalsIdentifiers(typeName, Value.getTypeName(builtIn.type))) {
+                if (getDatabase().equalsIdentifiers(typeName, Value.getTypeName(builtIn.type))) {
                     throw DbException.get(ErrorCode.DOMAIN_ALREADY_EXISTS_1, typeName);
                 }
-                Table table = session.getDatabase().getFirstUserTable();
+                Table table = getDatabase().getFirstUserTable();
                 if (table != null) {
                     StringBuilder builder = new StringBuilder(typeName).append(" (");
                     table.getSQL(builder, HasSQL.TRACE_SQL_FLAGS).append(')');

--- a/h2/src/main/org/h2/command/ddl/CreateFunctionAlias.java
+++ b/h2/src/main/org/h2/command/ddl/CreateFunctionAlias.java
@@ -34,7 +34,7 @@ public class CreateFunctionAlias extends SchemaCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Schema schema = getSchema();
         if (schema.findFunctionOrAggregate(aliasName) != null) {
             if (!ifNotExists) {

--- a/h2/src/main/org/h2/command/ddl/CreateIndex.java
+++ b/h2/src/main/org/h2/command/ddl/CreateIndex.java
@@ -58,7 +58,7 @@ public class CreateIndex extends SchemaCommand {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         boolean persistent = db.isPersistent();
         Table table = getSchema().findTableOrView(session, tableName);
         if (table == null) {

--- a/h2/src/main/org/h2/command/ddl/CreateLinkedTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateLinkedTable.java
@@ -84,7 +84,7 @@ public class CreateLinkedTable extends SchemaCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (getSchema().resolveTableOrView(session, tableName) != null) {
             if (ifNotExists) {
                 return 0;

--- a/h2/src/main/org/h2/command/ddl/CreateRole.java
+++ b/h2/src/main/org/h2/command/ddl/CreateRole.java
@@ -37,7 +37,7 @@ public class CreateRole extends DefineCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         RightOwner rightOwner = db.findUserOrRole(roleName);
         if (rightOwner != null) {
             if (rightOwner instanceof Role) {

--- a/h2/src/main/org/h2/command/ddl/CreateSchema.java
+++ b/h2/src/main/org/h2/command/ddl/CreateSchema.java
@@ -36,7 +36,7 @@ public class CreateSchema extends DefineCommand {
     @Override
     public long update() {
         session.getUser().checkSchemaAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         RightOwner owner = db.findUserOrRole(authorization);
         if (owner == null) {
             throw DbException.get(ErrorCode.USER_OR_ROLE_NOT_FOUND_1, authorization);

--- a/h2/src/main/org/h2/command/ddl/CreateSequence.java
+++ b/h2/src/main/org/h2/command/ddl/CreateSequence.java
@@ -45,7 +45,7 @@ public class CreateSequence extends SchemaOwnerCommand {
 
     @Override
     long update(Schema schema) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (schema.findSequence(sequenceName) != null) {
             if (ifNotExists) {
                 return 0;

--- a/h2/src/main/org/h2/command/ddl/CreateSynonym.java
+++ b/h2/src/main/org/h2/command/ddl/CreateSynonym.java
@@ -48,7 +48,7 @@ public class CreateSynonym extends SchemaOwnerCommand {
 
     @Override
     long update(Schema schema) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         data.session = session;
         db.lockMeta(session);
 

--- a/h2/src/main/org/h2/command/ddl/CreateTable.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTable.java
@@ -71,7 +71,7 @@ public class CreateTable extends CommandWithColumns {
     public long update() {
         Schema schema = getSchema();
         boolean isSessionTemporary = data.temporary && !data.globalTemporary;
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         String tableEngine = data.tableEngine;
         if (tableEngine != null || db.getSettings().defaultTableEngine != null) {
             session.getUser().checkAdmin();

--- a/h2/src/main/org/h2/command/ddl/CreateTrigger.java
+++ b/h2/src/main/org/h2/command/ddl/CreateTrigger.java
@@ -87,7 +87,7 @@ public class CreateTrigger extends SchemaCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (getSchema().findTrigger(triggerName) != null) {
             if (ifNotExists) {
                 return 0;

--- a/h2/src/main/org/h2/command/ddl/CreateUser.java
+++ b/h2/src/main/org/h2/command/ddl/CreateUser.java
@@ -93,7 +93,7 @@ public class CreateUser extends DefineCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         RightOwner rightOwner = db.findUserOrRole(userName);
         if (rightOwner != null) {
             if (rightOwner instanceof User) {

--- a/h2/src/main/org/h2/command/ddl/CreateView.java
+++ b/h2/src/main/org/h2/command/ddl/CreateView.java
@@ -79,7 +79,7 @@ public class CreateView extends SchemaOwnerCommand {
 
     @Override
     long update(Schema schema) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         TableView view = null;
         Table old = schema.findTableOrView(session, viewName);
         if (old != null) {

--- a/h2/src/main/org/h2/command/ddl/DropAggregate.java
+++ b/h2/src/main/org/h2/command/ddl/DropAggregate.java
@@ -28,7 +28,7 @@ public class DropAggregate extends SchemaOwnerCommand {
 
     @Override
     long update(Schema schema) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         UserAggregate aggregate = schema.findAggregate(name);
         if (aggregate == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropConstant.java
+++ b/h2/src/main/org/h2/command/ddl/DropConstant.java
@@ -36,7 +36,7 @@ public class DropConstant extends SchemaOwnerCommand {
 
     @Override
     long update(Schema schema) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Constant constant = schema.findConstant(constantName);
         if (constant == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropDatabase.java
+++ b/h2/src/main/org/h2/command/ddl/DropDatabase.java
@@ -42,7 +42,7 @@ public class DropDatabase extends DefineCommand {
             dropAllObjects();
         }
         if (deleteFiles) {
-            session.getDatabase().setDeleteFilesOnDisconnect(true);
+            getDatabase().setDeleteFilesOnDisconnect(true);
         }
         return 0;
     }
@@ -50,7 +50,7 @@ public class DropDatabase extends DefineCommand {
     private void dropAllObjects() {
         User user = session.getUser();
         user.checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         db.lockMeta(session);
 
         // There can be dependencies between tables e.g. using computed columns,

--- a/h2/src/main/org/h2/command/ddl/DropDomain.java
+++ b/h2/src/main/org/h2/command/ddl/DropDomain.java
@@ -29,7 +29,7 @@ public class DropDomain extends AlterDomain {
 
     public DropDomain(SessionLocal session, Schema schema) {
         super(session, schema);
-        dropAction = session.getDatabase().getSettings().dropRestrict ? ConstraintActionType.RESTRICT
+        dropAction = getDatabase().getSettings().dropRestrict ? ConstraintActionType.RESTRICT
                 : ConstraintActionType.CASCADE;
     }
 
@@ -40,7 +40,7 @@ public class DropDomain extends AlterDomain {
     @Override
     long update(Schema schema, Domain domain) {
         forAllDependencies(session, domain, this::copyColumn, this::copyDomain, true);
-        session.getDatabase().removeSchemaObject(session, domain);
+        getDatabase().removeSchemaObject(session, domain);
         return 0;
     }
 

--- a/h2/src/main/org/h2/command/ddl/DropFunctionAlias.java
+++ b/h2/src/main/org/h2/command/ddl/DropFunctionAlias.java
@@ -28,7 +28,7 @@ public class DropFunctionAlias extends SchemaOwnerCommand {
 
     @Override
     long update(Schema schema) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         FunctionAlias functionAlias = schema.findFunction(aliasName);
         if (functionAlias == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropIndex.java
+++ b/h2/src/main/org/h2/command/ddl/DropIndex.java
@@ -41,7 +41,7 @@ public class DropIndex extends SchemaCommand {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Index index = getSchema().findIndex(session, indexName);
         if (index == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropRole.java
+++ b/h2/src/main/org/h2/command/ddl/DropRole.java
@@ -32,7 +32,7 @@ public class DropRole extends DefineCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Role role = db.findRole(roleName);
         if (role == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropSchema.java
+++ b/h2/src/main/org/h2/command/ddl/DropSchema.java
@@ -27,7 +27,7 @@ public class DropSchema extends DefineCommand {
 
     public DropSchema(SessionLocal session) {
         super(session);
-        dropAction = session.getDatabase().getSettings().dropRestrict ?
+        dropAction = getDatabase().getSettings().dropRestrict ?
                 ConstraintActionType.RESTRICT : ConstraintActionType.CASCADE;
     }
 
@@ -37,7 +37,7 @@ public class DropSchema extends DefineCommand {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Schema schema = db.findSchema(schemaName);
         if (schema == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropSequence.java
+++ b/h2/src/main/org/h2/command/ddl/DropSequence.java
@@ -44,7 +44,7 @@ public class DropSequence extends SchemaOwnerCommand {
             if (sequence.getBelongsToTable()) {
                 throw DbException.get(ErrorCode.SEQUENCE_BELONGS_TO_A_TABLE_1, sequenceName);
             }
-            session.getDatabase().removeSchemaObject(session, sequence);
+            getDatabase().removeSchemaObject(session, sequence);
         }
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/DropSynonym.java
+++ b/h2/src/main/org/h2/command/ddl/DropSynonym.java
@@ -37,7 +37,7 @@ public class DropSynonym extends SchemaOwnerCommand {
                 throw DbException.get(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_1, synonymName);
             }
         } else {
-            session.getDatabase().removeSchemaObject(session, synonym);
+            getDatabase().removeSchemaObject(session, synonym);
         }
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/DropTable.java
+++ b/h2/src/main/org/h2/command/ddl/DropTable.java
@@ -35,7 +35,7 @@ public class DropTable extends DefineCommand {
 
     public DropTable(SessionLocal session) {
         super(session);
-        dropAction = session.getDatabase().getSettings().dropRestrict ?
+        dropAction = getDatabase().getSettings().dropRestrict ?
                 ConstraintActionType.RESTRICT :
                     ConstraintActionType.CASCADE;
     }
@@ -109,7 +109,7 @@ public class DropTable extends DefineCommand {
             Table table = schemaAndTable.schema.findTableOrView(session, schemaAndTable.tableName);
             if (table != null) {
                 table.setModified();
-                Database db = session.getDatabase();
+                Database db = getDatabase();
                 db.lockMeta(session);
                 db.removeSchemaObject(session, table);
             }

--- a/h2/src/main/org/h2/command/ddl/DropTrigger.java
+++ b/h2/src/main/org/h2/command/ddl/DropTrigger.java
@@ -38,7 +38,7 @@ public class DropTrigger extends SchemaCommand {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         TriggerObject trigger = getSchema().findTrigger(triggerName);
         if (trigger == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropUser.java
+++ b/h2/src/main/org/h2/command/ddl/DropUser.java
@@ -37,7 +37,7 @@ public class DropUser extends DefineCommand {
     @Override
     public long update() {
         session.getUser().checkAdmin();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         User user = db.findUser(userName);
         if (user == null) {
             if (!ifExists) {

--- a/h2/src/main/org/h2/command/ddl/DropView.java
+++ b/h2/src/main/org/h2/command/ddl/DropView.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.constraint.ConstraintActionType;
+import org.h2.engine.Database;
 import org.h2.engine.DbObject;
 import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
@@ -29,7 +30,7 @@ public class DropView extends SchemaCommand {
 
     public DropView(SessionLocal session, Schema schema) {
         super(session, schema);
-        dropAction = session.getDatabase().getSettings().dropRestrict ?
+        dropAction = getDatabase().getSettings().dropRestrict ?
                 ConstraintActionType.RESTRICT :
                 ConstraintActionType.CASCADE;
     }
@@ -74,19 +75,20 @@ public class DropView extends SchemaCommand {
             ArrayList<Table> copyOfDependencies = new ArrayList<>(tableView.getTables());
 
             view.lock(session, Table.EXCLUSIVE_LOCK);
-            session.getDatabase().removeSchemaObject(session, view);
+            Database database = getDatabase();
+            database.removeSchemaObject(session, view);
 
             // remove dependent table expressions
             for (Table childTable: copyOfDependencies) {
                 if (TableType.VIEW == childTable.getTableType()) {
                     TableView childTableView = (TableView) childTable;
                     if (childTableView.isTableExpression() && childTableView.getName() != null) {
-                        session.getDatabase().removeSchemaObject(session, childTableView);
+                        database.removeSchemaObject(session, childTableView);
                     }
                 }
             }
             // make sure its all unlocked
-            session.getDatabase().unlockMeta(session);
+            database.unlockMeta(session);
         }
         return 0;
     }

--- a/h2/src/main/org/h2/command/ddl/GrantRevoke.java
+++ b/h2/src/main/org/h2/command/ddl/GrantRevoke.java
@@ -67,7 +67,7 @@ public class GrantRevoke extends DefineCommand {
     }
 
     public void setGranteeName(String granteeName) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         grantee = db.findUserOrRole(granteeName);
         if (grantee == null) {
             throw DbException.get(ErrorCode.USER_OR_ROLE_NOT_FOUND_1, granteeName);
@@ -76,7 +76,7 @@ public class GrantRevoke extends DefineCommand {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         User user = session.getUser();
         if (roleNames != null) {
             user.checkAdmin();
@@ -125,12 +125,12 @@ public class GrantRevoke extends DefineCommand {
     }
 
     private void grantRight(DbObject object) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Right right = grantee.getRightForObject(object);
         if (right == null) {
             int id = getPersistedObjectId();
             if (id == 0) {
-                id = session.getDatabase().allocateObjectId();
+                id = getDatabase().allocateObjectId();
             }
             right = new Right(db, id, grantee, rightMask, object);
             grantee.grantRight(object, right);
@@ -152,7 +152,7 @@ public class GrantRevoke extends DefineCommand {
                 throw DbException.get(ErrorCode.ROLE_ALREADY_GRANTED_1, grantedRole.getTraceSQL());
             }
         }
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         int id = getObjectId();
         Right right = new Right(db, id, grantee, grantedRole);
         db.addDatabaseObject(session, right);
@@ -175,7 +175,7 @@ public class GrantRevoke extends DefineCommand {
         }
         int mask = right.getRightMask();
         int newRight = mask & ~rightMask;
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (newRight == 0) {
             db.removeDatabaseObject(session, right);
         } else {
@@ -190,7 +190,7 @@ public class GrantRevoke extends DefineCommand {
         if (right == null) {
             return;
         }
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         db.removeDatabaseObject(session, right);
     }
 

--- a/h2/src/main/org/h2/command/ddl/SetComment.java
+++ b/h2/src/main/org/h2/command/ddl/SetComment.java
@@ -35,7 +35,7 @@ public class SetComment extends DefineCommand {
 
     @Override
     public long update() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         DbObject object = null;
         int errorCode = ErrorCode.GENERAL_ERROR_1;
         if (schemaName == null) {

--- a/h2/src/main/org/h2/command/ddl/TruncateTable.java
+++ b/h2/src/main/org/h2/command/ddl/TruncateTable.java
@@ -49,7 +49,7 @@ public class TruncateTable extends DefineCommand {
                 Sequence sequence = column.getSequence();
                 if (sequence != null) {
                     sequence.modify(sequence.getStartValue(), null, null, null, null, null, null);
-                    session.getDatabase().updateMeta(session, sequence);
+                    getDatabase().updateMeta(session, sequence);
                 }
             }
         }

--- a/h2/src/main/org/h2/command/dml/BackupCommand.java
+++ b/h2/src/main/org/h2/command/dml/BackupCommand.java
@@ -51,7 +51,7 @@ public class BackupCommand extends Prepared {
     }
 
     private void backupTo(String fileName) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (!db.isPersistent()) {
             throw DbException.get(ErrorCode.DATABASE_IS_NOT_PERSISTENT);
         }

--- a/h2/src/main/org/h2/command/dml/Call.java
+++ b/h2/src/main/org/h2/command/dml/Call.java
@@ -83,7 +83,7 @@ public class Call extends Prepared {
             for (int i = 0; i < columnCount; i++) {
                 String name = result.getColumnName(i);
                 String alias = result.getAlias(i);
-                Expression e = new ExpressionColumn(session.getDatabase(), new Column(name, result.getColumnType(i)));
+                Expression e = new ExpressionColumn(getDatabase(), new Column(name, result.getColumnType(i)));
                 if (!alias.equals(name)) {
                     e = new Alias(e, alias, false);
                 }

--- a/h2/src/main/org/h2/command/dml/Explain.java
+++ b/h2/src/main/org/h2/command/dml/Explain.java
@@ -70,7 +70,7 @@ public class Explain extends Prepared {
 
     @Override
     public ResultInterface query(long maxrows) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         Expression[] expressions = { new ExpressionColumn(db, new Column("PLAN", TypeInfo.TYPE_VARCHAR)) };
         result = new LocalResult(session, expressions, 1, 1);
         int sqlFlags = HasSQL.ADD_PLAN_INFORMATION;

--- a/h2/src/main/org/h2/command/dml/Help.java
+++ b/h2/src/main/org/h2/command/dml/Help.java
@@ -39,7 +39,7 @@ public class Help extends Prepared {
     public Help(SessionLocal session, String[] conditions) {
         super(session);
         this.conditions = conditions;
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         expressions = new Expression[] { //
                 new ExpressionColumn(db, new Column("SECTION", TypeInfo.TYPE_VARCHAR)), //
                 new ExpressionColumn(db, new Column("TOPIC", TypeInfo.TYPE_VARCHAR)), //

--- a/h2/src/main/org/h2/command/dml/Insert.java
+++ b/h2/src/main/org/h2/command/dml/Insert.java
@@ -412,7 +412,7 @@ public final class Insert extends CommandWithValues implements ResultTarget {
 
         Expression condition = null;
         for (Column column : indexedColumns) {
-            ExpressionColumn expr = new ExpressionColumn(session.getDatabase(),
+            ExpressionColumn expr = new ExpressionColumn(getDatabase(),
                     table.getSchema().getName(), table.getName(), column.getName());
             for (int i = 0; i < columns.length; i++) {
                 if (expr.getColumnName(session, i).equals(columns[i].getName())) {

--- a/h2/src/main/org/h2/command/dml/ScriptBase.java
+++ b/h2/src/main/org/h2/command/dml/ScriptBase.java
@@ -111,7 +111,7 @@ abstract class ScriptBase extends Prepared {
     }
 
     private void initStore() {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         byte[] key = null;
         if (cipher != null && password != null) {
             char[] pass = password.optimize(session).

--- a/h2/src/main/org/h2/command/dml/ScriptCommand.java
+++ b/h2/src/main/org/h2/command/dml/ScriptCommand.java
@@ -153,14 +153,14 @@ public class ScriptCommand extends ScriptBase {
 
     private LocalResult createResult() {
         return new LocalResult(session, new Expression[] {
-                new ExpressionColumn(session.getDatabase(), new Column("SCRIPT", TypeInfo.TYPE_VARCHAR)) }, 1, 1);
+                new ExpressionColumn(getDatabase(), new Column("SCRIPT", TypeInfo.TYPE_VARCHAR)) }, 1, 1);
     }
 
     @Override
     public ResultInterface query(long maxrows) {
         session.getUser().checkAdmin();
         reset();
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         if (schemaNames != null) {
             for (String schemaName : schemaNames) {
                 Schema schema = db.findSchema(schemaName);

--- a/h2/src/main/org/h2/command/dml/Set.java
+++ b/h2/src/main/org/h2/command/dml/Set.java
@@ -83,7 +83,7 @@ public class Set extends Prepared {
 
     @Override
     public long update() {
-        Database database = session.getDatabase();
+        Database database = getDatabase();
         String name = SetTypes.getTypeName(type);
         switch (type) {
         case SetTypes.ALLOW_LITERALS: {

--- a/h2/src/main/org/h2/command/dml/TransactionCommand.java
+++ b/h2/src/main/org/h2/command/dml/TransactionCommand.java
@@ -50,7 +50,7 @@ public class TransactionCommand extends Prepared {
             break;
         case CommandInterface.CHECKPOINT:
             session.getUser().checkAdmin();
-            session.getDatabase().checkpoint();
+            getDatabase().checkpoint();
             break;
         case CommandInterface.SAVEPOINT:
             session.addSavepoint(savepointName);
@@ -60,7 +60,7 @@ public class TransactionCommand extends Prepared {
             break;
         case CommandInterface.CHECKPOINT_SYNC:
             session.getUser().checkAdmin();
-            session.getDatabase().sync();
+            getDatabase().sync();
             break;
         case CommandInterface.PREPARE_COMMIT:
             session.prepareCommit(transactionName);
@@ -83,7 +83,7 @@ public class TransactionCommand extends Prepared {
             // throttle, to allow testing concurrent
             // execution of shutdown and query
             session.throttle();
-            Database db = session.getDatabase();
+            Database db = getDatabase();
             if (db.setExclusiveSession(session, true)) {
                 db.setCompactMode(type);
                 // close the database, but don't update the persistent setting

--- a/h2/src/main/org/h2/command/query/Query.java
+++ b/h2/src/main/org/h2/command/query/Query.java
@@ -489,12 +489,12 @@ public abstract class Query extends Prepared {
             return queryWithoutCacheLazyCheck(limit, target);
         }
         fireBeforeSelectTriggers();
-        if (noCache || !session.getDatabase().getOptimizeReuseResults() ||
+        if (noCache || !getDatabase().getOptimizeReuseResults() ||
                 (session.isLazyQueryExecution() && !neverLazy)) {
             return queryWithoutCacheLazyCheck(limit, target);
         }
         Value[] params = getParameterValues();
-        long now = session.getDatabase().getModificationDataId();
+        long now = getDatabase().getModificationDataId();
         if (isEverything(ExpressionVisitor.DETERMINISTIC_VISITOR)) {
             if (lastResult != null && !lastResult.isClosed() &&
                     limit == lastLimit) {
@@ -535,11 +535,11 @@ public abstract class Query extends Prepared {
             return executeExists();
         }
         fireBeforeSelectTriggers();
-        if (noCache || !session.getDatabase().getOptimizeReuseResults()) {
+        if (noCache || !getDatabase().getOptimizeReuseResults()) {
             return executeExists();
         }
         Value[] params = getParameterValues();
-        long now = session.getDatabase().getModificationDataId();
+        long now = getDatabase().getModificationDataId();
         if (isEverything(ExpressionVisitor.DETERMINISTIC_VISITOR)) {
             if (lastExists != null) {
                 if (sameResultAsLast(params, lastParameters, lastEvaluated)) {
@@ -604,7 +604,7 @@ public abstract class Query extends Prepared {
      */
     int initExpression(ArrayList<String> expressionSQL, Expression e, boolean mustBeInResult,
             ArrayList<TableFilter> filters) {
-        Database db = session.getDatabase();
+        Database db = getDatabase();
         // special case: SELECT 1 AS A FROM DUAL ORDER BY A
         // (oracle supports it, but only in order by, not in group by and
         // not in having):
@@ -1001,7 +1001,7 @@ public abstract class Query extends Prepared {
         if (!checkInit) {
             init();
         }
-        return new DerivedTable(forCreateView ? session.getDatabase().getSystemSession() : session, alias,
+        return new DerivedTable(forCreateView ? getDatabase().getSystemSession() : session, alias,
                 columnTemplates, this, topQuery);
     }
 

--- a/h2/src/main/org/h2/command/query/Select.java
+++ b/h2/src/main/org/h2/command/query/Select.java
@@ -626,7 +626,7 @@ public class Select extends Query {
         ArrayList<Index> list = topTableFilter.getTable().getIndexes();
         if (list != null) {
             int[] sortTypes = sort.getSortTypesWithNullOrdering();
-            DefaultNullOrdering defaultNullOrdering = session.getDatabase().getDefaultNullOrdering();
+            DefaultNullOrdering defaultNullOrdering = getDatabase().getDefaultNullOrdering();
             loop: for (Index index : list) {
                 if (index.getCreateSQL() == null) {
                     // can't use the scan index
@@ -775,7 +775,7 @@ public class Select extends Query {
         int columnCount = expressions.size();
         LocalResult result = null;
         if (!lazy && (target == null ||
-                !session.getDatabase().getSettings().optimizeInsertFromSelect)) {
+                !getDatabase().getSettings().optimizeInsertFromSelect)) {
             result = createLocalResult(result);
         }
         // Do not add rows before OFFSET to result if possible
@@ -894,7 +894,7 @@ public class Select extends Query {
                     i = expandColumnList(filter, i, false, exceptTableColumns);
                 }
             } else {
-                Database db = session.getDatabase();
+                Database db = getDatabase();
                 String schemaName = w.getSchemaName();
                 TableFilter filter = null;
                 for (TableFilter f : filters) {
@@ -935,7 +935,7 @@ public class Select extends Query {
                     Column left = entry.getKey(), right = entry.getValue();
                     if (!filter.isCommonJoinColumnToExclude(right)
                             && (except == null || except.remove(left) == null && except.remove(right) == null)) {
-                        Database database = session.getDatabase();
+                        Database database = getDatabase();
                         Expression e;
                         if (left == right
                                 || DataType.hasTotalOrdering(left.getType().getValueType())
@@ -967,7 +967,7 @@ public class Select extends Query {
     private int addExpandedColumn(TableFilter filter, int index, HashMap<Column, ExpressionColumn> except,
             String schema, String alias, Column c) {
         if ((except == null || except.remove(c) == null) && c.getVisible()) {
-            ExpressionColumn ec = new ExpressionColumn(session.getDatabase(), schema, alias, filter.getColumnName(c));
+            ExpressionColumn ec = new ExpressionColumn(getDatabase(), schema, alias, filter.getColumnName(c));
             expressions.add(index++, ec);
         }
         return index;
@@ -1030,7 +1030,7 @@ public class Select extends Query {
             throw DbException.get(ErrorCode.WITH_TIES_WITHOUT_ORDER_BY);
         }
 
-        Database db = session.getDatabase();
+        Database db = getDatabase();
 
         // first the select list (visible columns),
         // then 'ORDER BY' expressions,
@@ -1200,7 +1200,7 @@ public class Select extends Query {
             }
         }
         cost = preparePlan(session.isParsingCreateView());
-        if (distinct && session.getDatabase().getSettings().optimizeDistinct &&
+        if (distinct && getDatabase().getSettings().optimizeDistinct &&
                 !isGroupQuery && filters.size() == 1 &&
                 expressions.size() == 1 && condition == null) {
             Expression expr = expressions.get(0);
@@ -1691,7 +1691,7 @@ public class Select extends Query {
             break;
         }
         case ExpressionVisitor.EVALUATABLE: {
-            if (!session.getDatabase().getSettings().optimizeEvaluatableSubqueries) {
+            if (!getDatabase().getSettings().optimizeEvaluatableSubqueries) {
                 return false;
             }
             break;

--- a/h2/src/main/org/h2/command/query/TableValueConstructor.java
+++ b/h2/src/main/org/h2/command/query/TableValueConstructor.java
@@ -240,7 +240,7 @@ public class TableValueConstructor extends Query {
             expressions.add(new ExpressionColumn(database, null, null, columns[i].getName()));
         }
         this.expressions = expressions;
-        table = new TableValueConstructorTable(session.getDatabase().getMainSchema(), session, columns, rows);
+        table = new TableValueConstructorTable(database.getMainSchema(), session, columns, rows);
         columnResolver = new TableValueColumnResolver();
     }
 

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -227,7 +227,7 @@ public final class Database implements DataHandler, CastDataProvider {
         this.filePasswordHash = ci.getFilePasswordHash();
         this.databaseName = databaseName;
         this.databaseShortName = parseDatabaseShortName();
-        this.maxLengthInplaceLob = persistent ? Constants.DEFAULT_MAX_LENGTH_INPLACE_LOB : Integer.MAX_VALUE;
+        this.maxLengthInplaceLob = persistent ? Constants.DEFAULT_MAX_LENGTH_INPLACE_LOB : Integer.MAX_VALUE - 8;
         this.cipher = cipher;
         this.autoServerMode = ci.getProperty("AUTO_SERVER", false);
         this.autoServerPort = ci.getProperty("AUTO_SERVER_PORT", 0);

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -227,7 +227,7 @@ public final class Database implements DataHandler, CastDataProvider {
         this.filePasswordHash = ci.getFilePasswordHash();
         this.databaseName = databaseName;
         this.databaseShortName = parseDatabaseShortName();
-        this.maxLengthInplaceLob = Constants.DEFAULT_MAX_LENGTH_INPLACE_LOB;
+        this.maxLengthInplaceLob = persistent ? Constants.DEFAULT_MAX_LENGTH_INPLACE_LOB : Integer.MAX_VALUE;
         this.cipher = cipher;
         this.autoServerMode = ci.getProperty("AUTO_SERVER", false);
         this.autoServerPort = ci.getProperty("AUTO_SERVER_PORT", 0);
@@ -1249,8 +1249,10 @@ public final class Database implements DataHandler, CastDataProvider {
      */
     private synchronized void closeOpenFilesAndUnlock() {
         try {
-            lobStorage.close();
-            if (!store.getMvStore().isClosed()) {
+            if (lobStorage != null) {
+                lobStorage.close();
+            }
+            if (store != null && !store.getMvStore().isClosed()) {
                 if (compactMode == CommandInterface.SHUTDOWN_IMMEDIATELY) {
                     store.closeImmediately();
                 } else {
@@ -1260,13 +1262,13 @@ public final class Database implements DataHandler, CastDataProvider {
                             dbSettings.defragAlways ? -1 : dbSettings.maxCompactTime;
                     store.close(allowedCompactionTime);
                 }
-            }
-            if (persistent) {
-                // Don't delete temp files if everything is already closed
-                // (maybe in checkPowerOff), the database could be open now
-                // (even from within another process).
-                if (lock != null || fileLockMethod == FileLockMethod.NO || fileLockMethod == FileLockMethod.FS) {
-                    deleteOldTempFiles();
+                if (persistent) {
+                    // Don't delete temp files if everything is already closed
+                    // (maybe in checkPowerOff), the database could be open now
+                    // (even from within another process).
+                    if (lock != null || fileLockMethod == FileLockMethod.NO || fileLockMethod == FileLockMethod.FS) {
+                        deleteOldTempFiles();
+                    }
                 }
             }
         } finally {

--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -55,6 +55,7 @@ import org.h2.util.NetworkConnectionInfo;
 import org.h2.util.SmallLRUCache;
 import org.h2.util.TimeZoneProvider;
 import org.h2.util.Utils;
+import org.h2.value.CompareMode;
 import org.h2.value.Value;
 import org.h2.value.ValueLob;
 import org.h2.value.ValueNull;
@@ -138,8 +139,8 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
     }
 
     private final int serialId = nextSerialId++;
-    private final Database database;
-    private final User user;
+    private Database database;
+    private User user;
     private final int id;
 
     private NetworkConnectionInfo networkConnectionInfo;
@@ -307,7 +308,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
 
     private void initVariables() {
         if (variables == null) {
-            variables = database.newStringMap();
+            variables = newStringsMap();
         }
     }
 
@@ -326,7 +327,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         } else {
             if (value instanceof ValueLob) {
                 // link LOB values, to make sure we have our own object
-                value = ((ValueLob) value).copy(database, LobStorageFrontend.TABLE_ID_SESSION_VARIABLE);
+                value = ((ValueLob) value).copy(getDatabase(), LobStorageFrontend.TABLE_ID_SESSION_VARIABLE);
             }
             old = variables.put(name, value);
         }
@@ -390,7 +391,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      */
     public void addLocalTempTable(Table table) {
         if (localTempTables == null) {
-            localTempTables = database.newStringMap();
+            localTempTables = newStringsMap();
         }
         if (localTempTables.putIfAbsent(table.getName(), table) != null) {
             StringBuilder builder = new StringBuilder();
@@ -411,8 +412,11 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         if (localTempTables != null) {
             localTempTables.remove(table.getName());
         }
-        synchronized (database) {
-            table.removeChildrenAndResources(this);
+        Database db = database;
+        if (db != null) {
+            synchronized (db) {
+                table.removeChildrenAndResources(this);
+            }
         }
     }
 
@@ -445,7 +449,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      */
     public void addLocalTempTableIndex(Index index) {
         if (localTempTableIndexes == null) {
-            localTempTableIndexes = database.newStringMap();
+            localTempTableIndexes = newStringsMap();
         }
         if (localTempTableIndexes.putIfAbsent(index.getName(), index) != null) {
             throw DbException.get(ErrorCode.INDEX_ALREADY_EXISTS_1, index.getTraceSQL());
@@ -501,7 +505,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      */
     public void addLocalTempTableConstraint(Constraint constraint) {
         if (localTempTableConstraints == null) {
-            localTempTableConstraints = database.newStringMap();
+            localTempTableConstraints = newStringsMap();
         }
         String name = constraint.getName();
         if (localTempTableConstraints.putIfAbsent(name, constraint) != null) {
@@ -612,9 +616,9 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         if (queryCacheSize > 0) {
             if (queryCache == null) {
                 queryCache = SmallLRUCache.newInstance(queryCacheSize);
-                modificationMetaID = database.getModificationMetaId();
+                modificationMetaID = getDatabase().getModificationMetaId();
             } else {
-                long newModificationMetaID = database.getModificationMetaId();
+                long newModificationMetaID = getDatabase().getModificationMetaId();
                 if (newModificationMetaID != modificationMetaID) {
                     queryCache.clear();
                     modificationMetaID = newModificationMetaID;
@@ -654,6 +658,9 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
     }
 
     public Database getDatabase() {
+        if (database == null) {
+            throw DbException.get(ErrorCode.DATABASE_IS_CLOSED);
+        }
         return database;
     }
 
@@ -714,7 +721,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
                 Analyze.analyzeTable(this, table, rowCount, false);
             }
             // analyze can lock the meta
-            database.unlockMeta(this);
+            getDatabase().unlockMeta(this);
             // table analysis opens a new transaction(s),
             // so we need to commit afterwards whatever leftovers might be
             commit(true);
@@ -731,7 +738,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
             temporaryLobs.clear();
         }
         if (temporaryResultLobs != null && !temporaryResultLobs.isEmpty()) {
-            long keepYoungerThan = System.nanoTime() - database.getSettings().lobTimeout * 1_000_000L;
+            long keepYoungerThan = System.nanoTime() - getDatabase().getSettings().lobTimeout * 1_000_000L;
             while (!temporaryResultLobs.isEmpty()) {
                 TimeoutValue tv = temporaryResultLobs.getFirst();
                 if (onTimeout && tv.created - keepYoungerThan >= 0) {
@@ -751,7 +758,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         }
         currentTransactionName = null;
         currentTimestamp = null;
-        database.throwLastBackgroundException();
+        getDatabase().throwLastBackgroundException();
     }
 
     private void endTransaction() {
@@ -763,11 +770,11 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         }
         unlockAll();
         if (idsToRelease != null) {
-            database.releaseDatabaseObjectIds(idsToRelease);
+            getDatabase().releaseDatabaseObjectIds(idsToRelease);
             idsToRelease = null;
         }
         if (hasTransaction() && !transaction.allowNonRepeatableRead()) {
-            snapshotDataModificationId = database.getNextModificationDataId();
+            snapshotDataModificationId = getDatabase().getNextModificationDataId();
         }
     }
 
@@ -874,15 +881,16 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         // so, we should prevent double-closure
         if (state.getAndSet(State.CLOSED) != State.CLOSED) {
             try {
+                if (queryCache != null) {
+                    queryCache.clear();
+                }
                 database.throwLastBackgroundException();
 
                 database.checkPowerOff();
 
                 // release any open table locks
                 if (hasPreparedTransaction()) {
-                    if (currentTransactionName != null) {
-                        removeLobMap = null;
-                    }
+                    removeLobMap = null;
                     endTransaction();
                 } else {
                     rollback();
@@ -897,6 +905,8 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
                 database.unlockMeta(this);
             } finally {
                 database.removeSession(this);
+                database = null;
+                user = null;
             }
         }
     }
@@ -994,10 +1004,11 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
             return trace;
         }
         String traceModuleName = "jdbc[" + id + "]";
-        if (isClosed()) {
+        Database db = database;
+        if (isClosed() || db == null) {
             return new TraceSystem(null).getTrace(traceModuleName);
         }
-        trace = database.getTraceSystem().getTrace(traceModuleName);
+        trace = db.getTraceSystem().getTrace(traceModuleName);
         return trace;
     }
 
@@ -1012,7 +1023,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      */
     public Value getNextValueFor(Sequence sequence, Prepared prepared) {
         Value value;
-        Mode mode = database.getMode();
+        Mode mode = getMode();
         if (mode.nextValueReturnsDifferentValues || prepared == null) {
             value = sequence.getNext(this);
         } else {
@@ -1089,7 +1100,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      */
     public void addSavepoint(String name) {
         if (savepoints == null) {
-            savepoints = database.newStringMap();
+            savepoints = newStringsMap();
         }
         savepoints.put(name, setSavepoint());
     }
@@ -1117,7 +1128,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         if (hasPendingTransaction()) {
             // need to commit even if rollback is not possible (create/drop
             // table and so on)
-            database.prepareCommit(this, transactionName);
+            getDatabase().prepareCommit(this, transactionName);
         }
         currentTransactionName = transactionName;
     }
@@ -1146,7 +1157,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
                 rollback();
             }
         } else {
-            ArrayList<InDoubtTransaction> list = database.getInDoubtTransactions();
+            ArrayList<InDoubtTransaction> list = getDatabase().getInDoubtTransactions();
             int state = commit ? InDoubtTransaction.COMMIT : InDoubtTransaction.ROLLBACK;
             boolean found = false;
             for (InDoubtTransaction p: list) {
@@ -1216,7 +1227,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
                     cancelAtNs = Utils.currentNanoTimePlusMillis(queryTimeout);
                 }
             } else {
-                if (currentTimestamp != null && !database.getMode().dateTimeValueWithinTransaction) {
+                if (currentTimestamp != null && !getMode().dateTimeValueWithinTransaction) {
                     currentTimestamp = null;
                 }
                 if (nextValueFor != null) {
@@ -1300,7 +1311,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
 
     @Override
     public void setCurrentSchemaName(String schemaName) {
-        Schema schema = database.getSchema(schemaName);
+        Schema schema = getDatabase().getSchema(schemaName);
         setCurrentSchema(schema);
     }
 
@@ -1323,7 +1334,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
 
     @Override
     public DataHandler getDataHandler() {
-        return database;
+        return getDatabase();
     }
 
     /**
@@ -1373,7 +1384,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      */
     public void addProcedure(Procedure procedure) {
         if (procedures == null) {
-            procedures = database.newStringMap();
+            procedures = newStringsMap();
         }
         procedures.put(procedure.getName(), procedure);
     }
@@ -1438,7 +1449,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         /*
          * This implementation needs to be lock-free.
          */
-        if (database.getLockMode() == Constants.LOCK_MODE_OFF || locks.isEmpty()) {
+        if (getDatabase().getLockMode() == Constants.LOCK_MODE_OFF || locks.isEmpty()) {
             return Collections.emptySet();
         }
         /*
@@ -1480,11 +1491,11 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         transitionToState(State.RUNNING, true);
         // Even in exclusive mode, we have to let the LOB session proceed, or we
         // will get deadlocks.
-        if (database.getLobSession() == this) {
+        if (getDatabase().getLobSession() == this) {
             return;
         }
         while (isOpen()) {
-            SessionLocal exclusive = database.getExclusiveSession();
+            SessionLocal exclusive = getDatabase().getExclusiveSession();
             if (exclusive == null || exclusive == this) {
                 break;
             }
@@ -1527,7 +1538,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
     }
 
     public void setQueryTimeout(int queryTimeout) {
-        int max = database.getSettings().maxQueryTimeout;
+        int max = getDatabase().getSettings().maxQueryTimeout;
         if (max != 0 && (max < queryTimeout || queryTimeout == 0)) {
             // the value must be at most max
             queryTimeout = max;
@@ -1589,10 +1600,10 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      */
     public Transaction getTransaction() {
         if (transaction == null) {
-            Store store = database.getStore();
+            Store store = getDatabase().getStore();
             if (store.getMvStore().isClosed()) {
-                Throwable backgroundException = database.getBackgroundException();
-                database.shutdownImmediately();
+                Throwable backgroundException = getDatabase().getBackgroundException();
+                getDatabase().shutdownImmediately();
                 throw DbException.get(ErrorCode.DATABASE_IS_CLOSED, backgroundException);
             }
             transaction = store.getTransactionStore().begin(this, this.lockTimeout, id, isolationLevel);
@@ -1623,7 +1634,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
                 case SNAPSHOT:
                 case SERIALIZABLE:
                     if (!transaction.hasStatementDependencies()) {
-                        for (Schema schema : database.getAllSchemasNoMeta()) {
+                        for (Schema schema : getDatabase().getAllSchemasNoMeta()) {
                             for (Table table : schema.getAllTablesAndViews(null)) {
                                 if (table instanceof MVTable) {
                                     addTableToDependencies((MVTable)table, maps);
@@ -1756,7 +1767,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
                             VersionedValue<Object> restoredValue) {
         // Here we are relying on the fact that map which backs table's primary index
         // has the same name as the table itself
-        Store store = database.getStore();
+        Store store = getDatabase().getStore();
         MVTable table = store.getTable(map.getName());
         if (table != null) {
             Row oldRow = existingValue == null ? null : (Row) existingValue.getCurrentValue();
@@ -1847,12 +1858,12 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
 
     @Override
     public Mode getMode() {
-        return database.getMode();
+        return getDatabase().getMode();
     }
 
     @Override
     public JavaObjectSerializer getJavaObjectSerializer() {
-        return database.getJavaObjectSerializer();
+        return getDatabase().getJavaObjectSerializer();
     }
 
     @Override
@@ -1888,7 +1899,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
     public StaticSettings getStaticSettings() {
         StaticSettings settings = staticSettings;
         if (settings == null) {
-            DbSettings dbSettings = database.getSettings();
+            DbSettings dbSettings = getDatabase().getSettings();
             staticSettings = settings = new StaticSettings(dbSettings.databaseToUpper, dbSettings.databaseToLower,
                     dbSettings.caseInsensitiveIdentifiers);
         }
@@ -1897,7 +1908,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
 
     @Override
     public DynamicSettings getDynamicSettings() {
-        return new DynamicSettings(database.getMode(), timeZone);
+        return new DynamicSettings(getMode(), timeZone);
     }
 
     @Override
@@ -1935,7 +1946,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      */
     public boolean areEqual(Value a, Value b) {
         // can not use equals because ValueDecimal 0.0 is not equal to 0.00.
-        return a.compareTo(b, this, database.getCompareMode()) == 0;
+        return a.compareTo(b, this, getCompareMode()) == 0;
     }
 
     /**
@@ -1948,7 +1959,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      *         1 otherwise
      */
     public int compare(Value a, Value b) {
-        return a.compareTo(b, this, database.getCompareMode());
+        return a.compareTo(b, this, getCompareMode());
     }
 
     /**
@@ -1963,7 +1974,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      *         is not defined due to NULL comparison
      */
     public int compareWithNull(Value a, Value b, boolean forEquality) {
-        return a.compareWithNull(b, forEquality, this, database.getCompareMode());
+        return a.compareWithNull(b, forEquality, this, getCompareMode());
     }
 
     /**
@@ -1976,7 +1987,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      *         1 otherwise
      */
     public int compareTypeSafe(Value a, Value b) {
-        return a.compareTypeSafe(b, database.getCompareMode(), this);
+        return a.compareTypeSafe(b, getCompareMode(), this);
     }
 
     /**
@@ -2044,7 +2055,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
 
     @Override
     public boolean zeroBasedEnums() {
-        return database.zeroBasedEnums();
+        return getDatabase().zeroBasedEnums();
     }
 
     /**
@@ -2064,7 +2075,7 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      *         explicitly, {@code false} otherwise
      */
     public boolean isQuirksMode() {
-        return quirksMode || database.isStarting();
+        return quirksMode || getDatabase().isStarting();
     }
 
     @Override
@@ -2083,4 +2094,11 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
         }
     }
 
+    private CompareMode getCompareMode() {
+        return getDatabase().getCompareMode();
+    }
+
+    private <T> HashMap<String,T> newStringsMap() {
+        return getDatabase().newStringMap();
+    }
 }

--- a/h2/src/main/org/h2/mvstore/AppendOnlyMultiFileStore.java
+++ b/h2/src/main/org/h2/mvstore/AppendOnlyMultiFileStore.java
@@ -58,7 +58,7 @@ public final class AppendOnlyMultiFileStore extends FileStore<MFChunk>
     /**
      * All files currently used by this store. This includes current one at first position.
      * Previous files are opened in read-only mode.
-     * Locical length of this array is determined by fileCount.
+     * Logical length of this array is defined by fileCount.
      */
     @SuppressWarnings("MismatchedReadAndWriteOfArray")
     private final FileChannel[] fileChannels;
@@ -89,7 +89,6 @@ public final class AppendOnlyMultiFileStore extends FileStore<MFChunk>
     protected MFChunk createChunk(Map<String, String> map) {
         return new MFChunk(map);
     }
-
 
     @Override
     public boolean shouldSaveNow(int unsavedMemory, int autoCommitMemory) {


### PR DESCRIPTION
Clear LocalSession.database and LocalSession. User fields to allow for in-memory data to be collected upon database closer in presence of dangling JDBC statements / connections.
Use only in-line LOBs in case of in-memory database.
Fixes #3633 