### PR TITLE
Upgrade to the latest OSGi JDBC specification

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -44,6 +44,7 @@
     <junit.version>5.6.2</junit.version>
     <lucene.version>8.5.2</lucene.version>
     <osgi.version>5.0.0</osgi.version>
+    <osgi.jdbc.version>1.1.0</osgi.jdbc.version>
     <pgjdbc.version>42.4.0</pgjdbc.version>
     <javax.servlet.version>4.0.1</javax.servlet.version>
     <jakarta.servlet.version>5.0.0</jakarta.servlet.version>
@@ -90,9 +91,10 @@
       <version>${osgi.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.enterprise</artifactId>
-      <version>${osgi.version}</version>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.jdbc</artifactId>
+        <version>${osgi.jdbc.version}</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.locationtech.jts</groupId>

--- a/h2/src/main/META-INF/MANIFEST.MF
+++ b/h2/src/main/META-INF/MANIFEST.MF
@@ -53,7 +53,7 @@ Import-Package: javax.crypto,
  org.apache.lucene.util;version="[8.5.2,9.0.0)";resolution:=optional,
  org.locationtech.jts.geom;version="1.17.0";resolution:=optional,
  org.osgi.framework;version="1.5",
- org.osgi.service.jdbc;version="1.0";resolution:=optional,
+ org.osgi.service.jdbc;version="1.1";resolution:=optional,
  org.slf4j;version="[1.7.0,1.8.0)";resolution:=optional
 Export-Package: org.h2;version="${version}",
  org.h2.api;version="${version}",

--- a/h2/src/main/org/h2/util/OsgiDataSourceFactory.java
+++ b/h2/src/main/org/h2/util/OsgiDataSourceFactory.java
@@ -289,7 +289,7 @@ public class OsgiDataSourceFactory implements DataSourceFactory {
      */
     static void registerService(BundleContext bundleContext,
             org.h2.Driver driver) {
-        Hashtable<String, String> properties = new Hashtable<>();
+        Hashtable<String, Object> properties = new Hashtable<>();
         properties.put(
                 DataSourceFactory.OSGI_JDBC_DRIVER_CLASS,
                 org.h2.Driver.class.getName());
@@ -299,6 +299,12 @@ public class OsgiDataSourceFactory implements DataSourceFactory {
         properties.put(
                 DataSourceFactory.OSGI_JDBC_DRIVER_VERSION,
                 Constants.FULL_VERSION);
+        properties.put(DataSourceFactory.OSGI_JDBC_CAPABILITY, new String[] {
+                DataSourceFactory.OSGI_JDBC_CAPABILITY_DRIVER,
+                DataSourceFactory.OSGI_JDBC_CAPABILITY_DATASOURCE,
+                DataSourceFactory.OSGI_JDBC_CAPABILITY_CONNECTIONPOOLDATASOURCE,
+                DataSourceFactory.OSGI_JDBC_CAPABILITY_XADATASOURCE
+        });
         bundleContext.registerService(
                 DataSourceFactory.class.getName(),
                 new OsgiDataSourceFactory(driver), properties);

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -52,6 +52,8 @@ public class Build extends BuildBase {
     private static final String MYSQL_CONNECTOR_VERSION = "8.0.27";
 
     private static final String OSGI_VERSION = "5.0.0";
+    
+    private static final String OSGI_JDBC_VERSION = "1.1.0";
 
     private static final String PGJDBC_VERSION = "42.4.0";
 
@@ -159,7 +161,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
                 File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar" +
                 File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
                 File.pathSeparator + "ext/asm-" + ASM_VERSION + ".jar" +
                 File.pathSeparator + javaToolsJar;
@@ -200,7 +202,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar" +
                 File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar");
 
         files = files("src/main").
@@ -275,7 +277,7 @@ public class Build extends BuildBase {
             File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
             File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
             File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
-            File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+            File.pathSeparator + "ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar" +
             File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
             File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
             File.pathSeparator + "ext/slf4j-nop-" + SLF4J_VERSION + ".jar" +
@@ -404,9 +406,9 @@ public class Build extends BuildBase {
         downloadOrVerify("ext/org.osgi.core-" + OSGI_VERSION + ".jar",
                 "org/osgi", "org.osgi.core", OSGI_VERSION,
                 "6e5e8cd3c9059c08e1085540442a490b59a7783c", offline);
-        downloadOrVerify("ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar",
-                "org/osgi", "org.osgi.enterprise", OSGI_VERSION,
-                "4f6e081c38b951204e2b6a60d33ab0a90bfa1ad3", offline);
+        downloadOrVerify("ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar",
+                "org/osgi", "org.osgi.service.jdbc", OSGI_JDBC_VERSION,
+                "07673601d60c98d876b82530ff4363ed9e428c1e", offline);
         downloadOrVerify("ext/jts-core-" + JTS_VERSION + ".jar",
                 "org/locationtech/jts", "jts-core", JTS_VERSION,
                 "7e1973b5babdd98734b1ab903fc1155714402eec", offline);
@@ -604,7 +606,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar" +
                 File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar");
     }
 
@@ -629,7 +631,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar" +
                 File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
                 File.pathSeparator + "ext/asm-" + ASM_VERSION + ".jar" +
                 File.pathSeparator + "ext/junit-jupiter-api-" + JUNIT_VERSION + ".jar" +
@@ -649,7 +651,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar" +
                 File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar",
                 "-subpackages", "org.h2.mvstore",
                 "-exclude", "org.h2.mvstore.db");
@@ -669,7 +671,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar" +
                 File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
                 File.pathSeparator + "ext/asm-" + ASM_VERSION + ".jar" +
                 File.pathSeparator + "ext/junit-jupiter-api-" + JUNIT_VERSION + ".jar" +
@@ -896,7 +898,7 @@ public class Build extends BuildBase {
                 File.pathSeparator + "ext/lucene-analyzers-common-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/lucene-queryparser-" + LUCENE_VERSION + ".jar" +
                 File.pathSeparator + "ext/org.osgi.core-" + OSGI_VERSION + ".jar" +
-                File.pathSeparator + "ext/org.osgi.enterprise-" + OSGI_VERSION + ".jar" +
+                File.pathSeparator + "ext/org.osgi.service.jdbc-" + OSGI_JDBC_VERSION + ".jar" +
                 File.pathSeparator + "ext/jts-core-" + JTS_VERSION + ".jar" +
                 File.pathSeparator + "ext/slf4j-api-" + SLF4J_VERSION + ".jar" +
                 File.pathSeparator + "ext/slf4j-nop-" + SLF4J_VERSION + ".jar" +


### PR DESCRIPTION
In the latest release of the JDBC specification there was a requirement added that datasources should promote what methods they implement. H2 implements all methods and could therefore simply publish all.

This also migrates from the org.osgi.enterprise artifact to the more specific org.osgi.service.jdbc one.

FYI @stbischof