### PR TITLE
Update Maven central URL

### DIFF
--- a/h2/src/docsrc/html/build.html
+++ b/h2/src/docsrc/html/build.html
@@ -100,7 +100,7 @@ Example:
 </pre>
 <p>
 New versions of this database are first uploaded to http://hsql.sourceforge.net/m2-repo/ and then automatically
-synchronized with the main <a href="https://repo1.maven.org/maven2/com/h2database/h2/">Maven repository</a>;
+synchronized with the main <a href="https://repo.maven.apache.org/maven2/com/h2database/h2/">Maven repository</a>;
 however after a new release it may take a few hours before they are available there.
 </p>
 <h3>Maven Plugin to Start and Stop the TCP Server</h3>

--- a/h2/src/docsrc/html/cheatSheet.html
+++ b/h2/src/docsrc/html/cheatSheet.html
@@ -112,7 +112,7 @@ li {
     <a href="https://github.com/h2database/h2database">open source</a>,
     <a href="license.html">free to use and distribute</a>.
 </li><li><a href="https://h2database.com/html/download.html">Download</a>:
-    <a href="https://repo1.maven.org/maven2/com/h2database/h2/${version}/h2-${version}.jar" class="link">jar</a>,
+    <a href="https://repo.maven.apache.org/maven2/com/h2database/h2/${version}/h2-${version}.jar" class="link">jar</a>,
     <a href="${downloadRoot}/h2-setup-${versionDate}.exe" class="link">installer (Windows)</a>,
     <a href="${downloadRoot}/h2-${versionDate}.zip" class="link">zip</a>.
 </li><li>To start the

--- a/h2/src/main/org/h2/tools/Upgrade.java
+++ b/h2/src/main/org/h2/tools/Upgrade.java
@@ -130,7 +130,7 @@ public final class Upgrade {
             //
     };
 
-    private static final String REPOSITORY = "https://repo1.maven.org/maven2";
+    private static final String REPOSITORY = "https://repo.maven.apache.org/maven2";
 
     /**
      * Performs database upgrade from an older version of H2.

--- a/h2/src/tools/org/h2/build/BuildBase.java
+++ b/h2/src/tools/org/h2/build/BuildBase.java
@@ -579,7 +579,7 @@ public class BuildBase {
      */
     protected void downloadUsingMaven(String target, String group,
             String artifact, String version, String sha1Checksum) {
-        String repoDir = "https://repo1.maven.org/maven2";
+        String repoDir = "https://repo.maven.apache.org/maven2";
         Path targetFile = Paths.get(target);
         if (Files.exists(targetFile)) {
             return;

--- a/h2/src/tools/org/h2/dev/util/Migrate.java
+++ b/h2/src/tools/org/h2/dev/util/Migrate.java
@@ -37,7 +37,7 @@ public class Migrate {
     private static final String PASSWORD  = "sa";
     private static final File OLD_H2_FILE = new File("./h2-1.2.127.jar");
     private static final String DOWNLOAD_URL =
-            "https://repo1.maven.org/maven2/com/h2database/h2/1.2.127/h2-1.2.127.jar";
+            "https://repo.maven.apache.org/maven2/com/h2database/h2/1.2.127/h2-1.2.127.jar";
     private static final String CHECKSUM =
             "056e784c7cf009483366ab9cd8d21d02fe47031a";
     private static final String TEMP_SCRIPT = "backup.sql";


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/MNG-5151 Maven updated the default URL from `repo1.maven.org/maven2` -> `repo.maven.apache.org/maven2`.

Updated references to suit.