### PR TITLE
Allow upgrade tool to use a local directory of h2 release jars instead requiring network connectivity to mavencentral

### DIFF
--- a/h2/src/main/org/h2/tools/Upgrade.java
+++ b/h2/src/main/org/h2/tools/Upgrade.java
@@ -249,8 +249,17 @@ public final class Upgrade {
             throw new IllegalArgumentException("version=" + version);
         }
         String fullVersion = prefix + version;
-        byte[] data = downloadUsingMaven("com.h2database", "h2", fullVersion,
-                CHECKSUMS[version >= 202 ? (version >>> 1) - 20 : version - 120]);
+        byte[] data;
+        if (System.getProperty("h2LocalJars") != null) {
+            Path h2Jar = Paths.get(System.getProperty("h2LocalJars"),"h2-" + fullVersion + ".jar");
+            if (!Files.exists(h2Jar)) {
+                throw new IOException("Unable to locally find " + h2Jar);
+            }
+            data = Files.readAllBytes(Paths.get(System.getProperty("h2LocalJars"),fullVersion + ".jar"));
+        } else {
+            data = downloadUsingMaven("com.h2database", "h2", fullVersion,
+                    CHECKSUMS[version >= 202 ? (version >>> 1) - 20 : version - 120]);
+        }
         ZipInputStream is = new ZipInputStream(new ByteArrayInputStream(data));
         HashMap<String, byte[]> map = new HashMap<>(version >= 198 ? 2048 : 1024);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
In some security environments, network access to maven central has been removed.  This PR adds an optional system property named "h2LocalJars" which, if set, causes the Upgrade tool to search that directory for the jar.  An application can keep all past jars that it used available and then the tool could be used to upgrade them without requiring any download access.

Here is the idea, change anything you wish.