### PR TITLE
 Implement JSONArray support in FieldReference 

### DIFF
--- a/h2/src/main/org/h2/expression/FieldReference.java
+++ b/h2/src/main/org/h2/expression/FieldReference.java
@@ -12,11 +12,13 @@ import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
 import org.h2.mvstore.db.Store;
 import org.h2.util.ParserUtil;
+import org.h2.util.json.JSONArray;
 import org.h2.util.json.JSONObject;
 import org.h2.util.json.JSONValue;
 import org.h2.value.ExtTypeInfoRow;
 import org.h2.value.TypeInfo;
 import org.h2.value.Value;
+import org.h2.value.ValueInteger;
 import org.h2.value.ValueJson;
 import org.h2.value.ValueNull;
 import org.h2.value.ValueRow;
@@ -52,6 +54,19 @@ public final class FieldReference extends Operation1 {
                     JSONValue jsonValue = ((JSONObject) value).getFirst(fieldName);
                     if (jsonValue != null) {
                         return ValueJson.fromJson(jsonValue);
+                    }
+                } else if (value instanceof JSONArray) {
+                    JSONArray jsonArray = (JSONArray) value;
+                    try {
+                        int arrayIndex = Integer.parseInt(fieldName);
+                        JSONValue jsonValue = jsonArray.getElement(arrayIndex);
+                        if (jsonValue != null) {
+                            return ValueJson.fromJson(jsonValue);
+                        }
+                    } catch (ArrayIndexOutOfBoundsException | NumberFormatException ignored) {
+                    }
+                    if ("length".equalsIgnoreCase(fieldName)) {
+                        return ValueInteger.get(jsonArray.length());
                     }
                 }
             }

--- a/h2/src/test/org/h2/test/scripts/other/field-reference.sql
+++ b/h2/src/test/org/h2/test/scripts/other/field-reference.sql
@@ -41,3 +41,15 @@ SELECT JSON '{"a": 4, "b": 5, "c": 6}'."d";
 
 SELECT JSON '[1]'."d";
 >> null
+
+SELECT JSON '[1, 2, 3]'."1";
+>> 2
+
+SELECT JSON '[1, 2, 3]'."100";
+>> null
+
+SELECT JSON '[1, 2, 3]'."-1";
+>> null
+
+SELECT JSON '[1, 2, 3]'."length";
+>> 3


### PR DESCRIPTION
# What?

Extends the support in `FieldReference` to check for `JSONArray` in addition to `JSONObject`. In doing so, allows `SELECT JSON '["alpha"]'."0"` dereferences, which previously would return `NULL`. Since I was already in there, I also taught it to honor `SELECT JSON '["alpha"]'."length"` since it was cheap and handy for my specific use-case

# Why?

With any reasonably complicated object structure stored in a `JSON` column, one is almost certainly going to encounter a JSON array, and there did not appear to be any existing syntax for dereferencing the array indices in order to continue with traversal:

```sql
-- Given
CREATE TABLE mytable (myjson JSON);
INSERT INTO mytable (myjson) VALUES ('
{
  "outer": [
    {
      "inner": "ok"
    }
  ]
}
' FORMAT JSON);

-- previously:
SELECT (myjson)."outer"."???"."inner" FROM mytable;
>> null

-- versus after:
SELECT (myjson)."outer"."0"."inner" FROM mytable;
>> "ok"
```