### PR TITLE
Pass mapped columns to table filters of subqueries

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,18 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #3945: Column not found in correlated subquery, when referencing outer column from LEFT JOIN .. ON clause
+</li>
+<li>Issue #4097: StackOverflowException when using multiple SELECT statements in one query (2.3.230)
+</li>
+<li>Issue #3982: Potential issue when using ROUND
+</li>
+<li>Issue #3894: Race condition causing stale data in query last result cache
+</li>
+<li>Issue #4075: infinite loop in compact
+</li>
+<li>Issue #4091: Wrong case with linked table to postgresql
+</li>
 <li>Issue #4088: BadGrammarException when the same alias is used within two different CTEs
 </li>
 <li>Issue #4079: [2.3.230] Regression in ORDER BY ... DESC on dates

--- a/h2/src/main/org/h2/command/query/Query.java
+++ b/h2/src/main/org/h2/command/query/Query.java
@@ -336,8 +336,10 @@ public abstract class Query extends Prepared {
      * @param level
      *            the subquery level (0 is the top level query, 1 is the first
      *            subquery level)
+     * @param outer
+     *            whether this method was called from the outer query
      */
-    public abstract void mapColumns(ColumnResolver resolver, int level);
+    public abstract void mapColumns(ColumnResolver resolver, int level, boolean outer);
 
     /**
      * Change the evaluatable flag. This is used when building the execution

--- a/h2/src/main/org/h2/command/query/Select.java
+++ b/h2/src/main/org/h2/command/query/Select.java
@@ -1155,7 +1155,7 @@ public class Select extends Query {
         }
         // map columns in select list and condition
         for (TableFilter f : filters) {
-            mapColumns(f, 0);
+            mapColumns(f, 0, false);
         }
         mapCondition(havingIndex);
         mapCondition(qualifyIndex);
@@ -1596,12 +1596,15 @@ public class Select extends Query {
     }
 
     @Override
-    public void mapColumns(ColumnResolver resolver, int level) {
+    public void mapColumns(ColumnResolver resolver, int level, boolean outer) {
         for (Expression e : expressions) {
             e.mapColumns(resolver, level, Expression.MAP_INITIAL);
         }
         if (condition != null) {
             condition.mapColumns(resolver, level, Expression.MAP_INITIAL);
+        }
+        for (TableFilter tableFilter : topFilters) {
+            tableFilter.mapColumns(resolver, level, outer);
         }
     }
 

--- a/h2/src/main/org/h2/command/query/SelectUnion.java
+++ b/h2/src/main/org/h2/command/query/SelectUnion.java
@@ -303,9 +303,9 @@ public class SelectUnion extends Query {
     }
 
     @Override
-    public void mapColumns(ColumnResolver resolver, int level) {
-        left.mapColumns(resolver, level);
-        right.mapColumns(resolver, level);
+    public void mapColumns(ColumnResolver resolver, int level, boolean outer) {
+        left.mapColumns(resolver, level, outer);
+        right.mapColumns(resolver, level, outer);
     }
 
     @Override

--- a/h2/src/main/org/h2/command/query/TableValueConstructor.java
+++ b/h2/src/main/org/h2/command/query/TableValueConstructor.java
@@ -262,7 +262,7 @@ public class TableValueConstructor extends Query {
     }
 
     @Override
-    public void mapColumns(ColumnResolver resolver, int level) {
+    public void mapColumns(ColumnResolver resolver, int level, boolean outer) {
         int columnCount = visibleColumnCount;
         for (ArrayList<Expression> row : rows) {
             for (int i = 0; i < columnCount; i++) {

--- a/h2/src/main/org/h2/expression/ArrayConstructorByQuery.java
+++ b/h2/src/main/org/h2/expression/ArrayConstructorByQuery.java
@@ -65,7 +65,7 @@ public final class ArrayConstructorByQuery extends Expression {
 
     @Override
     public void mapColumns(ColumnResolver resolver, int level, int state) {
-        query.mapColumns(resolver, level + 1);
+        query.mapColumns(resolver, level + 1, true);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/Subquery.java
+++ b/h2/src/main/org/h2/expression/Subquery.java
@@ -90,7 +90,7 @@ public final class Subquery extends Expression {
     @Override
     public void mapColumns(ColumnResolver resolver, int level, int state) {
         outerResolvers.add(resolver);
-        query.mapColumns(resolver, level + 1);
+        query.mapColumns(resolver, level + 1, true);
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/condition/PredicateWithSubquery.java
+++ b/h2/src/main/org/h2/expression/condition/PredicateWithSubquery.java
@@ -29,7 +29,7 @@ abstract class PredicateWithSubquery extends Condition {
 
     @Override
     public void mapColumns(ColumnResolver resolver, int level, int state) {
-        query.mapColumns(resolver, level + 1);
+        query.mapColumns(resolver, level + 1, true);
     }
 
     @Override


### PR DESCRIPTION
Closes #3945.

Please note that these changes don't fix issues when subqueries use outer columns in their inner derived tables or other constructed tables.