### PR TITLE
Fixes support of empty string in CSVs

### DIFF
--- a/h2/src/main/org/h2/tools/Csv.java
+++ b/h2/src/main/org/h2/tools/Csv.java
@@ -537,6 +537,8 @@ public class Csv implements SimpleRowSource {
         if (input == null) {
             return null;
         }
+        
+        boolean nullStringIsEmpty = nullString==null || nullString.isEmpty();
         String[] row = new String[columnNames.length];
         try {
             int i = 0;
@@ -558,7 +560,7 @@ public class Csv implements SimpleRowSource {
                     // Empty Strings should be NULL
                     // in order to prevent conversion of zero-length String
                     // to Number
-                    row[i++] = v!=null && v.length() > 0
+                    row[i++] = v!=null && (v.length()>0 || !nullStringIsEmpty)
                             ? v
                             : null;
                 }

--- a/h2/src/test/org/h2/test/db/TestCsv.java
+++ b/h2/src/test/org/h2/test/db/TestCsv.java
@@ -319,7 +319,7 @@ public class TestCsv extends TestDb {
         assertEquals("D", meta.getColumnLabel(4));
         assertTrue(rs.next());
         assertEquals(null, rs.getString(1));
-        assertEquals(null, rs.getString(2));
+        assertEquals("", rs.getString(2));
         // null is never quoted
         assertEquals("\\N", rs.getString(3));
         // an empty string is always parsed as null


### PR DESCRIPTION
Hi,

This is a minor enhancement to #3786 to allow H2 to still write/read empty string if the `nullString` option is set in `CSVREAD` and `CSVWRITE` functions to be explicitly different from `""` or `null`.

Typically, when using MSQL/MARIADB modes, a NULL value is not the same as an empty string (as where for Oracle, an empty string is converted to NULL).