### PR TITLE
Adds support of quotedNulls in CSV handling

### DIFF
--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -3382,8 +3382,10 @@ The following options are supported:
 
 ""lineSeparator"" (the line separator used for writing; ignored for reading),
 
-""null"", Support reading existing CSV files that contain explicit ""null"" delimiters.
+""null"" Support reading existing CSV files that contain explicit ""null"" delimiters.
 Note that an empty, unquoted values are also treated as null.
+
+""quotedNulls"" (quotes the nullString. true of false; disabled by default),
 
 ""preserveWhitespace"" (true or false; disabled by default),
 


### PR DESCRIPTION
Adds support for `quotedNulls` option in `CSVREAD` and `CSVWRITE` functions (see [here](https://github.com/h2database/h2database/pull/3837#issuecomment-1624504669)) and reestablish previous behavior of CSV handling prior to 2.2.220.

This should fix the breaking change introduced by #3786 and extends its feature since with this PR the handling of the `nullString` in CSV can be more finely adjusted.