### PR TITLE
Improve performance of TCP client driver when it is used from virtual threads

### DIFF
--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -181,7 +181,8 @@ public abstract class Command implements CommandInterface {
         Database database = getDatabase();
         session.waitIfExclusiveModeEnabled();
         boolean callStop = true;
-        synchronized (session) {
+        session.lock();
+        try {
             session.startStatementWithinTransaction(this);
             Session oldSession = session.setThreadLocalSession();
             try {
@@ -230,6 +231,8 @@ public abstract class Command implements CommandInterface {
                     stop();
                 }
             }
+        } finally {
+            session.unlock();
         }
     }
 
@@ -237,7 +240,8 @@ public abstract class Command implements CommandInterface {
     public ResultWithGeneratedKeys executeUpdate(Object generatedKeysRequest) {
         long start = 0;
         boolean callStop = true;
-        synchronized (session) {
+        session.lock();
+        try {
             Database database = getDatabase();
             session.waitIfExclusiveModeEnabled();
             commitIfNonTransactional();
@@ -300,6 +304,8 @@ public abstract class Command implements CommandInterface {
                     }
                 }
             }
+        } finally {
+            session.unlock();
         }
     }
 

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -7088,7 +7088,8 @@ public final class Parser extends ParserBase {
         // it twice - once without the flag set, and if we didn't see a recursive term,
         // then we just compile it again.
         TableView view;
-        synchronized (session) {
+        session.lock();
+        try {
             view = new TableView(schema, id, cteViewName, querySQL,
                     queryParameters, columnTemplateArray, session,
                     true, false, true,
@@ -7110,6 +7111,8 @@ public final class Parser extends ParserBase {
             }
             // both removeSchemaObject and removeLocalTempTable hold meta locks
             database.unlockMeta(session);
+        } finally {
+            session.unlock();
         }
         view.setTableExpression(true);
         view.setTemporary(isTemporary);

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -607,7 +607,9 @@ public final class Database implements DataHandler, CastDataProvider {
                 lastRecords.add(rec);
             }
         }
-        synchronized (systemSession) {
+        final SessionLocal systemSession = this.systemSession;
+        systemSession.lock();
+        try {
             executeMeta(firstRecords);
             // Domains may depend on other domains
             int count = domainRecords.size();
@@ -652,6 +654,8 @@ public final class Database implements DataHandler, CastDataProvider {
                 }
             }
             executeMeta(lastRecords);
+        } finally {
+            systemSession.unlock();
         }
     }
 

--- a/h2/src/main/org/h2/engine/Engine.java
+++ b/h2/src/main/org/h2/engine/Engine.java
@@ -235,7 +235,8 @@ public final class Engine {
                 throw DbException.get(ErrorCode.DATABASE_CALLED_AT_SHUTDOWN);
             }
         }
-        synchronized (session) {
+        session.lock();
+        try {
             session.setAllowLiterals(true);
             DbSettings defaultSettings = DbSettings.DEFAULT;
             for (String setting : ci.getKeys()) {
@@ -286,6 +287,8 @@ public final class Engine {
             }
             session.setAllowLiterals(false);
             session.commit(true);
+        } finally {
+            session.unlock();
         }
         return session;
     }

--- a/h2/src/main/org/h2/engine/Session.java
+++ b/h2/src/main/org/h2/engine/Session.java
@@ -6,6 +6,7 @@
 package org.h2.engine;
 
 import java.util.ArrayList;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.h2.command.CommandInterface;
 import org.h2.jdbc.meta.DatabaseMeta;
@@ -90,6 +91,8 @@ public abstract class Session implements CastDataProvider, AutoCloseable {
 
     }
 
+    private final ReentrantLock lock = new ReentrantLock();
+
     private ArrayList<String> sessionState;
 
     boolean sessionStateChanged;
@@ -99,6 +102,32 @@ public abstract class Session implements CastDataProvider, AutoCloseable {
     volatile StaticSettings staticSettings;
 
     Session() {
+    }
+
+    /**
+     * Locks this session with a reentrant lock.
+     *
+     * <pre>
+     * final Session session = ...;
+     * session.lock();
+     * try {
+     *     ...
+     * } finally {
+     *     session.unlock();
+     * }
+     * </pre>
+     */
+    public final void lock() {
+        lock.lock();
+    }
+
+    /**
+     * Unlocks this session.
+     *
+     * @see #lock()
+     */
+    public final void unlock() {
+        lock.unlock();
     }
 
     /**

--- a/h2/src/main/org/h2/engine/SessionLocal.java
+++ b/h2/src/main/org/h2/engine/SessionLocal.java
@@ -553,9 +553,13 @@ public final class SessionLocal extends Session implements TransactionStore.Roll
     }
 
     @Override
-    public synchronized CommandInterface prepareCommand(String sql,
-            int fetchSize) {
-        return prepareLocal(sql);
+    public CommandInterface prepareCommand(String sql, int fetchSize) {
+        lock();
+        try {
+            return prepareLocal(sql);
+        } finally {
+            unlock();
+        }
     }
 
     /**

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -264,17 +264,22 @@ public final class SessionRemote extends Session implements DataHandler {
         }
     }
 
-    private synchronized void setAutoCommitSend(boolean autoCommit) {
-        for (int i = 0, count = 0; i < transferList.size(); i++) {
-            Transfer transfer = transferList.get(i);
-            try {
-                traceOperation("SESSION_SET_AUTOCOMMIT", autoCommit ? 1 : 0);
-                transfer.writeInt(SessionRemote.SESSION_SET_AUTOCOMMIT).
-                        writeBoolean(autoCommit);
-                done(transfer);
-            } catch (IOException e) {
-                removeServer(e, i--, ++count);
+    private void setAutoCommitSend(boolean autoCommit) {
+        lock();
+        try {
+            for (int i = 0, count = 0; i < transferList.size(); i++) {
+                Transfer transfer = transferList.get(i);
+                try {
+                    traceOperation("SESSION_SET_AUTOCOMMIT", autoCommit ? 1 : 0);
+                    transfer.writeInt(SessionRemote.SESSION_SET_AUTOCOMMIT).
+                            writeBoolean(autoCommit);
+                    done(transfer);
+                } catch (IOException e) {
+                    removeServer(e, i--, ++count);
+                }
             }
+        } finally {
+            unlock();
         }
     }
 
@@ -475,9 +480,14 @@ public final class SessionRemote extends Session implements DataHandler {
     }
 
     @Override
-    public synchronized CommandInterface prepareCommand(String sql, int fetchSize) {
-        checkClosed();
-        return new CommandRemote(this, transferList, sql, fetchSize);
+    public CommandInterface prepareCommand(String sql, int fetchSize) {
+        lock();
+        try {
+            checkClosed();
+            return new CommandRemote(this, transferList, sql, fetchSize);
+        } finally {
+            unlock();
+        }
     }
 
     /**
@@ -548,7 +558,8 @@ public final class SessionRemote extends Session implements DataHandler {
     public void close() {
         RuntimeException closeError = null;
         if (transferList != null) {
-            synchronized (this) {
+            lock();
+            try {
                 for (Transfer transfer : transferList) {
                     try {
                         traceOperation("SESSION_CLOSE", 0);
@@ -562,6 +573,8 @@ public final class SessionRemote extends Session implements DataHandler {
                         trace.error(e, "close");
                     }
                 }
+            } finally {
+                unlock();
             }
             transferList = null;
         }
@@ -745,30 +758,34 @@ public final class SessionRemote extends Session implements DataHandler {
     }
 
     @Override
-    public synchronized int readLob(long lobId, byte[] hmac, long offset,
-            byte[] buff, int off, int length) {
-        checkClosed();
-        for (int i = 0, count = 0; i < transferList.size(); i++) {
-            Transfer transfer = transferList.get(i);
-            try {
-                traceOperation("LOB_READ", (int) lobId);
-                transfer.writeInt(SessionRemote.LOB_READ);
-                transfer.writeLong(lobId);
-                transfer.writeBytes(hmac);
-                transfer.writeLong(offset);
-                transfer.writeInt(length);
-                done(transfer);
-                length = transfer.readInt();
-                if (length <= 0) {
+    public int readLob(long lobId, byte[] hmac, long offset, byte[] buff, int off, int length) {
+        lock();
+        try {
+            checkClosed();
+            for (int i = 0, count = 0; i < transferList.size(); i++) {
+                Transfer transfer = transferList.get(i);
+                try {
+                    traceOperation("LOB_READ", (int) lobId);
+                    transfer.writeInt(SessionRemote.LOB_READ);
+                    transfer.writeLong(lobId);
+                    transfer.writeBytes(hmac);
+                    transfer.writeLong(offset);
+                    transfer.writeInt(length);
+                    done(transfer);
+                    length = transfer.readInt();
+                    if (length <= 0) {
+                        return length;
+                    }
+                    transfer.readBytes(buff, off, length);
                     return length;
+                } catch (IOException e) {
+                    removeServer(e, i--, ++count);
                 }
-                transfer.readBytes(buff, off, length);
-                return length;
-            } catch (IOException e) {
-                removeServer(e, i--, ++count);
             }
+            return 1;
+        } finally {
+            unlock();
         }
-        return 1;
     }
 
     @Override
@@ -799,24 +816,32 @@ public final class SessionRemote extends Session implements DataHandler {
     public String getCurrentSchemaName() {
         String schema = currentSchemaName;
         if (schema == null) {
-            synchronized (this) {
+            lock();
+            try {
                 try (CommandInterface command = prepareCommand("CALL SCHEMA()", 1);
                         ResultInterface result = command.executeQuery(1, false)) {
                     result.next();
                     currentSchemaName = schema = result.currentRow()[0].getString();
                 }
+            } finally {
+                unlock();
             }
         }
         return schema;
     }
 
     @Override
-    public synchronized void setCurrentSchemaName(String schema) {
-        currentSchemaName = null;
-        try (CommandInterface command = prepareCommand(
-                StringUtils.quoteIdentifier(new StringBuilder("SET SCHEMA "), schema).toString(), 0)) {
-            command.executeUpdate(null);
-            currentSchemaName = schema;
+    public void setCurrentSchemaName(String schema) {
+        lock();
+        try {
+            currentSchemaName = null;
+            try (CommandInterface command = prepareCommand(
+                    StringUtils.quoteIdentifier(new StringBuilder("SET SCHEMA "), schema).toString(), 0)) {
+                command.executeUpdate(null);
+                currentSchemaName = schema;
+            }
+        } finally {
+            unlock();
         }
     }
 

--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 
 import org.h2.api.ErrorCode;
 import org.h2.command.CommandInterface;
+import org.h2.engine.Session;
 import org.h2.expression.ParameterInterface;
 import org.h2.message.DbException;
 import org.h2.message.TraceObject;
@@ -116,7 +117,9 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
             int id = getNextId(TraceObject.RESULT_SET);
             debugCodeAssign("ResultSet", TraceObject.RESULT_SET, id, "executeQuery()");
             batchIdentities = null;
-            synchronized (session) {
+            final Session session = this.session;
+            session.lock();
+            try {
                 checkClosed();
                 closeOldResultSet();
                 ResultInterface result;
@@ -134,6 +137,8 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
                 }
                 resultSet = new JdbcResultSet(conn, this, command, result, id, scrollable, updatable,
                         cachedColumnLabelMap);
+            } finally {
+                session.unlock();
             }
             return resultSet;
         } catch (Exception e) {
@@ -203,7 +208,9 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
 
     private long executeUpdateInternal() {
         closeOldResultSet();
-        synchronized (session) {
+        final Session session = this.session;
+        session.lock();
+        try {
             try {
                 setExecutingStatement(command);
                 ResultWithGeneratedKeys result = command.executeUpdate(generatedKeysRequest);
@@ -216,6 +223,8 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
             } finally {
                 setExecutingStatement(null);
             }
+        } finally {
+            session.unlock();
         }
         return updateCount;
     }
@@ -236,7 +245,9 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
             debugCodeCall("execute");
             checkClosed();
             boolean returnsResultSet;
-            synchronized (session) {
+            final Session session = this.session;
+            session.lock();
+            try {
                 closeOldResultSet();
                 boolean lazy = false;
                 try {
@@ -263,6 +274,8 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
                         setExecutingStatement(null);
                     }
                 }
+            } finally {
+                session.unlock();
             }
             return returnsResultSet;
         } catch (Throwable e) {

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLegacy.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaLegacy.java
@@ -650,7 +650,8 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
 
     private ResultInterface executeQuery(String sql, Value... args) {
         checkClosed();
-        synchronized (session) {
+        session.lock();
+        try {
             CommandInterface command = session.prepareCommand(sql, Integer.MAX_VALUE);
             int l = args.length;
             if (l > 0) {
@@ -662,6 +663,8 @@ public final class DatabaseMetaLegacy extends DatabaseMetaLocalBase {
             ResultInterface result = command.executeQuery(0, false);
             command.close();
             return result;
+        } finally {
+            session.unlock();
         }
     }
 

--- a/h2/src/main/org/h2/jdbc/meta/DatabaseMetaRemote.java
+++ b/h2/src/main/org/h2/jdbc/meta/DatabaseMetaRemote.java
@@ -330,7 +330,8 @@ public class DatabaseMetaRemote extends DatabaseMeta {
         if (session.isClosed()) {
             throw DbException.get(ErrorCode.DATABASE_CALLED_AT_SHUTDOWN);
         }
-        synchronized (session) {
+        session.lock();
+        try {
             int objectId = session.getNextId();
             for (int i = 0, count = 0; i < transferList.size(); i++) {
                 Transfer transfer = transferList.get(i);
@@ -349,6 +350,8 @@ public class DatabaseMetaRemote extends DatabaseMeta {
                 }
             }
             return null;
+        } finally {
+            session.unlock();
         }
     }
 

--- a/h2/src/main/org/h2/schema/Sequence.java
+++ b/h2/src/main/org/h2/schema/Sequence.java
@@ -515,14 +515,20 @@ public final class Sequence extends SchemaObject {
             // This session may not lock the sys table (except if it has already
             // locked it) because it must be committed immediately, otherwise
             // other threads can not access the sys table.
-            SessionLocal sysSession = database.getSystemSession();
-            synchronized (sysSession) {
+            final SessionLocal sysSession = database.getSystemSession();
+            sysSession.lock();
+            try {
                 flushInternal(sysSession);
                 sysSession.commit(false);
+            } finally {
+                sysSession.unlock();
             }
         } else {
-            synchronized (session) {
+            session.lock();
+            try {
                 flushInternal(session);
+            } finally {
+                session.unlock();
             }
         }
     }

--- a/h2/src/main/org/h2/server/TcpServerThread.java
+++ b/h2/src/main/org/h2/server/TcpServerThread.java
@@ -278,6 +278,7 @@ public class TcpServerThread implements Runnable {
     }
 
     private void process() throws IOException {
+        final SessionLocal session = this.session;
         int operation = transfer.readInt();
         switch (operation) {
         case SessionRemote.SESSION_PREPARE:
@@ -349,8 +350,11 @@ public class TcpServerThread implements Runnable {
             setParameters(command);
             int old = session.getModificationId();
             ResultInterface result;
-            synchronized (session) {
+            session.lock();
+            try {
                 result = command.executeQuery(maxRows, false);
+            } finally {
+                session.unlock();
             }
             cache.addObject(objectId, result);
             int columnCount = result.getVisibleColumnCount();
@@ -404,8 +408,11 @@ public class TcpServerThread implements Runnable {
             }
             int old = session.getModificationId();
             ResultWithGeneratedKeys result;
-            synchronized (session) {
+            session.lock();
+            try {
                 result = command.executeUpdate(generatedKeysRequest);
+            } finally {
+                session.unlock();
             }
             int status;
             if (session.isClosed()) {
@@ -528,8 +535,11 @@ public class TcpServerThread implements Runnable {
             }
             int old = session.getModificationId();
             ResultInterface result;
-            synchronized (session) {
+            session.lock();
+            try {
                 result = DatabaseMetaServer.process(session, code, args);
+            } finally {
+                session.unlock();
             }
             int columnCount = result.getVisibleColumnCount();
             int state = getState(old);


### PR DESCRIPTION
There is a significant improvement for this use case:
https://github.com/h2database/h2database/issues/3850#issuecomment-1666725360

Both in-memory and persistent embedded databases don't look like being affected.