### PR TITLE
Fix count(*) for linked table to Oracle

### DIFF
--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -470,8 +470,8 @@ public class TableLink extends Table {
 
     @Override
     public synchronized long getRowCount(SessionLocal session) {
-        //The foo alias is used to support the PostgreSQL syntax
-        String sql = "SELECT COUNT(*) FROM " + qualifiedTableName + " as foo";
+        //The T alias is used to support the PostgreSQL syntax
+        String sql = "SELECT COUNT(*) FROM " + qualifiedTableName + " T";
         try {
             PreparedStatement prep = execute(sql, null, false, session);
             ResultSet rs = prep.getResultSet();


### PR DESCRIPTION
Oracle does not support `as` in table aliases.
Simple SQL like `select count(*) from linked` does not work for linked tables to Oracle. Because H2 will translate this sql to `select count(*) from linked as foo`.