### PR TITLE
Prevent page double release

### DIFF
--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -866,28 +866,18 @@ public class MVStore implements AutoCloseable {
                     !map.isVolatile() &&
                     map.hasChangesSince(lastStoredVersion)) {
                 assert rootReference.version <= version : rootReference.version + " > " + version;
-                Page<?,?> rootPage = rootReference.root;
-                if (!rootPage.isSaved() ||
-                        // after deletion previously saved leaf
-                        // may pop up as a root, but we still need
-                        // to save new root pos in meta
-                        rootPage.isLeaf()) {
-                    changed.add(rootPage);
-                }
+                // simply checking rootPage.isSaved() won't work here because
+                // after deletion previously saved page
+                // may pop up as a root, but we still need
+                // to save new root pos in meta
+                changed.add(rootReference.root);
             }
         }
         RootReference<?,?> rootReference = meta.setWriteVersion(version);
         if (meta.hasChangesSince(lastStoredVersion) || metaChanged) {
             assert rootReference != null && rootReference.version <= version
                     : rootReference == null ? "null" : rootReference.version + " > " + version;
-            Page<?, ?> rootPage = rootReference.root;
-            if (!rootPage.isSaved() ||
-                    // after deletion previously saved leaf
-                    // may pop up as a root, but we still need
-                    // to save new root pos in meta
-                    rootPage.isLeaf()) {
-                changed.add(rootPage);
-            }
+            changed.add(rootReference.root);
         }
         return changed;
     }


### PR DESCRIPTION
Fixes #3682  
There is a bug in a corner case of MVMap.remove(), when B-tree height is reduced and existing (saved) page pops up as a new tree root. Subsequent immediate commit() and store closure would fail to recognize root update negating result of the removal, but not the release of previous root page, as not used any more. Later this manifest itself as double release of that page.