### PR TITLE
invalidate cached EXISTS() result

### DIFF
--- a/h2/src/test/org/h2/test/scripts/queries/query-cache.sql
+++ b/h2/src/test/org/h2/test/scripts/queries/query-cache.sql
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2004-2025 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+-- Issue #4299: verify that uncommitted changes from the same transaction
+-- invalidate cached result of EXISTS().
+--
+CREATE TABLE TEST(PK INTEGER PRIMARY KEY) AS SELECT VALUES ((1));
+> ok
+
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED;
+> ok
+
+@reconnect off
+
+@autocommit off
+
+SELECT ? FROM DUAL WHERE EXISTS(SELECT 1 FROM TEST WHERE PK = 1);
+{
+1
+>> 1
+};
+> update count: 0
+
+UPDATE TEST SET PK = 2 WHERE PK = 1;
+> update count: 1
+
+SELECT ? FROM DUAL WHERE EXISTS(SELECT 1 FROM TEST WHERE PK = 1);
+{
+1
+>> <no result>
+};
+> update count: 0
+
+@autocommit on
+
+DROP TABLE TEST;
+> ok

--- a/h2/src/tools/org/h2/build/Build.java
+++ b/h2/src/tools/org/h2/build/Build.java
@@ -23,6 +23,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map.Entry;
+import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
@@ -108,7 +109,8 @@ public class Build extends BuildBase {
                 "com.mysql", "mysql-connector-j", MYSQL_CONNECTOR_VERSION,
                 "3f78d2963935f44a61edb3961a591cdc392c8941");
         downloadUsingMaven("ext/sqlite-" + SQLITE_VERSION + ".jar",
-            "org.xerial", "sqlite-jdbc", SQLITE_VERSION, "7fa71c4dfab806490cb909714fb41373ec552c29");
+                "org.xerial", "sqlite-jdbc", SQLITE_VERSION,
+                "7fa71c4dfab806490cb909714fb41373ec552c29");
         compile();
 
         String cp = "temp" +
@@ -932,12 +934,14 @@ public class Build extends BuildBase {
                     "-ea",
                     "-Xmx128m",
                     "-XX:MaxDirectMemorySize=2g",
+                    "-Duser.timezone=" + TimeZone.getDefault().getID(),
                     "-cp", cp,
                     "org.h2.test.TestAll", "ci"));
         } else {
             ret = execJava(args(
                     "-ea",
                     "-Xmx128m",
+                    "-Duser.timezone=" + TimeZone.getDefault().getID(),
                     "-cp", cp,
                     "org.h2.test.TestAll"));
         }


### PR DESCRIPTION
Fixes #4299 
I've missed this case when did #4262
Test has been added.