### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # H2 Security Model
 
-Please read the [Securing your H2](https://h2database.com/html/security.html) on our web site. H2 is __not__ designed to be run in an adversarial environment.
+Please read the [Securing your H2](https://h2database.com/html/security.html) page on our web site. H2 is __not__ designed to be run in an adversarial environment.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# H2 Security Model
+
+Please read the [Securing your H2](https://h2database.com/html/security.html) on our web site. H2 is __not__ designed to be run in an adversarial environment.


### PR DESCRIPTION
GitHub uses SECURITY.md as the norm for providing Security details. This doc is a stub designed to highlight the Security page on your web site.