### PR TITLE
SHUTDOWN COMPACT: parallel map copy (¼ cores default, override with h2.compactThreads)

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #4273: SHUTDOWN COMPACT: parallel map copy (¼ cores default, override with h2.compactThreads)
+</li>
 <li>Issue #4263: Documentation: SET TRUNCATE_LARGE_LENGTH is broken
 </li>
 <li>Issue #4208: Lost update when attempting to atomically increment a value using SELECT FOR UPDATE

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -408,7 +408,7 @@ public final class MVStore implements AutoCloseable {
                 }
             }
 
-            int poolSize = Integer.getInteger("h2.compactThreads", 1);
+            int poolSize = Integer.getInteger("h2.compactThreads", Math.max(1, Runtime.getRuntime().availableProcessors() / 4));
             ExecutorService pool = Executors.newFixedThreadPool(poolSize);
             CompletableFuture.allOf(
                 // We are going to cheat a little bit in the copyFrom() by employing "incomplete" pages,


### PR DESCRIPTION
### Description
This PR adds an option to run map copy in parallel during MVStore.compact().

- Controlled by system property h2.compactThreads (default = 1).
- Uses ExecutorService and CompletableFuture to copy multiple maps concurrently.
- Falls back to sequential behavior if h2.compactThreads=1.
- Significantly reduces compaction time on large databases. For example, compacting a 80 GB store down to 20 GB took about 50 min → 20 min with 8 threads.

The change preserves existing logic and metadata handling, only parallelizing the map copy loop.