### PR TITLE
Replace BitSet with immutable data structure

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/BitSetHelper.java
+++ b/h2/src/main/org/h2/mvstore/tx/BitSetHelper.java
@@ -8,10 +8,7 @@ package org.h2.mvstore.tx;
 import java.util.Arrays;
 
 /**
- * Class BitSetHelper.
- * <UL>
- * <LI> 10/17/25 12:25 PM initial creation
- * </UL>
+ * Class BitSetHelper provides very limited functionality of BitSet used by TransactionStore.
  *
  * @author <a href="mailto:andrei.tokar@gmail.com">Andrei Tokar</a>
  */
@@ -19,7 +16,6 @@ public class BitSetHelper
 {
     private static final int ADDRESS_BITS_PER_WORD = 6;
     private static final int BITS_PER_WORD = 1 << ADDRESS_BITS_PER_WORD;
-    private static final int BIT_INDEX_MASK = BITS_PER_WORD - 1;
     private static final long WORD_MASK = 0xffffffffffffffffL;
 
     private BitSetHelper() {
@@ -32,22 +28,11 @@ public class BitSetHelper
 
     public static long[] flip(long[] bits, int bitIndex) {
         int wordIndex = wordIndex(bitIndex);
-        bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
+
+        int length = bits.length;
+        while (--length > wordIndex && bits[length] == 0L) {/**/}
+        bits = Arrays.copyOf(bits, Math.max(length, wordIndex) + 1);
         bits[wordIndex] ^= 1L << bitIndex;
-        return bits;
-    }
-
-    public static long[] set(long[] bits, int nitIndex) {
-        int wordIndex = wordIndex(nitIndex);
-        bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
-        bits[wordIndex] |= 1L << nitIndex;
-        return bits;
-    }
-
-    public static long[] clear(long[] bits, int transactionId) {
-        int wordIndex = wordIndex(transactionId);
-        bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
-        bits[wordIndex] &= ~(1L << transactionId);
         return bits;
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/BitSetHelper.java
+++ b/h2/src/main/org/h2/mvstore/tx/BitSetHelper.java
@@ -18,26 +18,29 @@ import java.util.Arrays;
 public class BitSetHelper
 {
     private static final int ADDRESS_BITS_PER_WORD = 6;
+    private static final int BITS_PER_WORD = 1 << ADDRESS_BITS_PER_WORD;
+    private static final int BIT_INDEX_MASK = BITS_PER_WORD - 1;
+    private static final long WORD_MASK = 0xffffffffffffffffL;
 
     private BitSetHelper() {
     }
 
-    public static boolean get(long[] bits, int transactionId) {
-        int wordIndex = wordIndex(transactionId);
-        return wordIndex < bits.length && (bits[wordIndex] & (1L << transactionId)) != 0;
+    public static boolean get(long[] bits, int bitIndex) {
+        int wordIndex = wordIndex(bitIndex);
+        return wordIndex < bits.length && (bits[wordIndex] & (1L << bitIndex)) != 0;
     }
 
-    public static long[] flip(long[] bits, int transactionId) {
-        int wordIndex = wordIndex(transactionId);
+    public static long[] flip(long[] bits, int bitIndex) {
+        int wordIndex = wordIndex(bitIndex);
         bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
-        bits[wordIndex] ^= 1L << transactionId;
+        bits[wordIndex] ^= 1L << bitIndex;
         return bits;
     }
 
-    public static long[] set(long[] bits, int transactionId) {
-        int wordIndex = wordIndex(transactionId);
+    public static long[] set(long[] bits, int nitIndex) {
+        int wordIndex = wordIndex(nitIndex);
         bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
-        bits[wordIndex] |= 1L << transactionId;
+        bits[wordIndex] |= 1L << nitIndex;
         return bits;
     }
 
@@ -46,6 +49,53 @@ public class BitSetHelper
         bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
         bits[wordIndex] &= ~(1L << transactionId);
         return bits;
+    }
+
+    public static int nextSetBit(long[] bits, int bitIndex) {
+        int wordIndex = wordIndex(bitIndex);
+        if (wordIndex >= bits.length) {
+            return -1;
+        }
+
+        long word = bits[wordIndex] & (WORD_MASK << bitIndex);
+
+        while (true) {
+            if (word != 0) {
+                return (wordIndex * BITS_PER_WORD) + Long.numberOfTrailingZeros(word);
+            }
+            if (++wordIndex == bits.length) {
+                return -1;
+            }
+            word = bits[wordIndex];
+        }
+    }
+
+    public static int nextClearBit(long[] bits, int bitIndex) {
+        int wordIndex = wordIndex(bitIndex);
+        if (wordIndex >= bits.length) {
+            return bitIndex;
+        }
+
+        long word = ~bits[wordIndex] & (WORD_MASK << bitIndex);
+
+        while (true) {
+            if (word != 0) {
+                return (wordIndex * BITS_PER_WORD) + Long.numberOfTrailingZeros(word);
+            }
+            if (++wordIndex == bits.length) {
+                return bits.length * BITS_PER_WORD;
+            }
+            word = ~bits[wordIndex];
+        }
+    }
+
+    public static int length(long[] bits) {
+        int wordsInUse = bits.length;
+        if (wordsInUse == 0)
+            return 0;
+
+        return BITS_PER_WORD * (wordsInUse - 1) +
+            (BITS_PER_WORD - Long.numberOfLeadingZeros(bits[wordsInUse - 1]));
     }
 
     private static int wordIndex(int index) {

--- a/h2/src/main/org/h2/mvstore/tx/BitSetHelper.java
+++ b/h2/src/main/org/h2/mvstore/tx/BitSetHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2004-2025 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.mvstore.tx;
+
+import java.util.Arrays;
+
+/**
+ * Class BitSetHelper.
+ * <UL>
+ * <LI> 10/17/25 12:25 PM initial creation
+ * </UL>
+ *
+ * @author <a href="mailto:andrei.tokar@gmail.com">Andrei Tokar</a>
+ */
+public class BitSetHelper
+{
+    private static final int ADDRESS_BITS_PER_WORD = 6;
+
+    private BitSetHelper() {
+    }
+
+    public static boolean get(long[] bits, int transactionId) {
+        int wordIndex = wordIndex(transactionId);
+        return wordIndex < bits.length && (bits[wordIndex] & (1L << transactionId)) != 0;
+    }
+
+    public static long[] flip(long[] bits, int transactionId) {
+        int wordIndex = wordIndex(transactionId);
+        bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
+        bits[wordIndex] ^= 1L << transactionId;
+        return bits;
+    }
+
+    public static long[] set(long[] bits, int transactionId) {
+        int wordIndex = wordIndex(transactionId);
+        bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
+        bits[wordIndex] |= 1L << transactionId;
+        return bits;
+    }
+
+    public static long[] clear(long[] bits, int transactionId) {
+        int wordIndex = wordIndex(transactionId);
+        bits = Arrays.copyOf(bits, Math.max(bits.length, wordIndex + 1));
+        bits[wordIndex] &= ~(1L << transactionId);
+        return bits;
+    }
+
+    private static int wordIndex(int index) {
+        return index >> ADDRESS_BITS_PER_WORD;
+    }
+}

--- a/h2/src/main/org/h2/mvstore/tx/Snapshot.java
+++ b/h2/src/main/org/h2/mvstore/tx/Snapshot.java
@@ -5,8 +5,6 @@
  */
 package org.h2.mvstore.tx;
 
-import java.util.BitSet;
-
 import org.h2.mvstore.RootReference;
 
 /**
@@ -22,9 +20,9 @@ final class Snapshot<K,V> {
     /**
      * The committing transactions (see also TransactionStore.committingTransactions).
      */
-    final BitSet committingTransactions;
+    final long[] committingTransactions;
 
-    Snapshot(RootReference<K,V> root, BitSet committingTransactions) {
+    Snapshot(RootReference<K,V> root, long[] committingTransactions) {
         this.root = root;
         this.committingTransactions = committingTransactions;
     }
@@ -33,7 +31,7 @@ final class Snapshot<K,V> {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + committingTransactions.hashCode();
+        result = prime * result + System.identityHashCode(committingTransactions);
         result = prime * result + root.hashCode();
         return result;
     }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -336,7 +336,7 @@ public final class Transaction {
             // The purpose of the following loop is to get a coherent picture
             // In order to get such a "snapshot", we wait for a moment of silence,
             // when no new transaction were committed / closed.
-            BitSet committingTransactions;
+            long[] committingTransactions;
             do {
                 committingTransactions = store.committingTransactions.get();
                 for (MVMap<Object,VersionedValue<Object>> map : maps) {

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -488,7 +488,7 @@ public final class Transaction {
      * Commit the transaction. Afterward, this transaction is closed.
      */
     public void commit() {
-        assert store.openTransactions.get().get(transactionId);
+        assert store.isTransactionOpen(transactionId);
         markTransactionEnd();
         Throwable ex = null;
         boolean hasChanges = false;

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -82,7 +82,7 @@ public class TransactionStore {
      * and undo record are still around.
      * Nevertheless, all of those should be considered by other transactions as committed.
      */
-    final AtomicReference<BitSet> committingTransactions = new AtomicReference<>(new BitSet());
+    final AtomicReference<long[]> committingTransactions = new AtomicReference<>(new long[0]);
 
     private boolean init;
 
@@ -537,10 +537,10 @@ public class TransactionStore {
     private void flipCommittingTransactionsBit(int transactionId, boolean flag) {
         boolean success;
         do {
-            BitSet original = committingTransactions.get();
-            assert original.get(transactionId) != flag : flag ? "Double commit" : "Mysterious bit's disappearance";
-            BitSet clone = (BitSet) original.clone();
-            clone.set(transactionId, flag);
+            long[] original = committingTransactions.get();
+            assert BitSetHelper.get(original, transactionId) != flag :
+                    flag ? "Double commit" : "Mysterious bit's disappearance";
+            long[] clone = BitSetHelper.flip(original, transactionId);
             success = committingTransactions.compareAndSet(original, clone);
         } while(!success);
     }

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -63,7 +63,7 @@ public class TransactionStore {
      * Key: opId, value: [ mapId, key, oldValue ].
      */
     @SuppressWarnings("unchecked")
-    final MVMap<Long,Record<?,?>>[] undoLogs = new MVMap[MAX_OPEN_TRANSACTIONS];
+    private final MVMap<Long,Record<?,?>>[] undoLogs = new MVMap[MAX_OPEN_TRANSACTIONS];
     private final MVMap.Builder<Long, Record<?,?>> undoLogBuilder;
 
     private final DataType<?> dataType;
@@ -73,7 +73,7 @@ public class TransactionStore {
      * It provides easy way to find first unoccupied slot, and also allows for copy-on-write
      * non-blocking updates.
      */
-    final AtomicReference<VersionedBitSet> openTransactions = new AtomicReference<>(new VersionedBitSet());
+    private final AtomicReference<VersionedBitSet> openTransactions = new AtomicReference<>(new VersionedBitSet());
 
     /**
      * This is intended to be the source of ultimate truth about transaction being committed.
@@ -203,7 +203,7 @@ public class TransactionStore {
                         if (store.hasData(mapName)) {
                             int transactionId = StringUtils.parseUInt31(mapName, UNDO_LOG_NAME_PREFIX.length() + 1,
                                     mapName.length());
-                            if (!openTransactions.get().get(transactionId)) {
+                            if (!isTransactionOpen(transactionId)) {
                                 Object[] data = preparedTransactions.get(transactionId);
                                 int status;
                                 String name;
@@ -247,6 +247,10 @@ public class TransactionStore {
             }
             init = true;
         }
+    }
+
+    boolean isTransactionOpen(int transactionId) {
+        return openTransactions.get().get(transactionId);
     }
 
     private void markUndoLogAsCommitted(int transactionId) {

--- a/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
@@ -206,7 +206,7 @@ class TxDecisionMaker<K,V> extends MVMap.DecisionMaker<VersionedValue<V>> {
         TransactionStore store = transaction.store;
         do {
             blockingTx = store.getTransaction(transactionId);
-            result = store.committingTransactions.get().get(transactionId);
+            result = BitSetHelper.get(store.committingTransactions.get(), transactionId);
         } while (blockingTx != store.getTransaction(transactionId));
 
         if (!result) {

--- a/h2/src/main/org/h2/mvstore/tx/VersionedBitSet.java
+++ b/h2/src/main/org/h2/mvstore/tx/VersionedBitSet.java
@@ -11,23 +11,38 @@ import java.util.BitSet;
  * Class VersionedBitSet extends standard BitSet to add a version field.
  * This will allow bit set and version to be changed atomically.
  */
-final class VersionedBitSet extends BitSet {
-    private static final long serialVersionUID = 1L;
+final class VersionedBitSet {
 
-    private long version;
+    public final long[] bits;
+    private final long version;
 
-    public VersionedBitSet() {}
+    public VersionedBitSet() {
+        bits = new long[0];
+        version = 0;
+    }
+
+    public VersionedBitSet(VersionedBitSet other, int bitToFlip) {
+        bits = BitSetHelper.flip(other.bits, bitToFlip);
+        version = other.version + 1;
+    }
+
+    public boolean get(int bitIndex) {
+        return BitSetHelper.get(bits, bitIndex);
+    }
+
+    public int nextSetBit(int bitIndex) {
+        return BitSetHelper.nextSetBit(bits, bitIndex);
+    }
+
+    public int nextClearBit(int bitIndex) {
+        return BitSetHelper.nextClearBit(bits, bitIndex);
+    }
+
+    public int length() {
+        return BitSetHelper.length(bits);
+    }
 
     public long getVersion() {
         return version;
-    }
-
-    public void setVersion(long version) {
-        this.version = version;
-    }
-
-    @Override
-    public VersionedBitSet clone() {
-        return (VersionedBitSet)super.clone();
     }
 }

--- a/h2/src/main/org/h2/mvstore/tx/VersionedBitSet.java
+++ b/h2/src/main/org/h2/mvstore/tx/VersionedBitSet.java
@@ -8,8 +8,8 @@ package org.h2.mvstore.tx;
 import java.util.BitSet;
 
 /**
- * Class VersionedBitSet extends standard BitSet to add a version field.
- * This will allow bit set and version to be changed atomically.
+ * Class VersionedBitSet combines very limited functionality of a standard BitSet and a version field.
+ * This will allow bit set to be immutable. In addition, it allows bit set and version to be changed atomically.
  */
 final class VersionedBitSet {
 


### PR DESCRIPTION
Fix #4293 It replaces TransactionStore.openTransactions and TransactionStore.committingTransactions with immutable long[]