### PR TITLE
Align H2 batch update counting with Oracle JDBC behavior

### DIFF
--- a/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcPreparedStatement.java
@@ -1267,11 +1267,14 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
             BatchResult batchResult = executeBatchInternal();
             long[] longResult = batchResult.getUpdateCounts();
             int size = longResult.length;
+            long totalUpdateCount = 0;
             int[] intResult = new int[size];
             for (int i = 0; i < size; i++) {
                 long updateCount = longResult[i];
+                totalUpdateCount += updateCount;
                 intResult[i] = updateCount <= Integer.MAX_VALUE ? (int) updateCount : SUCCESS_NO_INFO;
             }
+            updateCount = totalUpdateCount;
             List<SQLException> exceptions = batchResult.getExceptions();
             if (!exceptions.isEmpty()) {
                 throw new JdbcBatchUpdateException(createBatchException(exceptions), intResult);
@@ -1299,6 +1302,13 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
             }
             BatchResult batchResult = executeBatchInternal();
             long[] result = batchResult.getUpdateCounts();
+            long totalUpdateCount = 0L;
+            for (long updateCountItem : result) {
+                if (updateCountItem > 0L) {
+                    totalUpdateCount += updateCountItem;
+                }
+            }
+            updateCount = totalUpdateCount;
             List<SQLException> exceptions = batchResult.getExceptions();
             if (!exceptions.isEmpty()) {
                 throw new JdbcBatchUpdateException(createBatchException(exceptions), result);

--- a/h2/src/main/org/h2/jdbc/JdbcStatement.java
+++ b/h2/src/main/org/h2/jdbc/JdbcStatement.java
@@ -807,10 +807,12 @@ public class JdbcStatement extends TraceObject implements Statement {
             int size = batchCommands.size();
             int[] result = new int[size];
             SQLException exception = null, last = null;
+            long totalUpdateCount = 0L;
             for (int i = 0; i < size; i++) {
                 int updateCount;
                 try {
                     long longUpdateCount = executeUpdateInternal(batchCommands.get(i), null);
+                    totalUpdateCount += longUpdateCount;
                     updateCount = longUpdateCount <= Integer.MAX_VALUE ? (int) longUpdateCount : SUCCESS_NO_INFO;
                 } catch (Exception e) {
                     SQLException s = DbException.toSQLException(e);
@@ -823,6 +825,7 @@ public class JdbcStatement extends TraceObject implements Statement {
                 }
                 result[i] = updateCount;
             }
+            updateCount = totalUpdateCount;
             batchCommands = null;
             if (exception != null) {
                 throw new JdbcBatchUpdateException(exception, result);

--- a/h2/src/test/org/h2/test/TestBase.java
+++ b/h2/src/test/org/h2/test/TestBase.java
@@ -506,6 +506,24 @@ public abstract class TestBase {
     }
 
     /**
+     * Check if two integer arrays are equal, and if not throw an exception.
+     *
+     * @param expected the expected array
+     * @param actual the actual array
+     * @throws AssertionError if the arrays are not equal
+     */
+    public void assertEquals(int[] expected, int[] actual) {
+        if (expected.length != actual.length) {
+            fail("Expected length: " + expected.length + " actual length: " + actual.length);
+        }
+        for (int i = 0; i < expected.length; i++) {
+            if (expected[i] != actual[i]) {
+                fail("Difference at index [" + i + "]: expected: " + expected[i] + " actual: " + actual[i]);
+            }
+        }
+    }
+
+    /**
      * Check if two values are equal, and if not throw an exception.
      *
      * @param expected the expected value

--- a/h2/src/test/org/h2/test/jdbc/TestBatchUpdates.java
+++ b/h2/src/test/org/h2/test/jdbc/TestBatchUpdates.java
@@ -129,6 +129,7 @@ public class TestBatchUpdates extends TestDb {
             total += t;
         }
         assertEquals(4, total);
+        assertEquals(4, call.getUpdateCount());
         conn.close();
     }
 
@@ -215,7 +216,6 @@ public class TestBatchUpdates extends TestDb {
         prep.setInt(1, 4);
         prep.addBatch();
         int[] updateCount = prep.executeBatch();
-        int updateCountLen = updateCount.length;
 
         // PreparedStatement p;
         // p = conn.prepareStatement(COFFEE_UPDATE);
@@ -226,8 +226,8 @@ public class TestBatchUpdates extends TestDb {
         // p.setInt(1,4);
         // System.out.println("upc="+p.executeUpdate());
 
-        trace("updateCount length:" + updateCountLen);
-        assertEquals(3, updateCountLen);
+        assertEquals(new int[]{2, 3, 4}, updateCount);
+        assertEquals(9, prep.getUpdateCount());
         String query1 = "SELECT COUNT(*) FROM TEST WHERE TYPE_ID=2";
         String query2 = "SELECT COUNT(*) FROM TEST WHERE TYPE_ID=3";
         String query3 = "SELECT COUNT(*) FROM TEST WHERE TYPE_ID=4";
@@ -250,7 +250,6 @@ public class TestBatchUpdates extends TestDb {
         trace("testAddBatch02");
         int i = 0;
         int[] retValue = { 0, 0, 0 };
-        int updCountLength = 0;
         String sUpdCoffee = COFFEE_UPDATE1;
         String sDelCoffee = COFFEE_DELETE1;
         String sInsCoffee = COFFEE_INSERT1;
@@ -258,9 +257,8 @@ public class TestBatchUpdates extends TestDb {
         stat.addBatch(sDelCoffee);
         stat.addBatch(sInsCoffee);
         int[] updateCount = stat.executeBatch();
-        updCountLength = updateCount.length;
-        trace("updateCount Length:" + updCountLength);
-        assertEquals(3, updCountLength);
+        assertEquals(new int[]{1, 1, 1}, updateCount);
+        assertEquals(3, stat.getUpdateCount());
         String query1 = "SELECT COUNT(*) FROM TEST WHERE TYPE_ID=1";
         ResultSet rs = stat.executeQuery(query1);
         rs.next();
@@ -308,7 +306,6 @@ public class TestBatchUpdates extends TestDb {
         trace("testExecuteBatch01");
         int i = 0;
         int[] retValue = { 0, 0, 0 };
-        int updCountLength = 0;
         String sPrepStmt = COFFEE_UPDATE;
         trace("Prepared Statement String:" + sPrepStmt);
         // get the PreparedStatement object
@@ -320,14 +317,10 @@ public class TestBatchUpdates extends TestDb {
         prep.setInt(1, 3);
         prep.addBatch();
         int[] updateCount = prep.executeBatch();
-        updCountLength = updateCount.length;
         trace("Successfully Updated");
-        trace("updateCount Length:" + updCountLength);
-        if (updCountLength != 3) {
-            fail("executeBatch");
-        } else {
-            trace("executeBatch executes the Batch of SQL statements");
-        }
+        assertEquals(new int[]{1, 2, 3}, updateCount);
+        assertEquals(6, prep.getUpdateCount());
+        trace("executeBatch executes the Batch of SQL statements");
         // 1 is the number that is set First for Type Id in Prepared Statement
         String query1 = "SELECT COUNT(*) FROM TEST WHERE TYPE_ID=1";
         // 2 is the number that is set second for Type id in Prepared Statement
@@ -362,13 +355,9 @@ public class TestBatchUpdates extends TestDb {
         prep.setInt(1, 2);
         prep.setInt(1, 3);
         int[] updateCount = prep.executeBatch();
-        int updCountLength = updateCount.length;
-        trace("UpdateCount Length : " + updCountLength);
-        if (updCountLength == 0) {
-            trace("executeBatch does not execute Empty Batch");
-        } else {
-            fail("executeBatch");
-        }
+        assertEquals(new int[]{}, updateCount);
+        assertEquals(-1, prep.getUpdateCount());
+        trace("executeBatch does not execute Empty Batch");
     }
 
     private void testExecuteBatch03() throws SQLException {
@@ -396,7 +385,6 @@ public class TestBatchUpdates extends TestDb {
         trace("testExecuteBatch04");
         int i = 0;
         int[] retValue = { 0, 0, 0 };
-        int updCountLength = 0;
         String sUpdCoffee = COFFEE_UPDATE1;
         String sInsCoffee = COFFEE_INSERT1;
         String sDelCoffee = COFFEE_DELETE1;
@@ -404,14 +392,10 @@ public class TestBatchUpdates extends TestDb {
         stat.addBatch(sDelCoffee);
         stat.addBatch(sInsCoffee);
         int[] updateCount = stat.executeBatch();
-        updCountLength = updateCount.length;
+        assertEquals(new int[]{1, 1, 1}, updateCount);
+        assertEquals(3, stat.getUpdateCount());
         trace("Successfully Updated");
-        trace("updateCount Length:" + updCountLength);
-        if (updCountLength != 3) {
-            fail("executeBatch");
-        } else {
-            trace("executeBatch executes the Batch of SQL statements");
-        }
+        trace("executeBatch executes the Batch of SQL statements");
         String query1 = "SELECT COUNT(*) FROM TEST WHERE TYPE_ID=1";
         ResultSet rs = stat.executeQuery(query1);
         rs.next();
@@ -430,15 +414,10 @@ public class TestBatchUpdates extends TestDb {
 
     private void testExecuteBatch05() throws SQLException {
         trace("testExecuteBatch05");
-        int updCountLength = 0;
         int[] updateCount = stat.executeBatch();
-        updCountLength = updateCount.length;
-        trace("updateCount Length:" + updCountLength);
-        if (updCountLength == 0) {
-            trace("executeBatch Method does not execute the Empty Batch ");
-        } else {
-            fail("executeBatch 0!=" + updCountLength);
-        }
+        assertEquals(new int[]{}, updateCount);
+        assertEquals(-1, stat.getUpdateCount());
+        trace("executeBatch Method does not execute the Empty Batch ");
     }
 
     private void testExecuteBatch06() throws SQLException {

--- a/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestPreparedStatement.java
@@ -277,7 +277,9 @@ public class TestPreparedStatement extends TestDb {
             prep.setCharacterStream(2, new StringReader(getString(i)), -1);
             prep.addBatch();
         }
-        prep.executeBatch();
+        var updateCount = prep.executeBatch();
+        assertEquals(new int[]{1, 1, 1}, updateCount);
+        assertEquals(3, prep.getUpdateCount());
         rs = stat.executeQuery("SELECT * FROM TEST ORDER BY ID");
         for (int i = 0; i < 3; i++) {
             assertTrue(rs.next());

--- a/h2/src/test/org/h2/test/jdbc/TestStatement.java
+++ b/h2/src/test/org/h2/test/jdbc/TestStatement.java
@@ -422,6 +422,7 @@ public class TestStatement extends TestDb {
         ps.setString(2, "v4");
         ps.addBatch();
         assertTrue(Arrays.equals(new int[] {1, 1}, ps.executeBatch()));
+        assertEquals(2, ps.getUpdateCount());
         ps.setInt(1, 5);
         ps.setString(2, "v5");
         ps.addBatch();
@@ -429,6 +430,7 @@ public class TestStatement extends TestDb {
         ps.setString(2, "v6");
         ps.addBatch();
         assertTrue(Arrays.equals(new long[] {1, 1}, ps.executeLargeBatch()));
+        assertEquals(2, ps.getLargeUpdateCount());
         ps.setInt(1, 7);
         ps.setString(2, "v7");
         assertEquals(1, ps.executeUpdate());


### PR DESCRIPTION
H2 now matches Oracle's behavior for batched commands: getUpdateCount() returns the total number of updated rows in the last batch, improving consistency for unit tests that mirror Oracle production environments.

Previously, H2 always returned -1 for batched commands. This change could potentially cause compatibility issues for code that expects -1 as the update count, though relying on -1 in such cases is likely to indicate unusual or improper handling of update results.