### PR TITLE
Allow 0 as a valid chunk id

### DIFF
--- a/h2/src/main/org/h2/command/CommandContainer.java
+++ b/h2/src/main/org/h2/command/CommandContainer.java
@@ -88,7 +88,7 @@ public class CommandContainer extends Command {
     @Override
     public ArrayList<? extends ParameterInterface> getParameters() {
         ArrayList<Parameter> parameters = prepared.getParameters();
-        if (parameters.size() > 0 && prepared.isWithParamValues()) {
+        if (!parameters.isEmpty() && prepared.isWithParamValues()) {
             parameters = new ArrayList<>();
         }
         return parameters;

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -172,7 +172,7 @@ public abstract class Chunk<C extends Chunk<C>> {
     }
 
     Chunk(Map<String, String> map, boolean full) {
-        this(DataUtils.readHexInt(map, ATTR_CHUNK, 0));
+        this(DataUtils.readHexInt(map, ATTR_CHUNK, -1));
         block = DataUtils.readHexLong(map, ATTR_BLOCK, 0);
         len = DataUtils.readHexInt(map, ATTR_LEN, 0);
         version = DataUtils.readHexLong(map, ATTR_VERSION, id);
@@ -206,7 +206,7 @@ public abstract class Chunk<C extends Chunk<C>> {
 
     Chunk(int id) {
         this.id = id;
-        if (id <= 0) {
+        if (id < 0 || id > MAX_ID) {
             throw DataUtils.newMVStoreException(
                     DataUtils.ERROR_FILE_CORRUPT, "Invalid chunk id {0}", id);
         }

--- a/h2/src/main/org/h2/mvstore/RandomAccessStore.java
+++ b/h2/src/main/org/h2/mvstore/RandomAccessStore.java
@@ -290,7 +290,7 @@ public abstract class RandomAccessStore extends FileStore<SFChunk>
                         // no (valid) next
                         break;
                     }
-                    SFChunk test = readChunkHeaderAndFooter(newest.next, newest.id + 1);
+                    SFChunk test = readChunkHeaderAndFooter(newest.next, (newest.id + 1) & Chunk.MAX_ID);
                     if (test == null || test.version <= newest.version) {
                         break;
                     }
@@ -386,7 +386,7 @@ public abstract class RandomAccessStore extends FileStore<SFChunk>
             if (chunk == null) {
                 writeStoreHeader = true;
             } else if (chunk.next != c.block) {
-                // the last prediction did not matched
+                // the last prediction did not match
                 writeStoreHeader = true;
             } else {
                 long headerVersion = DataUtils.readHexLong(storeHeader, HDR_VERSION, 0);


### PR DESCRIPTION
Chunk Ids are assigned as incremental numbers started at 1. After about 67,000,000 (2**26 -1 ) commits chunk Id may wrap around and become 0. Unfortunately zero is considered as invalid chunk id, and will be reported as store corruption.
This PR allows zero as valid chunk id. It may fix (can not verify that) issue #4052. 