### PR TITLE
Limit the row list allocation based on the row count

### DIFF
--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -418,7 +418,7 @@ public class MVTable extends TableBase {
         long i = 0;
         Store store = session.getDatabase().getStore();
 
-        int bufferSize = database.getMaxMemoryRows() / 2;
+        int bufferSize = (int) Math.min(total, database.getMaxMemoryRows() / 2);
         ArrayList<Row> buffer = new ArrayList<>(bufferSize);
         String n = getName() + ':' + index.getName();
         ArrayList<String> bufferNames = Utils.newSmallArrayList();


### PR DESCRIPTION
Profiling https://github.com/topicusonderwijs/tribe-krd-quarkus startup it reports a huge amount of allocations due to this:

![image](https://user-images.githubusercontent.com/13125299/225078754-4f34a767-f774-4cd4-88b5-d118b222d581.png)

and zooming in (the orange ones are "out of TLAB allocations":

![image](https://user-images.githubusercontent.com/13125299/225078843-b50baeff-336f-4835-97c5-21f338354e1d.png)

Configuration of H2 is `mem` and the ORM policy is drop and create, but still, with this PR it would save a huge amount of allocations (it's a quite large model, actually).
