### PR TITLE
Construct FormatTokenEnum.TOKENS during class initialization

### DIFF
--- a/h2/src/main/org/h2/mode/ToDateTokenizer.java
+++ b/h2/src/main/org/h2/mode/ToDateTokenizer.java
@@ -617,7 +617,24 @@ final class ToDateTokenizer {
 
         private static final List<FormatTokenEnum> INLINE_LIST = Collections.singletonList(INLINE);
 
-        private static List<FormatTokenEnum>[] TOKENS;
+        private static final List<FormatTokenEnum>[] TOKENS;
+
+        static {
+            @SuppressWarnings("unchecked")
+            List<FormatTokenEnum>[] tokens = new List[25];
+            for (FormatTokenEnum token : FormatTokenEnum.values()) {
+                String name = token.name();
+                if (name.indexOf('_') >= 0) {
+                    for (String tokenLets : name.split("_")) {
+                        putToCache(tokens, token, tokenLets);
+                    }
+                } else {
+                    putToCache(tokens, token, name);
+                }
+            }
+            TOKENS = tokens;
+        }
+
         private final ToDateParslet toDateParslet;
         private final Pattern patternToUse;
 
@@ -655,32 +672,12 @@ final class ToDateTokenizer {
             if (formatStr != null && !formatStr.isEmpty()) {
                 char key = Character.toUpperCase(formatStr.charAt(0));
                 if (key >= 'A' && key <= 'Y') {
-                    List<FormatTokenEnum>[] tokens = TOKENS;
-                    if (tokens == null) {
-                        tokens = initTokens();
-                    }
-                    return tokens[key - 'A'];
+                    return TOKENS[key - 'A'];
                 } else if (key == '"') {
                     return INLINE_LIST;
                 }
             }
             return null;
-        }
-
-        @SuppressWarnings("unchecked")
-        private static List<FormatTokenEnum>[] initTokens() {
-            List<FormatTokenEnum>[] tokens = new List[25];
-            for (FormatTokenEnum token : FormatTokenEnum.values()) {
-                String name = token.name();
-                if (name.indexOf('_') >= 0) {
-                    for (String tokenLets : name.split("_")) {
-                        putToCache(tokens, token, tokenLets);
-                    }
-                } else {
-                    putToCache(tokens, token, name);
-                }
-            }
-            return TOKENS = tokens;
         }
 
         private static void putToCache(List<FormatTokenEnum>[] cache, FormatTokenEnum token, String name) {

--- a/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -353,11 +353,9 @@ public class TestCompatibilityOracle extends TestDb {
 
     private void assertResultDate(String expected, Statement stat, String sql)
             throws SQLException {
-        SimpleDateFormat iso8601 = new SimpleDateFormat(
-                "yyyy-MM-dd'T'HH:mm:ss");
         ResultSet rs = stat.executeQuery(sql);
         if (rs.next()) {
-            assertEquals(expected, iso8601.format(rs.getTimestamp(1)));
+            assertEquals(LocalDateTime.parse(expected), rs.getObject(1, LocalDateTime.class));
         } else {
             assertEquals(expected, null);
         }


### PR DESCRIPTION
Closes #3687.

I don't think that race in the current implementation is really possible with OpenJDK-based JVMs, this method is not expected to be compiled. But delayed initialization is meaningless anyway, because `initTokens()` always called immediately after initialization of `FormatTokenEnum` class.