### PR TITLE
fix premature id re-use after recursive CTE view released

### DIFF
--- a/h2/src/main/org/h2/command/ddl/DropTable.java
+++ b/h2/src/main/org/h2/command/ddl/DropTable.java
@@ -105,7 +105,7 @@ public class DropTable extends DefineCommand {
                     }
                 }
                 if (!dependencies.isEmpty()) {
-                    throw DbException.get(ErrorCode.CANNOT_DROP_2, table.getName(), String.join(", ", dependencies));
+                    throw DbException.get(ErrorCode.CANNOT_DROP_2, table.getName(), String.join(", ", new HashSet<>(dependencies)));
                 }
             }
             table.lock(session, Table.EXCLUSIVE_LOCK);

--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -408,14 +408,13 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
      * @param table the table
      */
     public void removeLocalTempTable(Table table) {
-        modificationId++;
-        if (localTempTables != null) {
-            localTempTables.remove(table.getName());
-        }
-        Database db = database;
-        if (db != null) {
-            synchronized (db) {
-                table.removeChildrenAndResources(this);
+        if (localTempTables != null && localTempTables.remove(table.getName()) != null) {
+            modificationId++;
+            Database db = database;
+            if (db != null) {
+                synchronized (db) {
+                    table.removeChildrenAndResources(this);
+                }
             }
         }
     }

--- a/h2/src/main/org/h2/table/Table.java
+++ b/h2/src/main/org/h2/table/Table.java
@@ -586,8 +586,7 @@ public abstract class Table extends SchemaObject {
     @Override
     public void removeChildrenAndResources(SessionLocal session) {
         while (!dependentViews.isEmpty()) {
-            TableView view = dependentViews.get(0);
-            dependentViews.remove(0);
+            TableView view = dependentViews.remove(0);
             database.removeSchemaObject(session, view);
         }
         while (synonyms != null && !synonyms.isEmpty()) {

--- a/h2/src/main/org/h2/table/TableView.java
+++ b/h2/src/main/org/h2/table/TableView.java
@@ -264,7 +264,6 @@ public final class TableView extends QueryExpressionTable {
     public void removeChildrenAndResources(SessionLocal session) {
         removeCurrentViewFromOtherTables();
         super.removeChildrenAndResources(session);
-        database.removeMeta(session, getId());
         querySQL = null;
         index = null;
         clearIndexCaches(database);

--- a/h2/src/test/org/h2/test/db/TestIssue_3040.java
+++ b/h2/src/test/org/h2/test/db/TestIssue_3040.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2004-2023 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.test.db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.h2.test.TestBase;
+import org.h2.test.TestDb;
+
+public class TestIssue_3040 extends TestDb
+{
+  public static final String TABLE_TO_QUERY = "TO_QUERY";
+  public static final String QUERY_STATEMENT =
+      "WITH TMP_TO_QUERY  as (SELECT avg(SIMPLE_VALUE) AVG_SIMPLE_VALUE FROM public."
+      + TABLE_TO_QUERY
+      + ")  SELECT * FROM TMP_TO_QUERY";
+
+
+  /**
+   * Run just this test.
+   *
+   * @param a ignored
+   */
+  public static void main(String... a) throws Exception {
+      TestBase.createCaller().init().testFromMain();
+  }
+
+  @Override
+  public void test() throws SQLException {
+    createTableTest();
+  }
+
+  public void createTableTest() throws SQLException {
+    deleteDb(getTestName());
+    try (Connection connection = getConnection(getTestName())) {
+      createTable(connection, TABLE_TO_QUERY);
+
+      runCTE(connection);
+
+      // another connection to simulate parallel execution with connection pools
+      // sequence used for GENERATED_ID will get the same ID as temp table used for CTE query
+      try (Connection conn2 = getConnection(getTestName())) {
+        createTable(conn2, "WITH_MISSING_SEQUENCE");
+      }
+      // commit to release again already released systemIds, could be just another query to trigger tx commit
+      connection.commit();
+      // id reused again, sequence entry from MVStore gets dropped as side effect.
+      runCTE(connection);
+
+    }
+    // try to reconnect to already corrupted file
+    try (Connection connection = getConnection(getTestName())) {
+      runCTE(connection);
+    }
+  }
+
+  private static void createTable(Connection connection, String tableName) {
+    try (Statement st = connection.createStatement()) {
+      st.execute("CREATE TABLE public." + tableName + " (GENERATED_ID IDENTITY PRIMARY KEY, SIMPLE_VALUE INT)");
+    } catch (SQLException ex) {
+      System.out.println("error: " + ex);
+      ex.printStackTrace();
+    }
+  }
+
+  private static void runCTE(Connection connection) {
+    try (PreparedStatement st = connection.prepareStatement(QUERY_STATEMENT)) {
+      st.executeQuery();
+    } catch (SQLException ex) {
+      System.out.println("error: " + ex);
+      ex.printStackTrace();
+    }
+  }
+}

--- a/h2/src/test/org/h2/test/db/TestReadOnly.java
+++ b/h2/src/test/org/h2/test/db/TestReadOnly.java
@@ -72,10 +72,11 @@ public class TestReadOnly extends TestDb {
                 "jdbc:h2:zip:"+dir+"/readonly.zip!/readonlyInZip", getUser(), getPassword());
         conn.createStatement().execute("select * from test where id=1");
         conn.close();
-        Server server = Server.createTcpServer("-baseDir", dir);
-        server.start();
-        int port = server.getPort();
+        Server server = null;
         try {
+            server = Server.createTcpServer("-baseDir", dir);
+            server.start();
+            int port = server.getPort();
             conn = getConnection(
                     "jdbc:h2:tcp://localhost:" + port + "/zip:readonly.zip!/readonlyInZip",
                         getUser(), getPassword());
@@ -88,7 +89,7 @@ public class TestReadOnly extends TestDb {
             conn.createStatement().execute("select * from test where id=1");
             conn.close();
         } finally {
-            server.stop();
+            if (server != null) server.stop();
         }
         deleteDb("readonlyInZip");
     }

--- a/h2/src/test/org/h2/test/server/TestWeb.java
+++ b/h2/src/test/org/h2/test/server/TestWeb.java
@@ -130,19 +130,24 @@ public class TestWeb extends TestDb {
         Server server = Server.createWebServer(
                 "-webPort", "8182", "-properties", "null");
         server.start();
-        assertContains(server.getStatus(), "server running");
-        Server server2 = Server.createWebServer(
-                "-webPort", "8182", "-properties", "null");
-        assertEquals("Not started", server2.getStatus());
         try {
-            server2.start();
-            fail();
-        } catch (Exception e) {
-            assertContains(e.toString(), "port may be in use");
-            assertContains(server2.getStatus(),
-                    "could not be started");
+            assertContains(server.getStatus(), "server running");
+            Server server2 = Server.createWebServer(
+                    "-webPort", "8182", "-properties", "null");
+            assertEquals("Not started", server2.getStatus());
+            try {
+                server2.start();
+                fail();
+            } catch (Exception e) {
+                assertContains(e.toString(), "port may be in use");
+                assertContains(server2.getStatus(),
+                        "could not be started");
+            } finally {
+                server2.stop();
+            }
+        } finally {
+            server.stop();
         }
-        server.stop();
     }
 
     private void testTools() throws Exception {

--- a/h2/src/test/org/h2/test/unit/TestAutoReconnect.java
+++ b/h2/src/test/org/h2/test/unit/TestAutoReconnect.java
@@ -63,8 +63,9 @@ public class TestAutoReconnect extends TestDb {
 
     private void testWrongUrl() throws Exception {
         deleteDb(getTestName());
-        Server tcp = Server.createTcpServer().start();
+        Server tcp = null;
         try {
+            tcp = Server.createTcpServer().start();
             conn = getConnection("jdbc:h2:" + getBaseDir() + '/' + getTestName() + ";AUTO_SERVER=TRUE");
             assertThrows(ErrorCode.DATABASE_ALREADY_OPEN_1,
                     () -> getConnection("jdbc:h2:" + getBaseDir() + '/' + getTestName() + ";OPEN_NEW=TRUE"));
@@ -78,7 +79,7 @@ public class TestAutoReconnect extends TestDb {
                     "jdbc:h2:" + getBaseDir() + '/' + getTestName() + ";AUTO_SERVER=TRUE;OPEN_NEW=TRUE"));
             conn.close();
         } finally {
-            tcp.stop();
+            if (tcp != null) tcp.stop();
         }
     }
 

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -118,15 +118,27 @@ public class TestTools extends TestDb {
     }
 
     private void testTcpServerWithoutPort() throws Exception {
-        Server s1 = Server.createTcpServer().start();
-        Server s2 = Server.createTcpServer().start();
-        assertTrue(s1.getPort() != s2.getPort());
-        s1.stop();
-        s2.stop();
-        s1 = Server.createTcpServer("-tcpPort", "9123").start();
-        assertEquals(9123, s1.getPort());
-        assertThrows(ErrorCode.EXCEPTION_OPENING_PORT_2, () -> Server.createTcpServer("-tcpPort", "9123").start());
-        s1.stop();
+        Server s1 = null;
+        try {
+            s1 = Server.createTcpServer().start();
+            Server s2 = null;
+            try {
+                s2 = Server.createTcpServer().start();
+                assertTrue(s1.getPort() != s2.getPort());
+            } finally {
+                if (s2 != null) s2.stop();
+            }
+        } finally {
+            if (s1 != null) s1.stop();
+        }
+
+        try {
+            s1 = Server.createTcpServer("-tcpPort", "9123").start();
+            assertEquals(9123, s1.getPort());
+            assertThrows(ErrorCode.EXCEPTION_OPENING_PORT_2, () -> Server.createTcpServer("-tcpPort", "9123").start());
+        } finally {
+            if (s1 != null) s1.stop();
+        }
     }
 
     private void testConsole() throws Exception {


### PR DESCRIPTION
Fixes issue #3040 
Minor code cleanups
tests: always shutdown server on test failure to minimize effect on further tests