### PR TITLE
Fixed unit test is support en_GB locale

### DIFF
--- a/h2/src/test/org/h2/test/db/TestFunctions.java
+++ b/h2/src/test/org/h2/test/db/TestFunctions.java
@@ -1557,7 +1557,7 @@ public class TestFunctions extends TestDb implements AggregateFunction {
         assertResult("34", stat, "SELECT TO_CHAR(X, 'SS') FROM T");
         assertResult("29554", stat, "SELECT TO_CHAR(X, 'SSSSS') FROM T");
         expected = new SimpleDateFormat("h:mm:ss aa").format(timestamp1979);
-        if (Locale.getDefault().getLanguage().equals(Locale.ENGLISH.getLanguage())) {
+        if (Locale.getDefault().equals(Locale.US)) {
             assertEquals("8:12:34 AM", expected);
         }
         assertResult(expected, stat, "SELECT TO_CHAR(X, 'TS') FROM T");


### PR DESCRIPTION
Fixed a unit test which now supports locale en_GB
The reason for the change is because if you locale is set to en_GB the time format will have am/pm in lowercase.  Where as if your locale is en_US AM/PM is in uppercase. 




I wrote the code, it's mine, and I'm contributing it to H2 for distribution multiple-licensed under the MPL 2.0, and the EPL 1.0 (https://h2database.com/html/license.html).