### PR TITLE
fix assertion about chunks and free space bits always being in sync

### DIFF
--- a/h2/src/main/org/h2/mvstore/RandomAccessStore.java
+++ b/h2/src/main/org/h2/mvstore/RandomAccessStore.java
@@ -157,8 +157,9 @@ public abstract class RandomAccessStore extends FileStore<SFChunk>
     @Override
     protected final boolean validateFileLength(String msg) {
         assert saveChunkLock.isHeldByCurrentThread();
-        assert getFileLengthInUse() == measureFileLengthInUse() :
-                getFileLengthInUse() + " != " + measureFileLengthInUse() + " " + msg;
+        assert !mvStore.isLockedByCurrentThread() || getFileLengthInUse() == measureFileLengthInUse() :
+                        mvStore.isLockedByCurrentThread() + " && " +
+                        getFileLengthInUse() + " != " + measureFileLengthInUse() + " " + msg;
         return true;
     }
 
@@ -676,7 +677,9 @@ public abstract class RandomAccessStore extends FileStore<SFChunk>
     protected void shrinkStoreIfPossible(int minPercent) {
         assert saveChunkLock.isHeldByCurrentThread();
         long result = getFileLengthInUse();
-        assert result == measureFileLengthInUse() : result + " != " + measureFileLengthInUse();
+        assert !mvStore.isLockedByCurrentThread() || result == measureFileLengthInUse() :
+                mvStore.isLockedByCurrentThread() + " && " +
+                result + " != " + measureFileLengthInUse();
         shrinkIfPossible(minPercent);
     }
 

--- a/h2/src/test/org/h2/test/store/SequenceMap.java
+++ b/h2/src/test/org/h2/test/store/SequenceMap.java
@@ -48,7 +48,7 @@ public class SequenceMap extends MVMap<Long, Long> {
 
                     @Override
                     public Long next() {
-                        return Long.valueOf(x++);
+                        return x++;
                     }
 
                 };

--- a/h2/src/test/org/h2/test/synth/TestCrashAPI.java
+++ b/h2/src/test/org/h2/test/synth/TestCrashAPI.java
@@ -236,7 +236,7 @@ public class TestCrashAPI extends TestDb implements Runnable {
             }
             throw e;
         }
-        int len = random.getInt(50);
+        int len = random.getInt(statements.size());
         int first = random.getInt(statements.size() - len);
         int end = first + len;
         Statement stat = conn.createStatement();


### PR DESCRIPTION
Fixes #4048
Assertion became faulty when asynchronous chunk creation/save pipeline was introduced.
If this check coincide with dropUnusedChuncks() call, chunks may be removed from the chunks map, but not from freespace BitSet yet.