### PR TITLE
Make DB_CLOSE_ON_EXIT safer

### DIFF
--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -549,7 +549,7 @@ It is possible to set the value in the database URL: <code>jdbc:h2:~/test;DB_CLO
 <h3 id="do_not_close_on_exit">Don't Close a Database when the VM Exits</h3>
 <p>
 By default, a database is closed when the last connection is closed. However, if it is never closed,
-the database is closed when the virtual machine exits normally, using a shutdown hook.
+a persistent database is closed when the virtual machine exits normally, using a shutdown hook.
 In some situations, the database should not be closed in this case, for example because the
 database is still used at virtual machine shutdown (to store the shutdown process in the database for example).
 For those cases, the automatic closing of the database can be disabled in the database URL.
@@ -560,6 +560,10 @@ The database URL to disable database closing on exit is:
 <pre>
 String url = "jdbc:h2:~/test;DB_CLOSE_ON_EXIT=FALSE";
 </pre>
+<b>Warning:</b> when database closing on exit is disabled, an application <b>must</b> execute the
+<a href="commands.html#shutdown">SHUTDOWN</a> command by itself in its own shutdown hook
+after completion of all operations with database to avoid data loss
+and should not try to establish new connections to database after that.
 
 <h2 id="execute_sql_on_connection">Execute SQL on Connection</h2>
 <p>

--- a/h2/src/main/org/h2/engine/ConnectionInfo.java
+++ b/h2/src/main/org/h2/engine/ConnectionInfo.java
@@ -119,6 +119,7 @@ public class ConnectionInfo implements Cloneable {
         String[] commonSettings = { //
                 "ACCESS_MODE_DATA", "AUTO_RECONNECT", "AUTO_SERVER", "AUTO_SERVER_PORT", //
                 "CACHE_TYPE", //
+                "DB_CLOSE_ON_EXIT", //
                 "FILE_LOCK", //
                 "JMX", //
                 "NETWORK_TIMEOUT", //

--- a/h2/src/main/org/h2/engine/DbSettings.java
+++ b/h2/src/main/org/h2/engine/DbSettings.java
@@ -89,13 +89,6 @@ public class DbSettings extends SettingsBase {
     public final boolean caseInsensitiveIdentifiers = get("CASE_INSENSITIVE_IDENTIFIERS", false);
 
     /**
-     * Database setting <code>DB_CLOSE_ON_EXIT</code> (default: true).
-     * Close the database when the virtual machine exits normally, using a
-     * shutdown hook.
-     */
-    public final boolean dbCloseOnExit = get("DB_CLOSE_ON_EXIT", true);
-
-    /**
      * Database setting <code>DEFAULT_CONNECTION</code> (default: false).
      * Whether Java functions can use
      * <code>DriverManager.getConnection("jdbc:default:connection")</code> to

--- a/h2/src/main/org/h2/engine/DelayedDatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/DelayedDatabaseCloser.java
@@ -56,7 +56,7 @@ class DelayedDatabaseCloser extends Thread {
         WeakReference<Database> ref = databaseRef;
         if (ref != null && (database = ref.get()) != null) {
             try {
-                database.close(false);
+                database.close();
             } catch (RuntimeException e) {
                 // this can happen when stopping a web application,
                 // if loading classes is no longer allowed

--- a/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
+++ b/h2/src/main/org/h2/engine/OnExitDatabaseCloser.java
@@ -82,7 +82,7 @@ class OnExitDatabaseCloser extends Thread {
         RuntimeException root = null;
         for (Database database : DATABASES.keySet()) {
             try {
-                database.close(true);
+                database.onShutdown();
             } catch (RuntimeException e) {
                 // this can happen when stopping a web application,
                 // if loading classes is no longer allowed

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -854,4 +854,4 @@ allotted mismatched wise terminator guarding revolves notion piece submission re
 duplicating unnested hardening sticky massacred
 bck clo cur hwm materializedview udca vol connectionpooldatasource xadatasource
 ampm sssssff sstzh tzs yyyysssss newsequentialid solidus openjdk furthermore ssff secons nashorn fractions
-btrim underscores ffl decomposed decomposition subfield infinities retryable salted
+btrim underscores ffl decomposed decomposition subfield infinities retryable salted establish


### PR DESCRIPTION
`DB_CLOSE_ON_EXIT` is one of the most popular misused dangerous settings.

1. Default value of this setting is now `FALSE` for in-memory databases to avoid registration of shutdown hook. I'm not sure about that, but I think we don't really need to explicitly close any in-memory databases on VM shutdown. Anyway, it is possible to restore this feature with `DB_CLOSE_ON_EXIT=TRUE`.
2. For persistent databases the default value is still `TRUE` as it should, but if it was set to `FALSE` explicitly, the shutdown hook is registered anyway and VM shutdown event executes a [`CHECKPOINT` ](https://h2database.com/html/commands.html#checkpoint) command to flush data on disk for more safety.
3. Documentation of this setting now has all necessary warnings and explains how to use it properly.

@grandinj