### PR TITLE
Disallow plain webAdminPassword values to force usage of hashes

### DIFF
--- a/h2/src/docsrc/html/tutorial.html
+++ b/h2/src/docsrc/html/tutorial.html
@@ -443,7 +443,9 @@ Supported settings are:
 <ul><li><code>webAllowOthers</code>: allow other computers to connect.
 </li><li><code>webPort</code>: the port of the H2 Console
 </li><li><code>webSSL</code>: use encrypted TLS (HTTPS) connections.
-</li><li><code>webAdminPassword</code>: password to access preferences and tools of H2 Console.
+</li><li><code>webAdminPassword</code>: hash of password to access preferences and tools of H2 Console,
+use <code>org.h2.server.web.WebServer.encodeAdminPassword(String)</code> to generate a hash for your password.
+Always use long complex passwords, especially when access from other hosts is enabled.
 </li></ul>
 <p>
 In addition to those settings, the properties of the last recently used connection

--- a/h2/src/main/org/h2/api/ErrorCode.java
+++ b/h2/src/main/org/h2/api/ErrorCode.java
@@ -1890,9 +1890,8 @@ public class ErrorCode {
     /**
      * The error with code <code>90125</code> is thrown when
      * PreparedStatement.setBigDecimal is called with object that extends the
-     * class BigDecimal, and the system property h2.allowBigDecimalExtensions is
-     * not set. Using extensions of BigDecimal is dangerous because the database
-     * relies on the behavior of BigDecimal. Example of wrong usage:
+     * class BigDecimal. Using extensions of BigDecimal is dangerous because the
+     * database relies on the behavior of BigDecimal. Example of wrong usage:
      * <pre>
      * BigDecimal bd = new MyDecimal("$10.3");
      * prep.setBigDecimal(1, bd);

--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -473,6 +473,11 @@ public class Constants {
     public static final int QUERY_STATISTICS_MAX_ENTRIES = 100;
 
     /**
+     * The minimum number of characters in web admin password.
+     */
+    public static final int MIN_WEB_ADMIN_PASSWORD_LENGTH = 12;
+
+    /**
      * Announced version for PgServer.
      */
     public static final String PG_VERSION = "8.2.23";

--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -162,7 +162,7 @@ public class WebServer implements Service {
     private String externalNames;
     private boolean isDaemon;
     private final Set<WebThread> running =
-            Collections.synchronizedSet(new HashSet<WebThread>());
+            Collections.synchronizedSet(new HashSet<>());
     private boolean ssl;
     private byte[] adminPassword;
     private final HashMap<String, ConnectionInfo> connInfoMap = new HashMap<>();
@@ -926,17 +926,32 @@ public class WebServer implements Service {
             adminPassword = null;
             return;
         }
-        if (password.length() == 128) {
-            try {
-                adminPassword = StringUtils.convertHexToBytes(password);
-                return;
-            } catch (Exception ex) {}
+        if (password.length() != 128) {
+            throw new IllegalArgumentException(
+                    "Use result of org.h2.server.web.WebServer.encodeAdminPassword(String)");
+        }
+        adminPassword = StringUtils.convertHexToBytes(password);
+    }
+
+    /**
+     * Generates a random salt and returns it with a hash of specified password
+     * with this salt.
+     *
+     * @param password
+     *            the password
+     * @return a salt and hash of salted password as a hex encoded string to be
+     *         used in configuration file
+     * @throws IllegalArgumentException when password is too short
+     */
+    public static String encodeAdminPassword(String password) {
+        if (password.length() < Constants.MIN_WEB_ADMIN_PASSWORD_LENGTH) {
+            throw new IllegalArgumentException("Min length: " + Constants.MIN_WEB_ADMIN_PASSWORD_LENGTH);
         }
         byte[] salt = MathUtils.secureRandomBytes(32);
         byte[] hash = SHA256.getHashWithSalt(password.getBytes(StandardCharsets.UTF_8), salt);
         byte[] total = Arrays.copyOf(salt, 64);
         System.arraycopy(hash, 0, total, 32, 32);
-        adminPassword = total;
+        return StringUtils.convertBytesToHex(total);
     }
 
     /**

--- a/h2/src/main/org/h2/tools/Server.java
+++ b/h2/src/main/org/h2/tools/Server.java
@@ -29,6 +29,7 @@ public class Server extends Tool implements Runnable, ShutdownHandler {
     private final Service service;
     private Server web, tcp, pg;
     private ShutdownHandler shutdownHandler;
+    private boolean fromCommandLine;
     private boolean started;
 
     public Server() {
@@ -75,7 +76,11 @@ public class Server extends Tool implements Runnable, ShutdownHandler {
      * <tr><td>[-webSSL]</td>
      * <td>Use encrypted (HTTPS) connections</td></tr>
      * <tr><td>[-webAdminPassword]</td>
-     * <td>Password of DB Console administrator</td></tr>
+     * <td>Hash of password of DB Console administrator, can be generated with
+     * {@linkplain WebServer#encodeAdminPassword(String)}. Can be passed only to
+     * the {@link #runTool(String...)} method, this method rejects it. It is
+     * also possible to store this setting in configuration file of H2
+     * Console.</td></tr>
      * <tr><td>[-browser]</td>
      * <td>Start a browser connecting to the web server</td></tr>
      * <tr><td>[-tcp]</td>
@@ -123,7 +128,9 @@ public class Server extends Tool implements Runnable, ShutdownHandler {
      * @throws SQLException on failure
      */
     public static void main(String... args) throws SQLException {
-        new Server().runTool(args);
+        Server server = new Server();
+        server.fromCommandLine = true;
+        server.runTool(args);
     }
 
     private void verifyArgs(String... args) throws SQLException {
@@ -146,6 +153,9 @@ public class Server extends Tool implements Runnable, ShutdownHandler {
                 } else if ("-webPort".equals(arg)) {
                     i++;
                 } else if ("-webAdminPassword".equals(arg)) {
+                    if (fromCommandLine) {
+                        throwUnsupportedOption(arg);
+                    }
                     i++;
                 } else {
                     throwUnsupportedOption(arg);
@@ -249,6 +259,9 @@ public class Server extends Tool implements Runnable, ShutdownHandler {
                 } else if ("-webPort".equals(arg)) {
                     i++;
                 } else if ("-webAdminPassword".equals(arg)) {
+                    if (fromCommandLine) {
+                        throwUnsupportedOption(arg);
+                    }
                     i++;
                 } else {
                     showUsageAndThrowUnsupportedOption(arg);

--- a/h2/src/test/org/h2/test/server/TestWeb.java
+++ b/h2/src/test/org/h2/test/server/TestWeb.java
@@ -42,6 +42,9 @@ import javax.servlet.http.Part;
 import org.h2.api.ErrorCode;
 import org.h2.engine.Constants;
 import org.h2.engine.SysProperties;
+import org.h2.jdbc.JdbcSQLFeatureNotSupportedException;
+import org.h2.jdbc.JdbcSQLNonTransientException;
+import org.h2.server.web.WebServer;
 import org.h2.server.web.WebServlet;
 import org.h2.store.fs.FileUtils;
 import org.h2.test.TestBase;
@@ -159,10 +162,25 @@ public class TestWeb extends TestDb {
         conn.createStatement().execute(
                 "create table test(id int) as select 1");
         conn.close();
+        String hash = WebServer.encodeAdminPassword("1234567890AB");
+        try {
+            Server.main("-web", "-webPort", "8182",
+                    "-properties", "null", "-tcp", "-tcpPort", "9101", "-webAdminPassword", hash);
+            fail("Expected exception");
+        } catch (JdbcSQLFeatureNotSupportedException e) {
+            // Expected
+        }
         Server server = new Server();
         server.setOut(new PrintStream(new ByteArrayOutputStream()));
+        try {
+            server.runTool("-web", "-webPort", "8182",
+                    "-properties", "null", "-tcp", "-tcpPort", "9101", "-webAdminPassword", "123");
+            fail("Expected exception");
+        } catch (JdbcSQLNonTransientException e) {
+            // Expected
+        }
         server.runTool("-web", "-webPort", "8182",
-                "-properties", "null", "-tcp", "-tcpPort", "9101", "-webAdminPassword", "123");
+                "-properties", "null", "-tcp", "-tcpPort", "9101", "-webAdminPassword", hash);
         try {
             String url = "http://localhost:8182";
             WebClient client;
@@ -170,7 +188,7 @@ public class TestWeb extends TestDb {
             client = new WebClient();
             result = client.get(url);
             client.readSessionId(result);
-            result = client.get(url, "adminLogin.do?password=123");
+            result = client.get(url, "adminLogin.do?password=1234567890AB");
             result = client.get(url, "tools.jsp");
             FileUtils.delete(getBaseDir() + "/backup.zip");
             result = client.get(url, "tools.do?tool=Backup&args=-dir," +

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -854,4 +854,4 @@ allotted mismatched wise terminator guarding revolves notion piece submission re
 duplicating unnested hardening sticky massacred
 bck clo cur hwm materializedview udca vol connectionpooldatasource xadatasource
 ampm sssssff sstzh tzs yyyysssss newsequentialid solidus openjdk furthermore ssff secons nashorn fractions
-btrim underscores ffl decomposed decomposition subfield infinities retryable
+btrim underscores ffl decomposed decomposition subfield infinities retryable salted


### PR DESCRIPTION
`webAdminPassword` setting allowed both clear-text passwords and hashes of salted passwords from the beginning, but there were no documented methods for generation of such hashes. It was possible to write a clear-text password to configuration file and then save settings of H2 Console from H2 Console itself to get a configuration file with hashed password, but this way wasn't documented either.

1. A new public method is added and documented for this purpose. This method requires at least 12 characters for more safety.
2. Clear-text passwords from all sources are not accepted any more. Old installations with password hashes in configuration files will continue to work after this change.
3. `runTool()` method still allows this parameter to be passed (now only with salted hash), but `main()` method rejects this parameter to make these strange people happy.

(This setting is probably needed for less than 1% of users, why so many people think that it is something important?)

@grandinj