### PR TITLE
feat: implement restore points

### DIFF
--- a/h2/src/docsrc/help/information_schema.csv
+++ b/h2/src/docsrc/help/information_schema.csv
@@ -88,6 +88,10 @@ Contains statistics of queries when query statistics gathering is enabled.
 Contains additional information about referential constraints.
 "
 
+"RESTORE_POINTS",,"
+Contains information about restore points.
+"
+
 "RIGHTS",,"
 Contains information about granted rights and roles.
 "
@@ -660,6 +664,18 @@ The rule for UPDATE in referenced table ('RESTRICT', 'CASCADE', 'SET DEFAULT', o
 
 "REFERENTIAL_CONSTRAINTS","DELETE_RULE","
 The rule for DELETE in referenced table ('RESTRICT', 'CASCADE', 'SET DEFAULT', or 'SET NULL').
+"
+
+"RESTORE_POINTS",RESTORE_POINT_NAME,"
+The name of a restore point.
+"
+
+"RESTORE_POINTS",CREATED_AT,"
+The timestamp at which a restore point has been created.
+"
+
+"RESTORE_POINTS",DATABASE_VERSION,"
+The database version a particular restore point references.
 "
 
 "RIGHTS","GRANTEETYPE","

--- a/h2/src/main/org/h2/api/ErrorCode.java
+++ b/h2/src/main/org/h2/api/ErrorCode.java
@@ -2261,7 +2261,25 @@ public class ErrorCode {
      */
     public static final int GROUP_BY_NOT_IN_THE_RESULT = 90157;
 
-    // next is 90158
+    /**
+     * The error with code <code>90158</code> is thrown when a restore point is
+     * being created, but a restore point with the given name already exists.
+     */
+    public static final int RESTORE_POINT_ALREADY_EXISTS = 90158;
+
+    /**
+     * The error with code <code>90159</code> is thrown when a restore point
+     * is being referenced that does not exist.
+     */
+    public static final int RESTORE_POINT_NOT_FOUND = 90159;
+
+    /**
+     * The error with code <code>90160</code> is thrown when a restore point is being
+     * returned to via RESTORE TO POINT, but switching the database to exclusive mode failed.
+     */
+    public static final int COULD_NOT_SWITCH_DATABASE_TO_EXCLUSIVE_MODE = 90160;
+
+    // next is 90161
 
     private ErrorCode() {
         // utility class

--- a/h2/src/main/org/h2/api/ErrorCode.java
+++ b/h2/src/main/org/h2/api/ErrorCode.java
@@ -2273,13 +2273,7 @@ public class ErrorCode {
      */
     public static final int RESTORE_POINT_NOT_FOUND = 90159;
 
-    /**
-     * The error with code <code>90160</code> is thrown when a restore point is being
-     * returned to via RESTORE TO POINT, but switching the database to exclusive mode failed.
-     */
-    public static final int COULD_NOT_SWITCH_DATABASE_TO_EXCLUSIVE_MODE = 90160;
-
-    // next is 90161
+    // next is 90160
 
     private ErrorCode() {
         // utility class

--- a/h2/src/main/org/h2/command/CommandInterface.java
+++ b/h2/src/main/org/h2/command/CommandInterface.java
@@ -564,6 +564,21 @@ public interface CommandInterface extends AutoCloseable {
     int ALTER_TYPE = 105;
 
     /**
+     * The type of a CREATE RESTORE POINT statement.
+     */
+    int CREATE_RESTORE_POINT = 106;
+
+    /**
+     * The type of a RESTORE TO POINT statement.
+     */
+    int RESTORE_TO_POINT = 107;
+
+    /**
+     * The type of a DROP RESTORE POINT statement.
+     */
+    int DROP_RESTORE_POINT = 108;
+
+    /**
      * Get command type.
      *
      * @return one of the constants above

--- a/h2/src/main/org/h2/command/dml/RestorePointCommand.java
+++ b/h2/src/main/org/h2/command/dml/RestorePointCommand.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2004-2024 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: Enno Thieleke
+ */
+package org.h2.command.dml;
+
+import org.h2.api.ErrorCode;
+import org.h2.command.CommandInterface;
+import org.h2.command.Prepared;
+import org.h2.engine.Database;
+import org.h2.engine.SessionLocal;
+import org.h2.message.DbException;
+import org.h2.mvstore.MVStore;
+import org.h2.mvstore.db.Store;
+import org.h2.mvstore.tx.TransactionStore;
+import org.h2.mvstore.type.RestorePoint;
+import org.h2.result.ResultInterface;
+import org.h2.value.ValueBigint;
+import org.h2.value.ValueTimestampTimeZone;
+
+/**
+ * This class represents the statements for dealing with restore points.
+ */
+public class RestorePointCommand extends Prepared {
+
+    private final int type;
+    private final String name;
+
+    public RestorePointCommand(SessionLocal session, int type, String name) {
+        super(session);
+        this.type = type;
+        this.name = name;
+    }
+
+    @Override
+    public long update() {
+        session.getUser().checkAdmin();
+        switch (type) {
+        case CommandInterface.CREATE_RESTORE_POINT:
+            createRestorePoint();
+            break;
+        case CommandInterface.RESTORE_TO_POINT:
+            restoreToPoint();
+            break;
+        case CommandInterface.DROP_RESTORE_POINT:
+            dropRestorePoint();
+            break;
+        default: throw DbException.getInternalError("type=" + type);
+        }
+        return 0;
+    }
+
+    private void createRestorePoint() {
+        Database db = getDatabase();
+        MVStore mvStore = db.getStore().getMvStore();
+        mvStore.lock();
+        int autoCommitDelay = mvStore.getAutoCommitDelay();
+        try {
+            if (mvStore.findRestorePoint(name) != null) {
+                throw DbException.get(ErrorCode.RESTORE_POINT_ALREADY_EXISTS, name);
+            }
+            mvStore.setAutoCommitDelay(0);
+            session.commit(false); // Commit pending changes.
+            ValueTimestampTimeZone createdAt = db.currentTimestamp();
+            ValueBigint databaseVersion = ValueBigint.get(mvStore.getCurrentVersion() + 1);
+            // The oldest database version to keep across all restore points is always the same.
+            long temp = mvStore.getOldestRestorePointVersion();
+            ValueBigint oldestDatabaseVersionToKeep;
+            if (temp == Long.MAX_VALUE) {
+                oldestDatabaseVersionToKeep = databaseVersion;
+            } else {
+                oldestDatabaseVersionToKeep = ValueBigint.get(temp);
+            }
+            RestorePoint rp = new RestorePoint(name, createdAt, oldestDatabaseVersionToKeep, databaseVersion);
+            mvStore.addRestorePoint(rp.getDatabaseVersion().getLong(), rp);
+            mvStore.commit(); // Flush changes to disk.
+            db.getNextModificationMetaId(); // To invalidate previous results of selects from restore points.
+            assert databaseVersion.getLong() == mvStore.getCurrentVersion();
+        } finally {
+            mvStore.setAutoCommitDelay(autoCommitDelay);
+            mvStore.unlock();
+        }
+    }
+
+    private void restoreToPoint() {
+        Database db = getDatabase();
+        try {
+            if (!db.setExclusiveSession(session, true)) {
+                throw DbException.get(ErrorCode.COULD_NOT_SWITCH_DATABASE_TO_EXCLUSIVE_MODE);
+            }
+            RestorePoint rp = db.getStore().getMvStore().findRestorePoint(name);
+            if (rp == null) {
+                throw DbException.get(ErrorCode.RESTORE_POINT_NOT_FOUND, name);
+            }
+            session.rollback(); // Discard the implicitly started transaction.
+            Store store = db.getStore();
+            MVStore mvStore = store.getMvStore();
+            mvStore.lock();
+            int autoCommitDelay = mvStore.getAutoCommitDelay();
+            try {
+                mvStore.setAutoCommitDelay(0);
+                mvStore.rollbackTo(rp.getDatabaseVersion().getLong());
+
+                TransactionStore txStore = store.getTransactionStore();
+                txStore.reinit(); // This reads any leftover transactions back into the store...
+                txStore.endLeftoverTransactions(); // ...and this ends them (i.e. removes unwanted data).
+
+                /* This might have brought back restore points that have been deleted.
+                 * Or it might have removed restore points, which hadn't been created at the point we're returning to.
+                 */
+                db.executeMeta(session);
+            } finally {
+                mvStore.setAutoCommitDelay(autoCommitDelay);
+                mvStore.unlock();
+            }
+        } finally {
+            db.unsetExclusiveSession(session);
+        }
+    }
+
+    private void dropRestorePoint() {
+        Database db = getDatabase();
+        MVStore mvStore = db.getStore().getMvStore();
+        mvStore.lock();
+        try {
+            RestorePoint rp = mvStore.findRestorePoint(name);
+            if (rp == null) {
+                throw DbException.get(ErrorCode.RESTORE_POINT_NOT_FOUND, name);
+            }
+            mvStore.removeRestorePoint(rp.getDatabaseVersion().getLong());
+            session.commit(false);
+            db.getNextModificationMetaId(); // To invalidate previous results of selects from restore points.
+        } finally {
+            mvStore.unlock();
+        }
+    }
+
+    @Override
+    public boolean isTransactional() {
+        return false;
+    }
+
+    @Override
+    public boolean needRecompile() {
+        return false;
+    }
+
+    @Override
+    public ResultInterface queryMeta() {
+        return null;
+    }
+
+    @Override
+    public int getType() {
+        return type;
+    }
+}

--- a/h2/src/main/org/h2/command/dml/RestorePointCommand.java
+++ b/h2/src/main/org/h2/command/dml/RestorePointCommand.java
@@ -46,7 +46,8 @@ public class RestorePointCommand extends Prepared {
         case CommandInterface.DROP_RESTORE_POINT:
             dropRestorePoint();
             break;
-        default: throw DbException.getInternalError("type=" + type);
+        default:
+            throw DbException.getInternalError("type=" + type);
         }
         return 0;
     }
@@ -87,7 +88,7 @@ public class RestorePointCommand extends Prepared {
         Database db = getDatabase();
         try {
             if (!db.setExclusiveSession(session, true)) {
-                throw DbException.get(ErrorCode.COULD_NOT_SWITCH_DATABASE_TO_EXCLUSIVE_MODE);
+                throw DbException.get(ErrorCode.DATABASE_IS_IN_EXCLUSIVE_MODE);
             }
             RestorePoint rp = db.getStore().getMvStore().findRestorePoint(name);
             if (rp == null) {

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -641,6 +641,8 @@ public class DbException extends RuntimeException {
         case GENERATED_COLUMN_CANNOT_BE_UPDATABLE_BY_CONSTRAINT_2:
         case COLUMN_ALIAS_IS_NOT_SPECIFIED_1:
         case GROUP_BY_NOT_IN_THE_RESULT:
+        case RESTORE_POINT_ALREADY_EXISTS:
+        case RESTORE_POINT_NOT_FOUND:
             return new JdbcSQLSyntaxErrorException(message, sql, state, errorCode, cause, stackTrace);
         case HEX_STRING_ODD_1:
         case HEX_STRING_WRONG_1:
@@ -687,6 +689,7 @@ public class DbException extends RuntimeException {
         case INVALID_DATABASE_NAME_1:
         case AUTHENTICATOR_NOT_AVAILABLE:
         case METHOD_DISABLED_ON_AUTOCOMMIT_TRUE:
+        case COULD_NOT_SWITCH_DATABASE_TO_EXCLUSIVE_MODE:
             return new JdbcSQLNonTransientConnectionException(message, sql, state, errorCode, cause, stackTrace);
         case ROW_NOT_FOUND_WHEN_DELETING_1:
         case CONCURRENT_UPDATE_1:

--- a/h2/src/main/org/h2/message/DbException.java
+++ b/h2/src/main/org/h2/message/DbException.java
@@ -689,7 +689,6 @@ public class DbException extends RuntimeException {
         case INVALID_DATABASE_NAME_1:
         case AUTHENTICATOR_NOT_AVAILABLE:
         case METHOD_DISABLED_ON_AUTOCOMMIT_TRUE:
-        case COULD_NOT_SWITCH_DATABASE_TO_EXCLUSIVE_MODE:
             return new JdbcSQLNonTransientConnectionException(message, sql, state, errorCode, cause, stackTrace);
         case ROW_NOT_FOUND_WHEN_DELETING_1:
         case CONCURRENT_UPDATE_1:

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -1005,10 +1005,16 @@ public final class MVStore implements AutoCloseable {
         return fileStore != null && fileStore.hasChangesSince(lastStoredVersion);
     }
 
+    /**
+     * For internal use only.
+     */
     public void lock() {
         storeLock.lock();
     }
 
+    /**
+     * For internal use only.
+     */
     public void unlock() {
         storeLock.unlock();
     }

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -6,6 +6,7 @@
 package org.h2.mvstore.tx;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
@@ -173,6 +174,12 @@ public class TransactionStore {
                                                 .keyType(StringDataType.INSTANCE)
                                                 .valueType(metaDataType);
         return store.openMap(TYPE_REGISTRY_NAME, typeRegistryBuilder);
+    }
+
+    public void reinit() {
+        init = false;
+        Arrays.fill(undoLogs, null);
+        init();
     }
 
     /**

--- a/h2/src/main/org/h2/mvstore/type/RestorePoint.java
+++ b/h2/src/main/org/h2/mvstore/type/RestorePoint.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-2024 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: Enno Thieleke
+ */
+package org.h2.mvstore.type;
+
+import org.h2.value.ValueBigint;
+import org.h2.value.ValueTimestampTimeZone;
+
+public class RestorePoint implements Comparable<RestorePoint> {
+
+    private final String name;
+    private final ValueTimestampTimeZone createdAt;
+    private final ValueBigint oldestDatabaseVersionToKeep, databaseVersion;
+
+    public RestorePoint(
+            String name,
+            ValueTimestampTimeZone createdAt,
+            ValueBigint oldestDatabaseVersionToKeep,
+            ValueBigint databaseVersion
+    ) {
+        this.name = name;
+        this.createdAt = createdAt;
+        this.oldestDatabaseVersionToKeep = oldestDatabaseVersionToKeep;
+        this.databaseVersion = databaseVersion;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ValueTimestampTimeZone getCreatedAt() {
+        return createdAt;
+    }
+
+    public ValueBigint getOldestDatabaseVersionToKeep() {
+        return oldestDatabaseVersionToKeep;
+    }
+
+    public ValueBigint getDatabaseVersion() {
+        return databaseVersion;
+    }
+
+    @Override
+    public int compareTo(RestorePoint o) {
+        // Only the database version is relevant, because within a single database it's not possible
+        // to have multiple restore points that reference the same version, because each restore point
+        // results in a new MVStore version.
+        return Long.compare(databaseVersion.getLong(), o.databaseVersion.getLong());
+    }
+}

--- a/h2/src/main/org/h2/mvstore/type/RestorePointDataType.java
+++ b/h2/src/main/org/h2/mvstore/type/RestorePointDataType.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2004-2024 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: Enno Thieleke
+ */
+package org.h2.mvstore.type;
+
+import java.nio.ByteBuffer;
+
+import org.h2.mvstore.DataUtils;
+import org.h2.mvstore.WriteBuffer;
+import org.h2.value.ValueBigint;
+import org.h2.value.ValueTimestampTimeZone;
+
+public class RestorePointDataType extends BasicDataType<RestorePoint> {
+
+    public static final RestorePointDataType INSTANCE = new RestorePointDataType();
+
+    private static final RestorePoint[] EMPTY_ARRAY = new RestorePoint[0];
+
+    @Override
+    public RestorePoint[] createStorage(int size) {
+        return size == 0 ? EMPTY_ARRAY : new RestorePoint[size];
+    }
+
+    @Override
+    public int compare(RestorePoint a, RestorePoint b) {
+        return a.compareTo(b);
+    }
+
+    @Override
+    public int getMemory(RestorePoint obj) {
+        // String + long + long + int + long + long
+        return StringDataType.INSTANCE.getMemory(obj.getName()) + 36;
+    }
+
+    @Override
+    public RestorePoint read(ByteBuffer buff) {
+        return new RestorePoint(
+                DataUtils.readString(buff),
+                ValueTimestampTimeZone.fromDateValueAndNanos(buff.getLong(), buff.getLong(), buff.getInt()),
+                ValueBigint.get(buff.getLong()),
+                ValueBigint.get(buff.getLong())
+        );
+    }
+
+    @Override
+    public void write(WriteBuffer buff, RestorePoint v) {
+        StringDataType.INSTANCE.write(buff, v.getName());
+        ValueTimestampTimeZone createdAt = v.getCreatedAt();
+        buff.putLong(createdAt.getDateValue())
+                .putLong(createdAt.getTimeNanos())
+                .putInt(createdAt.getTimeZoneOffsetSeconds())
+                .putLong(v.getOldestDatabaseVersionToKeep().getLong())
+                .putLong(v.getDatabaseVersion().getLong());
+    }
+}

--- a/h2/src/main/org/h2/res/_messages_cs.prop
+++ b/h2/src/main/org/h2/res/_messages_cs.prop
@@ -197,6 +197,9 @@
 90155=#Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=#Column alias is not specified for expression {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=Obecná chyba: {0}
 HY004=Neznámý datový typ: {0}
 HYC00=Vlastnost není podporována: {0}

--- a/h2/src/main/org/h2/res/_messages_de.prop
+++ b/h2/src/main/org/h2/res/_messages_de.prop
@@ -174,7 +174,7 @@
 90132=Aggregat-Funktion {0} nicht gefunden
 90133=Kann das Setting {0} nicht ändern wenn die Datenbank bereits geöffnet ist
 90134=Der Zugriff auf die Klasse {0} ist nicht erlaubt
-90135=Die Datenbank befindet sich im Exclusiv Modus; es können keine zusätzlichen Verbindungen geöffnet werden
+90135=Die Datenbank befindet sich im Exklusiv-Modus; es können keine zusätzlichen Verbindungen geöffnet werden
 90136=Bereich (Window) nicht gefunden: {0}
 90137=Werte können nur einer Variablen zugewiesen werden, nicht an: {0}
 90138=Ungültiger Datenbankname: {0}
@@ -197,6 +197,9 @@
 90155=Erzeugte Spalte {0} kann nicht durch eine referentielle Integrität mit dem Ausdruck {1} veränderbar sein
 90156=Spalten-Alias ist nicht für den Audruck {0} angegeben
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=Wiederherstellungspunkt {0} besteht bereits
+90159=Wiederherstellungspunkt {0} nicht gefunden
+90160=Konnte Datenbank nicht in Exklusiv-Modus versetzen
 HY000=Allgemeiner Fehler: {0}
 HY004=Unbekannter Datentyp: {0}
 HYC00=Dieses Feature wird nicht unterstützt: {0}

--- a/h2/src/main/org/h2/res/_messages_en.prop
+++ b/h2/src/main/org/h2/res/_messages_en.prop
@@ -197,6 +197,9 @@
 90155=Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=Column alias is not specified for expression {0}
 90157=Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=Restore point {0} already exists
+90159=Restore point {0} not found
+90160=Could not switch database to exclusive mode
 HY000=General error: {0}
 HY004=Unknown data type: {0}
 HYC00=Feature not supported: {0}

--- a/h2/src/main/org/h2/res/_messages_es.prop
+++ b/h2/src/main/org/h2/res/_messages_es.prop
@@ -197,6 +197,9 @@
 90155=#Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=#Column alias is not specified for expression {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=Error General : {0}
 HY004=Tipo de dato desconocido : {0}
 HYC00=Caracteristica no soportada: {0}

--- a/h2/src/main/org/h2/res/_messages_fr.prop
+++ b/h2/src/main/org/h2/res/_messages_fr.prop
@@ -197,6 +197,9 @@
 90155=#Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=#Column alias is not specified for expression {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=Erreur générale: {0}
 HY004=Type de données inconnu: {0}
 HYC00=Fonctionnalité non supportée: {0}

--- a/h2/src/main/org/h2/res/_messages_ja.prop
+++ b/h2/src/main/org/h2/res/_messages_ja.prop
@@ -197,6 +197,9 @@
 90155=#Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=#Column alias is not specified for expression {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=一般エラー: {0}
 HY004=不明なデータ型: {0}
 HYC00=機能はサポートされていません: {0}

--- a/h2/src/main/org/h2/res/_messages_pl.prop
+++ b/h2/src/main/org/h2/res/_messages_pl.prop
@@ -197,6 +197,9 @@
 90155=#Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=#Column alias is not specified for expression {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=Błąd ogólny: {0}
 HY004=Nieznany typ danych: {0}
 HYC00=Cecha nie jest wspierana: {0}

--- a/h2/src/main/org/h2/res/_messages_pt_br.prop
+++ b/h2/src/main/org/h2/res/_messages_pt_br.prop
@@ -197,6 +197,9 @@
 90155=#Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=#Column alias is not specified for expression {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=Erro geral: {0}
 HY004=Tipo de dados desconhecido: {0}
 HYC00=Recurso não suportado: {0}

--- a/h2/src/main/org/h2/res/_messages_ru.prop
+++ b/h2/src/main/org/h2/res/_messages_ru.prop
@@ -197,6 +197,9 @@
 90155=Генерируемый столбец {0} не может обновляться ссылочным ограничением с пунктом {1}
 90156=Имя столбца не указано для выражения {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=Внутренняя ошибка: {0}
 HY004=Неизвестный тип данных: {0}
 HYC00=Данная функция не поддерживается: {0}

--- a/h2/src/main/org/h2/res/_messages_sk.prop
+++ b/h2/src/main/org/h2/res/_messages_sk.prop
@@ -197,6 +197,9 @@
 90155=#Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=#Column alias is not specified for expression {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=Všeobecná chyba: {0}
 HY004=Neznámy dátový typ: {0}
 HYC00=Vlastnosť nie je podporovaná: {0}

--- a/h2/src/main/org/h2/res/_messages_zh_cn.prop
+++ b/h2/src/main/org/h2/res/_messages_zh_cn.prop
@@ -197,6 +197,9 @@
 90155=#Generated column {0} cannot be updatable by a referential constraint with {1} clause
 90156=#Column alias is not specified for expression {0}
 90157=#Column index {0} in GROUP BY clause is outside valid range 1 - {1}
+90158=#Restore point {0} already exists
+90159=#Restore point {0} not found
+90160=#Could not switch database to exclusive mode
 HY000=常规错误: {0}
 HY004=位置数据类型: {0}
 HYC00=不支持的特性: {0}

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -1355,6 +1355,32 @@ This command is part of the 2-phase-commit protocol.
 COMMIT TRANSACTION XID_TEST
 "
 
+"Commands (Other)","CREATE RESTORE POINT","
+@h2@ CREATE RESTORE POINT restorePointName
+","
+Creates a database restore point.
+
+Admin rights are required to execute this command.
+This command can be executed while the database is in use.
+Everything that is committed at the instant of creation will be part of the restore point.
+There is no limit as to how many restore points there can be.
+
+This is an experimental feature and should not be used in production environments.
+","
+CREATE RESTORE POINT RP1
+"
+
+"Commands (Other)","DROP RESTORE POINT","
+@h2@ DROP RESTORE POINT restorePointName
+","
+Drops a database restore point.
+
+Admin rights are required to execute this command.
+This command can be executed while the database is in use.
+","
+DROP RESTORE POINT RP1
+"
+
 "Commands (Other)","GRANT RIGHT","
 GRANT { { SELECT | INSERT | UPDATE | DELETE } [,..] | ALL [ PRIVILEGES ] } ON
 { @h2@ { SCHEMA schemaName } | { [ TABLE ] [schemaName.]tableName @h2@ [,...] } }
@@ -1407,6 +1433,18 @@ Prepares committing a transaction.
 This command is part of the 2-phase-commit protocol.
 ","
 PREPARE COMMIT XID_TEST
+"
+
+"Commands (Other)","RESTORE TO POINT","
+@h2@ RESTORE TO POINT restorePointName
+","
+Restores a database to the point in time at which the used restore point has been created.
+
+Admin rights are required to execute this command.
+This command requires an exclusive session and will disconnect other sessions.
+If there were any ongoing transactions (local and/or distributed) at the time of creation of the restore point, they are being discarded.
+","
+RESTORE TO POINT RP1
 "
 
 "Commands (Other)","REVOKE RIGHT","

--- a/h2/src/main/org/h2/schema/Schema.java
+++ b/h2/src/main/org/h2/schema/Schema.java
@@ -844,4 +844,19 @@ public class Schema extends DbObject {
         }
     }
 
+    /**
+     * Simply removes references to all database objects (without removing them from META).
+     * This is useful when going back to a restore point.
+     */
+    public void clear() {
+        tablesAndViews.clear();
+        domains.clear();
+        synonyms.clear();
+        indexes.clear();
+        sequences.clear();
+        triggers.clear();
+        constraints.clear();
+        constants.clear();
+        functionsAndAggregates.clear();
+    }
 }

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -1865,6 +1865,9 @@ public final class InformationSchemaTable extends MetaTable {
     }
 
     private void restorePoints(SessionLocal session, Value indexFrom, Value indexTo, ArrayList<Row> rows) {
+        if (!session.getUser().isAdmin()) {
+            return;
+        }
         session.getDatabase()
                 .getStore()
                 .getMvStore()

--- a/h2/src/main/org/h2/table/InformationSchemaTable.java
+++ b/h2/src/main/org/h2/table/InformationSchemaTable.java
@@ -109,9 +109,7 @@ public final class InformationSchemaTable extends MetaTable {
 
     private static final int REFERENTIAL_CONSTRAINTS = PARAMETERS + 1;
 
-    private static final int RESTORE_POINTS = REFERENTIAL_CONSTRAINTS + 1;
-
-    private static final int ROUTINES = RESTORE_POINTS + 1;
+    private static final int ROUTINES = REFERENTIAL_CONSTRAINTS + 1;
 
     private static final int SCHEMATA = ROUTINES + 1;
 
@@ -157,11 +155,13 @@ public final class InformationSchemaTable extends MetaTable {
 
     private static final int USERS = SYNONYMS + 1;
 
+    private static final int RESTORE_POINTS = USERS + 1;
+
     /**
      * The number of meta table types. Supported meta table types are
      * {@code 0..META_TABLE_TYPE_COUNT - 1}.
      */
-    public static final int META_TABLE_TYPE_COUNT = USERS + 1;
+    public static final int META_TABLE_TYPE_COUNT = RESTORE_POINTS + 1;
 
     private final boolean isView;
 
@@ -478,15 +478,6 @@ public final class InformationSchemaTable extends MetaTable {
                     column("DELETE_RULE"), //
             };
             indexColumnName = "CONSTRAINT_NAME";
-            break;
-        case RESTORE_POINTS:
-            setMetaTableName("RESTORE_POINTS");
-            cols = new Column[] {
-                    column("RESTORE_POINT_NAME"), //
-                    column("CREATED_AT", TypeInfo.TYPE_TIMESTAMP_TZ), //
-                    column("DATABASE_VERSION", TypeInfo.TYPE_BIGINT), //
-            };
-            indexColumnName = "RESTORE_POINT_NAME";
             break;
         case ROUTINES:
             setMetaTableName("ROUTINES");
@@ -864,6 +855,16 @@ public final class InformationSchemaTable extends MetaTable {
                     column("REMARKS"), //
             };
             break;
+        case RESTORE_POINTS:
+            setMetaTableName("RESTORE_POINTS");
+            isView = false;
+            cols = new Column[] {
+                    column("RESTORE_POINT_NAME"), //
+                    column("CREATED_AT", TypeInfo.TYPE_TIMESTAMP_TZ), //
+                    column("DATABASE_VERSION", TypeInfo.TYPE_BIGINT), //
+            };
+            indexColumnName = "RESTORE_POINT_NAME";
+            break;
         default:
             throw DbException.getInternalError("type=" + type);
         }
@@ -935,9 +936,6 @@ public final class InformationSchemaTable extends MetaTable {
         case REFERENTIAL_CONSTRAINTS:
             referentialConstraints(session, indexFrom, indexTo, rows, catalog);
             break;
-        case RESTORE_POINTS:
-            restorePoints(session, indexFrom, indexTo, rows);
-            break;
         case ROUTINES:
             routines(session, rows, catalog);
             break;
@@ -1004,6 +1002,9 @@ public final class InformationSchemaTable extends MetaTable {
             break;
         case USERS:
             users(session, rows);
+            break;
+        case RESTORE_POINTS:
+            restorePoints(session, indexFrom, indexTo, rows);
             break;
         default:
             throw DbException.getInternalError("type=" + type);

--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -69,6 +69,7 @@ import org.h2.test.db.TestPowerOff;
 import org.h2.test.db.TestQueryCache;
 import org.h2.test.db.TestReadOnly;
 import org.h2.test.db.TestRecursiveQueries;
+import org.h2.test.db.TestRestorePoint;
 import org.h2.test.db.TestRights;
 import org.h2.test.db.TestRunscript;
 import org.h2.test.db.TestSQLInjection;
@@ -772,6 +773,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
             addTest(new TestViewAlterTable());
             addTest(new TestViewDropView());
             addTest(new TestSynonymForTable());
+            addTest(new TestRestorePoint());
 
             // jdbc
             addTest(new TestBatchUpdates());

--- a/h2/src/test/org/h2/test/db/TestRestorePoint.java
+++ b/h2/src/test/org/h2/test/db/TestRestorePoint.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2004-2024 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: Enno Thieleke
+ */
+package org.h2.test.db;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.h2.api.ErrorCode;
+import org.h2.test.TestAll;
+import org.h2.test.TestBase;
+import org.h2.test.TestDb;
+
+/**
+ * Test restore point statements.
+ */
+public class TestRestorePoint extends TestDb {
+
+    private boolean pseudoReconnect, autoCommit;
+
+    private Connection conn;
+    private Statement stat;
+
+    /**
+     * Run just this test.
+     *
+     * @param a ignored
+     */
+    public static void main(String... a) throws Exception {
+        for (boolean memory : new boolean[] {false, true}) {
+            TestAll conf = new TestAll();
+            conf.memory = memory;
+            TestBase.createCaller().init(conf).testFromMain();
+        }
+    }
+
+    @Override
+    public void test() throws Exception {
+        if (!config.memory) {
+            test(false, false);
+            test(false, true);
+        }
+        test(true, false);
+        test(true, true);
+    }
+
+    private void test(boolean pseudoReconnect, boolean autoCommit) throws Exception {
+        this.pseudoReconnect = pseudoReconnect;
+        this.autoCommit = autoCommit;
+        testCreateRestorePoint();
+        testDropRestorePoint();
+        testRestoreToPoint1();
+        testRestoreToPoint2();
+        testCreateRestorePointWithConcurrentTransaction();
+        testRestoreToPointWithConcurrentTransaction();
+        testMemoryFreeing();
+        testDefragAlways();
+        deleteDb(getTestName());
+    }
+
+    private void connect() throws Exception {
+        connect(true);
+    }
+
+    private void connect(boolean deleteDb) throws Exception {
+        if (deleteDb) {
+            deleteDb(getTestName());
+        }
+        conn = getConnection(getTestName());
+        conn.setAutoCommit(autoCommit);
+        stat = conn.createStatement();
+    }
+
+    private void connect(String url) throws Exception {
+        conn = DriverManager.getConnection(url, getUser(), getPassword());
+        stat = conn.createStatement();
+    }
+
+    private void disconnect() throws Exception {
+        conn.close();
+    }
+
+    private void reconnect() throws Exception {
+        if (!autoCommit) {
+            conn.commit();
+        }
+        if (!pseudoReconnect) {
+            disconnect();
+            connect(false);
+        }
+    }
+
+    private void reconnect(String url) throws Exception {
+        disconnect();
+        connect(url);
+    }
+
+    private void testCreateRestorePoint() throws Exception {
+        connect();
+        stat.execute("create restore point rp1");
+        assertRestorePoints(stat, "RP1");
+        assertThrows(ErrorCode.RESTORE_POINT_ALREADY_EXISTS, stat).execute("create restore point rp1");
+
+        reconnect();
+        stat.execute("create restore point rp2");
+        assertRestorePoints(stat, "RP1", "RP2");
+        assertThrows(ErrorCode.RESTORE_POINT_ALREADY_EXISTS, stat).execute("create restore point rp2");
+
+        reconnect();
+        stat.execute("create restore point rp3");
+        assertRestorePoints(stat, "RP1", "RP2", "RP3");
+        assertThrows(ErrorCode.RESTORE_POINT_ALREADY_EXISTS, stat).execute("create restore point rp3");
+
+        disconnect();
+    }
+
+    private void testDropRestorePoint() throws Exception {
+        connect();
+        stat.execute("create restore point rp1");
+        assertRestorePoints(stat, "RP1");
+
+        reconnect();
+        stat.execute("create restore point rp2");
+        assertRestorePoints(stat, "RP1", "RP2");
+        stat.execute("drop restore point rp1");
+        assertRestorePoints(stat, "RP2");
+
+        disconnect();
+    }
+
+    private void testRestoreToPoint1() throws Exception {
+        connect();
+        stat.execute("create table my_table(id int primary key)");
+        stat.execute("insert into my_table values(1)");
+        stat.execute("create restore point rp1");
+
+        reconnect();
+        stat.execute("create restore point rp2");
+        stat.execute("insert into my_table values(2)");
+        stat.execute("insert into my_table values(3)");
+        stat.execute("create restore point rp3");
+        stat.execute("insert into my_table values(4)");
+
+        reconnect();
+        assertSingleValue(stat, "select count(*) from my_table", 4);
+        stat.execute("restore to point rp3");
+        assertSingleValue(stat, "select count(*) from my_table", 3);
+
+        reconnect();
+        assertSingleValue(stat, "select count(*) from my_table", 3);
+        stat.execute("restore to point rp1");
+        assertSingleValue(stat, "select count(*) from my_table", 1);
+        // Restoring to a point before other RPs discards those other RPs too.
+        assertRestorePoints(stat, "RP1");
+
+        disconnect();
+    }
+
+    private void testRestoreToPoint2() throws Exception {
+        connect();
+        stat.execute("create restore point rp1");
+
+        reconnect();
+        stat.execute("create restore point rp2");
+
+        reconnect();
+        stat.execute("drop restore point rp1");
+        assertRestorePoints(stat, "RP2");
+
+        reconnect();
+        stat.execute("restore to point rp2");
+
+        reconnect();
+        /* Restoring to the point RP2, which has been created before the
+         * earlier restore point RP1 has been dropped, also restores said
+         * earlier restore point RP1.
+         */
+        assertRestorePoints(stat, "RP1", "RP2");
+
+        disconnect();
+    }
+
+    private void testCreateRestorePointWithConcurrentTransaction() throws Exception {
+        if (!autoCommit) {
+            return;
+        }
+        connect();
+        stat.execute("create restore point rp1");
+
+        Connection conn2 = getConnection(getTestName());
+        conn2.setAutoCommit(false);
+        Statement stat2 = conn2.createStatement();
+        stat2.execute("create table my_table(id int primary key)");
+        stat2.execute("insert into my_table values(1)");
+        stat.execute("create restore point rp2");
+
+        // Because table creations are not transactional, but inserts are,
+        // we should be able to see the table, but without any data, because it's not committed yet.
+        assertSingleValue(stat, "select count(*) from my_table", 0);
+
+        // Let the other client commit its pending transaction.
+        conn2.commit();
+        conn2.close();
+
+        conn.rollback(); // This dissociates the previous result from our session so we can read the now committed value from the other session.
+        assertSingleValue(stat, "select count(*) from my_table", 1);
+
+        stat.execute("restore to point rp2");
+        // The data should not exist anymore, because we've restored the database to a point where it never existed in the first place.
+        assertSingleValue(stat, "select count(*) from my_table", 0);
+
+        stat.execute("restore to point rp1");
+        // Now the table should be gone as well, because RP1 has been created before the table.
+        assertThrows(ErrorCode.TABLE_OR_VIEW_NOT_FOUND_DATABASE_EMPTY_1, stat).execute("select count(*) from my_table");
+
+        disconnect();
+    }
+
+    private void testRestoreToPointWithConcurrentTransaction() throws Exception {
+        if (!autoCommit) {
+            return;
+        }
+        connect();
+
+        Connection conn2 = getConnection(getTestName());
+        conn2.setAutoCommit(false);
+        Statement stat2 = conn2.createStatement();
+        stat2.execute("create table my_table(id int primary key)");
+        stat2.execute("insert into my_table values(1)");
+
+        stat.execute("create restore point rp1");
+        stat.execute("restore to point rp1");
+        try {
+            stat2.execute("select count(*) from my_table");
+            fail("Got a result, but expected the connection to be closed");
+        } catch (SQLException ignore) {
+            // I have observed exceptions with different error codes, so I'm not checking for a specific one.
+        }
+
+        disconnect();
+    }
+
+    /**
+     * This test ensures that returning to a restore point actually frees up memory.
+     * If we don't return to a restore point, we essentially hog memory,
+     * because with every statement we create a new MVStore version (auto-commit is turned on).
+     */
+    private void testMemoryFreeing() throws Exception {
+        if (!config.memory || !autoCommit) {
+            return;
+        }
+        connect();
+
+        stat.execute("create table test(id bigint generated always as identity primary key, v binary varying)");
+        PreparedStatement prepInsert = conn.prepareStatement("insert into test(v) values ?");
+        PreparedStatement prepSelect = conn.prepareStatement("select v from test where id = 1");
+        prepInsert.setBytes(1, new byte[9_999]);
+        prepInsert.executeUpdate();
+        stat.execute("create restore point p");
+        PreparedStatement prepDelete = conn.prepareStatement("delete from test");
+        for (int i = 1; i <= 5_000; i++) {
+            prepDelete.executeUpdate();
+            prepInsert.setBytes(1, new byte[1_000_000]);
+            prepInsert.executeUpdate();
+
+            stat.execute("restore to point p");
+            try (ResultSet r = prepSelect.executeQuery()) {
+                assertTrue(r.next());
+                assertTrue(r.getBytes(1).length == 9_999);
+            }
+        }
+
+        disconnect();
+    }
+
+    private void testDefragAlways() throws Exception {
+        if (config.memory || !autoCommit || pseudoReconnect) {
+            return;
+        }
+        deleteDb(getTestName());
+
+        String url = "jdbc:h2:" + getBaseDir() + "/" + getTestName() + ";DEFRAG_ALWAYS=true";
+//        String url = "jdbc:h2:" + getBaseDir() + "/" + getTestName() + ";MAX_COMPACT_TIME=5000";
+        connect(url);
+        stat.execute("create table test(id bigint generated always as identity primary key, v int)");
+
+        PreparedStatement prepInsert = conn.prepareStatement("insert into test(v) values ?");
+        for (int i = 1; i <= 10; i++) {
+            prepInsert.setInt(1, i);
+            prepInsert.executeUpdate();
+        }
+        stat.execute("create restore point p1");
+
+        reconnect(url);
+        prepInsert = conn.prepareStatement("insert into test(v) values ?");
+        for (int i = 11; i <= 20; i++) {
+            prepInsert.setInt(1, i);
+            prepInsert.executeUpdate();
+        }
+        stat.execute("create restore point p2");
+
+        reconnect(url);
+        prepInsert = conn.prepareStatement("insert into test(v) values ?");
+        for (int i = 21; i <= 30; i++) {
+            prepInsert.setInt(1, i);
+            prepInsert.executeUpdate();
+        }
+
+        reconnect(url);
+        assertSingleValue(stat, "select count(*) from test", 30);
+        stat.execute("restore to point p2");
+        assertSingleValue(stat, "select count(*) from test", 20);
+        stat.execute("restore to point p1");
+        assertSingleValue(stat, "select count(*) from test", 10);
+
+        disconnect();
+    }
+
+    private void assertRestorePoints(Statement stat, String... restorePointNames) throws Exception {
+        try (ResultSet r = stat.executeQuery("select * from information_schema.restore_points order by restore_point_name")) {
+            List<String> actualRestorePointNames = new ArrayList<>();
+            while (r.next()) {
+                actualRestorePointNames.add(r.getString("restore_point_name"));
+            }
+            assertEquals(List.of(restorePointNames), actualRestorePointNames);
+        }
+    }
+
+    private void printRestorePoints(Statement stat) throws Exception {
+        try (ResultSet r = stat.executeQuery("select * from information_schema.restore_points order by restore_point_name")) {
+            while (r.next()) {
+                System.out.printf(
+                        "restore_point_name=%s, created_at=%s, oldest_database_version_to_keep=%s, database_version=%s%n",
+                        r.getString("restore_point_name"),
+                        r.getObject("created_at", ZonedDateTime.class),
+                        r.getLong("oldest_database_version_to_keep"),
+                        r.getLong("database_version")
+                );
+            }
+        }
+    }
+}

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1199,7 +1199,7 @@ public class TestMetaData extends TestDb {
                 "USERS", "CHECK_CONSTRAINTS", "COLLATIONS", "COLUMNS", "COLUMN_PRIVILEGES",
                 "CONSTRAINT_COLUMN_USAGE", "DOMAINS", "DOMAIN_CONSTRAINTS", "ELEMENT_TYPES", "FIELDS",
                 "KEY_COLUMN_USAGE", "PARAMETERS",
-                "REFERENTIAL_CONSTRAINTS", "ROUTINES", "SCHEMATA", "SEQUENCES", "TABLES", "TABLE_CONSTRAINTS",
+                "REFERENTIAL_CONSTRAINTS", "RESTORE_POINTS", "ROUTINES", "SCHEMATA", "SEQUENCES", "TABLES", "TABLE_CONSTRAINTS",
                 "TABLE_PRIVILEGES", "TRIGGERS", "VIEWS" }) {
             rs.next();
             assertEquals(name, rs.getString("TABLE_NAME"));

--- a/h2/src/test/org/h2/test/jdbc/TestMetaData.java
+++ b/h2/src/test/org/h2/test/jdbc/TestMetaData.java
@@ -1195,11 +1195,11 @@ public class TestMetaData extends TestDb {
         rs = meta.getTables(null, "INFORMATION_SCHEMA", null, new String[] { "BASE TABLE", "VIEW" });
         for (String name : new String[] { "CONSTANTS", "ENUM_VALUES",
                 "INDEXES", "INDEX_COLUMNS", "INFORMATION_SCHEMA_CATALOG_NAME", "IN_DOUBT", "LOCKS",
-                "QUERY_STATISTICS", "RIGHTS", "ROLES", "SESSIONS", "SESSION_STATE", "SETTINGS", "SYNONYMS",
+                "QUERY_STATISTICS", "RESTORE_POINTS", "RIGHTS", "ROLES", "SESSIONS", "SESSION_STATE", "SETTINGS", "SYNONYMS",
                 "USERS", "CHECK_CONSTRAINTS", "COLLATIONS", "COLUMNS", "COLUMN_PRIVILEGES",
                 "CONSTRAINT_COLUMN_USAGE", "DOMAINS", "DOMAIN_CONSTRAINTS", "ELEMENT_TYPES", "FIELDS",
                 "KEY_COLUMN_USAGE", "PARAMETERS",
-                "REFERENTIAL_CONSTRAINTS", "RESTORE_POINTS", "ROUTINES", "SCHEMATA", "SEQUENCES", "TABLES", "TABLE_CONSTRAINTS",
+                "REFERENTIAL_CONSTRAINTS", "ROUTINES", "SCHEMATA", "SEQUENCES", "TABLES", "TABLE_CONSTRAINTS",
                 "TABLE_PRIVILEGES", "TRIGGERS", "VIEWS" }) {
             rs.next();
             assertEquals(name, rs.getString("TABLE_NAME"));

--- a/h2/src/test/org/h2/test/store/TestMVStore.java
+++ b/h2/src/test/org/h2/test/store/TestMVStore.java
@@ -1394,7 +1394,7 @@ public class TestMVStore extends TestBase {
             }
             assertEquals(1000, m.size());
             // memory calculations were adjusted, so as this out-of-the-thin-air number
-            assertEquals(93832, s.getUnsavedMemory());
+            assertEquals(94064, s.getUnsavedMemory());
             s.commit();
             assertEquals(2, s.getFileStore().getWriteCount());
         }
@@ -1567,14 +1567,14 @@ public class TestMVStore extends TestBase {
         try (MVStore s = openStore(fileName)) {
             s.setRetentionTime(Integer.MAX_VALUE);
             Map<String, String> m = s.getMetaMap();
-            assertEquals("[]", s.getMapNames().toString());
+            assertEquals("[restorePoints]", s.getMapNames().toString());
             MVMap<String, String> data = s.openMap("data");
             data.put("1", "Hello");
             data.put("2", "World");
             s.commit();
             assertEquals(1, s.getCurrentVersion());
 
-            assertEquals("[data]", s.getMapNames().toString());
+            assertEquals("[data, restorePoints]", s.getMapNames().toString());
             assertEquals("data", s.getMapName(data.getId()));
             assertNull(s.getMapName(s.getMetaMap().getId()));
             assertNull(s.getMapName(data.getId() + 1));


### PR DESCRIPTION
This feature request is about implementing restore points in H2. The idea is that one can mark a database state and return to it easily without resorting to backups. The primary motivation for this is integration testing.

### The current implementation status is:

Restore points can be used with SQL, e.g.
- `create restore point rp1`
- `restore to point rp1`
- `drop restore point rp1`

and they can be selected via `select restore_point_name, created_at, database_version from information_schema.restore_points`. Using one of the first three commands requires admin privileges.
It is possible to create or drop a restore point while the database is in use concurrently. When restoring to a point, all concurrent sessions are dropped, any ongoing transactions a reaped, the database is brought back to a previous state and any data created since is completely lost.

Restore points are saved as a separate `MVMap` and inventoried by `MVStore.meta`. This way they can be accessed without accessing the `public.sys` system table which in turn means that a database need not be started.

Creating one or more restore points makes a `FileStore` effectively append only. If no restore points exist, e.g. because none have been created or all have been dropped, this restriction does not apply and the `FileStore` is free to do maintenance work.

The  `DEFRAG_ALWAYS=true` flag _works_ even with restore points. The compaction routine, that is called on a database shutdown, will copy all store versions, i.e. chunks, referenced by restore points and the latest one.

When used with in-memory databases, the behavior is the same as with persistent databases, but because of how the `MVStore` is versioning data, the entire history up to the oldest restore point is kept. This also means that a JVM can run out of memory although just a fraction of data or none at all is referenced by the latest version of the `MVStore`. Restoring an in-memory database to a point releases used memory of course.

Restore points are marked as an experimental feature and that they should not be used in a production environment.

### Notes:

My understanding of [chunks and pages](http://h2database.com/html/mvstore.html#fileFormat) of a `FileStore` is as follows: Chunks reference pages, which reference pages, possibly across chunks. There can be only one (hehe) chunk for one version. This is what, to my understanding, makes it safe to compact databases across different versions. If a chunk is copied from one `FileStore` to another, all pages across all relevant chunks are copied from a source `FileStore` into a single new chunk to a destination `FileStore`.



Link to the previous discussion(s) in the mailing list: https://groups.google.com/g/h2-database/c/iJLjES5j2TU