### PR TITLE
Fix: Upper case at login form for choose language

### DIFF
--- a/h2/src/main/org/h2/server/web/WebServer.java
+++ b/h2/src/main/org/h2/server/web/WebServer.java
@@ -68,7 +68,7 @@ public class WebServer implements Service {
         { "pl", "Polski"},
         { "pt_BR", "Portugu\u00eas (Brasil)"},
         { "pt_PT", "Portugu\u00eas (Europeu)"},
-        { "ru", "\u0440\u0443\u0441\u0441\u043a\u0438\u0439"},
+        { "ru", "\u0420\u0443\u0441\u0441\u043a\u0438\u0439"},
         { "sk", "Slovensky"},
         { "tr", "T\u00fcrk\u00e7e"},
         { "uk", "\u0423\u043A\u0440\u0430\u0457\u043D\u0441\u044C\u043A\u0430"},


### PR DESCRIPTION
Changed Upper case at login form for choose language.

Fixed issue: #4295 

Contribution by Gittensor, learn more at https://gittensor.io/