### PR TITLE
Make GREATEST and LEAST compliant with the SQL Standard

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,12 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3089: GREATEST and LEAST aren't fully compliant with the SQL Standard
+</li>
+<li>PR #3861: Improve SET EXCLUSIVE 2 and use stable time source for timeout exceptions
+</li>
+<li>PR #3859: Fix conversion of PK columns to identity columns
+</li>
 <li>Issue #3855: StackOverflowError when using TRACE_LEVEL_SYSTEM_OUT=4
 </li>
 <li>PR #3854: Fix issues with newer JVMs

--- a/h2/src/docsrc/html/features.html
+++ b/h2/src/docsrc/html/features.html
@@ -887,6 +887,7 @@ It means a NULL value may be specified for this column in INSERT command and it 
 </li><li>Attempt to reference a non-unique set of columns from a referential constraint
 will create an UNIQUE constraint on them automatically.
 </li><li>Unsafe comparison operators between numeric and boolean values are allowed.
+</li><li>GREATEST and LEAST ignore NULL values by default.
 </li><li>IDENTITY() and SCOPE_IDENTITY() are supported, but both are implemented like SCOPE_IDENTITY()
 </li><li>SYSDATE, SYSTIMESTAMP, and TODAY are supported.
 </li></ul>
@@ -950,6 +951,7 @@ Do not change value of DATABASE_TO_LOWER and CASE_INSENSITIVE_IDENTIFIERS after 
 </li><li>Identifiers may be quoted using square brackets as in <code>[Test]</code>.
 </li><li>For unique indexes, <code>NULL</code> is distinct.
     That means only one row with <code>NULL</code> in one of the columns is allowed.
+</li><li>GREATEST and LEAST ignore NULL values by default.
 </li><li>Text can be concatenated using '+'.
 </li><li>Arguments of LOG() function are swapped.
 </li><li>MONEY data type is treated like NUMERIC(19, 4) data type. SMALLMONEY data type is treated like NUMERIC(10, 4)
@@ -1084,6 +1086,7 @@ Do not change value of DATABASE_TO_LOWER after creation of database.
     digits are not be truncated, but the value is rounded.
 </li><li>The system columns <code>ctid</code> and
     <code>oid</code> are supported.
+</li><li>GREATEST and LEAST ignore NULL values by default.
 </li><li>LOG(x) is base 10 in this mode.
 </li><li>REGEXP_REPLACE():
     <ul>

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -2440,7 +2440,7 @@ public final class Database implements DataHandler, CastDataProvider {
 
     /**
      * get authenticator for database users
-     * 
+     *
      * @return authenticator set for database
      */
     public Authenticator getAuthenticator() {

--- a/h2/src/main/org/h2/engine/Mode.java
+++ b/h2/src/main/org/h2/engine/Mode.java
@@ -152,6 +152,11 @@ public class Mode {
     public boolean treatEmptyStringsAsNull;
 
     /**
+     * If {@code true} GREATEST and LEAST ignore nulls
+     */
+    public boolean greatestLeastIgnoreNulls;
+
+    /**
      * Support the pseudo-table SYSIBM.SYSDUMMY1.
      */
     public boolean sysDummy1;
@@ -494,6 +499,8 @@ public class Mode {
         mode.createUniqueConstraintForReferencedColumns = true;
         // Legacy numeric with boolean comparison
         mode.numericWithBooleanComparison = true;
+        // Legacy GREATEST and LEAST null treatment
+        mode.greatestLeastIgnoreNulls = true;
         add(mode);
 
         mode = new Mode(ModeEnum.DB2);
@@ -547,6 +554,7 @@ public class Mode {
         mode.aliasColumnName = true;
         mode.squareBracketQuotedNames = true;
         mode.nullsDistinct = NullsDistinct.NOT_DISTINCT;
+        mode.greatestLeastIgnoreNulls = true;
         mode.allowPlusForStringConcat = true;
         mode.swapLogFunctionParameters = true;
         mode.swapConvertFunctionParameters = true;
@@ -667,6 +675,7 @@ public class Mode {
         mode = new Mode(ModeEnum.PostgreSQL);
         mode.aliasColumnName = true;
         mode.systemColumns = true;
+        mode.greatestLeastIgnoreNulls = true;
         mode.logIsLogBase10 = true;
         mode.regexpReplaceBackslashReferences = true;
         mode.insertOnConflict = true;

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -6568,17 +6568,21 @@ SELECT FILE_WRITE('Hello world', '/tmp/hello.txt')) LEN;
 "
 
 "Functions (System)","GREATEST","
-GREATEST(aValue, bValue [,...])
+GREATEST(aValue, bValue [,...]) @h2@ [{RESPECT|IGNORE} NULLS]
 ","
-Returns the largest value that is not NULL, or NULL if all values are NULL.
+Returns the largest value or NULL if any value is NULL or the largest value cannot be determined.
+For example, ROW (NULL, 1) is neither equal to nor smaller than nor larger than ROW (1, 1).
+If IGNORE NULLS is specified, NULL values are ignored.
 ","
 CALL GREATEST(1, 2, 3);
 "
 
 "Functions (System)","LEAST","
-LEAST(aValue, bValue [,...])
+LEAST(aValue, bValue [,...]) @h2@ [{RESPECT|IGNORE} NULLS]
 ","
-Returns the smallest value that is not NULL, or NULL if all values are NULL.
+Returns the smallest value or NULL if any value is NULL or the smallest value cannot be determined.
+For example, ROW (NULL, 1) is neither equal to nor smaller than nor larger than ROW (1, 1).
+If IGNORE NULLS is specified, NULL values are ignored.
 ","
 CALL LEAST(1, 2, 3);
 "

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -2707,6 +2707,25 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL, Typ
         return false;
     }
 
+    /**
+     * Scans this and specified values until a first NULL occurrence and returns
+     * a value where NULL appears earlier, or {@code null} if these two values
+     * have first NULL on the same position.
+     * 
+     * @param v
+     *            a value of the same data type as this value, must be neither
+     *            equal to nor smaller than nor greater than this value
+     * @return this value, the specified value, or {@code null}
+     */
+    public Value getValueWithFirstNull(Value v) {
+        return this == ValueNull.INSTANCE ? v == ValueNull.INSTANCE ? null : ValueNull.INSTANCE
+                : v == ValueNull.INSTANCE ? ValueNull.INSTANCE : getValueWithFirstNullImpl(v);
+    }
+
+    Value getValueWithFirstNullImpl(Value v) {
+        return this;
+    }
+
     private static byte convertToByte(long x, Object column) {
         if (x > Byte.MAX_VALUE || x < Byte.MIN_VALUE) {
             throw DbException.get(

--- a/h2/src/main/org/h2/value/ValueCollectionBase.java
+++ b/h2/src/main/org/h2/value/ValueCollectionBase.java
@@ -103,6 +103,25 @@ public abstract class ValueCollectionBase extends Value {
     }
 
     @Override
+    Value getValueWithFirstNullImpl(Value v) {
+        ValueCollectionBase r = (ValueCollectionBase) v;
+        Value[] leftArray = values, rightArray = r.values;
+        int leftLength = leftArray.length, rightLength = rightArray.length;
+        int len = Math.min(leftLength, rightLength);
+        for (int i = 0; i < len; i++) {
+            Value v1 = leftArray[i];
+            Value v2 = rightArray[i];
+            Value c = v1.getValueWithFirstNull(v2);
+            if (c == v1) {
+                return this;
+            } else if (c == v2) {
+                return v;
+            }
+        }
+        return null;
+    }
+
+    @Override
     public int getMemory() {
         int memory = 72 + values.length * Constants.MEMORY_POINTER;
         for (Value v : values) {

--- a/h2/src/test/org/h2/test/scripts/functions/system/greatest.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/greatest.sql
@@ -2,3 +2,39 @@
 -- and the EPL 1.0 (https://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+SELECT ID, GREATEST(A, B, C), GREATEST(A, B, C) RESPECT NULLS, GREATEST(A, B, C) IGNORE NULLS FROM (VALUES
+    (1, NULL, NULL, NULL),
+    (2, NULL, 2, 1),
+    (3, 3, 5, NULL),
+    (4, 2, 6, 8))
+    T(ID, A, B, C);
+> ID GREATEST(A, B, C) RESPECT NULLS GREATEST(A, B, C) RESPECT NULLS GREATEST(A, B, C) IGNORE NULLS
+> -- ------------------------------- ------------------------------- ------------------------------
+> 1  null                            null                            null
+> 2  null                            null                            2
+> 3  null                            null                            5
+> 4  8                               8                               8
+> rows: 4
+
+SELECT ID, GREATEST(A, B, C) FROM (VALUES
+    (1, (1, 1), (1, 2), (1, 3)),
+    (2, (1, NULL), (1, NULL), (1, NULL)),
+    (3, (1, NULL), (1, NULL), (2, NULL)),
+    (4, (2, NULL), (2, NULL), (1, NULL)),
+    (5, (1, NULL), (2, NULL), (1, NULL)),
+    (6, (2, NULL), (1, NULL), (2, NULL)),
+    (7, (1, 1), (NULL, 1), (NULL, 2)),
+    (8, (1, NULL), (NULL, NULL), (2, NULL)))
+    T(ID, A, B, C);
+> ID GREATEST(A, B, C) RESPECT NULLS
+> -- -------------------------------
+> 1  ROW (1, 3)
+> 2  null
+> 3  ROW (2, null)
+> 4  null
+> 5  ROW (2, null)
+> 6  null
+> 7  null
+> 8  null
+> rows: 8

--- a/h2/src/test/org/h2/test/scripts/functions/system/least.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/system/least.sql
@@ -2,3 +2,39 @@
 -- and the EPL 1.0 (https://h2database.com/html/license.html).
 -- Initial Developer: H2 Group
 --
+
+SELECT ID, LEAST(A, B, C), LEAST(A, B, C) RESPECT NULLS, LEAST(A, B, C) IGNORE NULLS FROM (VALUES
+    (1, NULL, NULL, NULL),
+    (2, NULL, 2, 1),
+    (3, 3, 5, NULL),
+    (4, 2, 6, 8))
+    T(ID, A, B, C);
+> ID LEAST(A, B, C) RESPECT NULLS LEAST(A, B, C) RESPECT NULLS LEAST(A, B, C) IGNORE NULLS
+> -- ---------------------------- ---------------------------- ---------------------------
+> 1  null                         null                         null
+> 2  null                         null                         1
+> 3  null                         null                         3
+> 4  2                            2                            2
+> rows: 4
+
+SELECT ID, LEAST(A, B, C) FROM (VALUES
+    (1, (1, 1), (1, 2), (1, 3)),
+    (2, (1, NULL), (1, NULL), (1, NULL)),
+    (3, (1, NULL), (1, NULL), (2, NULL)),
+    (4, (2, NULL), (2, NULL), (1, NULL)),
+    (5, (1, NULL), (2, NULL), (1, NULL)),
+    (6, (2, NULL), (1, NULL), (2, NULL)),
+    (7, (1, 1), (NULL, 1), (NULL, 2)),
+    (8, (1, NULL), (NULL, NULL), (2, NULL)))
+    T(ID, A, B, C);
+> ID LEAST(A, B, C) RESPECT NULLS
+> -- ----------------------------
+> 1  ROW (1, 1)
+> 2  null
+> 3  null
+> 4  ROW (1, null)
+> 5  null
+> 6  ROW (1, null)
+> 7  null
+> 8  null
+> rows: 8

--- a/h2/src/test/org/h2/test/scripts/testScript.sql
+++ b/h2/src/test/org/h2/test/scripts/testScript.sql
@@ -1666,22 +1666,6 @@ select id from test where c=v order by id;
 drop table test;
 > ok
 
-CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR(255), C INT);
-> ok
-
-INSERT INTO TEST VALUES(1, '10', NULL), (2, '0', NULL);
-> update count: 2
-
-SELECT LEAST(ID, C, NAME), GREATEST(ID, C, NAME), LEAST(NULL, C), GREATEST(NULL, NULL), ID FROM TEST ORDER BY ID;
-> LEAST(ID, C, NAME) GREATEST(ID, C, NAME) LEAST(NULL, C) CAST(NULL AS CHARACTER VARYING) ID
-> ------------------ --------------------- -------------- ------------------------------- --
-> 1                  10                    null           null                            1
-> 0                  2                     null           null                            2
-> rows (ordered): 2
-
-DROP TABLE TEST;
-> ok
-
 create table people (family varchar(1) not null, person varchar(1) not null);
 > ok
 


### PR DESCRIPTION
Closes #3089.

`GREATEST` and `LEAST` are part of SQL:2023 Standard. Many database systems, including the H2, historically have these functions with various implementations, sometimes not fully compliant with the new Standard.

A default implementation is changed to be fully compliant with the Standard.
An implementation for `Legacy` compatibility mode is almost the same as it was in H2 historically¹, so it is possible to use this mode in applications if they need old behavior.
Implementations for `PostgreSQL` and `MSSQLServer` compatibility modes are also the same as they were before because these systems have the same incompatibility as H2.
Implementations for all other compatibility modes are also standard-compliant.

Optional non-standard clauses are introduced to have a possibility to use both standard and historic implementations if they are needed. These clauses were suggested here:
https://modern-sql.com/caniuse/greatest-least#null

With `RESPECT NULLS` standard-compliant implementation will be used in any compatibility mode.

With `IGNORE NULLS` old-style implementation will be used in any compatibility mode.

¹ There is also a difference in comparison operations with row values or array data types. These operations now use the same rules as regular comparison operations, earlier they incorrectly used rules of ordering operations.



