### PR TITLE
Fix index-sorted optimization for queries with IN predicate

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #4144: [2.3.232] Regression in ORDER BY ... DESC with WHERE ... IN and OR clauses
+</li>
 <li>Issue #4139: Oracle compatibility mode: unexpected Column alias is not specified exception in CTE
 </li>
 <li>Issue #4136: ArrayIndexOutOfBoundsException with compound index

--- a/h2/src/main/org/h2/command/query/Query.java
+++ b/h2/src/main/org/h2/command/query/Query.java
@@ -9,6 +9,7 @@ import static org.h2.expression.Expression.WITHOUT_PARENTHESES;
 import static org.h2.util.HasSQL.DEFAULT_SQL_FLAGS;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -126,9 +127,9 @@ public abstract class Query extends Prepared {
     boolean distinct;
 
     /**
-     * Whether the result needs to support random access.
+     * Sort types for IN predicate.
      */
-    boolean randomAccessResult;
+    int[] inPredicateSortTypes;
 
     /**
      * The visible columns (the ones required in the result).
@@ -148,6 +149,7 @@ public abstract class Query extends Prepared {
     private ResultInterface lastResult;
     private Boolean lastExists;
     private Value[] lastParameters;
+    private int[] lastInPredicateSortTypes;
     private boolean cacheableChecked;
     private boolean neverLazy;
 
@@ -422,21 +424,30 @@ public abstract class Query extends Prepared {
     }
 
     /**
-     * Returns whether results support random access.
+     * Returns whether result is generated for the IN predicate.
      *
-     * @return whether results support random access
+     * @return whether result is generated for the IN predicate
      */
-    public boolean isRandomAccessResult() {
-        return randomAccessResult;
+    public boolean isInPredicateResult() {
+        return inPredicateSortTypes != null;
     }
 
     /**
-     * Whether results need to support random access.
-     *
-     * @param b the new value
+     * Convert results to compatible with IN predicate.
      */
-    public void setRandomAccessResult(boolean b) {
-        randomAccessResult = b;
+    public void setInPredicateResult() {
+        if (inPredicateSortTypes == null) {
+            inPredicateSortTypes = new int[0];
+        }
+    }
+
+    /**
+     * Sets sort types for the IN predicate.
+     *
+     * @param inPredicateSortTypes sort types for the IN predicate
+     */
+    public void setInPredicateResultSortTypes(int[] inPredicateSortTypes) {
+        this.inPredicateSortTypes = inPredicateSortTypes;
     }
 
     @Override
@@ -519,7 +530,8 @@ public abstract class Query extends Prepared {
         Value[] params = getParameterValues();
         long now = session.getStatementModificationDataId(), maxDataModificationId = getMaxDataModificationId();
         if (lastResult != null && !lastResult.isClosed() && limit == lastLimit //
-                && maxDataModificationId <= lastEvaluated && sameParameters(params, lastParameters)) {
+                && maxDataModificationId <= lastEvaluated && sameParameters(params, lastParameters)
+                && Arrays.equals(inPredicateSortTypes, lastInPredicateSortTypes)) {
             lastResult = lastResult.createShallowCopy(session);
             if (lastResult != null) {
                 lastResult.reset();
@@ -531,11 +543,13 @@ public abstract class Query extends Prepared {
         if (maxDataModificationId <= now) {
             lastParameters = params;
             lastResult = r;
+            lastInPredicateSortTypes = inPredicateSortTypes;
             lastEvaluated = now;
             lastLimit = limit;
         } else {
             lastParameters = null;
             lastResult = null;
+            lastInPredicateSortTypes = null;
             lastLimit = lastEvaluated = 0L;
         }
         lastExists = null;
@@ -1038,8 +1052,8 @@ public abstract class Query extends Prepared {
             }
         }
         result.done();
-        if (randomAccessResult && !distinct) {
-            result = convertToDistinct(result);
+        if (inPredicateSortTypes != null) {
+            result = convertToInPredicateValueListIfNecessary(result);
         }
         if (target != null) {
             while (result.next()) {
@@ -1051,15 +1065,37 @@ public abstract class Query extends Prepared {
         return result;
     }
 
+    private LocalResult convertToInPredicateValueListIfNecessary(LocalResult result) {
+        if (distinct) {
+            if (inPredicateSortTypes == null) {
+                return result;
+            }
+            if (sort != null) {
+                int[] sortTypes = sort.getSortTypes();
+                int l = inPredicateSortTypes.length;
+                testSort: if (sortTypes.length >= l) {
+                    for (int i = 0; i < l; i++) {
+                        if ((sortTypes[i] & SortOrder.DESCENDING) != (inPredicateSortTypes[i]
+                                & SortOrder.DESCENDING)) {
+                            break testSort;
+                        }
+                    }
+                    return result;
+                }
+            }
+        }
+        return convertToInPredicateValueList(result);
+    }
+
     /**
-     * Convert a result into a distinct result, using the current columns.
+     * Convert a result into result with value list of the IN predicate.
      *
      * @param result the source
      * @return the distinct result
      */
-    LocalResult convertToDistinct(ResultInterface result) {
+    LocalResult convertToInPredicateValueList(ResultInterface result) {
         LocalResult distinctResult = new LocalResult(session, expressionArray, visibleColumnCount, resultColumnCount);
-        distinctResult.setDistinct();
+        distinctResult.setInPredicateValueListResult(inPredicateSortTypes);
         result.reset();
         while (result.next()) {
             distinctResult.addRow(result.currentRow());

--- a/h2/src/main/org/h2/command/query/Select.java
+++ b/h2/src/main/org/h2/command/query/Select.java
@@ -899,8 +899,8 @@ public class Select extends Query {
             if (fetch > 0) {
                 lazyResult.setLimit(fetch);
             }
-            if (randomAccessResult) {
-                return convertToDistinct(lazyResult);
+            if (inPredicateSortTypes != null) {
+                return convertToInPredicateValueList(lazyResult);
             } else {
                 return lazyResult;
             }
@@ -1285,12 +1285,8 @@ public class Select extends Query {
                     boolean reverse = sortIndex.isReverse();
                     if (current.getIndexType().isScan() || current == index) {
                         topTableFilter.setIndex(index, reverse);
-                        if (!topTableFilter.hasInComparisons()) {
-                            // in(select ...) and in(1,2,3) may return the key in
-                            // another order
-                            indexSortedColumns = sortIndex.getSortedColumns();
-                            break;
-                        }
+                        indexSortedColumns = sortIndex.getSortedColumns();
+                        break;
                     } else if (index.getIndexColumns() != null
                             && index.getIndexColumns().length >= current
                                     .getIndexColumns().length) {

--- a/h2/src/main/org/h2/command/query/SelectUnion.java
+++ b/h2/src/main/org/h2/command/query/SelectUnion.java
@@ -132,7 +132,7 @@ public class SelectUnion extends Query {
         }
         int columnCount = left.getColumnCount();
         if (session.isLazyQueryExecution() && unionType == UnionType.UNION_ALL && !distinct &&
-                sort == null && !randomAccessResult && forUpdate == null &&
+                sort == null && inPredicateSortTypes == null && forUpdate == null &&
                 offset == 0 && !fetchPercent && !withTies && isReadOnly()) {
             // limit 0 means no rows
             if (fetch != 0) {

--- a/h2/src/main/org/h2/expression/condition/ConditionInQuery.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInQuery.java
@@ -43,7 +43,7 @@ public final class ConditionInQuery extends PredicateWithSubquery {
          * Need to do it now because other methods may be invoked in different
          * order.
          */
-        query.setRandomAccessResult(true);
+        query.setInPredicateResult();
         query.setNeverLazy(true);
         query.setDistinctIfPossible();
         this.all = all;

--- a/h2/src/main/org/h2/index/IndexCondition.java
+++ b/h2/src/main/org/h2/index/IndexCondition.java
@@ -8,7 +8,7 @@ package org.h2.index;
 import static org.h2.util.HasSQL.TRACE_SQL_FLAGS;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.TreeSet;
 
@@ -22,6 +22,7 @@ import org.h2.expression.ValueExpression;
 import org.h2.expression.condition.Comparison;
 import org.h2.message.DbException;
 import org.h2.result.ResultInterface;
+import org.h2.result.SortOrder;
 import org.h2.table.Column;
 import org.h2.table.IndexColumn;
 import org.h2.table.TableType;
@@ -95,7 +96,7 @@ public class IndexCondition {
             this.column = column.getColumn();
             this.columns = null;
             this.compoundColumns = false;
-        } else if (columns !=null) {
+        } else if (columns != null) {
             this.column = null;
             this.columns = columns;
             this.compoundColumns = true;
@@ -162,7 +163,7 @@ public class IndexCondition {
      * @return the index condition
      */
     public static IndexCondition getInQuery(ExpressionColumn column, Query query) {
-        assert query.isRandomAccessResult();
+        assert query.isInPredicateResult();
         return new IndexCondition(Comparison.IN_QUERY, column, null, null, null, query);
     }
 
@@ -181,20 +182,30 @@ public class IndexCondition {
      * same type as the column, distinct, and sorted.
      *
      * @param session the session
+     * @param sortTypes sort types
      * @return the value list
      */
-    public Value[] getCurrentValueList(SessionLocal session) {
-        TreeSet<Value> valueSet = new TreeSet<>(session.getDatabase().getCompareMode());
+    public Value[] getCurrentValueList(SessionLocal session, int[] sortTypes) {
+        Comparator<Value> comparator;
+        if (compoundColumns) {
+            SortOrder sortOrder = SortOrder.ofSortTypes(session, sortTypes);
+            comparator = (o1, o2) -> sortOrder.compare(((ValueRow) o1).getList(), ((ValueRow) o2).getList());
+        } else {
+            comparator = session.getDatabase().getCompareMode();
+            if ((sortTypes[0] & SortOrder.DESCENDING) != 0) {
+                comparator = comparator.reversed();
+            }
+        }
+        TreeSet<Value> valueSet = new TreeSet<>(comparator);
         if (compareType == Comparison.IN_LIST) {
-            if (isCompoundColumns()) {
+            if (compoundColumns) {
                 Column[] columns = getColumns();
                 for (Expression e : expressionList) {
                     ValueRow v = (ValueRow) e.getValue(session);
                     v = Column.convert(session, columns, v);
                     valueSet.add(v);
                 }
-            }
-            else {
+            } else {
                 Column column = getColumn();
                 for (Expression e : expressionList) {
                     Value v = e.getValue(session);
@@ -212,18 +223,19 @@ public class IndexCondition {
         } else {
             throw DbException.getInternalError("compareType = " + compareType);
         }
-        Value[] array = valueSet.toArray(new Value[valueSet.size()]);
-        Arrays.sort(array, session.getDatabase().getCompareMode());
-        return array;
+        return valueSet.toArray(new Value[valueSet.size()]);
     }
 
     /**
      * Get the current result of the expression. The rows may not be of the same
      * type, therefore the rows may not be unique.
      *
+     * @param session the session
+     * @param sortTypes sort types
      * @return the result
      */
-    public ResultInterface getCurrentResult() {
+    public ResultInterface getCurrentResult(SessionLocal session, int[] sortTypes) {
+        expressionQuery.setInPredicateResultSortTypes(sortTypes);
         return expressionQuery.query(0);
     }
 

--- a/h2/src/main/org/h2/result/LocalResult.java
+++ b/h2/src/main/org/h2/result/LocalResult.java
@@ -221,6 +221,19 @@ public class LocalResult implements ResultInterface, ResultTarget {
     }
 
     /**
+     * Configures result to hold value list of the IN predicate.
+     *
+     * @param inPredicateSortTypes sort order bit masks or an empty array
+     */
+    public void setInPredicateValueListResult(int[] inPredicateSortTypes) {
+        distinct = true;
+        distinctRows = new TreeMap<>(session.getDatabase().getCompareMode());
+        if (inPredicateSortTypes.length != 0) {
+            sort = SortOrder.ofSortTypes(session, inPredicateSortTypes);
+        }
+    }
+
+    /**
      * @return whether this result is a distinct result
      */
     private boolean isAnyDistinct() {

--- a/h2/src/main/org/h2/result/SortOrder.java
+++ b/h2/src/main/org/h2/result/SortOrder.java
@@ -67,6 +67,23 @@ public final class SortOrder implements Comparator<Value[]> {
     private final ArrayList<QueryOrderBy> orderList;
 
     /**
+     * Construct a new sort order object with specified sort types.
+     *
+     * @param session the session
+     * @param sortTypes sort types of all columns
+     *
+     * @return a sort order
+     */
+    public static SortOrder ofSortTypes(SessionLocal session, int[] sortTypes) {
+        int length = sortTypes.length;
+        int[] queryColumnIndexes = new int[length];
+        for (int i = 0; i < length; i++) {
+            queryColumnIndexes[i] = i;
+        }
+        return new SortOrder(session, queryColumnIndexes, sortTypes, null);
+    }
+
+    /**
      * Construct a new sort order object with default sort directions.
      *
      * @param session the session

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1227,24 +1227,6 @@ public class TableFilter implements ColumnResolver {
         return hashCode;
     }
 
-    /**
-     * Are there any index conditions that involve IN(...).
-     *
-     * @return whether there are IN(...) comparisons
-     */
-    public boolean hasInComparisons() {
-        for (IndexCondition cond : indexConditions) {
-            int compareType = cond.getCompareType();
-            switch (compareType) {
-            case Comparison.IN_LIST:
-            case Comparison.IN_ARRAY:
-            case Comparison.IN_QUERY:
-                return true;
-            }
-        }
-        return false;
-    }
-
     public TableFilter getNestedJoin() {
         return nestedJoin;
     }

--- a/h2/src/test/org/h2/test/scripts/predicates/in.sql
+++ b/h2/src/test/org/h2/test/scripts/predicates/in.sql
@@ -426,3 +426,86 @@ EXPLAIN SELECT V, V IN (SELECT * FROM TEST) FROM (VALUES 1, 1000000000000) T(V);
 
 DROP TABLE TEST;
 > ok
+
+CREATE TABLE D(A INT, B INT, C INT);
+> ok
+
+CREATE INDEX D_IDX ON D(A DESC, B);
+> ok
+
+INSERT INTO D VALUES (1, 1, 1), (1, 2, 2), (2, 1, 4), (2, 2, 3);
+> update count: 4
+
+SELECT * FROM D WHERE (A, B) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A DESC, B;
+> A B C
+> - - -
+> 2 1 4
+> 2 2 3
+> 1 1 1
+> 1 2 2
+> rows (ordered): 4
+
+EXPLAIN SELECT * FROM D WHERE (A, B) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A DESC, B;
+>> SELECT "PUBLIC"."D"."A", "PUBLIC"."D"."B", "PUBLIC"."D"."C" FROM "PUBLIC"."D" /* PUBLIC.D_IDX: IN(ROW (1, 1), ROW (1, 2), ROW (1, 3), ROW (2, 1), ROW (2, 2), ROW (2, 3)) */ WHERE ROW ("A", "B") IN(ROW (1, 1), ROW (1, 2), ROW (1, 3), ROW (2, 1), ROW (2, 2), ROW (2, 3)) ORDER BY 1 DESC, 2 /* index sorted */
+
+SELECT * FROM D WHERE (A, B) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A, B DESC;
+> A B C
+> - - -
+> 1 2 2
+> 1 1 1
+> 2 2 3
+> 2 1 4
+> rows (ordered): 4
+
+EXPLAIN SELECT * FROM D WHERE (A, B) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A, B DESC;
+>> SELECT "PUBLIC"."D"."A", "PUBLIC"."D"."B", "PUBLIC"."D"."C" FROM "PUBLIC"."D" /* PUBLIC.D_IDX: IN(ROW (1, 1), ROW (1, 2), ROW (1, 3), ROW (2, 1), ROW (2, 2), ROW (2, 3)) */ WHERE ROW ("A", "B") IN(ROW (1, 1), ROW (1, 2), ROW (1, 3), ROW (2, 1), ROW (2, 2), ROW (2, 3)) ORDER BY 1, 2 DESC /* index sorted */
+
+
+SELECT * FROM D WHERE (A, B) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A, B;
+> A B C
+> - - -
+> 1 1 1
+> 1 2 2
+> 2 1 4
+> 2 2 3
+> rows (ordered): 4
+
+EXPLAIN SELECT * FROM D WHERE (A, B) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A, B;
+>> SELECT "PUBLIC"."D"."A", "PUBLIC"."D"."B", "PUBLIC"."D"."C" FROM "PUBLIC"."D" /* PUBLIC.D_IDX: IN(ROW (1, 1), ROW (1, 2), ROW (1, 3), ROW (2, 1), ROW (2, 2), ROW (2, 3)) */ WHERE ROW ("A", "B") IN(ROW (1, 1), ROW (1, 2), ROW (1, 3), ROW (2, 1), ROW (2, 2), ROW (2, 3)) ORDER BY 1, 2 /* index sorted: 1 of 2 columns */
+
+SELECT * FROM D WHERE A IN (1, 2) ORDER BY A DESC, B;
+> A B C
+> - - -
+> 2 1 4
+> 2 2 3
+> 1 1 1
+> 1 2 2
+> rows (ordered): 4
+
+EXPLAIN SELECT * FROM D WHERE A IN (1, 2) ORDER BY A DESC, B;
+>> SELECT "PUBLIC"."D"."A", "PUBLIC"."D"."B", "PUBLIC"."D"."C" FROM "PUBLIC"."D" /* PUBLIC.D_IDX: A IN(1, 2) */ WHERE "A" IN(1, 2) ORDER BY 1 DESC, 2 /* index sorted */
+
+SELECT * FROM D WHERE (A, C) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A, B;
+> A B C
+> - - -
+> 1 1 1
+> 1 2 2
+> 2 2 3
+> rows (ordered): 3
+
+EXPLAIN SELECT * FROM D WHERE (A, C) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A, B;
+>> SELECT "PUBLIC"."D"."A", "PUBLIC"."D"."B", "PUBLIC"."D"."C" FROM "PUBLIC"."D" /* PUBLIC.D_IDX: A IN(1, 1, 1, 2, 2, 2) */ WHERE ROW ("A", "C") IN(ROW (1, 1), ROW (1, 2), ROW (1, 3), ROW (2, 1), ROW (2, 2), ROW (2, 3)) ORDER BY 1, 2 /* index sorted: 1 of 2 columns */
+
+SELECT * FROM D WHERE (A, C) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A, B DESC;
+> A B C
+> - - -
+> 1 2 2
+> 1 1 1
+> 2 2 3
+> rows (ordered): 3
+
+EXPLAIN SELECT * FROM D WHERE (A, C) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)) ORDER BY A, B DESC;
+>> SELECT "PUBLIC"."D"."A", "PUBLIC"."D"."B", "PUBLIC"."D"."C" FROM "PUBLIC"."D" /* PUBLIC.D_IDX: A IN(1, 1, 1, 2, 2, 2) */ WHERE ROW ("A", "C") IN(ROW (1, 1), ROW (1, 2), ROW (1, 3), ROW (2, 1), ROW (2, 2), ROW (2, 3)) ORDER BY 1, 2 DESC /* index sorted */
+
+DROP TABLE D;
+> ok


### PR DESCRIPTION
Closes #4144.

Index-sorted optimization for queries with IN predicate was disabled in older versions of H2 because correct order of rows wasn't ensured, but in recent versions of H2 it was unintentionally enabled in some really unusual cases.

With these changes index conditions for the IN predicate sort values in expected order and this optimization is enabled back.

`OPTIMIZE_IN_LIST=FALSE` can still disable all these optimizations.