### PR TITLE
Fix issues with newer JVMs

### DIFF
--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -868,7 +868,7 @@ public final class Database implements DataHandler, CastDataProvider {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, DbObject> getMap(int type) {
+    private ConcurrentHashMap<String, DbObject> getMap(int type) {
         Map<String, ? extends DbObject> result;
         switch (type) {
         case DbObject.USER:
@@ -890,7 +890,7 @@ public final class Database implements DataHandler, CastDataProvider {
         default:
             throw DbException.getInternalError("type=" + type);
         }
-        return (Map<String, DbObject>) result;
+        return (ConcurrentHashMap<String, DbObject>) result;
     }
 
     /**
@@ -922,7 +922,7 @@ public final class Database implements DataHandler, CastDataProvider {
         if (id > 0 && !starting) {
             checkWritingAllowed();
         }
-        Map<String, DbObject> map = getMap(obj.getType());
+        ConcurrentHashMap<String, DbObject> map = getMap(obj.getType());
         if (obj.getType() == DbObject.USER) {
             User user = (User) obj;
             if (user.isAdmin() && systemUser.getName().equals(SYSTEM_USER_NAME)) {
@@ -1527,7 +1527,7 @@ public final class Database implements DataHandler, CastDataProvider {
             DbObject obj, String newName) {
         checkWritingAllowed();
         int type = obj.getType();
-        Map<String, DbObject> map = getMap(type);
+        ConcurrentHashMap<String, DbObject> map = getMap(type);
         if (SysProperties.CHECK) {
             if (!map.containsKey(obj.getName())) {
                 throw DbException.getInternalError("not found: " + obj.getName());
@@ -1579,7 +1579,7 @@ public final class Database implements DataHandler, CastDataProvider {
         checkWritingAllowed();
         String objName = obj.getName();
         int type = obj.getType();
-        Map<String, DbObject> map = getMap(type);
+        ConcurrentHashMap<String, DbObject> map = getMap(type);
         if (SysProperties.CHECK && !map.containsKey(objName)) {
             throw DbException.getInternalError("not found: " + objName);
         }

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -1028,7 +1028,8 @@ The class must be available in the classpath of the database engine
 The sourceCodeString must define a single method with no parameters that returns ""org.h2.api.Trigger"".
 See CREATE ALIAS for requirements regarding the compilation.
 Alternatively, javax.script.ScriptEngineManager can be used to create an instance of ""org.h2.api.Trigger"".
-Currently javascript (included in every JRE) and ruby (with JRuby) are supported.
+Currently JavaScript (included in older JREs or provided by org.graalvm.js:js-scriptengine library in newer JREs)
+and ruby (with JRuby) are supported.
 In that case the source must begin respectively with ""//javascript"" or ""#ruby"".
 
 BEFORE triggers are called after data conversion is made, default values are set,
@@ -1073,7 +1074,7 @@ CREATE TRIGGER TRIG_INS BEFORE INSERT ON TEST FOR EACH ROW CALL 'MyTrigger';
 CREATE TRIGGER TRIG_SRC BEFORE INSERT ON TEST AS
     'org.h2.api.Trigger create() { return new MyTrigger(""constructorParam""); }';
 CREATE TRIGGER TRIG_JS BEFORE INSERT ON TEST AS '//javascript
-return new Packages.MyTrigger(""constructorParam"");';
+return new (Java.type(""org.example.MyTrigger""))(""constructorParam"");';
 CREATE TRIGGER TRIG_RUBY BEFORE INSERT ON TEST AS '#ruby
 Java::MyPackage::MyTrigger.new(""constructorParam"")';
 "

--- a/h2/src/main/org/h2/tools/Csv.java
+++ b/h2/src/main/org/h2/tools/Csv.java
@@ -544,7 +544,7 @@ public class Csv implements SimpleRowSource {
         if (input == null) {
             return null;
         }
-        
+
         String[] row = new String[columnNames.length];
         try {
             int i = 0;
@@ -769,7 +769,7 @@ public class Csv implements SimpleRowSource {
     public void setQuotedNulls(boolean quotedNulls) {
         this.quotedNulls = quotedNulls;
     }
-    
+
     /**
      * Returns true if the {@link #getNullString() null values} are quoted.
      *

--- a/h2/src/test/org/h2/test/db/TestCsv.java
+++ b/h2/src/test/org/h2/test/db/TestCsv.java
@@ -655,23 +655,25 @@ public class TestCsv extends TestDb {
     private void testCsvQuotedString4() throws Exception { testCsvQuotedNullStrings(true, ""); }
     private void testCsvQuotedString5() throws Exception { testCsvQuotedNullStrings(false, "$empty"); }
     private void testCsvQuotedString6() throws Exception { testCsvQuotedNullStrings(true, "$empty"); }
-    
+
     private void testCsvQuotedNullStrings(boolean quotedStrings, String nullString) throws Exception {
         String fileName = getBaseDir() + "/test.csv";
         FileUtils.delete(fileName);
-        
+
         deleteDb("csv");
         Connection conn = DriverManager.getConnection("jdbc:h2:mem:test");
         Statement stat = conn.createStatement();
         stat.execute("DROP TABLE IF EXISTS TEST");
-        stat.execute("CREATE TABLE TEST(ID char(2) NOT NULL, NAME varchar(255), HEIGHT integer, BIRTHDATE date, PRIMARY KEY (ID))");
+        stat.execute("CREATE TABLE TEST(ID char(2) NOT NULL, NAME varchar(255), HEIGHT integer, BIRTHDATE date,"
+                + " PRIMARY KEY (ID))");
         stat.execute("INSERT INTO TEST VALUES('01', 'Penrosed Roberto', 511, '1958-03-29')");
         stat.execute("INSERT INTO TEST VALUES('02', NULL, 512, '1975-07-12')");
         stat.execute("INSERT INTO TEST VALUES('03', 'Smith John', NULL, '1971-11-03')");
         stat.execute("INSERT INTO TEST VALUES('04', 'Hatchet Eve', 500, NULL)");
         stat.execute("INSERT INTO TEST VALUES('05', NULL, NULL, NULL)");
-        stat.execute("CALL CSVWRITE('" + fileName + "', 'SELECT * FROM TEST ORDER BY ID','quotedNulls=" + quotedStrings + " nullString=" + nullString + "')");
-        
+        stat.execute("CALL CSVWRITE('" + fileName + "', 'SELECT * FROM TEST ORDER BY ID','quotedNulls=" + quotedStrings
+                + " nullString=" + nullString + "')");
+
         InputStream fis = FileUtils.newInputStream(fileName);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         byte[] buffer = new byte[1024];
@@ -682,7 +684,7 @@ public class TestCsv extends TestDb {
         }
         baos.close();
         fis.close();
-        
+
         String csvWrittenContent = new String(baos.toByteArray());
         if (quotedStrings) {
             assertTrue(csvWrittenContent.contains("\""+nullString+"\""));
@@ -690,15 +692,16 @@ public class TestCsv extends TestDb {
             assertTrue(csvWrittenContent.contains(nullString));
             assertFalse(csvWrittenContent.contains("\""+nullString+"\""));
         }
-        
+
         stat.execute("DELETE FROM TEST");
-        stat.execute("INSERT INTO TEST SELECT * FROM CSVREAD('" + fileName + "', NULL, 'quotedNulls="+quotedStrings+" nullString="+nullString+"')");
-        
+        stat.execute("INSERT INTO TEST SELECT * FROM CSVREAD('" + fileName + "', NULL, 'quotedNulls=" + quotedStrings
+                + " nullString=" + nullString + "')");
+
         //check imported results
         ResultSet rs = stat.executeQuery("SELECT * FROM TEST ORDER BY ID");
         for (int i = 1 ; i <= 5 ; ++i) {
             assertTrue("Missing record " + i, rs.next());
-            
+
             if (i == 1) {
                 assertEquals("Penrosed Roberto", rs.getString("NAME"));
                 assertEquals(511, rs.getInt("HEIGHT"));
@@ -716,7 +719,7 @@ public class TestCsv extends TestDb {
             }
         }
         rs.close();
-        
+
         FileUtils.delete(fileName);
     }
 }

--- a/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
+++ b/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
@@ -16,6 +16,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
+import javax.script.ScriptEngineManager;
+
 import org.h2.api.ErrorCode;
 import org.h2.api.Trigger;
 import org.h2.message.DbException;
@@ -506,6 +508,10 @@ public class TestTriggersConstraints extends TestDb implements Trigger {
     }
 
     private void testTriggerAsJavascript() throws SQLException {
+        ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
+        if (scriptEngineManager.getEngineByName("javascript") == null) {
+            return;
+        }
         deleteDb("trigger");
         testTrigger("javascript");
     }
@@ -531,7 +537,7 @@ public class TestTriggersConstraints extends TestDb implements Trigger {
             String triggerClassName = this.getClass().getName() + "."
                     + TestTriggerAlterTable.class.getSimpleName();
             final String body = "//javascript\n"
-                    + "new Packages." + triggerClassName + "();";
+                    + "new (Java.type(\"" + triggerClassName + "\"))();";
             stat.execute("create trigger test_upd before insert on test as $$"
                     + body + " $$");
         } else {

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -410,7 +410,7 @@ public class TestPreparedStatement extends TestDb {
 
     private void testCancelReuse(Connection conn) throws Exception {
         conn.createStatement().execute(
-                "CREATE ALIAS SLEEP FOR 'java.lang.Thread.sleep'");
+                "CREATE ALIAS SLEEP FOR 'java.lang.Thread.sleep(long)'");
         // sleep for 10 seconds
         final PreparedStatement prep = conn.prepareStatement(
                 "SELECT SLEEP(?) FROM SYSTEM_RANGE(1, 10000) LIMIT ?");

--- a/h2/src/test/org/h2/test/unit/TestPgServer.java
+++ b/h2/src/test/org/h2/test/unit/TestPgServer.java
@@ -136,7 +136,7 @@ public class TestPgServer extends TestDb {
             Connection conn = DriverManager.getConnection(
                     "jdbc:postgresql://localhost:5535/pgserver", "sa", "sa");
             Statement stat = conn.createStatement();
-            stat.execute("create alias sleep for 'java.lang.Thread.sleep'");
+            stat.execute("create alias sleep for 'java.lang.Thread.sleep(long)'");
 
             // create a table with 200 rows (cancel interval is 127)
             stat.execute("create table test(id int)");

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -855,3 +855,4 @@ duplicating unnested hardening sticky massacred
 bck clo cur hwm materializedview udca vol connectionpooldatasource xadatasource
 ampm sssssff sstzh tzs yyyysssss newsequentialid solidus openjdk furthermore ssff secons nashorn fractions
 btrim underscores ffl decomposed decomposition subfield infinities retryable salted establish
+hatchet fis loom birthdate penrosed eve graalvm roberto polyglot truffle scriptengine


### PR DESCRIPTION
1. Modern versions of JRE and JDK don't have a JavaScript engine, but Graal.JS can be installed. `js-scriptengine`, `js`, `graal-sdk`, `truffle-api`, and `icu4j` libraries are required. H2 allows JavaScript triggers for a some reason. Graal.JS is more restrictive than Nashorn and it needs an additional configuration, with these changes H2 adds this configuration if Graal.JS is detected. I also changed unusual `Packages.path` syntax to `Java.type("path")` in documentation and test case, because `Packages.path` doesn't work in Graal.JS (at least without additional compatibility modules), unlike more popular syntax. Test case is now disabled automatically if JVM doesn't have any implementation of JavaScript.

2. There are two single-argument overloads of `Thread.sleep()` since Java 19, so it isn't possible to create a generic alias for all its overloads, two tests are fixed to load only `Thread.sleep(long)`.

There are two unrelated minor changes.

1. Signature of `Database.getMap()` is changed to reflect the actual type of its result in modern versions of H2, with `ConcurrentHashMap` it is more clear that users of this method can use only locks on metadata in the future, a lock on the whole database isn't strictly required.
2. `Database.getTempTableName()` is not synchronized on the whole database any more, it only needs an atomic counter to avoid generation of the same name for two concurrent sessions.