### PR TITLE
Fix the NullPointerException caused by accessing 'user' after the ses…

### DIFF
--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -2847,9 +2847,9 @@ public final class InformationSchemaTable extends MetaTable {
         NetworkConnectionInfo networkConnectionInfo = s.getNetworkConnectionInfo();
         Command command = s.getCurrentCommand();
         int blockingSessionId = s.getBlockingSessionId();
-        //Fix bug the NullPointerException caused by accessing 'user' after the session has been closed.
         User user = s.getUser();
-        if(user==null) {
+        if (user == null) {
+            // Session was closed concurrently
             return;
         }
         add(session, rows,

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -2847,11 +2847,16 @@ public final class InformationSchemaTable extends MetaTable {
         NetworkConnectionInfo networkConnectionInfo = s.getNetworkConnectionInfo();
         Command command = s.getCurrentCommand();
         int blockingSessionId = s.getBlockingSessionId();
+        //Fix bug the NullPointerException caused by accessing 'user' after the session has been closed.
+        User user = s.getUser();
+        if(user==null) {
+            return;
+        }
         add(session, rows,
                 // SESSION_ID
                 ValueInteger.get(s.getId()),
                 // USER_NAME
-                s.getUser().getName(),
+                user.getName(),
                 // SERVER
                 networkConnectionInfo == null ? null : networkConnectionInfo.getServer(),
                 // CLIENT_ADDR


### PR DESCRIPTION
Fix bug the NullPointerException caused by accessing 'user' after the session has been closed.
![图片](https://github.com/h2database/h2database/assets/6645267/56fa1a14-2679-4cf6-b812-460fd117486b)
