### PR TITLE
LZFOutputStream with better spatial performance

### DIFF
--- a/h2/src/main/org/h2/compress/LZFOutputStream.java
+++ b/h2/src/main/org/h2/compress/LZFOutputStream.java
@@ -35,9 +35,8 @@ public class LZFOutputStream extends OutputStream {
     }
 
     private void ensureOutput(int len) {
-        // TODO calculate the maximum overhead (worst case) for the output
-        // buffer
-        int outputLen = (len < 100 ? len + 100 : len) * 2;
+        // calculate the maximum overhead (worst case) for the output buffer
+        int outputLen = len / 32 * 33 + 1 + 4;
         if (outBuffer == null || outBuffer.length < outputLen) {
             outBuffer = new byte[outputLen];
         }


### PR DESCRIPTION
According to the implementation of CompressLZF, it can be concluded that in the worst case scenario, there will be an additional control byte for every 32 bytes. In LZFOutputStream, we also need to write a 4-byte file header. I recalculated the length of the outBuffer in LZFOutputStream. This will save some memory compared to the original implementation.