### PR TITLE
Read data types from CAST specifications passed as UNNEST parameters

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,14 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3693: Wrong result when intersecting unnested arrays
+</li>
+<li>PR #3691: GitHub Workflows security hardening
+</li>
+<li>PR #3688: Construct FormatTokenEnum.TOKENS during class initialization
+</li>
+<li>Issue #3682: MVStoreException at accountForRemovedPage
+</li>
 <li>Issue #3664: [2.1.214] NulllPointerException in org.h2.command.query.Select.queryDistinct
 </li>
 <li>PR #3650: fix version number in the archives html table

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4541,8 +4541,11 @@ public class Parser {
             do {
                 Expression expr = readExpression();
                 TypeInfo columnType = TypeInfo.TYPE_NULL;
-                if (expr.isConstant()) {
-                    expr = expr.optimize(session);
+                boolean constant = expr.isConstant();
+                if (constant || expr instanceof CastSpecification) {
+                    if (constant) {
+                        expr = expr.optimize(session);
+                    }
                     TypeInfo exprType = expr.getType();
                     if (exprType.getValueType() == Value.ARRAY) {
                         columnType = (TypeInfo) exprType.getExtTypeInfo();


### PR DESCRIPTION
Closes #3693.

Unfortunately, our initialization logic cannot handle arguments of table functions well, there are many issues, mostly because we need to know structure and column types of their tables too early.

In this PR an additional quirk for cast specification is introduced.

