### PR TITLE
4304: Fix removal of Materialized Views (DROP SCHEMA / DROP ALL OBJECTS)

### DIFF
--- a/h2/src/main/org/h2/command/ddl/DropDatabase.java
+++ b/h2/src/main/org/h2/command/ddl/DropDatabase.java
@@ -61,25 +61,7 @@ public class DropDatabase extends DefineCommand {
             ArrayList<Table> toRemove = new ArrayList<>(tables.size());
             for (Table t : tables) {
                 if (t.getName() != null &&
-                        TableType.VIEW == t.getTableType()) {
-                    toRemove.add(t);
-                }
-            }
-            for (Table t : tables) {
-                if (t.getName() != null &&
-                        TableType.TABLE_LINK == t.getTableType()) {
-                    toRemove.add(t);
-                }
-            }
-            for (Table t : tables) {
-                if (t.getName() != null &&
-                        TableType.TABLE == t.getTableType()) {
-                    toRemove.add(t);
-                }
-            }
-            for (Table t : tables) {
-                if (t.getName() != null &&
-                        TableType.EXTERNAL_TABLE_ENGINE == t.getTableType()) {
+                        TableType.SYSTEM_TABLE != t.getTableType()) {
                     toRemove.add(t);
                 }
             }

--- a/h2/src/main/org/h2/table/MaterializedView.java
+++ b/h2/src/main/org/h2/table/MaterializedView.java
@@ -207,7 +207,7 @@ public class MaterializedView extends Table {
 
     @Override
     public void removeChildrenAndResources(SessionLocal session) {
-        table.removeChildrenAndResources(session);
+        database.removeSchemaObject(session, table);
         database.removeMeta(session, getId());
         querySQL = null;
         invalidate();


### PR DESCRIPTION
Small fix for cleanup of resources during the execution of DROP ALL OBJECTS, DROP SCHEMA and alike in the case when a materialized view is present.
You can find a reproducible example in:
Fixes #4304 