### PR TITLE
Reject invalid ASIN and ACOS arguments and fix PK index for other numeric data types

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3981: Unexpected result when using trigonometric functions
+</li>
 <li>Issue #3983: INVISIBLE columns should be ignored in INSERT statement without explicit column list
 </li>
 <li>Issue #3960: NullPointerException when executing batch insert

--- a/h2/src/main/org/h2/expression/function/MathFunction1.java
+++ b/h2/src/main/org/h2/expression/function/MathFunction1.java
@@ -156,9 +156,15 @@ public final class MathFunction1 extends Function1 {
             d = Math.tanh(d);
             break;
         case ASIN:
+            if (d < -1d || d > 1d) {
+                throw DbException.getInvalidValueException("ASIN() argument", d);
+            }
             d = Math.asin(d);
             break;
         case ACOS:
+            if (d < -1d || d > 1d) {
+                throw DbException.getInvalidValueException("ACOS() argument", d);
+            }
             d = Math.acos(d);
             break;
         case ATAN:

--- a/h2/src/main/org/h2/index/RangeIndex.java
+++ b/h2/src/main/org/h2/index/RangeIndex.java
@@ -95,8 +95,9 @@ public class RangeIndex extends VirtualTableIndex {
         if (step == 0L) {
             throw DbException.get(ErrorCode.STEP_SIZE_MUST_NOT_BE_ZERO);
         }
-        return new SingleRowCursor((step > 0 ? min <= max : min >= max)
-                ? Row.get(new Value[]{ ValueBigint.get(first ^ min >= max ? min : max) }, 1) : null);
+        return (step > 0 ? min <= max : min >= max)
+                ? new SingleRowCursor(Row.get(new Value[] { ValueBigint.get(first ^ min >= max ? min : max) }, 1))
+                : SingleRowCursor.EMPTY;
     }
 
     @Override

--- a/h2/src/main/org/h2/index/SingleRowCursor.java
+++ b/h2/src/main/org/h2/index/SingleRowCursor.java
@@ -13,6 +13,12 @@ import org.h2.result.SearchRow;
  * A cursor with at most one row.
  */
 public class SingleRowCursor implements Cursor {
+
+    /**
+     * An empty cursor.
+     */
+    public static final SingleRowCursor EMPTY = new SingleRowCursor(null);
+
     private Row row;
     private boolean end;
 

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -334,7 +334,7 @@ public final class MVSecondaryIndex extends MVIndex<SearchRow, Value> {
                 return new SingleRowCursor(mvTable.getRow(session, key.getKey()));
             }
         }
-        return new SingleRowCursor(null);
+        return SingleRowCursor.EMPTY;
     }
 
     @Override

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -4845,8 +4845,10 @@ ABS(CAST(I AS BIGINT))
 ACOS(numeric)
 ","
 Calculate the arc cosine.
-See also Java ""Math.acos"".
-This method returns a double.
+
+Argument must be between -1 and 1 inclusive.
+
+This function returns a double precision value.
 ","
 ACOS(D)
 "
@@ -4855,8 +4857,10 @@ ACOS(D)
 ASIN(numeric)
 ","
 Calculate the arc sine.
-See also Java ""Math.asin"".
-This method returns a double.
+
+Argument must be between -1 and 1 inclusive.
+
+This function returns a double precision value.
 ","
 ASIN(D)
 "
@@ -4865,8 +4869,8 @@ ASIN(D)
 ATAN(numeric)
 ","
 Calculate the arc tangent.
-See also Java ""Math.atan"".
-This method returns a double.
+
+This function returns a double precision value.
 ","
 ATAN(D)
 "
@@ -4875,8 +4879,8 @@ ATAN(D)
 COS(numeric)
 ","
 Calculate the trigonometric cosine.
-See also Java ""Math.cos"".
-This method returns a double.
+
+This function returns a double precision value.
 ","
 COS(ANGLE)
 "
@@ -4885,8 +4889,8 @@ COS(ANGLE)
 COSH(numeric)
 ","
 Calculate the hyperbolic cosine.
-See also Java ""Math.cosh"".
-This method returns a double.
+
+This function returns a double precision value.
 ","
 COSH(X)
 "
@@ -4895,8 +4899,8 @@ COSH(X)
 @h2@ COT(numeric)
 ","
 Calculate the trigonometric cotangent (""1/TAN(ANGLE)"").
-See also Java ""Math.*"" functions.
-This method returns a double.
+
+This function returns a double precision value.
 ","
 COT(ANGLE)
 "
@@ -4905,8 +4909,8 @@ COT(ANGLE)
 SIN(numeric)
 ","
 Calculate the trigonometric sine.
-See also Java ""Math.sin"".
-This method returns a double.
+
+This function returns a double precision value.
 ","
 SIN(ANGLE)
 "
@@ -4915,8 +4919,8 @@ SIN(ANGLE)
 SINH(numeric)
 ","
 Calculate the hyperbolic sine.
-See also Java ""Math.sinh"".
-This method returns a double.
+
+This function returns a double precision value.
 ","
 SINH(ANGLE)
 "
@@ -4925,8 +4929,8 @@ SINH(ANGLE)
 TAN(numeric)
 ","
 Calculate the trigonometric tangent.
-See also Java ""Math.tan"".
-This method returns a double.
+
+This function returns a double precision value.
 ","
 TAN(ANGLE)
 "
@@ -4935,8 +4939,8 @@ TAN(ANGLE)
 TANH(numeric)
 ","
 Calculate the hyperbolic tangent.
-See also Java ""Math.tanh"".
-This method returns a double.
+
+This function returns a double precision value.
 ","
 TANH(X)
 "
@@ -4945,8 +4949,8 @@ TANH(X)
 @h2@ ATAN2(numeric, numeric)
 ","
 Calculate the angle when converting the rectangular coordinates to polar coordinates.
-See also Java ""Math.atan2"".
-This method returns a double.
+
+This function returns a double precision value.
 ","
 ATAN2(X, Y)
 "

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -378,10 +378,13 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL, Typ
 
     private static SoftReference<Value[]> softCache;
 
-    static final BigDecimal MAX_LONG_DECIMAL = BigDecimal.valueOf(Long.MAX_VALUE);
+    /**
+     * The largest BIGINT value, as a BigDecimal.
+     */
+    public static final BigDecimal MAX_LONG_DECIMAL = BigDecimal.valueOf(Long.MAX_VALUE);
 
     /**
-     * The smallest Long value, as a BigDecimal.
+     * The smallest BIGINT value, as a BigDecimal.
      */
     public static final BigDecimal MIN_LONG_DECIMAL = BigDecimal.valueOf(Long.MIN_VALUE);
 

--- a/h2/src/test/org/h2/test/db/TestTableEngines.java
+++ b/h2/src/test/org/h2/test/db/TestTableEngines.java
@@ -1007,8 +1007,8 @@ public class TestTableEngines extends TestDb {
 
         @Override
         public Cursor findFirstOrLast(SessionLocal session, boolean first) {
-            return new SingleRowCursor((Row)
-                    (set.isEmpty() ? null : first ? set.first() : set.last()));
+            return set.isEmpty() ? SingleRowCursor.EMPTY
+                    : new SingleRowCursor((Row) (first ? set.first() : set.last()));
         }
 
         @Override

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/acos.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/acos.sql
@@ -8,3 +8,12 @@ select acos(null) vn, acos(-1) r1;
 > ---- -----------------
 > null 3.141592653589793
 > rows: 1
+
+SELECT ACOS(-1.1);
+> exception INVALID_VALUE_2
+
+SELECT ACOS(1.1);
+> exception INVALID_VALUE_2
+
+SELECT ACOS(CAST('Infinity' AS DOUBLE PRECISION));
+> exception INVALID_VALUE_2

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/asin.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/asin.sql
@@ -8,3 +8,12 @@ select asin(null) vn, asin(-1) r1;
 > ---- -------------------
 > null -1.5707963267948966
 > rows: 1
+
+SELECT ASIN(-1.1);
+> exception INVALID_VALUE_2
+
+SELECT ASIN(1.1);
+> exception INVALID_VALUE_2
+
+SELECT ASIN(CAST('Infinity' AS DOUBLE PRECISION));
+> exception INVALID_VALUE_2

--- a/h2/src/test/org/h2/test/scripts/indexes.sql
+++ b/h2/src/test/org/h2/test/scripts/indexes.sql
@@ -435,3 +435,455 @@ EXPLAIN SELECT P.ID, G, MAX(CASE WHEN K = 'A' THEN V END) AS A, MAX(CASE WHEN K 
 
 DROP TABLE P, T;
 > ok
+
+CREATE TABLE TEST(A BIGINT PRIMARY KEY, B BIGINT UNIQUE);
+> ok
+
+INSERT INTO TEST VALUES (-9223372036854775808, -9223372036854775808), (0, 0),
+    (9223372036854775807, 9223372036854775807);
+> update count: 3
+
+SELECT * FROM TEST WHERE A > 'NaN'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'NaN'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'NaN'::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'NaN'::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 'Infinity'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'Infinity'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'Infinity'::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'Infinity'::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 1E19::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 1E19::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 1E19::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 1E19::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > '-Infinity'::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B > '-Infinity'::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A < '-Infinity'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < '-Infinity'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > -1E19::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B > -1E19::REAL;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A < -1E19::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < -1E19::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > 'NaN'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'NaN'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'NaN'::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'NaN'::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 'Infinity'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'Infinity'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'Infinity'::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'Infinity'::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 1E19::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 1E19::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 1E19::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 1E19::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > '-Infinity'::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B > '-Infinity'::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A < '-Infinity'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < '-Infinity'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > -1E19::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B > -1E19::DOUBLE PRECISION;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A < -1E19::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < -1E19::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > 9223372036854775808::NUMERIC;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 9223372036854775808::NUMERIC;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 9223372036854775808::NUMERIC;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 9223372036854775808::NUMERIC;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > -9223372036854775809::NUMERIC;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B > -9223372036854775809::NUMERIC;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A < -9223372036854775809::NUMERIC;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < -9223372036854775809::NUMERIC;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > 'NaN'::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'NaN'::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'NaN'::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'NaN'::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 'Infinity'::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'Infinity'::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'Infinity'::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'Infinity'::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 9223372036854775808::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 9223372036854775808::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 9223372036854775808::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 9223372036854775808::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A > '-Infinity'::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B > '-Infinity'::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A < '-Infinity'::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < '-Infinity'::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > -9223372036854775809::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE B > -9223372036854775809::DECFLOAT;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> 9223372036854775807  9223372036854775807
+> rows: 3
+
+SELECT * FROM TEST WHERE A < -9223372036854775809::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < -9223372036854775809::DECFLOAT;
+> A B
+> - -
+> rows: 0
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/test/org/h2/test/scripts/indexes.sql
+++ b/h2/src/test/org/h2/test/scripts/indexes.sql
@@ -713,6 +713,18 @@ SELECT * FROM TEST WHERE B > 9223372036854775808::NUMERIC;
 > - -
 > rows: 0
 
+SELECT * FROM TEST WHERE A >= 9223372036854775807::NUMERIC;
+> A                   B
+> ------------------- -------------------
+> 9223372036854775807 9223372036854775807
+> rows: 1
+
+SELECT * FROM TEST WHERE B >= 9223372036854775807::NUMERIC;
+> A                   B
+> ------------------- -------------------
+> 9223372036854775807 9223372036854775807
+> rows: 1
+
 SELECT * FROM TEST WHERE A < 9223372036854775808::NUMERIC;
 > A                    B
 > -------------------- --------------------
@@ -728,6 +740,20 @@ SELECT * FROM TEST WHERE B < 9223372036854775808::NUMERIC;
 > 0                    0
 > 9223372036854775807  9223372036854775807
 > rows: 3
+
+SELECT * FROM TEST WHERE A < 9223372036854775807::NUMERIC;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> rows: 2
+
+SELECT * FROM TEST WHERE B < 9223372036854775807::NUMERIC;
+> A                    B
+> -------------------- --------------------
+> -9223372036854775808 -9223372036854775808
+> 0                    0
+> rows: 2
 
 SELECT * FROM TEST WHERE A > -9223372036854775809::NUMERIC;
 > A                    B
@@ -887,3 +913,273 @@ SELECT * FROM TEST WHERE B < -9223372036854775809::DECFLOAT;
 
 DROP TABLE TEST;
 > ok
+
+CREATE TABLE TEST(A TINYINT PRIMARY KEY, B TINYINT UNIQUE);
+> ok
+
+INSERT INTO TEST VALUES (-128, -128), (0, 0), (127, 127);
+> update count: 3
+
+SELECT * FROM TEST WHERE A > 'NaN'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'NaN'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'NaN'::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'NaN'::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 'Infinity'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'Infinity'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'Infinity'::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'Infinity'::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 1E19::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 1E19::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 1E19::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 1E19::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A > '-Infinity'::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B > '-Infinity'::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A < '-Infinity'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < '-Infinity'::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > -1E19::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B > -1E19::REAL;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A < -1E19::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < -1E19::REAL;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > 'NaN'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'NaN'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'NaN'::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'NaN'::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 'Infinity'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 'Infinity'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 'Infinity'::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 'Infinity'::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A > 1E19::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B > 1E19::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A < 1E19::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B < 1E19::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A > '-Infinity'::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B > '-Infinity'::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A < '-Infinity'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < '-Infinity'::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE A > -1E19::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE B > -1E19::DOUBLE PRECISION;
+> A    B
+> ---- ----
+> -128 -128
+> 0    0
+> 127  127
+> rows: 3
+
+SELECT * FROM TEST WHERE A < -1E19::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+SELECT * FROM TEST WHERE B < -1E19::DOUBLE PRECISION;
+> A B
+> - -
+> rows: 0
+
+DROP TABLE TEST;
+> ok
+


### PR DESCRIPTION
1. `ASIN` and `ACOS` now throw an exception for out of range arguments as required by the SQL Standard.
2. Index cursors on delegated PK index now handle `Nan`, `Infinity`, `-Infinity` and large numeric values properly.

Closes #3981.