### PR TITLE
Increase database format version

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,10 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #3834: Increase database format version
+</li>
+<li>PR #3833: Disallow plain webAdminPassword values to force usage of hashes
+</li>
 <li>PR #3831: Add Oracle-style NOWAIT, WAIT n, and SKIP LOCKED to FOR UPDATE clause
 </li>
 <li>RP #3830: Fix time zone of time/timestamp with time zone AT LOCAL

--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -80,10 +80,10 @@ public abstract class FileStore<C extends Chunk<C>>
      */
     static final int BLOCK_SIZE = 4 * 1024;
 
-    private static final int FORMAT_WRITE_MIN = 2;
-    private static final int FORMAT_WRITE_MAX = 2;
-    private static final int FORMAT_READ_MIN = 2;
-    private static final int FORMAT_READ_MAX = 2;
+    private static final int FORMAT_WRITE_MIN = 3;
+    private static final int FORMAT_WRITE_MAX = 3;
+    private static final int FORMAT_READ_MIN = 3;
+    private static final int FORMAT_READ_MAX = 3;
 
     MVStore mvStore;
     private boolean closed;

--- a/h2/src/main/org/h2/tools/Upgrade.java
+++ b/h2/src/main/org/h2/tools/Upgrade.java
@@ -118,6 +118,15 @@ public final class Upgrade {
             /* 1.4.198 */ "32dd6b149cb722aa4c2dd4d40a74a9cd41e32ac59a4e755a66e5753660d61d46",
             /* 1.4.199 */ "3125a16743bc6b4cfbb61abba783203f1fb68230aa0fdc97898f796f99a5d42e",
             /* 1.4.200 */ "3ad9ac4b6aae9cd9d3ac1c447465e1ed06019b851b893dd6a8d76ddb6d85bca6",
+            /* 2.0.202 */ "95090f0609aacb0ee339128ef04077145ef28320ee874ea2e33a692938da5b97",
+            /* 2.0.204 */ "712a616409580bd4ac7c10e48f2599cc32ba3a433a1804da619c3f0a5ef66a04",
+            /* 2.0.206 */ "3b9607c5673fd8b87e49e3ac46bd88fd3561e863dce673a35234e8b5708f3deb",
+            /* 2.0.208 */ null,
+            /* 2.1.210 */ "edc57299926297fd9315e04de75f8538c4cb5fe97fd3da2a1e5cee6a4c98b5cd",
+            /* 2.1.212 */ "db9284c6ff9bf3bc0087851edbd34563f1180df3ae87c67c5fe2203c0e67a536",
+            /* 2.1.214 */ "d623cdc0f61d218cf549a8d09f1c391ff91096116b22e2475475fce4fbe72bd0",
+            /* 2.1.216 */ null,
+            /* 2.1.218 */ null,
             //
     };
 
@@ -227,7 +236,9 @@ public final class Upgrade {
             if ((version & 1) != 0 || version > Constants.BUILD_ID) {
                 throw new IllegalArgumentException("version=" + version);
             }
-            prefix = "2.0.";
+            int major = version / 100;
+            int minor = version / 10 % 10;
+            prefix = new StringBuilder().append(major).append('.').append(minor).append('.').toString();
         } else if (version >= 177) {
             prefix = "1.4.";
         } else if (version >= 146 && version != 147) {
@@ -238,7 +249,8 @@ public final class Upgrade {
             throw new IllegalArgumentException("version=" + version);
         }
         String fullVersion = prefix + version;
-        byte[] data = downloadUsingMaven("com.h2database", "h2", fullVersion, CHECKSUMS[version - 120]);
+        byte[] data = downloadUsingMaven("com.h2database", "h2", fullVersion,
+                CHECKSUMS[version >= 202 ? (version >>> 1) - 20 : version - 120]);
         ZipInputStream is = new ZipInputStream(new ByteArrayInputStream(data));
         HashMap<String, byte[]> map = new HashMap<>(version >= 198 ? 2048 : 1024);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -39,6 +39,8 @@ import org.h2.util.Utils;
  */
 public class TestMVStore extends TestBase {
 
+    private static final int CURRENT_FORMAT = 3;
+
     /**
      * Run just this test.
      *
@@ -426,9 +428,9 @@ public class TestMVStore extends TestBase {
                 open();
         s.setRetentionTime(Integer.MAX_VALUE);
         Map<String, Object> header = s.getStoreHeader();
-        assertEquals("2", header.get("format").toString());
-        header.put("formatRead", "2");
-        header.put("format", "3");
+        assertEquals(Integer.toString(CURRENT_FORMAT), header.get("format").toString());
+        header.put("formatRead", Integer.toString(CURRENT_FORMAT));
+        header.put("format", Integer.toString(CURRENT_FORMAT + 1));
         forceWriteStoreHeader(s);
         MVMap<Integer, String> m = s.openMap("data");
         forceWriteStoreHeader(s);
@@ -727,7 +729,7 @@ public class TestMVStore extends TestBase {
             m.put(1, 1);
             Map<String, Object> header = s.getStoreHeader();
             int format = Integer.parseInt(header.get("format").toString());
-            assertEquals(2, format);
+            assertEquals(CURRENT_FORMAT, format);
             header.put("format", Integer.toString(format + 1));
             forceWriteStoreHeader(s);
         }
@@ -849,7 +851,7 @@ public class TestMVStore extends TestBase {
             s.setRetentionTime(Integer.MAX_VALUE);
             long time = System.currentTimeMillis();
             Map<String, Object> m = s.getStoreHeader();
-            assertEquals("2", m.get("format").toString());
+            assertEquals(Integer.toString(CURRENT_FORMAT), m.get("format").toString());
             long creationTime = (Long) m.get("created");
             assertTrue(Math.abs(time - creationTime) < 100);
             m.put("test", "123");


### PR DESCRIPTION
There are various random incompatibilities in persisted databases between H2 2.1.214 and current H2 in both MVStore and database metadata layers.

It is very dangerous to open database created by H2 2.0.X or 2.1.X with H2 compiled from current sources and vice versa. A database format version is increased here to distinguish database files from H2 2.0/2.1 from database files for upcoming 2.2.220.

I also added existing 2.0 and 2.1 releases to `Upgrade` utility, maybe it will be useful for someone for migration to 2.2.