### PR TITLE
Remove lift configuration

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,9 +1,0 @@
-# Config file for SonaType Lift analysis tool
-#
-# config reference here: https://help.sonatype.com/lift/configuration-reference
-#
-
-# Tell sonatype where our pom file lives, so it can build it again
-#
-build = "maven -f h2/pom.xml compile"
-ignoreRules = [ "missingoverride", "none", "assert_used", "OperatorPrecedence" ]


### PR DESCRIPTION
The Lift service is being retired.

This repository seems to benefit from many tools provided by Lift including:

* Infer
* shellcheck
* findsecbugs
* errorprone

There are github actions for infer and shellcheck which might suffice if you thing they're worth while. FindSecBugs and ErrorProne are a little more build time oriented but solvable.