### PR TITLE
Add test coverage for JDK 17

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,28 +6,18 @@ permissions:
   contents: read #  to fetch code (actions/checkout)
 
 jobs:
-  java-8:
+  build:
+    strategy:
+      matrix:
+        java-version: [8, 11]
+    name: Java ${{ matrix.java-version }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
-    - name: Test
-      run: |
-        cd h2
-        echo $JAVA_OPTS
-        export JAVA_OPTS=-Xmx512m
-        ./build.sh jar testCI
-  java-11:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
+        java-version: ${{ matrix.java-version }}
     - name: Test
       run: |
         cd h2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,11 +13,12 @@ jobs:
     name: Java ${{ matrix.java-version }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java-version }}
+        distribution: temurin
     - name: Test
       run: |
         cd h2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
     - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [8, 11]
+        java-version: [8, 11, 17]
     name: Java ${{ matrix.java-version }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         java-version: [8, 11, 17]
     name: Java ${{ matrix.java-version }}

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -49,8 +49,21 @@
     <javax.servlet.version>4.0.1</javax.servlet.version>
     <jakarta.servlet.version>5.0.0</jakarta.servlet.version>
     <slf4j.version>1.7.30</slf4j.version>
+    <nashorn.version>15.4</nashorn.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-bom</artifactId>
+        <version>${asm.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
 
@@ -126,7 +139,6 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>${asm.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- END TEST DEPENDENCIES !-->
@@ -173,6 +185,20 @@
           <scope>system</scope>
           <version>1.8</version>
           <systemPath>${java.home}/../Classes/classes.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>nashorn</id>
+      <activation>
+        <jdk>[15,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.openjdk.nashorn</groupId>
+          <artifactId>nashorn-core</artifactId>
+          <version>${nashorn.version}</version>
+          <scope>test</scope>
         </dependency>
       </dependencies>
     </profile>

--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -39,7 +39,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <asm.version>8.0.1</asm.version>
+    <asm.version>9.4</asm.version>
     <jts.version>1.17.0</jts.version>
     <junit.version>5.6.2</junit.version>
     <lucene.version>8.5.2</lucene.version>

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -33,7 +33,7 @@ import org.h2.build.doc.XMLParser;
  */
 public class Build extends BuildBase {
 
-    private static final String ASM_VERSION = "8.0.1";
+    private static final String ASM_VERSION = "9.4";
 
     private static final String ARGS4J_VERSION = "2.33";
 
@@ -256,10 +256,10 @@ public class Build extends BuildBase {
                 "421e4aab2aaa809d1e66a96feb11f61ea698da19");
         downloadUsingMaven("ext/asm-commons-" + ASM_VERSION + ".jar",
                 "org.ow2.asm", "asm-commons", ASM_VERSION,
-                "019c7ba355f0737815205518e332a8dc08b417c6");
+                "8fc2810ddbcbbec0a8bbccb3f8eda58321839912");
         downloadUsingMaven("ext/asm-tree-" + ASM_VERSION + ".jar",
                 "org.ow2.asm", "asm-tree", ASM_VERSION,
-                "dfcad5abbcff36f8bdad5647fe6f4972e958ad59");
+                "a99175a17d7fdc18cbcbd0e8ea6a5d276844190a");
         downloadUsingMaven("ext/args4j-" + ARGS4J_VERSION + ".jar",
                 "args4j", "args4j", ARGS4J_VERSION,
                 "bd87a75374a6d6523de82fef51fc3cfe9baf9fc9");
@@ -417,7 +417,7 @@ public class Build extends BuildBase {
                 "c9ba885abfe975cda123bf6f8f0a69a1b46956d0", offline);
         downloadUsingMaven("ext/asm-" + ASM_VERSION + ".jar",
                 "org.ow2.asm", "asm", ASM_VERSION,
-                "3f5199523fb95304b44563f5d56d9f5a07270669");
+                "b4e0e2d2e023aa317b7cfcfc916377ea348e07d1");
         downloadUsingMaven("ext/apiguardian-" + APIGUARDIAN_VERSION + ".jar",
                 "org.apiguardian", "apiguardian-api", APIGUARDIAN_VERSION,
                 "fc9dff4bb36d627bdc553de77e1f17efd790876c");

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -1149,11 +1149,7 @@ public class Build extends BuildBase {
     }
 
     private boolean requiresNashornJavaScriptEngine() {
-        String version = System.getProperty("java.specification.version");
-        if (version.startsWith("1.")) {
-            version = version.substring(2);
-        }
-        return Integer.parseInt(version) >= 15; // Nashorn was removed in Java 15
+        return getJavaVersion() >= 15; // Nashorn was removed in Java 15
     }
 
 }


### PR DESCRIPTION
Since we'd like to use H2 on JDK 17, it would be great if it would be officially tested on it. Thus, this PR adds another CI build for JDK 17 (in addition to the ones for JDK 8 and 11). In order to work with JDK 17 bytecode, the test dependency on ASM was updated to 9.4. Since the Nashorn Javascript engine was removed in JDK 15, it's added as another test dependency when the build is running on 15 or later.