### PR TITLE
Server-side batch execution for prepared statements

### DIFF
--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -342,7 +342,7 @@ public abstract class Command implements CommandInterface {
             try {
                 session.endStatement();
                 if (callStop) {
-                    stop(true);
+                    stop(commitIfAutoCommit);
                 }
             } catch (Throwable nested) {
                 if (ex == null) {

--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -6,6 +6,7 @@
 package org.h2.command;
 
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Set;
 import org.h2.api.ErrorCode;
@@ -18,10 +19,13 @@ import org.h2.engine.SessionLocal;
 import org.h2.expression.ParameterInterface;
 import org.h2.message.DbException;
 import org.h2.message.Trace;
+import org.h2.result.BatchResult;
+import org.h2.result.MergedResult;
 import org.h2.result.ResultInterface;
 import org.h2.result.ResultWithGeneratedKeys;
 import org.h2.result.ResultWithPaddedStrings;
 import org.h2.util.Utils;
+import org.h2.value.Value;
 
 /**
  * Represents a SQL statement. This object is only used on the server side.
@@ -151,10 +155,10 @@ public abstract class Command implements CommandInterface {
     }
 
     @Override
-    public void stop() {
+    public void stop(boolean commitIfAutoCommit) {
         if (session.isOpen()) {
             commitIfNonTransactional();
-            if (isTransactional() && session.getAutoCommit()) {
+            if (commitIfAutoCommit && isTransactional() && session.getAutoCommit()) {
                 session.commit(false);
             }
         }
@@ -228,7 +232,7 @@ public abstract class Command implements CommandInterface {
                 session.resetThreadLocalSession(oldSession);
                 session.endStatement();
                 if (callStop) {
-                    stop();
+                    stop(true);
                 }
             }
         } finally {
@@ -238,74 +242,115 @@ public abstract class Command implements CommandInterface {
 
     @Override
     public ResultWithGeneratedKeys executeUpdate(Object generatedKeysRequest) {
-        long start = 0;
-        boolean callStop = true;
         session.lock();
         try {
-            Database database = getDatabase();
             session.waitIfExclusiveModeEnabled();
-            commitIfNonTransactional();
-            SessionLocal.Savepoint rollback = session.setSavepoint();
-            session.startStatementWithinTransaction(this);
-            DbException ex = null;
-            Session oldSession = session.setThreadLocalSession();
-            try {
-                while (true) {
-                    database.checkPowerOff();
-                    try {
-                        return update(generatedKeysRequest);
-                    } catch (DbException e) {
-                        // cannot retry some commands
-                        if (!isRetryable()) {
-                            throw e;
-                        }
-                        start = filterConcurrentUpdate(e, start);
-                    } catch (OutOfMemoryError e) {
-                        callStop = false;
-                        database.shutdownImmediately();
-                        throw DbException.convert(e);
-                    } catch (Throwable e) {
-                        throw DbException.convert(e);
-                    }
-                }
-            } catch (DbException e) {
-                e = e.addSQL(sql);
-                SQLException s = e.getSQLException();
-                database.exceptionThrown(s, sql);
-                if (s.getErrorCode() == ErrorCode.OUT_OF_MEMORY) {
-                    callStop = false;
-                    database.shutdownImmediately();
-                    throw e;
-                }
-                try {
-                    database.checkPowerOff();
-                    if (s.getErrorCode() == ErrorCode.DEADLOCK_1) {
-                        session.rollback();
-                    } else {
-                        session.rollbackTo(rollback);
-                    }
-                } catch (Throwable nested) {
-                    e.addSuppressed(nested);
-                }
-                ex = e;
-                throw e;
-            } finally {
-                session.resetThreadLocalSession(oldSession);
-                try {
-                    session.endStatement();
-                    if (callStop) {
-                        stop();
-                    }
-                } catch (Throwable nested) {
-                    if (ex == null) {
-                        throw nested;
-                    } else {
-                        ex.addSuppressed(nested);
-                    }
-                }
-            }
+            return executeUpdate(generatedKeysRequest, true);
         } finally {
             session.unlock();
+        }
+    }
+
+    @Override
+    public BatchResult executeBatchUpdate(ArrayList<Value[]> batchParameters, Object generatedKeysRequest) {
+        session.lock();
+        try {
+            session.waitIfExclusiveModeEnabled();
+            int size = batchParameters.size();
+            long[] updateCounts = new long[size];
+            MergedResult generatedKeys = generatedKeysRequest != null ? new MergedResult() : null;
+            ArrayList<SQLException> exceptions = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                Value[] set = batchParameters.get(i);
+                ArrayList<? extends ParameterInterface> parameters = getParameters();
+                for (int j = 0, l = set.length; j < l; j++) {
+                    parameters.get(j).setValue(set[j], true);
+                }
+                long updateCount;
+                try {
+                    ResultWithGeneratedKeys result = executeUpdate(generatedKeysRequest, i + 1 == size);
+                    updateCount = result.getUpdateCount();
+                    if (generatedKeys != null) {
+                        ResultInterface keys = result.getGeneratedKeys();
+                        if (keys != null) {
+                            generatedKeys.add(keys);
+                        }
+                    }
+                } catch (Exception e) {
+                    exceptions.add(DbException.toSQLException(e));
+                    updateCount = Statement.EXECUTE_FAILED;
+                }
+                updateCounts[i] = updateCount;
+            }
+            return new BatchResult(updateCounts, generatedKeys != null ? generatedKeys.getResult() : null, exceptions);
+        } finally {
+            session.unlock();
+        }
+    }
+
+    private ResultWithGeneratedKeys executeUpdate(Object generatedKeysRequest, boolean commitIfAutoCommit) {
+        long start = 0;
+        boolean callStop = true;
+        Database database = getDatabase();
+        commitIfNonTransactional();
+        SessionLocal.Savepoint rollback = session.setSavepoint();
+        session.startStatementWithinTransaction(this);
+        DbException ex = null;
+        Session oldSession = session.setThreadLocalSession();
+        try {
+            while (true) {
+                database.checkPowerOff();
+                try {
+                    return update(generatedKeysRequest);
+                } catch (DbException e) {
+                    // cannot retry some commands
+                    if (!isRetryable()) {
+                        throw e;
+                    }
+                    start = filterConcurrentUpdate(e, start);
+                } catch (OutOfMemoryError e) {
+                    callStop = false;
+                    database.shutdownImmediately();
+                    throw DbException.convert(e);
+                } catch (Throwable e) {
+                    throw DbException.convert(e);
+                }
+            }
+        } catch (DbException e) {
+            e = e.addSQL(sql);
+            SQLException s = e.getSQLException();
+            database.exceptionThrown(s, sql);
+            if (s.getErrorCode() == ErrorCode.OUT_OF_MEMORY) {
+                callStop = false;
+                database.shutdownImmediately();
+                throw e;
+            }
+            try {
+                database.checkPowerOff();
+                if (s.getErrorCode() == ErrorCode.DEADLOCK_1) {
+                    session.rollback();
+                } else {
+                    session.rollbackTo(rollback);
+                }
+            } catch (Throwable nested) {
+                e.addSuppressed(nested);
+            }
+            ex = e;
+            throw e;
+        } finally {
+            session.resetThreadLocalSession(oldSession);
+            try {
+                session.endStatement();
+                if (callStop) {
+                    stop(true);
+                }
+            } catch (Throwable nested) {
+                if (ex == null) {
+                    throw nested;
+                } else {
+                    ex.addSuppressed(nested);
+                }
+            }
         }
     }
 

--- a/h2/src/main/org/h2/command/CommandInterface.java
+++ b/h2/src/main/org/h2/command/CommandInterface.java
@@ -7,8 +7,10 @@ package org.h2.command;
 
 import java.util.ArrayList;
 import org.h2.expression.ParameterInterface;
+import org.h2.result.BatchResult;
 import org.h2.result.ResultInterface;
 import org.h2.result.ResultWithGeneratedKeys;
+import org.h2.value.Value;
 
 /**
  * Represents a SQL statement.
@@ -600,10 +602,29 @@ public interface CommandInterface extends AutoCloseable {
      */
     ResultWithGeneratedKeys executeUpdate(Object generatedKeysRequest);
 
+
     /**
-     * Stop the command execution, release all locks and resources
+     * Executes the statement with multiple sets of parameters.
+     *
+     * @param batchParameters
+     *            batch parameters
+     * @param generatedKeysRequest
+     *            {@code null} or {@code false} if generated keys are not needed,
+     *            {@code true} if generated keys should be configured
+     *            automatically, {@code int[]} to specify column indices to
+     *            return generated keys from, or {@code String[]} to specify
+     *            column names to return generated keys from
+     * @return result of batch execution
      */
-    void stop();
+    BatchResult executeBatchUpdate(ArrayList<Value[]> batchParameters, Object generatedKeysRequest);
+
+    /**
+     * Stop the command execution, release all locks and resources.
+     *
+     * @param commitIfAutoCommit
+     *            commit the session if auto-commit is enabled
+     */
+    void stop(boolean commitIfAutoCommit);
 
     /**
      * Close the statement.

--- a/h2/src/main/org/h2/command/CommandList.java
+++ b/h2/src/main/org/h2/command/CommandList.java
@@ -75,10 +75,10 @@ class CommandList extends Command {
     }
 
     @Override
-    public void stop() {
-        command.stop();
+    public void stop(boolean commitIfAutoCommit) {
+        command.stop(commitIfAutoCommit);
         if (remainingCommand != null) {
-            remainingCommand.stop();
+            remainingCommand.stop(commitIfAutoCommit);
         }
     }
 

--- a/h2/src/main/org/h2/engine/Constants.java
+++ b/h2/src/main/org/h2/engine/Constants.java
@@ -61,6 +61,12 @@ public class Constants {
     public static final int TCP_PROTOCOL_VERSION_20 = 20;
 
     /**
+     * The TCP protocol version number 21.
+     * @since 2.3.230 (TODO)
+     */
+    public static final int TCP_PROTOCOL_VERSION_21 = 21;
+
+    /**
      * Minimum supported version of TCP protocol.
      */
     public static final int TCP_PROTOCOL_VERSION_MIN_SUPPORTED = TCP_PROTOCOL_VERSION_17;
@@ -68,7 +74,7 @@ public class Constants {
     /**
      * Maximum supported version of TCP protocol.
      */
-    public static final int TCP_PROTOCOL_VERSION_MAX_SUPPORTED = TCP_PROTOCOL_VERSION_20;
+    public static final int TCP_PROTOCOL_VERSION_MAX_SUPPORTED = TCP_PROTOCOL_VERSION_21;
 
     /**
      * The major version of this database.

--- a/h2/src/main/org/h2/engine/SessionRemote.java
+++ b/h2/src/main/org/h2/engine/SessionRemote.java
@@ -73,6 +73,7 @@ public final class SessionRemote extends Session implements DataHandler {
     public static final int LOB_READ = 17;
     public static final int SESSION_PREPARE_READ_PARAMS2 = 18;
     public static final int GET_JDBC_META = 19;
+    public static final int COMMAND_EXECUTE_BATCH_UPDATE = 20;
 
     public static final int STATUS_ERROR = 0;
     public static final int STATUS_OK = 1;
@@ -642,6 +643,18 @@ public final class SessionRemote extends Session implements DataHandler {
      *             on I/O exception
      */
     public static DbException readException(Transfer transfer) throws IOException {
+        return DbException.convert(readSQLException(transfer));
+    }
+
+    /**
+     * Reads an exception as SQL exception.
+     * @param transfer
+     *            the transfer object
+     * @return the exception
+     * @throws IOException
+     *             on I/O exception
+     */
+    public static SQLException readSQLException(Transfer transfer) throws IOException {
         String sqlstate = transfer.readString();
         String message = transfer.readString();
         String sql = transfer.readString();
@@ -652,7 +665,7 @@ public final class SessionRemote extends Session implements DataHandler {
             // allow re-connect
             throw new IOException(s.toString(), s);
         }
-        return DbException.convert(s);
+        return s;
     }
 
     /**

--- a/h2/src/main/org/h2/result/BatchResult.java
+++ b/h2/src/main/org/h2/result/BatchResult.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2004-2024 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.result;
+
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Result of a batch execution.
+ */
+public class BatchResult {
+
+    private final long[] updateCounts;
+
+    private final ResultInterface generatedKeys;
+
+    private final List<SQLException> exceptions;
+
+    public BatchResult(long[] updateCounts, ResultInterface generatedKeys, List<SQLException> exceptions) {
+        this.updateCounts = updateCounts;
+        this.generatedKeys = generatedKeys;
+        this.exceptions = exceptions;
+    }
+
+    public long[] getUpdateCounts() {
+        return updateCounts;
+    }
+
+    public ResultInterface getGeneratedKeys() {
+        return generatedKeys;
+    }
+
+    public List<SQLException> getExceptions() {
+        return exceptions;
+    }
+
+}


### PR DESCRIPTION
1. `PreparedStatement.execute[Large]Batch()` methods now send all rows with parameters in a single request to a remote server instead of execution of every element in a separate request. This significantly reduces execution time of fast commands in large batches with real remote servers. Note: `Statement.execute[Large]Batch()` methods still execute every command in a separate request, I think these methods are rarely used.
2. All batch execution methods in both `Statement` and `PreparedStatement` don't allocate an empty `SQLException` to hold other exceptions in it any more. As it was [pointed out](https://github.com/h2database/h2database/pull/3996#issue-2115174172) by @turbanoff, this allocation significantly increases execution time of single-command batches in embedded in-memory mode.

These changes are mostly intended for remote connections, but they work well for embedded in-memory database too:

<details>
<summary>Reduced benchmark for corner cases (based on benchmark from another PR)</summary>

```Java
package org.sample;

import org.openjdk.jmh.annotations.*;
import java.util.concurrent.*;

import java.sql.*;

@OutputTimeUnit(TimeUnit.SECONDS)
@Warmup(iterations = 12, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
@State(Scope.Thread)
@Fork(2)
public class BatchInsertBenchmark {

    @Param({"1", "10", "100", "1000"})
    int rows;

    private PreparedStatement prepared;

    @Setup(Level.Invocation)
    public void setup() throws ClassNotFoundException, SQLException {
        if (prepared != null) {
            prepared.getConnection().close();
        }
        Connection conn = DriverManager.getConnection("jdbc:h2:mem:");
        Statement statement = conn.createStatement();
        statement.execute("CREATE table TO_FILL(a int primary key, b varchar)");
        statement.close();
        prepared = conn.prepareStatement("insert into TO_FILL(a, b) values (?, ? )");
        prepared.setInt(1, -1);
        prepared.setString(2, "value");
        prepared.executeUpdate();
    }

    @Benchmark
    public long[] executeLargeBatch() throws SQLException {
        for (int i = 0; i < rows; i++) {
            prepared.setInt(1, i);
            prepared.setString(2, "value" + i);
            prepared.addBatch();
        }
        return prepared.executeLargeBatch();
    }

    @Benchmark
    public long[] executeLargeBatchManyFailures() throws SQLException {
        for (int i = 0; i < rows; i++) {
            prepared.setInt(1, 0);
            prepared.setString(2, "value");
            prepared.addBatch();
        }
        try {
            return prepared.executeLargeBatch();
        } catch (BatchUpdateException e) {
            return e.getLargeUpdateCounts();
        }
    }

}
```
</details>

Mainline H2:
```
Benchmark                                           (rows)   Mode  Cnt      Score      Error  Units
BatchInsertBenchmark.executeLargeBatch                   1  thrpt   20  62437,377 ±  867,732  ops/s
BatchInsertBenchmark.executeLargeBatch                  10  thrpt   20  20825,418 ±  290,052  ops/s
BatchInsertBenchmark.executeLargeBatch                 100  thrpt   20   2618,407 ±  181,622  ops/s
BatchInsertBenchmark.executeLargeBatch                1000  thrpt   20    246,260 ±    1,255  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures       1  thrpt   20  64943,801 ± 1918,061  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures      10  thrpt   20   5053,851 ±   73,892  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures     100  thrpt   20    547,155 ±    6,377  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures    1000  thrpt   20     44,991 ±    0,431  ops/s
```

This PR:
```
Benchmark                                           (rows)   Mode  Cnt       Score       Error  Units
BatchInsertBenchmark.executeLargeBatch                   1  thrpt   20  156411,302 ±  5175,599  ops/s
BatchInsertBenchmark.executeLargeBatch                  10  thrpt   20   43891,349 ±  1433,532  ops/s
BatchInsertBenchmark.executeLargeBatch                 100  thrpt   20    4534,062 ±   149,524  ops/s
BatchInsertBenchmark.executeLargeBatch                1000  thrpt   20     467,745 ±     7,260  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures       1  thrpt   20  173071,881 ± 10004,550  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures      10  thrpt   20    5359,828 ±    50,552  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures     100  thrpt   20     592,051 ±    12,298  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures    1000  thrpt   20      61,786 ±     0,341  ops/s
```

Code proposed for the problem (2) in the mentioned PR:
```
Benchmark                                           (rows)   Mode  Cnt       Score       Error  Units
BatchInsertBenchmark.executeLargeBatch                   1  thrpt   20  151813,391 ±  4513,336  ops/s
BatchInsertBenchmark.executeLargeBatch                  10  thrpt   20   24564,676 ±   655,469  ops/s
BatchInsertBenchmark.executeLargeBatch                 100  thrpt   20    2480,789 ±    11,202  ops/s
BatchInsertBenchmark.executeLargeBatch                1000  thrpt   20     233,532 ±    19,691  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures       1  thrpt   20  164892,827 ± 10209,532  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures      10  thrpt   20    5216,781 ±    58,656  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures     100  thrpt   20     568,871 ±     7,134  ops/s
BatchInsertBenchmark.executeLargeBatchManyFailures    1000  thrpt   20      57,583 ±     0,750  ops/s
```
