### PR TITLE
Provides a default listener when no listener is set

### DIFF
--- a/h2/src/main/org/h2/api/DatabaseEventListener.java
+++ b/h2/src/main/org/h2/api/DatabaseEventListener.java
@@ -5,6 +5,8 @@
  */
 package org.h2.api;
 
+import org.h2.engine.Database;
+
 import java.sql.SQLException;
 import java.util.EventListener;
 
@@ -65,15 +67,18 @@ public interface DatabaseEventListener extends EventListener {
      * runtime with the SET SQL statement.
      *
      * @param url - the database URL
+     * @param database - the database reference
      */
-    default void init(String url) {
+    default void init(String url, Database database) {
     }
 
     /**
      * This method is called after the database has been opened. It is safe to
      * connect to the database and execute statements at this point.
+     *
+     * @param database - the database reference
      */
-    default void opened() {
+    default void opened(Database database) {
     }
 
     /**
@@ -105,8 +110,10 @@ public interface DatabaseEventListener extends EventListener {
      * This method is called before the database is closed normally. It is safe
      * to connect to the database and execute statements at this point, however
      * the connection must be closed before the method returns.
+     *
+     * @param database - the database reference
      */
-    default void closingDatabase() {
+    default void closingDatabase(Database database) {
     }
 
 }

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -246,6 +246,9 @@ public final class Database implements DataHandler, CastDataProvider {
         String s = ci.removeProperty("DATABASE_EVENT_LISTENER", null);
         if (s != null) {
             setEventListenerClass(StringUtils.trim(s, true, true, "'"));
+        } else if(Engine.getDefaultDatabaseEventListenerClass() != null) {
+            // If no listener class is specified, the default listener class is used
+            setEventListenerClass(Engine.getDefaultDatabaseEventListenerClass());
         }
         s = ci.removeProperty("MODE", null);
         if (s != null) {
@@ -1173,7 +1176,7 @@ public final class Database implements DataHandler, CastDataProvider {
                 DatabaseEventListener e = eventListener;
                 // set it to null, to make sure it's called only once
                 eventListener = null;
-                e.closingDatabase();
+                e.closingDatabase(this);
                 closing = true;
                 if (!userSessions.isEmpty()) {
                     trace.info("event listener {0} left connection open", e.getClass().getName());
@@ -1831,7 +1834,7 @@ public final class Database implements DataHandler, CastDataProvider {
                 if (cipher != null) {
                     url += ";CIPHER=" + cipher;
                 }
-                eventListener.init(url);
+                eventListener.init(url, this);
             } catch (Throwable e) {
                 throw DbException.get(
                         ErrorCode.ERROR_SETTING_DATABASE_EVENT_LISTENER_2, e,
@@ -2048,7 +2051,7 @@ public final class Database implements DataHandler, CastDataProvider {
      */
     void opened() {
         if (eventListener != null) {
-            eventListener.opened();
+            eventListener.opened(this);
         }
     }
 

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -8,6 +8,7 @@ package org.h2.engine;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
 import org.h2.command.dml.SetTypes;
@@ -37,6 +38,8 @@ public final class Engine {
     private static volatile long WRONG_PASSWORD_DELAY = SysProperties.DELAY_WRONG_PASSWORD_MIN;
 
     private static boolean JMX;
+
+    private static String defaultDatabaseEventListenerClass;
 
     static {
         if (SysProperties.THREAD_DEADLOCK_DETECTOR) {
@@ -393,6 +396,24 @@ public final class Engine {
                 throw DbException.get(ErrorCode.WRONG_USER_OR_PASSWORD);
             }
         }
+    }
+
+    /**
+     *  Set the global default listening class
+     *  Exposed for use by business callers
+     * @return
+     */
+    public static String getDefaultDatabaseEventListenerClass() {
+        return defaultDatabaseEventListenerClass;
+    }
+
+    /**
+     * Get the global default listening class
+     *
+     * @param defaultDatabaseEventListenerClass
+     */
+    public static void setDefaultDatabaseEventListenerClass(String defaultDatabaseEventListenerClass) {
+        Engine.defaultDatabaseEventListenerClass = defaultDatabaseEventListenerClass;
     }
 
     private Engine() {

--- a/h2/src/test/org/h2/samples/ShowProgress.java
+++ b/h2/src/test/org/h2/samples/ShowProgress.java
@@ -13,6 +13,7 @@ import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.api.DatabaseEventListener;
+import org.h2.engine.Database;
 import org.h2.engine.SessionLocal;
 import org.h2.jdbc.JdbcConnection;
 
@@ -149,7 +150,7 @@ public class ShowProgress implements DatabaseEventListener {
      * This method is called when the database is closed.
      */
     @Override
-    public void closingDatabase() {
+    public void closingDatabase(Database database) {
         System.out.println("Closing the database");
     }
 
@@ -159,7 +160,7 @@ public class ShowProgress implements DatabaseEventListener {
      * @param url the database URL
      */
     @Override
-    public void init(String url) {
+    public void init(String url, Database database) {
         System.out.println("Initializing the event listener for database " + url);
     }
 
@@ -167,7 +168,7 @@ public class ShowProgress implements DatabaseEventListener {
      * This method is called when the database is open.
      */
     @Override
-    public void opened() {
+    public void opened(Database database) {
         // do nothing
     }
 

--- a/h2/src/test/org/h2/test/db/TestListener.java
+++ b/h2/src/test/org/h2/test/db/TestListener.java
@@ -13,6 +13,7 @@ import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 
 import org.h2.api.DatabaseEventListener;
+import org.h2.engine.Database;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 
@@ -114,7 +115,7 @@ public class TestListener extends TestDb implements DatabaseEventListener {
     }
 
     @Override
-    public void closingDatabase() {
+    public void closingDatabase(Database database) {
         if (databaseUrl.toUpperCase().contains("CIPHER")) {
             return;
         }
@@ -128,12 +129,12 @@ public class TestListener extends TestDb implements DatabaseEventListener {
     }
 
     @Override
-    public void init(String url) {
+    public void init(String url, Database database) {
         this.databaseUrl = url;
     }
 
     @Override
-    public void opened() {
+    public void opened(Database database) {
         if (databaseUrl.toUpperCase().contains("CIPHER")) {
             return;
         }

--- a/h2/src/test/org/h2/test/jdbc/TestDatabaseEventListener.java
+++ b/h2/src/test/org/h2/test/jdbc/TestDatabaseEventListener.java
@@ -13,6 +13,7 @@ import java.util.Properties;
 
 import org.h2.Driver;
 import org.h2.api.DatabaseEventListener;
+import org.h2.engine.Database;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 
@@ -57,12 +58,12 @@ public class TestDatabaseEventListener extends TestDb {
         private String databaseUrl;
 
         @Override
-        public void init(String url) {
+        public void init(String url, Database database) {
             databaseUrl = url;
         }
 
         @Override
-        public void opened() {
+        public void opened(Database database) {
             try {
                 // using DriverManager.getConnection could result in a deadlock
                 // when using the server mode, but within the same process
@@ -232,12 +233,12 @@ public class TestDatabaseEventListener extends TestDb {
     public static final class MyDatabaseEventListener implements DatabaseEventListener {
 
         @Override
-        public void closingDatabase() {
+        public void closingDatabase(Database database) {
             calledClosingDatabase = true;
         }
 
         @Override
-        public void opened() {
+        public void opened(Database database) {
             calledOpened = true;
         }
 

--- a/h2/src/test/org/h2/test/unit/TestExit.java
+++ b/h2/src/test/org/h2/test/unit/TestExit.java
@@ -12,6 +12,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 import org.h2.api.DatabaseEventListener;
+import org.h2.engine.Database;
 import org.h2.test.TestBase;
 import org.h2.test.TestDb;
 import org.h2.test.utils.SelfDestructor;
@@ -136,7 +137,7 @@ public class TestExit extends TestDb {
     public static final class MyDatabaseEventListener implements DatabaseEventListener {
 
         @Override
-        public void closingDatabase() {
+        public void closingDatabase(Database database) {
             try {
                 getClosedFile().createNewFile();
             } catch (IOException e) {


### PR DESCRIPTION
Provides a default listener when no listener is set. And add parameters to know the exact event source.
Sometimes we need to manage and monitor the database as a server and adjust the database parameters when it happens.

For example, deleteFilesOnDisconnect is automatically set to true on the target node when the cluster is created. This can easily trigger the deletion of data files when the database is closed, resulting in the loss of data files and tables. We can correct the parameters through the listener