### PR TITLE
GCD, LCM, GCD_AGG, and LCM_AGG functions

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -31,7 +31,7 @@ Change Log
 </li>
 <li>PR #4168: simplify Store#close
 </li>
-<li>Issue #4161: h2 uses wrong index 
+<li>Issue #4161: h2 uses wrong index
 </li>
 <li>Issue #4159: Consider storing NO ACTION in the INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS columns
 when this is the declaration

--- a/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
+++ b/h2/src/main/org/h2/command/ddl/AlterTableAddConstraint.java
@@ -329,8 +329,8 @@ public class AlterTableAddConstraint extends AlterTable {
         if (indexColumns.length == 1 && needNullsDistinct == NullsDistinct.ALL_DISTINCT) {
             needNullsDistinct = NullsDistinct.DISTINCT;
         }
-        return new ConstraintUnique(tableSchema, id, name, table, false, indexColumns, index, isOwner, needNullsDistinct
-        );
+        return new ConstraintUnique(tableSchema, id, name, table, false, indexColumns, index, isOwner,
+                needNullsDistinct);
     }
 
     private void addConstraintToTable(Database db, Table table, Constraint constraint) {

--- a/h2/src/main/org/h2/command/dml/Delete.java
+++ b/h2/src/main/org/h2/command/dml/Delete.java
@@ -113,7 +113,8 @@ public final class Delete extends FilteredDataChangeStatement {
             }
         }
         TableFilter[] filters = new TableFilter[] { targetTableFilter };
-        PlanItem item = targetTableFilter.getBestPlanItem(session, filters, 0, new AllColumnsForPlan(filters), /*isSelectCommand*/false);
+        PlanItem item = targetTableFilter.getBestPlanItem(session, filters, 0, new AllColumnsForPlan(filters),
+                /* isSelectCommand */false);
         targetTableFilter.setPlanItem(item);
         targetTableFilter.prepare();
     }

--- a/h2/src/main/org/h2/command/dml/MergeUsing.java
+++ b/h2/src/main/org/h2/command/dml/MergeUsing.java
@@ -200,7 +200,8 @@ public final class MergeUsing extends DataChangeStatement {
 
         TableFilter[] filters = new TableFilter[] { sourceTableFilter, targetTableFilter };
         sourceTableFilter.addJoin(targetTableFilter, true, onCondition);
-        PlanItem item = sourceTableFilter.getBestPlanItem(session, filters, 0, new AllColumnsForPlan(filters), /*isSelectCommand*/ false);
+        PlanItem item = sourceTableFilter.getBestPlanItem(session, filters, 0, new AllColumnsForPlan(filters),
+                /* isSelectCommand */ false);
         sourceTableFilter.setPlanItem(item);
         sourceTableFilter.prepare();
 

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -129,7 +129,8 @@ public final class Update extends FilteredDataChangeStatement {
         }
         setClauseList.mapAndOptimize(session, targetTableFilter, null);
         TableFilter[] filters = new TableFilter[] { targetTableFilter };
-        PlanItem item = targetTableFilter.getBestPlanItem(session, filters, 0, new AllColumnsForPlan(filters), /*isSelectCommand*/false);
+        PlanItem item = targetTableFilter.getBestPlanItem(session, filters, 0, new AllColumnsForPlan(filters),
+                /* isSelectCommand */false);
         targetTableFilter.setPlanItem(item);
         targetTableFilter.prepare();
     }

--- a/h2/src/main/org/h2/constraint/ConstraintDomain.java
+++ b/h2/src/main/org/h2/constraint/ConstraintDomain.java
@@ -214,7 +214,8 @@ public class ConstraintDomain extends Constraint {
             Table table = targetColumn.getTable();
             TableFilter filter = new TableFilter(session, table, null, true, null, 0, null);
             TableFilter[] filters = { filter };
-            PlanItem item = filter.getBestPlanItem(session, filters, 0, new AllColumnsForPlan(filters), /*isSelectCommand*/true);
+            PlanItem item = filter.getBestPlanItem(session, filters, 0, new AllColumnsForPlan(filters),
+                    /* isSelectCommand */true);
             filter.setPlanItem(item);
             filter.prepare();
             filter.startQuery(session);

--- a/h2/src/main/org/h2/expression/OperationN.java
+++ b/h2/src/main/org/h2/expression/OperationN.java
@@ -6,6 +6,7 @@
 package org.h2.expression;
 
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.h2.engine.SessionLocal;
 import org.h2.message.DbException;
@@ -84,6 +85,74 @@ public abstract class OperationN extends Expression implements ExpressionWithVar
             }
         }
         return allConst;
+    }
+
+    /**
+     * Inlines subexpressions if possible.
+     *
+     * @param tester
+     *            the predicate to check whether subexpression can be inlined
+     */
+    protected final void inlineSubexpressions(Predicate<Expression> tester) {
+        for (int i = 0, sourceLength = args.length; i < sourceLength; i++) {
+            Expression e = args[i];
+            if (tester.test(e)) {
+                inlineSubexpressions(tester, i, sourceLength, e);
+                break;
+            }
+        }
+    }
+
+    private void inlineSubexpressions(Predicate<Expression> tester, int sourceOffset, int sourceLength,
+            Expression match1) {
+        int l1 = match1.getSubexpressionCount();
+        boolean many = false, forceCopy = false;
+        int targetLength = sourceLength;
+        if (l1 != 1) {
+            forceCopy = true;
+            targetLength += l1 - 1;
+        }
+        for (int i = sourceOffset + 1; i < sourceLength; i++) {
+            Expression e = args[i];
+            if (tester.test(e)) {
+                many = true;
+                int l2 = e.getSubexpressionCount();
+                if (l2 != 1) {
+                    forceCopy = true;
+                    targetLength += l2 - 1;
+                }
+            }
+        }
+        Expression[] source = args;
+        if (forceCopy) {
+            args = new Expression[targetLength];
+            System.arraycopy(source, 0, args, 0, sourceOffset);
+        }
+        copyArgs(match1, sourceOffset, l1);
+        if (many) {
+            for (int targetOffset = sourceOffset + l1; ++sourceOffset < sourceLength;) {
+                Expression e = source[sourceOffset];
+                if (tester.test(e)) {
+                    int l2 = e.getSubexpressionCount();
+                    copyArgs(e, targetOffset, l2);
+                    targetOffset += l2;
+                } else {
+                    args[targetOffset++] = e;
+                }
+            }
+        } else if (forceCopy) {
+            System.arraycopy(source, sourceOffset + 1, args, sourceOffset + l1, sourceLength - sourceOffset - 1);
+        }
+    }
+
+    private void copyArgs(Expression e, int offset, int count) {
+        if (e instanceof OperationN) {
+            System.arraycopy(((OperationN) e).args, 0, args, offset, count);
+        } else {
+            for (int j = 0; j < count; j++) {
+                args[offset + j] = e.getSubexpression(j);
+            }
+        }
     }
 
     @Override

--- a/h2/src/main/org/h2/expression/aggregate/AggregateDataGCD.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateDataGCD.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2004-2025 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.aggregate;
+
+import java.math.BigInteger;
+
+import org.h2.engine.SessionLocal;
+import org.h2.expression.function.GCDFunction;
+import org.h2.message.DbException;
+import org.h2.value.Value;
+import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+
+/**
+ * Data stored while calculating GCD_AGG or LCM_AGG aggregate.
+ */
+final class AggregateDataGCD extends AggregateData {
+
+    private final boolean lcm;
+
+    private boolean skipRemaining, overflow;
+
+    private BigInteger bi;
+
+    AggregateDataGCD(boolean lcm) {
+        this.lcm = lcm;
+    }
+
+    @Override
+    void add(SessionLocal session, Value v) {
+        if (v == ValueNull.INSTANCE || skipRemaining) {
+            return;
+        }
+        BigInteger n = v.getBigInteger();
+        if (lcm) {
+            if (n.signum() == 0) {
+                bi = BigInteger.ZERO;
+                skipRemaining = true;
+                overflow = false;
+            } else {
+                if (bi == null) {
+                    bi = n.abs();
+                } else if (!overflow) {
+                    bi = bi.multiply(n).abs().divide(bi.gcd(n));
+                    overflow = bi.bitLength() > GCDFunction.MAX_BIT_LENGTH;
+                }
+            }
+        } else {
+            if (bi == null) {
+                bi = n.abs();
+            } else if (n.signum() != 0) {
+                bi = bi.gcd(n);
+            } else {
+                return;
+            }
+            skipRemaining = bi.equals(BigInteger.ONE);
+        }
+    }
+
+    @Override
+    Value getValue(SessionLocal session) {
+        if (overflow) {
+            throw DbException.getValueTooLongException("NUMERIC", "unknown least common multiple", -1);
+        }
+        return bi != null ? ValueNumeric.get(bi) : ValueNull.INSTANCE;
+    }
+
+}

--- a/h2/src/main/org/h2/expression/aggregate/AggregateType.java
+++ b/h2/src/main/org/h2/expression/aggregate/AggregateType.java
@@ -235,4 +235,14 @@ public enum AggregateType {
      */
     JSON_ARRAYAGG,
 
+    /**
+     * The aggregate type for GCD_AGG(expression).
+     */
+    GCD_AGG,
+
+    /**
+     * The aggregate type for LCM_AGG(expression).
+     */
+    LCM_AGG,
+
 }

--- a/h2/src/main/org/h2/expression/function/ConcatFunction.java
+++ b/h2/src/main/org/h2/expression/function/ConcatFunction.java
@@ -95,6 +95,7 @@ public final class ConcatFunction extends FunctionN {
         if (allConst) {
             return TypedValueExpression.getTypedIfNull(getValue(session), type);
         }
+        inlineSubexpressions(t -> t instanceof ConcatFunction && ((ConcatFunction) t).function == function);
         return this;
     }
 

--- a/h2/src/main/org/h2/expression/function/GCDFunction.java
+++ b/h2/src/main/org/h2/expression/function/GCDFunction.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2004-2025 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.expression.function;
+
+import java.math.BigInteger;
+
+import org.h2.engine.Constants;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.expression.TypedValueExpression;
+import org.h2.message.DbException;
+import org.h2.value.TypeInfo;
+import org.h2.value.Value;
+import org.h2.value.ValueNull;
+import org.h2.value.ValueNumeric;
+
+/**
+ * GCD and LCM functions.
+ */
+public class GCDFunction extends FunctionN {
+
+    /**
+     * GCD() (non-standard).
+     */
+    public static final int GCD = 0;
+
+    /**
+     * LCM() (non-standard).
+     */
+    public static final int LCM = GCD + 1;
+
+    private static final String[] NAMES = { //
+            "GCD", "LCM" //
+    };
+
+    public static final int MAX_BIT_LENGTH = (int) Math.ceil(Constants.MAX_NUMERIC_PRECISION / Math.log10(2));
+
+    private final int function;
+
+    public GCDFunction(int function) {
+        super(new Expression[2]);
+        this.function = function;
+        type = TypeInfo.TYPE_NUMERIC_SCALE_0;
+    }
+
+    @Override
+    public Value getValue(SessionLocal session) {
+        Value v1 = args[0].getValue(session);
+        if (v1 == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        Value v2 = args[1].getValue(session);
+        if (v2 == ValueNull.INSTANCE) {
+            return ValueNull.INSTANCE;
+        }
+        BigInteger a = v1.getBigInteger(), b = v2.getBigInteger();
+        switch (function) {
+        case GCD:
+            return gcd(session, a, b);
+        case LCM:
+            return lcm(session, a, b);
+        default:
+            throw DbException.getInternalError("function=" + function);
+        }
+    }
+
+    private Value gcd(SessionLocal session, BigInteger a, BigInteger b) {
+        a = a.gcd(b);
+        int count = args.length;
+        if (count > 2) {
+            boolean one = a.equals(BigInteger.ONE);
+            for (int i = 2; i < count; i++) {
+                Value v = args[i].getValue(session);
+                if (v == ValueNull.INSTANCE) {
+                    return ValueNull.INSTANCE;
+                }
+                if (!one) {
+                    b = v.getBigInteger();
+                    if (b.signum() != 0) {
+                        a = a.gcd(b);
+                        one = a.equals(BigInteger.ONE);
+                    }
+                }
+            }
+        }
+        return ValueNumeric.get(a);
+    }
+
+    private Value lcm(SessionLocal session, BigInteger a, BigInteger b) {
+        boolean zero = a.signum() == 0 || b.signum() == 0;
+        a = zero ? BigInteger.ZERO : a.multiply(b).abs().divide(a.gcd(b));
+        int count = args.length;
+        if (count > 2) {
+            boolean overflow = !zero && a.bitLength() > MAX_BIT_LENGTH;
+            for (int i = 2; i < count; i++) {
+                Value v = args[i].getValue(session);
+                if (v == ValueNull.INSTANCE) {
+                    return ValueNull.INSTANCE;
+                }
+                if (!zero) {
+                    b = v.getBigInteger();
+                    if (b.signum() == 0) {
+                        a = BigInteger.ZERO;
+                        zero = true;
+                        overflow = false;
+                    } else if (!overflow) {
+                        a = a.multiply(b).abs().divide(a.gcd(b));
+                        overflow = a.bitLength() > MAX_BIT_LENGTH;
+                    }
+                }
+            }
+            if (overflow) {
+                throw DbException.getValueTooLongException("NUMERIC", "unknown least common multiple", -1);
+            }
+        }
+        return ValueNumeric.get(a);
+    }
+
+    @Override
+    public Expression optimize(SessionLocal session) {
+        boolean allConst = true, wasNull = false;
+        for (int i = 0, l = args.length; i < l; i++) {
+            Expression e = args[i].optimize(session);
+            wasNull |= checkType(e, getName());
+            args[i] = e;
+            if (allConst && !e.isConstant()) {
+                allConst = false;
+            }
+        }
+        if (allConst) {
+            return TypedValueExpression.getTypedIfNull(getValue(session), TypeInfo.TYPE_NUMERIC_SCALE_0);
+        } else if (wasNull) {
+            return TypedValueExpression.get(ValueNull.INSTANCE, TypeInfo.TYPE_NUMERIC_SCALE_0);
+        }
+        inlineSubexpressions(t -> t instanceof GCDFunction && ((GCDFunction) t).function == function);
+        return this;
+    }
+
+    /**
+     * Checks type of GCD, LCM, GCD_AGG, or LCM_AGG argument.
+     *
+     * @param e
+     *            the argument
+     * @param name
+     *            the name of the function
+     * @return {@code true} if argument has NULL data type, {@code false}
+     *         otherwise
+     */
+    public static boolean checkType(Expression e, String name) {
+        TypeInfo argType = e.getType();
+        switch (argType.getValueType()) {
+        case Value.NULL:
+            return true;
+        case Value.TINYINT:
+        case Value.SMALLINT:
+        case Value.INTEGER:
+        case Value.BIGINT:
+            break;
+        case Value.NUMERIC:
+            if (argType.getScale() == 0) {
+                break;
+            }
+            //$FALL-THROUGH$
+        default:
+            throw DbException.getInvalidValueException(name + " argument", e.getTraceSQL());
+        }
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return NAMES[function];
+    }
+
+}

--- a/h2/src/main/org/h2/index/Index.java
+++ b/h2/src/main/org/h2/index/Index.java
@@ -739,8 +739,8 @@ public abstract class Index extends SchemaObject {
         } else if (needsToReadFromScanIndex) {
             rc = rowsCost + rowsCost + sortingCost + 20;
         } else { // covering index
-            // The "+ 20" terms above, and the "+ columns.length" term here, 
-            // makes sure that when we pick a covering index, 
+            // The "+ 20" terms above, and the "+ columns.length" term here,
+            // makes sure that when we pick a covering index,
             // we pick the covering index that has the smallest number of
             // columns (the more columns we have in index - the higher cost).
             // This is faster because a smaller index will fit into fewer data

--- a/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSpatialIndex.java
@@ -294,7 +294,8 @@ public final class MVSpatialIndex extends MVIndex<Spatial, Value> implements Spa
                 return Long.MAX_VALUE;
             }
         }
-        return 10 * getCostRangeIndex(masks, dataMap.sizeAsLongMax(), filters, filter, sortOrder, true, allColumnsSet, isSelectCommand);
+        return 10 * getCostRangeIndex(masks, dataMap.sizeAsLongMax(), filters, filter, sortOrder, true, allColumnsSet,
+                isSelectCommand);
     }
 
     @Override

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -5453,6 +5453,30 @@ Returns the value 0. This function can be used even if numeric literals are disa
 ZERO()
 "
 
+"Functions (Numeric)","GCD","
+@h2@ GCD(numeric, numeric [,...])
+","
+Returns the greatest common divisor of specified arguments.
+Arguments must have TINYINT, SMALLINT, INTEGER, BIGINT, or NUMERIC data type with scale 0.
+This function returns result of NUMERIC data type with scale 0.
+
+For aggregate function see [GCD_AGG](https://h2database.com/html/functions-aggregate.html#gcd_agg).
+","
+GCD(A, B)
+"
+
+"Functions (Numeric)","LCM","
+@h2@ LCM(numeric, numeric [,...])
+","
+Returns the least common multiple of specified arguments.
+Arguments must have TINYINT, SMALLINT, INTEGER, BIGINT, or NUMERIC data type with scale 0.
+This function returns result of NUMERIC data type with scale 0.
+
+For aggregate function see [LCM_AGG](https://h2database.com/html/functions-aggregate.html#lcm_agg).
+","
+LCM(A, B)
+"
+
 "Functions (String)","ASCII","
 @h2@ ASCII(string)
 ","
@@ -7226,6 +7250,38 @@ If no rows are selected, the result is NULL.
 Aggregates are only allowed in select statements.
 ","
 ENVELOPE(X)
+"
+
+"Aggregate Functions (General)","GCD_AGG","
+@h2@ GCD_AGG(numeric)
+@h2@ [FILTER (WHERE expression)] @h2@ [OVER windowNameOrSpecification]
+","
+Returns the greatest common divisor of all values.
+Arguments must have TINYINT, SMALLINT, INTEGER, BIGINT, or NUMERIC data type with scale 0.
+This function returns result of NUMERIC data type with scale 0.
+NULL values are ignored in the calculation.
+If no rows are selected, the result is NULL.
+Aggregates are only allowed in select statements.
+
+For non-aggregate function see [GCD](https://h2database.com/html/functions.html#gcd).
+","
+GCD_AGG(V)
+"
+
+"Aggregate Functions (General)","LCM_AGG","
+@h2@ LCM_AGG(numeric)
+@h2@ [FILTER (WHERE expression)] @h2@ [OVER windowNameOrSpecification]
+","
+Returns the least common multiple of all values.
+Arguments must have TINYINT, SMALLINT, INTEGER, BIGINT, or NUMERIC data type with scale 0.
+This function returns result of NUMERIC data type with scale 0.
+NULL values are ignored in the calculation.
+If no rows are selected, the result is NULL.
+Aggregates are only allowed in select statements.
+
+For non-aggregate function see [LCM](https://h2database.com/html/functions.html#lcm).
+","
+LCM_AGG(V)
 "
 
 "Aggregate Functions (Binary Set)","COVAR_POP","

--- a/h2/src/main/org/h2/table/MaterializedView.java
+++ b/h2/src/main/org/h2/table/MaterializedView.java
@@ -129,13 +129,15 @@ public class MaterializedView extends Table {
 
     @Override
     public final Index getScanIndex(SessionLocal session) {
-        return getBestPlanItem(session, null, null, -1, null, null, /*isSelectCommand*/true).getIndex();
+        return getBestPlanItem(session, null, null, -1, null, null,
+                /* isSelectCommand */true).getIndex();
     }
 
     @Override
     public Index getScanIndex(SessionLocal session, int[] masks, TableFilter[] filters, int filter, //
             SortOrder sortOrder, AllColumnsForPlan allColumnsSet) {
-        return getBestPlanItem(session, masks, filters, filter, sortOrder, allColumnsSet, /*isSelectCommand*/true).getIndex();
+        return getBestPlanItem(session, masks, filters, filter, sortOrder, allColumnsSet,
+                /* isSelectCommand */true).getIndex();
     }
 
     @Override

--- a/h2/src/main/org/h2/table/QueryExpressionTable.java
+++ b/h2/src/main/org/h2/table/QueryExpressionTable.java
@@ -275,13 +275,15 @@ public abstract class QueryExpressionTable extends Table {
 
     @Override
     public final Index getScanIndex(SessionLocal session) {
-        return getBestPlanItem(session, null, null, -1, null, null, /*isSelectCommand*/true).getIndex();
+        return getBestPlanItem(session, null, null, -1, null, null,
+                /* isSelectCommand */true).getIndex();
     }
 
     @Override
     public Index getScanIndex(SessionLocal session, int[] masks, TableFilter[] filters, int filter, //
             SortOrder sortOrder, AllColumnsForPlan allColumnsSet) {
-        return getBestPlanItem(session, masks, filters, filter, sortOrder, allColumnsSet, /*isSelectCommand*/true).getIndex();
+        return getBestPlanItem(session, masks, filters, filter, sortOrder, allColumnsSet,
+                /* isSelectCommand */true).getIndex();
     }
 
     @Override

--- a/h2/src/main/org/h2/value/Value.java
+++ b/h2/src/main/org/h2/value/Value.java
@@ -15,6 +15,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.lang.ref.SoftReference;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -885,6 +886,10 @@ public abstract class Value extends VersionedValue<Value> implements HasSQL, Typ
      */
     public long getLong() {
         return convertToBigint(null).getLong();
+    }
+
+    public BigInteger getBigInteger() {
+        return getBigDecimal().toBigInteger();
     }
 
     public BigDecimal getBigDecimal() {

--- a/h2/src/main/org/h2/value/ValueBigint.java
+++ b/h2/src/main/org/h2/value/ValueBigint.java
@@ -183,6 +183,11 @@ public final class ValueBigint extends Value {
     }
 
     @Override
+    public BigInteger getBigInteger() {
+        return BigInteger.valueOf(value);
+    }
+
+    @Override
     public BigDecimal getBigDecimal() {
         return BigDecimal.valueOf(value);
     }

--- a/h2/src/main/org/h2/value/ValueBoolean.java
+++ b/h2/src/main/org/h2/value/ValueBoolean.java
@@ -6,6 +6,7 @@
 package org.h2.value;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import org.h2.engine.CastDataProvider;
 
@@ -90,6 +91,11 @@ public final class ValueBoolean extends Value {
     @Override
     public long getLong() {
         return value ? 1L : 0L;
+    }
+
+    @Override
+    public BigInteger getBigInteger() {
+        return value ? BigInteger.ONE : BigInteger.ZERO;
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueEnumBase.java
+++ b/h2/src/main/org/h2/value/ValueEnumBase.java
@@ -6,6 +6,7 @@
 package org.h2.value;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import org.h2.engine.CastDataProvider;
 import org.h2.util.StringUtils;
@@ -68,6 +69,11 @@ public class ValueEnumBase extends Value {
     @Override
     public long getLong() {
         return ordinal;
+    }
+
+    @Override
+    public BigInteger getBigInteger() {
+        return BigInteger.valueOf(ordinal);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueInteger.java
+++ b/h2/src/main/org/h2/value/ValueInteger.java
@@ -8,6 +8,7 @@ package org.h2.value;
 import static org.h2.util.Bits.INT_VH_BE;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.CastDataProvider;
@@ -157,6 +158,11 @@ public final class ValueInteger extends Value {
     @Override
     public long getLong() {
         return value;
+    }
+
+    @Override
+    public BigInteger getBigInteger() {
+        return BigInteger.valueOf(value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueInterval.java
+++ b/h2/src/main/org/h2/value/ValueInterval.java
@@ -11,6 +11,7 @@ import static org.h2.util.DateTimeUtils.NANOS_PER_MINUTE;
 import static org.h2.util.DateTimeUtils.NANOS_PER_SECOND;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 
 import org.h2.api.Interval;
@@ -252,6 +253,11 @@ public final class ValueInterval extends Value {
             l++;
         }
         return negative ? -l : l;
+    }
+
+    @Override
+    public BigInteger getBigInteger() {
+        return BigInteger.valueOf(getLong());
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueNull.java
+++ b/h2/src/main/org/h2/value/ValueNull.java
@@ -8,6 +8,7 @@ package org.h2.value;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import org.h2.engine.CastDataProvider;
 import org.h2.message.DbException;
@@ -110,6 +111,11 @@ public final class ValueNull extends Value {
     @Override
     public long getLong() {
         throw DbException.getInternalError();
+    }
+
+    @Override
+    public BigInteger getBigInteger() {
+        return null;
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueSmallint.java
+++ b/h2/src/main/org/h2/value/ValueSmallint.java
@@ -6,6 +6,7 @@
 package org.h2.value;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.CastDataProvider;
@@ -129,6 +130,11 @@ public final class ValueSmallint extends Value {
     @Override
     public long getLong() {
         return value;
+    }
+
+    @Override
+    public BigInteger getBigInteger() {
+        return BigInteger.valueOf(value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueStringBase.java
+++ b/h2/src/main/org/h2/value/ValueStringBase.java
@@ -6,6 +6,7 @@
 package org.h2.value;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 
 import org.h2.api.ErrorCode;
@@ -138,6 +139,15 @@ abstract class ValueStringBase extends Value {
     public final long getLong() {
         try {
             return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, value);
+        }
+    }
+
+    @Override
+    public final BigInteger getBigInteger() {
+        try {
+            return new BigInteger(value.trim());
         } catch (NumberFormatException e) {
             throw DbException.get(ErrorCode.DATA_CONVERSION_ERROR_1, e, value);
         }

--- a/h2/src/main/org/h2/value/ValueTinyint.java
+++ b/h2/src/main/org/h2/value/ValueTinyint.java
@@ -6,6 +6,7 @@
 package org.h2.value;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.CastDataProvider;
@@ -149,6 +150,11 @@ public final class ValueTinyint extends Value {
     @Override
     public long getLong() {
         return value;
+    }
+
+    @Override
+    public BigInteger getBigInteger() {
+        return BigInteger.valueOf(value);
     }
 
     @Override

--- a/h2/src/main/org/h2/value/ValueToObjectConverter.java
+++ b/h2/src/main/org/h2/value/ValueToObjectConverter.java
@@ -287,7 +287,7 @@ public final class ValueToObjectConverter extends TraceObject {
         } else if (type == BigDecimal.class) {
             return (T) value.getBigDecimal();
         } else if (type == BigInteger.class) {
-            return (T) value.getBigDecimal().toBigInteger();
+            return (T) value.getBigInteger();
         } else if (type == String.class) {
             return (T) value.getString();
         } else if (type == Boolean.class) {

--- a/h2/src/test/org/h2/test/db/TestIndex.java
+++ b/h2/src/test/org/h2/test/db/TestIndex.java
@@ -787,7 +787,8 @@ public class TestIndex extends TestDb {
     private void testCompoundIndex_4161() throws SQLException {
         Connection conn = getConnection("index");
         stat = conn.createStatement();
-        stat.execute("CREATE TABLE tbl ( c1 INTEGER, c2 INTEGER, c3 INTEGER, c4 INTEGER, c5 INTEGER, c6 INTEGER, c7 INTEGER );");
+        stat.execute("CREATE TABLE tbl ( c1 INTEGER, c2 INTEGER, c3 INTEGER, c4 INTEGER, c5 INTEGER, c6 INTEGER,"
+                + " c7 INTEGER );");
         stat.execute("insert into tbl select x, 0, 0, 0, 0, 0, 0 from system_range(1, 1000)");
 
         stat.execute("CREATE INDEX idx1 ON tbl ( c1, c2, c3, c4, c5 )");
@@ -805,5 +806,5 @@ public class TestIndex extends TestDb {
         conn.close();
         deleteDb("index");
     }
-    
+
 }

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -167,7 +167,7 @@ public class TestScript extends TestDb {
                 "corr",
                 "count",
                 "covar_pop", "covar_samp",
-                "envelope", "every", "histogram",
+                "envelope", "every", "gcd_agg", "histogram",
                 "json_arrayagg", "json_objectagg",
                 "listagg", "max", "min", "mode", "percentile", "rank",
                 "regr_avgx", "regr_avgy", "regr_count", "regr_intercept", "regr_r2", "regr_slope",
@@ -181,7 +181,7 @@ public class TestScript extends TestDb {
         for (String s : new String[] { "abs", "acos", "asin", "atan", "atan2",
                 "bitand", "bitcount", "bitget", "bitnot", "bitor", "bitxor", "ceil", "compress",
                 "cos", "cosh", "cot", "decrypt", "degrees", "encrypt", "exp",
-                "expand", "floor", "hash", "length", "log", "lshift", "mod", "ora-hash", "pi",
+                "expand", "floor", "gcd", "hash", "length", "log", "lshift", "mod", "ora-hash", "pi",
                 "power", "radians", "rand", "random-uuid", "rotate", "round",
                 "roundmagic", "rshift", "secure-rand", "sign", "sin", "sinh", "sqrt",
                 "tan", "tanh", "truncate", "zero" }) {

--- a/h2/src/test/org/h2/test/scripts/functions/aggregate/gcd_agg.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/aggregate/gcd_agg.sql
@@ -1,0 +1,42 @@
+-- Copyright 2004-2025 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+SELECT ARRAY_AGG(V) L, GCD_AGG(V), LCM_AGG(V)
+    FROM (VALUES (1, NULL), (1, 1), (2, 1), (2, NULL), (3, NULL), (3, NULL),
+    (4, 1), (4, 6), (5, 6), (5, -1), (6, 6), (6, 8), (7, -6), (7, 8), (8, 6), (8, -8), (9, -6), (9, -8),
+    (10, 0), (10, 2), (11, 2), (11, 0), (12, 0), (12, 0)) T(G, V)
+    GROUP BY G ORDER BY G;
+> L            GCD_AGG(V) LCM_AGG(V)
+> ------------ ---------- ----------
+> [null, 1]    1          1
+> [1, null]    1          1
+> [null, null] null       null
+> [1, 6]       1          6
+> [6, -1]      1          6
+> [6, 8]       2          24
+> [-6, 8]      2          24
+> [6, -8]      2          24
+> [-6, -8]     2          24
+> [0, 2]       2          0
+> [2, 0]       2          0
+> [0, 0]       0          0
+> rows (ordered): 12
+
+SELECT LCM_AGG(V) FROM (VALUES CAST(1E99999 AS NUMERIC), CAST(1.1E99999 AS NUMERIC)) T(V);
+> exception VALUE_TOO_LONG_2
+
+SELECT LCM_AGG(V) FROM (VALUES CAST(1E99999 AS NUMERIC), CAST(1.1E99999 AS NUMERIC), CAST(9.2E99999 AS NUMERIC)) T(V);
+> exception VALUE_TOO_LONG_2
+
+SELECT LCM_AGG(V) FROM (VALUES CAST(1E49999 AS NUMERIC), CAST(1.1E49999 AS NUMERIC),
+    CAST(9.0000001E99999 AS NUMERIC)) T(V);
+> exception VALUE_TOO_LONG_2
+
+SELECT LCM_AGG(V) FROM (VALUES CAST(1E49999 AS NUMERIC), CAST(1.1E49999 AS NUMERIC),
+    CAST(9.0000001E99999 AS NUMERIC), CAST(9.0000002E99999 AS NUMERIC)) T(V);
+> exception VALUE_TOO_LONG_2
+
+SELECT LCM_AGG(V) FROM (VALUES CAST(1E99999 AS NUMERIC), CAST(1.1E99999 AS NUMERIC), 0) T(V);
+>> 0

--- a/h2/src/test/org/h2/test/scripts/functions/numeric/gcd.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/numeric/gcd.sql
@@ -1,0 +1,103 @@
+-- Copyright 2004-2025 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+
+SELECT A, B, GCD(A, B), LCM(A, B)
+    FROM (VALUES (NULL, 1), (1, NULL), (NULL, NULL),
+    (1, 6), (6, -1), (6, 8), (-6, 8), (6, -8), (-6, -8),
+    (0, 2), (2, 0), (0, 0)) T(A, B);
+> A    B    GCD(A, B) LCM(A, B)
+> ---- ---- --------- ---------
+> -6   -8   2         24
+> -6   8    2         24
+> 0    0    0         0
+> 0    2    2         0
+> 1    6    1         6
+> 1    null null      null
+> 2    0    2         0
+> 6    -1   1         6
+> 6    -8   2         24
+> 6    8    2         24
+> null 1    null      null
+> null null null      null
+> rows: 12
+
+SELECT GCD(32, 12, 0, 40);
+>> 4
+
+SELECT GCD(32, 9, 40);
+>> 1
+
+SELECT GCD(32, 12, NULL);
+>> null
+
+SELECT GCD(32, 12, CAST(NULL AS INTEGER));
+>> null
+
+SELECT LCM(6, 9, 5, 0, 3);
+>> 0
+
+SELECT LCM(6, 9, 5, 22);
+>> 990
+
+SELECT LCM(CAST(1E99999 AS NUMERIC), CAST(1.1E99999 AS NUMERIC));
+> exception VALUE_TOO_LONG_2
+
+SELECT LCM(CAST(9E99999 AS NUMERIC), CAST(9.1E99999 AS NUMERIC), CAST(9.2E99999 AS NUMERIC));
+> exception VALUE_TOO_LONG_2
+
+SELECT LCM(CAST(1E49999 AS NUMERIC), CAST(1.1E49999 AS NUMERIC), CAST(9.0000001E99999 AS NUMERIC));
+> exception VALUE_TOO_LONG_2
+
+SELECT LCM(CAST(1E99999 AS NUMERIC), 0, CAST(1.1E99999 AS NUMERIC));
+>> 0
+
+SELECT LCM(CAST(1E99999 AS NUMERIC), CAST(1.1E99999 AS NUMERIC), 0);
+>> 0
+
+SELECT LCM(CAST(1E99999 AS NUMERIC), CAST(1.1E99999 AS NUMERIC), NULL);
+>> null
+
+SELECT LCM(CAST(1E99999 AS NUMERIC), CAST(1.1E99999 AS NUMERIC), CAST(NULL AS NUMERIC));
+>> null
+
+SELECT GCD(A, B), LCM(A, B) FROM (VALUES (CAST(6 AS TINYINT), CAST(10 AS TINYINT))) T(A, B);
+> GCD(A, B) LCM(A, B)
+> --------- ---------
+> 2         30
+> rows: 1
+
+SELECT GCD(A, B), LCM(A, B) FROM (VALUES (CAST(6 AS SMALLINT), CAST(10 AS SMALLINT))) T(A, B);
+> GCD(A, B) LCM(A, B)
+> --------- ---------
+> 2         30
+> rows: 1
+
+SELECT GCD(A, B), LCM(A, B) FROM (VALUES (CAST(6 AS INTEGER), CAST(10 AS INTEGER))) T(A, B);
+> GCD(A, B) LCM(A, B)
+> --------- ---------
+> 2         30
+> rows: 1
+
+SELECT GCD(A, B), LCM(A, B) FROM (VALUES (CAST(6 AS BIGINT), CAST(10 AS BIGINT))) T(A, B);
+> GCD(A, B) LCM(A, B)
+> --------- ---------
+> 2         30
+> rows: 1
+
+SELECT GCD(A, B), LCM(A, B) FROM (VALUES (CAST(6 AS NUMERIC), CAST(10 AS NUMERIC))) T(A, B);
+> GCD(A, B) LCM(A, B)
+> --------- ---------
+> 2         30
+> rows: 1
+
+SELECT GCD(A, B), LCM(A, B) FROM (VALUES (CAST(6 AS NUMERIC(10, 2)), CAST(10 AS NUMERIC(10, 2)))) T(A, B);
+> exception INVALID_VALUE_2
+
+SELECT GCD(A, B), LCM(A, B) FROM (VALUES (CAST(6 AS REAL), CAST(10 AS REAL))) T(A, B);
+> exception INVALID_VALUE_2
+
+EXPLAIN SELECT GCD(A, GCD(B, C, D), E, GCD(F, G, H), I)
+    FROM (VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9)) T(A, B, C, D, E, F, G, H, I);
+>> SELECT GCD("A", "B", "C", "D", "E", "F", "G", "H", "I") FROM (VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9)) "T"("A", "B", "C", "D", "E", "F", "G", "H", "I") /* table scan */

--- a/h2/src/tools/org/h2/build/doc/dictionary.txt
+++ b/h2/src/tools/org/h2/build/doc/dictionary.txt
@@ -857,3 +857,4 @@ ampm sssssff sstzh tzs yyyysssss newsequentialid solidus openjdk furthermore ssf
 btrim underscores ffl decomposed decomposition subfield infinities retryable salted establish
 hatchet fis loom birthdate penrosed eve graalvm roberto polyglot truffle scriptengine unstarted conversation
 recompilations normalizer tablename tablenames coarse stale configures deletions stricter
+competing opposed lcm gcd datetimeoffset inlines dto


### PR DESCRIPTION
- Non-standard `GCD` and `LCM` functions similar to [functions from PostgreSQL](https://www.postgresql.org/docs/current/functions-math.html), but allowing more than two arguments (like in Data Analysis Expressions) for convenience.
- Non-standard `GCD_AGG` and `LCM_AGG` aggregate functions.

They are very useful to calculate a sum of owner shares stored as simple fractions like 1/2, 3/17, 1/100, etc.