### PR TITLE
MSSQL mode: Discard table hints on plain UPDATE statements

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -1125,6 +1125,9 @@ public class Parser {
         TableFilter targetTableFilter = readSimpleTableFilter();
         command.setTableFilter(targetTableFilter);
         int backupIndex = tokenIndex;
+        if (database.getMode().discardWithTableHints) {
+            discardWithTableHints();
+        }
         command.setSetClauseList(readUpdateSetClause(targetTableFilter));
         if (database.getMode().allowUsingFromClauseInUpdateStatement && readIf(FROM)) {
             setTokenIndex(backupIndex);


### PR DESCRIPTION
This extends the MSSQL compatibility introduced in #1481.