### PR TITLE
Fix ConditionInConstantSet usage from other sessions

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,7 +21,18 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
-    <li>nothing here yet</li>
+<li>Issue #4302: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: Check constraint invalid
+</li>
+<li>Issue #4286: [2.4.240] SHUTDOWN COMPACT failure
+</li>
+<li>Issue #4293: Data Race in org.h2.mvstore.tx.TransactionStore.registerTransaction
+</li>
+<li>Issue #4299: READ_COMMITTED isolation level sometimes doesn't see uncommitted changes from the same transaction 2.4.240
+</li>
+<li>Issue #4048: Assertion error in shrinkStoreIfPossible
+</li>
+<li>Issue #4304: DROP SCHEMA &amp; DROP ALL OBJECTS is broken if a materialized view is present in the schema
+</li>
 </ul>
 
 <h2>Version 2.4.240 (2025-09-22)</h2>

--- a/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
+++ b/h2/src/test/org/h2/test/db/TestTriggersConstraints.java
@@ -60,6 +60,7 @@ public class TestTriggersConstraints extends TestDb implements Trigger {
         testTriggerAsJavascript();
         testTriggers();
         testConstraints();
+        testCheckConstraints();
         testCheckConstraintErrorMessage();
         testMultiPartForeignKeys();
         testConcurrent();
@@ -565,6 +566,19 @@ public class TestTriggersConstraints extends TestDb implements Trigger {
         assertSingleValue(stat, "select count(*) from test", 0);
         stat.execute("drop table test");
         conn.close();
+    }
+
+    private void testCheckConstraints() throws SQLException {
+        Connection conn = getConnection("trigger");
+        Statement stat = conn.createStatement();
+        stat.execute("DROP TABLE IF EXISTS TEST");
+        stat.execute("CREATE TABLE TEST(ID BIGINT PRIMARY KEY, A INT, B INT, CHECK (B IN (2, 3, 5)))");
+        Connection otherConnection = getConnection("trigger");
+        conn.close();
+        stat = otherConnection.createStatement();
+        stat.execute("INSERT INTO TEST VALUES (2, 3, 2)");
+        stat.execute("DROP TABLE TEST");
+        otherConnection.close();
     }
 
     private void testCheckConstraintErrorMessage() throws SQLException {


### PR DESCRIPTION
Closes #4302.

This is a fix for a particular issue about IN conditions with constants in CHECK expressions. I decided to push it separately because it was reported multiple times and there were attempts to fix it in the wrong place.

The whole problem with CHECK expressions is much wider and a complete solution isn't ready yet.