### PR TITLE
Mvstore misc

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #4317: Fix case for ChunkNotFound. MVStore performance improvements.
+</li>
 <li>Issue #4302: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: Check constraint invalid
 </li>
 <li>Issue #4286: [2.4.240] SHUTDOWN COMPACT failure

--- a/h2/src/main/org/h2/api/ErrorCode.java
+++ b/h2/src/main/org/h2/api/ErrorCode.java
@@ -404,8 +404,8 @@ public class ErrorCode {
 
     /**
      * The error with code <code>42104</code> is thrown when
-     * trying to query, modify or drop a table or view that does not exists
-     * in this schema and database but it is empty anyway. A common cause is
+     * trying to query, modify or drop a table or view that does not exist
+     * in this schema and database, but it is empty anyway. A common cause is
      * that the wrong database was opened.
      * Example:
      * <pre>

--- a/h2/src/main/org/h2/command/Command.java
+++ b/h2/src/main/org/h2/command/Command.java
@@ -6,6 +6,7 @@
 package org.h2.command;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Set;
@@ -306,7 +307,7 @@ public abstract class Command implements CommandInterface {
                     return update(generatedKeysRequest);
                 } catch (DbException e) {
                     // cannot retry some commands
-                    if (!isRetryable()) {
+                    if (!isRetryable() || e.getSQLException() instanceof SQLNonTransientException) {
                         throw e;
                     }
                     start = filterConcurrentUpdate(e, start);

--- a/h2/src/main/org/h2/command/dml/SetClauseList.java
+++ b/h2/src/main/org/h2/command/dml/SetClauseList.java
@@ -20,6 +20,7 @@ import org.h2.message.DbException;
 import org.h2.result.LocalResult;
 import org.h2.result.ResultTarget;
 import org.h2.result.Row;
+import org.h2.result.SearchRow;
 import org.h2.table.Column;
 import org.h2.table.ColumnResolver;
 import org.h2.table.DataChangeDeltaTable.ResultOption;
@@ -145,7 +146,7 @@ public final class SetClauseList implements HasSQL {
             }
             newRow.setValue(i, newValue);
         }
-        newRow.setKey(oldRow.getKey());
+
         table.convertUpdateRow(session, newRow, false);
         boolean result = true;
         if (onUpdate) {
@@ -166,6 +167,10 @@ public final class SetClauseList implements HasSQL {
         } else if (updateToCurrentValuesReturnsZero && oldRow.hasSameValues(newRow)) {
             result = false;
         }
+
+        int mainIndexColumn = table.getMainIndexColumn();
+        newRow.setKey(mainIndexColumn == SearchRow.ROWID_INDEX ? oldRow.getKey() : newRow.getValue(mainIndexColumn).getLong());
+
         if (deltaChangeCollectionMode == ResultOption.OLD) {
             deltaChangeCollector.addRow(oldRow.getValueList());
         } else if (deltaChangeCollectionMode == ResultOption.NEW) {

--- a/h2/src/main/org/h2/command/dml/Update.java
+++ b/h2/src/main/org/h2/command/dml/Update.java
@@ -89,7 +89,7 @@ public final class Update extends FilteredDataChangeStatement {
         // we need to update all indexes) before row triggers
 
         // the cached row is already updated - we need the old values
-        table.updateRows(prepared, session, rows);
+        table.updateRows(session, rows, prepared::checkCanceled);
         if (table.fireRow()) {
             for (rows.reset(); rows.next();) {
                 Row o = rows.currentRowForTable();

--- a/h2/src/main/org/h2/index/Index.java
+++ b/h2/src/main/org/h2/index/Index.java
@@ -7,6 +7,7 @@ package org.h2.index;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.h2.api.ErrorCode;
 import org.h2.command.query.AllColumnsForPlan;
@@ -362,6 +363,30 @@ public abstract class Index extends SchemaObject {
      */
     public long getDiskSpaceUsed(boolean approximate) {
         return 0L;
+    }
+
+    /**
+     * Determine if two given rows would result in the same entry in this index
+     *
+     * @param rowOne first row to compare
+     * @param rowTwo second row to compare
+     * @return true if rows are equvalent from this index point of view
+     */
+    public boolean areRowsEquivalent(Row rowOne, Row rowTwo) {
+        if (rowOne == rowTwo) {
+            return true;
+        }
+        if (rowOne.getKey() != rowTwo.getKey()) {
+            return false;
+        }
+        for (int index : columnIds) {
+            Value v1 = rowOne.getValue(index);
+            Value v2 = rowTwo.getValue(index);
+            if (!Objects.equals(v1, v2)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/h2/src/main/org/h2/jdbc/JdbcConnection.java
+++ b/h2/src/main/org/h2/jdbc/JdbcConnection.java
@@ -528,7 +528,8 @@ public class JdbcConnection extends TraceObject implements Connection, CastDataP
     public boolean isClosed() throws SQLException {
         try {
             debugCodeCall("isClosed");
-            return session == null || session.isClosed();
+            Session s = session;
+            return s == null || s.isClosed();
         } catch (Exception e) {
             throw logAndConvert(e);
         }
@@ -1657,9 +1658,11 @@ public class JdbcConnection extends TraceObject implements Connection, CastDataP
             } else {
                 clientInfo.clear();
             }
-            for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-                setClientInfo((String) entry.getKey(),
-                        (String) entry.getValue());
+            if (properties != null) {
+                for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+                    setClientInfo((String) entry.getKey(),
+                            (String) entry.getValue());
+                }
             }
         } catch (Exception e) {
             throw convertToClientInfoException(logAndConvert(e));

--- a/h2/src/main/org/h2/mvstore/Chunk.java
+++ b/h2/src/main/org/h2/mvstore/Chunk.java
@@ -548,11 +548,9 @@ public abstract class Chunk<C extends Chunk<C>> {
      *            removal is recorded, and retention period starts
      * @param version
      *            at which page was removed
-     * @return true if all of the pages, this chunk contains, were already
-     *         removed, and false otherwise
+     * @return true if all the pages, this chunk contains, were already removed, and false otherwise
      */
     boolean accountForRemovedPage(int pageNo, int pageLength, boolean pinned, long now, long version) {
-        assert buffer != null || isAllocated() : this;
         // legacy chunks do not have a table of content,
         // therefore pageNo is not valid, skip
         if (tocPos > 0) {

--- a/h2/src/main/org/h2/mvstore/Cursor.java
+++ b/h2/src/main/org/h2/mvstore/Cursor.java
@@ -163,10 +163,10 @@ public final class Cursor<K,V> implements Iterator<K> {
      * @param reverse true if traversal is in reverse direction, false otherwise
      * @return CursorPos representing path from the entry found,
      *         or from insertion point if not,
-     *         all the way up to to the root page provided
+     *         all the way up to the root page provided
      */
     static <K,V> CursorPos<K,V> traverseDown(Page<K,V> page, K key, boolean reverse) {
-        CursorPos<K,V> cursorPos = key != null ? CursorPos.traverseDown(page, key) :
+        CursorPos<K,V> cursorPos = key != null ? CursorPos.traverseDown(page, key, null) :
                 reverse ? page.getAppendCursorPos(null) : page.getPrependCursorPos(null);
         int index = cursorPos.index;
         if (index < 0) {

--- a/h2/src/main/org/h2/mvstore/CursorPos.java
+++ b/h2/src/main/org/h2/mvstore/CursorPos.java
@@ -62,8 +62,8 @@ public final class CursorPos<K,V> {
                 index = page.calculateTraversalIndex(key);
                 cursorPos = new CursorPos<>(page, index, cursorPos);
             } else {
-                Page<K, V> existinPage = existing.page;
-                if (existinPage == page) {
+                Page<K, V> existingPage = existing.page;
+                if (existingPage == page) {
                     // If we hit exactly the same page, as previous time, that means that subtree under this page
                     // also hasn't been modified since last attempt. Further traversal therefore is going to follow
                     // exactly same path, so lets just copy it from existing CursopPos chain
@@ -78,7 +78,7 @@ public final class CursorPos<K,V> {
                 existing = temp;
                 // if we hit page with exact set of keys, as last time,
                 // there is no need to do a key search again, use previous result
-                if (!page.sameKeys(existinPage)) {
+                if (!page.sameKeys(existingPage)) {
                     cursorPos.index = page.calculateTraversalIndex(key);
                 }
                 index = cursorPos.index;

--- a/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
+++ b/h2/src/main/org/h2/mvstore/FreeSpaceBitSet.java
@@ -149,9 +149,6 @@ public class FreeSpaceBitSet {
                         freeBlocksTotal += freeBlocks;
                         i = reservedHigh;
                         continue;
-                    } else {
-                        assert end < 0 : end;
-                        assert start == getAfterLastBlock() : start + " <> " + getAfterLastBlock();
                     }
                 }
                 assert set.nextSetBit(start) == -1 || set.nextSetBit(start) >= start + blocks :

--- a/h2/src/main/org/h2/mvstore/MVMap.java
+++ b/h2/src/main/org/h2/mvstore/MVMap.java
@@ -944,7 +944,6 @@ public class MVMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V
     protected final void beforeWrite() {
         assert !getRoot().isLockedByCurrentThread() : getRoot();
         if (closed) {
-            int id = getId();
             String mapName = store.getMapName(id);
             throw DataUtils.newMVStoreException(
                     DataUtils.ERROR_CLOSED, "Map {0}({1}) is closed. {2}", mapName, id, store.getPanicException());

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -812,12 +812,12 @@ public final class MVStore implements AutoCloseable {
                     try {
                         if (normalShutdown && fileStore != null && !fileStore.isReadOnly()) {
                             compactFully = allowedCompactionTime == -1 && fileStoreShallBeClosed;
-                            commit();
                             for (MVMap<?, ?> map : maps.values()) {
                                 if (map.isClosed()) {
                                     fileStore.deregisterMapRoot(map.getId());
                                 }
                             }
+                            commit();
                             setRetentionTime(0);
                             fileStore.stop(compactFully ? 0 : allowedCompactionTime);
                             assert oldestVersionToKeep.get() == currentVersion : oldestVersionToKeep.get() + " != "

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -413,6 +413,8 @@ public abstract class Page<K,V> implements Cloneable {
         return res;
     }
 
+    abstract int calculateTraversalIndex(K key);
+
     /**
      * Split the page. This modifies the current page.
      *
@@ -999,6 +1001,15 @@ public abstract class Page<K,V> implements Cloneable {
     }
 
     /**
+     * Determine whether this page and page provided share the same set of keys.
+     * @param page to compare keys with
+     * @return true if keys are the same
+     */
+    final boolean sameKeys(Page<K, V> page) {
+        return keys == page.keys;
+    }
+
+    /**
      * Create an array of page references.
      *
      * @param <K> the key class
@@ -1169,6 +1180,15 @@ public abstract class Page<K,V> implements Cloneable {
         @Override
         public V getValue(int index) {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        int calculateTraversalIndex(K key) {
+           int index = binarySearch(key);
+            if (++index < 0) {
+                index = -index;
+            }
+            return index;
         }
 
         @Override
@@ -1507,6 +1527,11 @@ public abstract class Page<K,V> implements Cloneable {
         }
 
         @Override
+        int calculateTraversalIndex(K key) {
+            return binarySearch(key);
+        }
+
+        @Override
         public Page<K,V> split(int at) {
             assert !isSaved();
             int b = getKeyCount() - at;
@@ -1634,7 +1659,7 @@ public abstract class Page<K,V> implements Cloneable {
         protected void readPayLoad(ByteBuffer buff) {
             int keyCount = getKeyCount();
             values = createValueStorage(keyCount);
-            map.getValueType().read(buff, values, getKeyCount());
+            map.getValueType().read(buff, values, keyCount);
         }
 
         @Override

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -151,7 +151,7 @@ public abstract class Page<K,V> implements Cloneable {
      * @param map the map
      * @return the new page
      */
-    static <K,V> Page<K,V> createEmptyLeaf(MVMap<K,V> map) {
+    public static <K,V> Page<K,V> createEmptyLeaf(MVMap<K,V> map) {
         return createLeaf(map, map.getKeyType().createStorage(0),
                 map.getValueType().createStorage(0), PAGE_LEAF_MEMORY);
     }
@@ -462,6 +462,16 @@ public abstract class Page<K,V> implements Cloneable {
         System.arraycopy(keys, 0, newKeys, 0, keyCount);
         System.arraycopy(extraKeys, 0, newKeys, keyCount, extraKeyCount);
         keys = newKeys;
+    }
+
+    /**
+     * Create copy of this page with specified entries removed.
+     *
+     * @param positionsToRemove bit set of positions to remove
+     * @return modified copy of this page
+     */
+    public Page<K,V> remove(long positionsToRemove) {
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -1563,6 +1573,27 @@ public abstract class Page<K,V> implements Cloneable {
             if(isPersistent()) {
                 recalculateMemory();
             }
+        }
+
+        @Override
+        public Page<K,V> remove(long positionsToRemove) {
+            assert positionsToRemove != 0;
+            int keyCount = getKeyCount() - Long.bitCount(positionsToRemove);
+            if (keyCount == 0) {
+                return map.createEmptyLeaf();
+            }
+            K[] newKeys = createKeyStorage(keyCount);
+            V[] newValues = values == null ? null : createValueStorage(keyCount);
+            for(int src = 0, dst = 0; dst < keyCount; ++src, positionsToRemove >>>= 1) {
+                if ((positionsToRemove & 1L) == 0) {
+                    newKeys[dst] = getKey(src);
+                    if (newValues != null) {
+                        newValues[dst] = values[src];
+                    }
+                    ++dst;
+                }
+            }
+            return createLeaf(map, newKeys, newValues, 0);
         }
 
         @Override

--- a/h2/src/main/org/h2/mvstore/SingleFileStore.java
+++ b/h2/src/main/org/h2/mvstore/SingleFileStore.java
@@ -213,17 +213,6 @@ public class SingleFileStore extends RandomAccessStore {
         }
     }
 
-    /**
-     * Calculates relative "priority" for chunk to be moved.
-     *
-     * @param block where chunk starts
-     * @return priority, bigger number indicate that chunk need to be moved sooner
-     */
-    @Override
-    public int getMovePriority(int block) {
-        return freeSpace.getMovePriority(block);
-    }
-
     @Override
     public void backup(ZipOutputStream out) throws IOException {
         boolean before = isSpaceReused();

--- a/h2/src/main/org/h2/mvstore/SingleFileStore.java
+++ b/h2/src/main/org/h2/mvstore/SingleFileStore.java
@@ -225,11 +225,6 @@ public class SingleFileStore extends RandomAccessStore {
     }
 
     @Override
-    protected long getAfterLastBlock_() {
-        return freeSpace.getAfterLastBlock();
-    }
-
-    @Override
     public void backup(ZipOutputStream out) throws IOException {
         boolean before = isSpaceReused();
         setReuseSpace(false);

--- a/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
+++ b/h2/src/main/org/h2/mvstore/db/LobStorageMap.java
@@ -426,13 +426,15 @@ public final class LobStorageMap implements LobStorageInterface
 
     @Override
     public void close() {
-        mvStore.setOldestVersionTracker(null);
-        Utils.shutdownExecutor(cleanupExecutor);
-        if (!mvStore.isClosed() && mvStore.isVersioningRequired()) {
-            // remove all session variables and temporary lobs
-            removeAllForTable(LobStorageFrontend.TABLE_ID_SESSION_VARIABLE);
-            // remove all dead LOBs, even deleted in current version, before the store closed
-            cleanup(mvStore.getCurrentVersion() + 1);
+        if (cleanupExecutor != null && !cleanupExecutor.isShutdown()) {
+            mvStore.setOldestVersionTracker(null);
+            Utils.shutdownExecutor(cleanupExecutor);
+            if (!mvStore.isClosed() && mvStore.isVersioningRequired()) {
+                // remove all session variables and temporary lobs
+                removeAllForTable(LobStorageFrontend.TABLE_ID_SESSION_VARIABLE);
+                // remove all dead LOBs, even deleted in current version, before the store closed
+                cleanup(mvStore.getCurrentVersion() + 1);
+            }
         }
     }
 

--- a/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
+++ b/h2/src/main/org/h2/mvstore/db/MVSecondaryIndex.java
@@ -244,25 +244,9 @@ public final class MVSecondaryIndex extends MVIndex<SearchRow, Value> {
 
     @Override
     public void update(SessionLocal session, Row oldRow, Row newRow) {
-        SearchRow searchRowOld = convertToKey(oldRow, null);
-        SearchRow searchRowNew = convertToKey(newRow, null);
-        if (!rowsAreEqual(searchRowOld, searchRowNew)) {
+        if (!areRowsEquivalent(oldRow, newRow)) {
             super.update(session, oldRow, newRow);
         }
-    }
-
-    private boolean rowsAreEqual(SearchRow rowOne, SearchRow rowTwo) {
-        if (rowOne == rowTwo) {
-            return true;
-        }
-        for (int index : columnIds) {
-            Value v1 = rowOne.getValue(index);
-            Value v2 = rowTwo.getValue(index);
-            if (!Objects.equals(v1, v2)) {
-                return false;
-            }
-        }
-        return rowOne.getKey() == rowTwo.getKey();
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/db/MVTable.java
+++ b/h2/src/main/org/h2/mvstore/db/MVTable.java
@@ -714,9 +714,33 @@ public class MVTable extends TableBase {
 
     @Override
     public void updateRows(Prepared prepared, SessionLocal session, LocalResult rows) {
-        super.updateRows(prepared, session, rows);
+        if (primaryIndex.getMainIndexColumn() == SearchRow.ROWID_INDEX) {
+            // in case we need to undo the update
+            SessionLocal.Savepoint rollback = session.setSavepoint();
+            int rowScanCount = 0;
+            while (rows.next()) {
+                if ((++rowScanCount & 127) == 0) {
+                    prepared.checkCanceled();
+                }
+                Row o = rows.currentRowForTable();
+                rows.next();
+                Row n = rows.currentRowForTable();
+                try {
+                    updateRow(session, o, n);
+                } catch (DbException e) {
+                    if (e.getErrorCode() == ErrorCode.CONCURRENT_UPDATE_1
+                            || e.getErrorCode() == ErrorCode.ROW_NOT_FOUND_WHEN_DELETING_1) {
+                        session.rollbackTo(rollback);
+                    }
+                    throw e;
+                }
+            }
+        } else {
+            super.updateRows(prepared, session, rows);
+        }
         if (rows.getRowCount() > 0) {
             session.registerTableAsUpdated(this);
+            analyzeIfRequired(session);
         }
     }
 

--- a/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
+++ b/h2/src/main/org/h2/mvstore/rtree/MVRTreeMap.java
@@ -110,11 +110,11 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
      */
     @Override
     public V remove(Object key) {
-        return operate((Spatial) key, null, DecisionMaker.REMOVE);
+        return operate((Spatial) key, null, DecisionMaker.removeDecision());
     }
 
     @Override
-    public V operate(Spatial key, V value, DecisionMaker<? super V> decisionMaker) {
+    public V operate(Spatial key, V value, DecisionMaker<V> decisionMaker) {
         int attempt = 0;
         final Collection<Page<Spatial,V>> removedPages = isPersistent() ? new ArrayList<>() : null;
         while(true) {
@@ -282,7 +282,7 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
 
     @Override
     public V put(Spatial key, V value) {
-        return operate(key, value, DecisionMaker.PUT);
+        return operate(key, value, DecisionMaker.putDecision());
     }
 
     /**
@@ -293,7 +293,7 @@ public final class MVRTreeMap<V> extends MVMap<Spatial, V> {
      * @param value the value
      */
     public void add(Spatial key, V value) {
-        operate(key, value, DecisionMaker.PUT);
+        operate(key, value, DecisionMaker.putDecision());
     }
 
     private Page<Spatial,V> split(Page<Spatial,V> p) {

--- a/h2/src/main/org/h2/mvstore/tx/CommitDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/CommitDecisionMaker.java
@@ -5,8 +5,15 @@
  */
 package org.h2.mvstore.tx;
 
+import org.h2.mvstore.CursorPos;
 import org.h2.mvstore.MVMap;
+import org.h2.mvstore.Page;
 import org.h2.value.VersionedValue;
+
+import java.util.BitSet;
+
+import static org.h2.value.VersionedValue.NO_ENTRY_ID;
+import static org.h2.value.VersionedValue.NO_OPERATION_ID;
 
 /**
  * Class CommitDecisionMaker makes a decision during post-commit processing
@@ -16,12 +23,113 @@ import org.h2.value.VersionedValue;
  * @author <a href='mailto:andrei.tokar@gmail.com'>Andrei Tokar</a>
  */
 final class CommitDecisionMaker<V> extends MVMap.DecisionMaker<VersionedValue<V>> {
+    private final int transactionId;
     private long undoKey;
     private MVMap.Decision decision;
+
+    private final BitSet entryIds;
+    private final int pageEntryIds[];
+    private int entryIdsCount;
+
+    public CommitDecisionMaker(Transaction transaction, int maxKeysPerPage) {
+        transactionId = transaction.getId();
+        pageEntryIds = new int[maxKeysPerPage];
+        entryIds = new BitSet((int)transaction.getLogId());
+    }
 
     void setUndoKey(long undoKey) {
         this.undoKey = undoKey;
         reset();
+    }
+
+    @Override
+    public void onPageReplaced() {
+        for (int i = 0; i < entryIdsCount; i++) {
+            entryIds.set(pageEntryIds[i]);
+        }
+        reset();
+    }
+
+    public boolean haveSeenEntry(int entryId) {
+        return entryIds.get(entryId);
+    }
+
+    @Override
+    public <K> CursorPos<K, VersionedValue<V>> decide(CursorPos<K, VersionedValue<V>> tip,
+                                                        K key, VersionedValue<V> providedValue) {
+        Page<K,VersionedValue<V>> p = tip.page;
+        assert p.isLeaf();
+        boolean update = false;
+        long toRemove = 0L;
+        for (int src = 0; src < p.getKeyCount(); src++) {
+            VersionedValue<V> value = p.getValue(src);
+            long operationId = value.getOperationId();
+            if (operationId != NO_OPERATION_ID && TransactionStore.getTransactionId(operationId) == transactionId) {
+                long entryId = value.getEntryId();
+                assert entryId != NO_ENTRY_ID;
+                assert !entryIds.get((int)entryId);
+                pageEntryIds[entryIdsCount++] = (int)entryId;
+
+                V currentValue = value.getCurrentValue();
+                if (currentValue == null) {
+                    toRemove |= 1L << src;
+                } else {
+                    update = true;
+                }
+            }
+        }
+        if (toRemove != 0L) {
+            p = p.remove(toRemove);
+            if (p.getKeyCount() == 0) {
+                CursorPos<K, VersionedValue<V>> pos = tip.parent;
+                if (pos != null) {
+                    int keyCount;
+                    int index;
+                    do {
+                        p = pos.page;
+                        index = pos.index;
+                        pos = pos.parent;
+                        keyCount = p.getKeyCount();
+                        // condition below should always be false, but older
+                        // versions (up to 1.4.197) may create
+                        // single-childed (with no keys) internal nodes,
+                        // which we skip here
+                    } while (keyCount == 0 && pos != null);
+
+                    if (keyCount <= 1) {
+                        if (keyCount == 1) {
+                            assert index <= 1;
+                            p = p.getChildPage(1 - index).copy();
+                        } else {
+                            // if root happens to be such single-childed
+                            // (with no keys) internal node, then just
+                            // replace it with empty leaf
+                            p = Page.createEmptyLeaf(p.map);
+                        }
+                        return new CursorPos<>(p, 0, pos);
+                    }
+                    p = p.copy();
+                    p.remove(index);
+                }
+                return new CursorPos<>(p, 0, pos);
+            }
+        } else if (update) {
+            p = p.copy();
+        } else {
+            return tip;
+        }
+        if (update) {
+            for (int i = 0; i < p.getKeyCount(); i++) {
+                VersionedValue<V> value = p.getValue(i);
+                long operationId = value.getOperationId();
+                if (operationId != NO_OPERATION_ID && TransactionStore.getTransactionId(operationId) == transactionId) {
+                    V currentValue = value.getCurrentValue();
+                    assert currentValue != null;
+                    p.setValue(i, VersionedValueCommitted.getInstance(currentValue));
+                }
+            }
+        }
+        return new CursorPos<>(p, p.getMemory(), tip.parent);
     }
 
     @Override
@@ -56,6 +164,7 @@ final class CommitDecisionMaker<V> extends MVMap.DecisionMaker<VersionedValue<V>
     @Override
     public void reset() {
         decision = null;
+        entryIdsCount = 0;
     }
 
     @Override

--- a/h2/src/main/org/h2/mvstore/tx/Record.java
+++ b/h2/src/main/org/h2/mvstore/tx/Record.java
@@ -21,9 +21,6 @@ import org.h2.value.VersionedValue;
  */
 final class Record<K,V> {
 
-    // -1 is a bogus map id
-    static final Record<?,?> COMMIT_MARKER = new Record<>(-1, null, null);
-
     /**
      * Map id for this change is related to
      */
@@ -39,6 +36,10 @@ final class Record<K,V> {
      * It is null if entry did not exist before the change (addition).
      */
     final VersionedValue<V> oldValue;
+
+    Record(int commitOrder) {
+        this(commitOrder, null, null);
+    }
 
     Record(int mapId, K key, VersionedValue<V> oldValue) {
         this.mapId = mapId;
@@ -93,12 +94,11 @@ final class Record<K,V> {
             }
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public Record<K,V> read(ByteBuffer buff) {
             int mapId = DataUtils.readVarInt(buff);
             if (mapId < 0) {
-                return (Record<K,V>)COMMIT_MARKER;
+                return new Record<>(mapId);
             }
             MVMap<K, VersionedValue<V>> map = transactionStore.getMap(mapId);
             K key = map.getKeyType().read(buff);

--- a/h2/src/main/org/h2/mvstore/tx/RollbackDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/RollbackDecisionMaker.java
@@ -8,6 +8,8 @@ package org.h2.mvstore.tx;
 import org.h2.mvstore.MVMap;
 import org.h2.value.VersionedValue;
 
+import static org.h2.value.VersionedValue.NO_OPERATION_ID;
+
 /**
  * Class RollbackDecisionMaker process undo log record during transaction rollback.
  *
@@ -40,7 +42,7 @@ final class RollbackDecisionMaker extends MVMap.DecisionMaker<Record<?,?>> {
             VersionedValue<Object> valueToRestore = existingValue.oldValue;
             long operationId;
             if (valueToRestore == null ||
-                    (operationId = valueToRestore.getOperationId()) == 0 ||
+                    (operationId = valueToRestore.getOperationId()) == NO_OPERATION_ID ||
                     TransactionStore.getTransactionId(operationId) == transactionId
                             && TransactionStore.getLogId(operationId) < toLogId) {
                 int mapId = existingValue.mapId;
@@ -48,7 +50,7 @@ final class RollbackDecisionMaker extends MVMap.DecisionMaker<Record<?,?>> {
                 if (map != null && !map.isClosed()) {
                     Object key = existingValue.key;
                     VersionedValue<Object> previousValue = map.operate(key, valueToRestore,
-                            MVMap.DecisionMaker.DEFAULT);
+                            MVMap.DecisionMaker.defaultDecision());
                     listener.onRollback(map, key, previousValue, valueToRestore);
                 }
             }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -337,12 +337,12 @@ public final class Transaction {
             // The purpose of the following loop is to get a coherent picture
             // In order to get such a "snapshot", we wait for a moment of silence,
             // when no new transaction were committed / closed.
-            long[] committingTransactions;
+            VersionedBitSet committingTransactions;
             do {
                 committingTransactions = store.committingTransactions.get();
                 for (MVMap<Object,VersionedValue<Object>> map : maps) {
                     TransactionMap<?,?> txMap = openMapX(map);
-                    txMap.setStatementSnapshot(new Snapshot(map.flushAndGetRoot(), committingTransactions));
+                    txMap.setStatementSnapshot(new Snapshot(map.flushAndGetRoot(), committingTransactions.bits));
                 }
                 if (isReadCommitted()) {
                     undoLogRootReferences = store.collectUndoLogRootReferences();
@@ -611,7 +611,7 @@ public final class Transaction {
         this.timeoutMillis = timeoutMillis > 0 ? timeoutMillis : store.timeoutMillis;
     }
 
-    private long getLogId() {
+    long getLogId() {
         return getLogId(statusAndLogId.get());
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -499,7 +499,7 @@ public final class Transaction {
             hasChanges = hasChanges(lastState);
             int previousStatus = getStatus(lastState);
             wasActive = isActive(previousStatus);
-            if (hasChanges) {
+            if (wasActive && hasChanges) {
                 store.commit(this, previousStatus == STATUS_COMMITTED);
             }
         } catch (Throwable e) {

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -395,7 +395,7 @@ public final class Transaction {
      *
      * @return key for the newly added undo log entry
      */
-    long log(Record<?,?> logRecord) {
+    <K,V> long log(int mapId, K key, VersionedValue<V> oldValue) {
         long currentState = statusAndLogId.getAndIncrement();
         long logId = getLogId(currentState);
         if (logId >= LOG_ID_LIMIT) {
@@ -406,7 +406,7 @@ public final class Transaction {
         }
         int currentStatus = getStatus(currentState);
         checkOpen(currentStatus);
-        long undoKey = store.addUndoLogRecord(transactionId, logId, logRecord);
+       long undoKey = store.addUndoLogRecord(transactionId, logId, new Record<>(mapId, key, oldValue));
         return undoKey;
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -490,7 +490,6 @@ public final class Transaction {
      */
     public void commit() {
         assert !store.isTransactionClosed(transactionId);
-        markTransactionEnd();
         Throwable ex = null;
         boolean wasActive = false;
         boolean hasChanges = false;
@@ -502,6 +501,7 @@ public final class Transaction {
             if (wasActive && hasChanges) {
                 store.commit(this, previousStatus == STATUS_COMMITTED);
             }
+            markTransactionEnd();
         } catch (Throwable e) {
             if (wasActive) {
                 ex = e;

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -236,7 +236,8 @@ public final class Transaction {
                     break;
                 case STATUS_CLOSED:
                     valid = currentStatus == STATUS_COMMITTED ||
-                            currentStatus == STATUS_ROLLED_BACK;
+                            currentStatus == STATUS_ROLLED_BACK ||
+                            currentStatus == STATUS_CLOSED;
                     break;
                 case STATUS_OPEN:
                 default:
@@ -641,9 +642,11 @@ public final class Transaction {
     void closeIt() {
         transactionMaps.clear();
         long lastState = setStatus(STATUS_CLOSED);
-        store.store.deregisterVersionUsage(txCounter);
-        if((hasChanges(lastState) || hasRollback(lastState))) {
-            notifyAllWaitingTransactions();
+        if (getStatus(lastState) != STATUS_CLOSED) {
+            store.store.deregisterVersionUsage(txCounter);
+            if ((hasChanges(lastState) || hasRollback(lastState))) {
+                notifyAllWaitingTransactions();
+            }
         }
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -644,13 +644,10 @@ public final class Transaction {
         long lastState = setStatus(STATUS_CLOSED);
         if (getStatus(lastState) != STATUS_CLOSED) {
             store.store.deregisterVersionUsage(txCounter);
-            if ((hasChanges(lastState) || hasRollback(lastState))) {
-                notifyAllWaitingTransactions();
-            }
         }
     }
 
-    private void notifyAllWaitingTransactions() {
+    void notifyAllWaitingTransactions() {
         if (notificationRequested) {
             synchronized (this) {
                 notifyAll();
@@ -735,7 +732,7 @@ public final class Transaction {
         long state;
         int status;
         while ((status = getStatus(state = statusAndLogId.get())) != STATUS_CLOSED
-                && status != STATUS_ROLLED_BACK && !hasRollback(state)) {
+                && status != STATUS_COMMITTED && status != STATUS_ROLLED_BACK && !hasRollback(state)) {
             if (waiter.getStatus() != STATUS_OPEN) {
                 waiter.tryThrowDeadLockException(true);
             }

--- a/h2/src/main/org/h2/mvstore/tx/Transaction.java
+++ b/h2/src/main/org/h2/mvstore/tx/Transaction.java
@@ -406,7 +406,7 @@ public final class Transaction {
         }
         int currentStatus = getStatus(currentState);
         checkOpen(currentStatus);
-       long undoKey = store.addUndoLogRecord(transactionId, logId, new Record<>(mapId, key, oldValue));
+        long undoKey = store.addUndoLogRecord(transactionId, logId, new Record<>(mapId, key, oldValue));
         return undoKey;
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -294,7 +294,8 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      */
     public void append(K key, V value) {
         long undoKey = transaction.log(map.getId(), key, null);
-        map.append(key, VersionedValueUncommitted.getInstance(undoKey, value, null));
+        long entryId = TransactionStore.getLogId(undoKey);
+        map.append(key, VersionedValueUncommitted.getInstance(undoKey, value, null, entryId));
         hasChanges = true;
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -293,8 +293,8 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
      * @param value to be appended
      */
     public void append(K key, V value) {
-        map.append(key, VersionedValueUncommitted.getInstance(
-                                        transaction.log(new Record<>(map.getId(), key, null)), value, null));
+        long undoKey = transaction.log(map.getId(), key, null);
+        map.append(key, VersionedValueUncommitted.getInstance(undoKey, value, null));
         hasChanges = true;
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionMap.java
@@ -23,6 +23,8 @@ import org.h2.mvstore.RootReference;
 import org.h2.mvstore.type.DataType;
 import org.h2.value.VersionedValue;
 
+import static org.h2.value.VersionedValue.NO_OPERATION_ID;
+
 /**
  * A map that supports transactions.
  *
@@ -167,7 +169,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
                 VersionedValue<?> currentValue = cursor.getValue();
                 assert currentValue != null;
                 long operationId = currentValue.getOperationId();
-                if (operationId != 0 &&         // skip committed entries
+                if (operationId != NO_OPERATION_ID &&         // skip committed entries
                         isIrrelevant(operationId, currentValue, committingTransactions)) {
                     --size;
                 }
@@ -196,7 +198,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
                                 // only the last undo entry for any given map
                                 // key should be considered
                                 long operationId = cursor.getKey();
-                                assert operationId != 0;
+                                assert operationId != NO_OPERATION_ID;
                                 if (currentValue.getOperationId() == operationId &&
                                         isIrrelevant(operationId, currentValue, committingTransactions)) {
                                     --size;
@@ -474,7 +476,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
                 VersionedValue<V> data = map.get(snapshot.root.root, key);
                 if (data != null) {
                     long id = data.getOperationId();
-                    if (id != 0L && transaction.transactionId == TransactionStore.getTransactionId(id)) {
+                    if (id != NO_OPERATION_ID && transaction.transactionId == TransactionStore.getTransactionId(id)) {
                         return data.getCurrentValue();
                     }
                 }
@@ -494,7 +496,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
             return null;
         }
         long id = data.getOperationId();
-        if (id != 0) {
+        if (id != NO_OPERATION_ID) {
             int tx = TransactionStore.getTransactionId(id);
             if (tx != transaction.transactionId && !BitSetHelper.get(committingTransactions, tx)) {
                 // added/modified/removed by uncommitted transaction, change should not be visible
@@ -595,7 +597,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
         VersionedValue<V> data = map.get(key);
         if (data != null) {
             long id = data.getOperationId();
-            return id != 0 && TransactionStore.getTransactionId(id) == transaction.transactionId
+            return id != NO_OPERATION_ID && TransactionStore.getTransactionId(id) == transaction.transactionId
                     && data.getCurrentValue() == null;
         }
         return false;
@@ -956,7 +958,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
         boolean shouldIgnoreRemoval(VersionedValue<?> data) {
             assert data.getCurrentValue() == null;
             long id = data.getOperationId();
-            if (id != 0) {
+            if (id != NO_OPERATION_ID) {
                 int tx = TransactionStore.getTransactionId(id);
                 return transactionId != tx && !BitSetHelper.get(committingTransactions, tx);
             }
@@ -987,7 +989,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
                 // or if value is a committed one, just return it.
                 if (data != null) {
                     long id = data.getOperationId();
-                    if (id != 0) {
+                    if (id != NO_OPERATION_ID) {
                         int tx = TransactionStore.getTransactionId(id);
                         if (tx != transactionId && !BitSetHelper.get(committingTransactions, tx)) {
                             // current value comes from another uncommitted transaction
@@ -1079,7 +1081,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
                 if (data != null) {
                     Object value = data.getCommittedValue();
                     long id = data.getOperationId();
-                    if (id != 0) {
+                    if (id != NO_OPERATION_ID) {
                         int tx = TransactionStore.getTransactionId(id);
                         if (tx == transactionId || BitSetHelper.get(committingTransactions, tx)) {
                             // value comes from this transaction or another committed transaction
@@ -1102,7 +1104,7 @@ public final class TransactionMap<K, V> extends AbstractMap<K,V> {
                 VersionedValue<V> data = uncommittedCursor.getValue();
                 if (data != null) {
                     long id = data.getOperationId();
-                    if (id != 0L && transactionId == TransactionStore.getTransactionId(id)) {
+                    if (id != NO_OPERATION_ID && transactionId == TransactionStore.getTransactionId(id)) {
                         uncommittedKey = key;
                         uncommittedValue = data.getCurrentValue();
                         return;

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -379,9 +379,9 @@ public class TransactionStore implements AutoCloseable
     /**
      * Determine entry id from provided value, if available, or take initial value from provided undoKey.
      *
-     * @param versionedValue
-     * @param undoKey
-     * @return
+     * @param versionedValue to extract entry id from
+     * @param undoKey for entry to be identified
+     * @return entry id, which is a transaction log id for the first update to a map entry within transaction
      */
     static long getEntryId(VersionedValue<?> versionedValue, long undoKey) {
         long entryId = NO_ENTRY_ID;

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -367,6 +367,9 @@ public class TransactionStore {
         store.commit();
     }
 
+    public void closeImmediately() {
+    }
+
     /**
      * Begin a new transaction.
      *

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -513,6 +513,9 @@ public class TransactionStore {
             // made by this transaction, to be considered as "committed"
             flipCommittingTransactionsBit(transactionId, true);
 
+            t.notifyAllWaitingTransactions();
+
+
             CommitDecisionMaker<Object> commitDecisionMaker = new CommitDecisionMaker<>();
             try {
                 while (cursor.hasNext()) {

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -6,7 +6,6 @@
 package org.h2.mvstore.tx;
 
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +26,7 @@ import org.h2.mvstore.type.MetaType;
 import org.h2.mvstore.type.ObjectDataType;
 import org.h2.mvstore.type.StringDataType;
 import org.h2.util.StringUtils;
+import org.h2.util.Utils;
 import org.h2.value.VersionedValue;
 
 /**
@@ -63,7 +63,7 @@ public class TransactionStore {
      * Key: opId, value: [ mapId, key, oldValue ].
      */
     @SuppressWarnings("unchecked")
-    private final MVMap<Long,Record<?,?>>[] undoLogs = new MVMap[MAX_OPEN_TRANSACTIONS];
+    private final MVMap<Long,Record<?,?>>[] undoLogs = new MVMap[MAX_OPEN_TRANSACTIONS+1];
     private final MVMap.Builder<Long, Record<?,?>> undoLogBuilder;
 
     private final DataType<?> dataType;
@@ -115,8 +115,7 @@ public class TransactionStore {
     /**
      * Hard limit on the number of concurrently opened transactions
      */
-    // TODO: introduce constructor parameter instead of a static field, driven by URL parameter
-    private static final int MAX_OPEN_TRANSACTIONS = 65535;
+    private static final int MAX_OPEN_TRANSACTIONS = Utils.getProperty("h2.maxOpenTransactions", 255);
 
     /**
      * Generate a string used to name undo log map for a specific transaction.

--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -560,6 +560,8 @@ public class TransactionStore implements AutoCloseable
 
             t.notifyAllWaitingTransactions();
 
+            t.markStatementStart(null);
+
             // Now mark log as "committed".
             // It does not change the way this transaction is treated by others,
             // but preserves fact of commit in case of abrupt termination.
@@ -587,6 +589,7 @@ public class TransactionStore implements AutoCloseable
                         map.operate(key, null, commitDecisionMaker);
                     }
                 }
+                t.markStatementEnd();
             } finally {
                 try {
                     undoLog.clear();

--- a/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
@@ -157,7 +157,7 @@ class TxDecisionMaker<K,V> extends MVMap.DecisionMaker<VersionedValue<V>> {
      * @return {@link org.h2.mvstore.MVMap.Decision#PUT}
      */
     MVMap.Decision logAndDecideToPut(VersionedValue<V> valueToLog, V lastValue) {
-        undoKey = transaction.log(new Record<>(mapId, key, valueToLog));
+        undoKey = transaction.log(mapId, key, valueToLog);
         this.lastValue = lastValue;
         return setDecision(MVMap.Decision.PUT);
     }

--- a/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
@@ -186,7 +186,7 @@ class TxDecisionMaker<K,V> extends MVMap.DecisionMaker<VersionedValue<V>> {
      * (transaction we are acting within).
      *
      * @param transactionId to check
-     * @return true it it is "current" transaction's id, false otherwise
+     * @return true it is "current" transaction's id, false otherwise
      */
     final boolean isThisTransaction(int transactionId) {
         return transactionId == transaction.transactionId;

--- a/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
+++ b/h2/src/main/org/h2/mvstore/tx/TxDecisionMaker.java
@@ -206,7 +206,7 @@ class TxDecisionMaker<K,V> extends MVMap.DecisionMaker<VersionedValue<V>> {
         TransactionStore store = transaction.store;
         do {
             blockingTx = store.getTransaction(transactionId);
-            result = BitSetHelper.get(store.committingTransactions.get(), transactionId);
+            result = store.committingTransactions.get().get(transactionId);
         } while (blockingTx != store.getTransaction(transactionId));
 
         if (!result) {
@@ -273,7 +273,7 @@ class TxDecisionMaker<K,V> extends MVMap.DecisionMaker<VersionedValue<V>> {
                 return logAndDecideToPut(null, null);
             } else {
                 long id = existingValue.getOperationId();
-                if (id == 0 // entry is a committed one
+                if (id == 0 // entry is a committed one,
                             // or it came from the same transaction
                         || isThisTransaction(blockingId = TransactionStore.getTransactionId(id))) {
                     if(existingValue.getCurrentValue() != null) {

--- a/h2/src/main/org/h2/mvstore/tx/VersionedValueCommitted.java
+++ b/h2/src/main/org/h2/mvstore/tx/VersionedValueCommitted.java
@@ -12,7 +12,8 @@ import org.h2.value.VersionedValue;
  *
  * @author <a href='mailto:andrei.tokar@gmail.com'>Andrei Tokar</a>
  */
-class VersionedValueCommitted<T> extends VersionedValue<T> {
+class VersionedValueCommitted<T> extends VersionedValue<T>
+{
     /**
      * The current value.
      */

--- a/h2/src/main/org/h2/mvstore/tx/VersionedValueCommitted.java
+++ b/h2/src/main/org/h2/mvstore/tx/VersionedValueCommitted.java
@@ -19,8 +19,14 @@ class VersionedValueCommitted<T> extends VersionedValue<T>
      */
     public final T value;
 
-    VersionedValueCommitted(T value) {
+    /**
+     * Transaction-scoped id for the entry, this value belongs to
+     */
+    private final long entryId;
+
+    protected VersionedValueCommitted(T value, long entryId) {
         this.value = value;
+        this.entryId = entryId;
     }
 
     /**
@@ -31,14 +37,25 @@ class VersionedValueCommitted<T> extends VersionedValue<T>
      * @param value the object to cast/wrap
      * @return VersionedValue instance
      */
-    @SuppressWarnings("unchecked")
     static <X> VersionedValue<X> getInstance(X value) {
         assert value != null;
-        return value instanceof VersionedValue ? (VersionedValue<X>)value : new VersionedValueCommitted<>(value);
+        return getInstance(value, NO_ENTRY_ID);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <X> VersionedValue<X> getInstance(X value, long entryId) {
+        return entryId == NO_ENTRY_ID && (value == null || value instanceof VersionedValue) ?
+                (VersionedValue<X>)value :
+                new VersionedValueCommitted<>(value, entryId);
     }
 
     @Override
-    public T getCurrentValue() {
+    public long getEntryId() {
+        return entryId;
+    }
+
+    @Override
+    public final T getCurrentValue() {
         return value;
     }
 

--- a/h2/src/main/org/h2/mvstore/tx/VersionedValueUncommitted.java
+++ b/h2/src/main/org/h2/mvstore/tx/VersionedValueUncommitted.java
@@ -12,12 +12,13 @@ import org.h2.value.VersionedValue;
  *
  * @author <a href='mailto:andrei.tokar@gmail.com'>Andrei Tokar</a>
  */
-class VersionedValueUncommitted<T> extends VersionedValueCommitted<T> {
+final class VersionedValueUncommitted<T> extends VersionedValueCommitted<T>
+{
     private final long operationId;
     private final T committedValue;
 
-    private VersionedValueUncommitted(long operationId, T value, T committedValue) {
-        super(value);
+    private VersionedValueUncommitted(long operationId, T value, T committedValue, long entryId) {
+        super(value, entryId);
         assert operationId != 0;
         this.operationId = operationId;
         this.committedValue = committedValue;
@@ -33,8 +34,8 @@ class VersionedValueUncommitted<T> extends VersionedValueCommitted<T> {
      * @param committedValue value after commit
      * @return VersionedValue instance
      */
-    static <X> VersionedValue<X> getInstance(long operationId, X value, X committedValue) {
-        return new VersionedValueUncommitted<>(operationId, value, committedValue);
+    static <X> VersionedValue<X> getInstance(long operationId, X value, X committedValue, long entryId) {
+        return new VersionedValueUncommitted<>(operationId, value, committedValue, entryId);
     }
 
     @Override
@@ -56,6 +57,6 @@ class VersionedValueUncommitted<T> extends VersionedValueCommitted<T> {
     public String toString() {
         return super.toString() +
                 " " + TransactionStore.getTransactionId(operationId) + "/" +
-                TransactionStore.getLogId(operationId) + " " + committedValue;
+                TransactionStore.getLogId(operationId) + "/" + getEntryId() + " " + committedValue;
     }
 }

--- a/h2/src/main/org/h2/table/TableLink.java
+++ b/h2/src/main/org/h2/table/TableLink.java
@@ -591,18 +591,18 @@ public class TableLink extends Table {
     }
 
     @Override
-    public void updateRows(Prepared prepared, SessionLocal session, LocalResult rows) {
+    public void updateRows(SessionLocal session, LocalResult rows, Runnable cancellationCheck) {
         checkReadOnly();
         if (emitUpdates) {
             while (rows.next()) {
-                prepared.checkCanceled();
+                cancellationCheck.run();
                 Row oldRow = rows.currentRowForTable();
                 rows.next();
                 Row newRow = rows.currentRowForTable();
                 linkedIndex.update(oldRow, newRow, session);
             }
         } else {
-            super.updateRows(prepared, session, rows);
+            super.updateRows(session, rows, cancellationCheck);
         }
     }
 

--- a/h2/src/main/org/h2/tools/Backup.java
+++ b/h2/src/main/org/h2/tools/Backup.java
@@ -56,6 +56,11 @@ public class Backup extends Tool {
         new Backup().runTool(args);
     }
 
+    /**
+     * Creates default instance
+     */
+    public Backup() {}
+
     @Override
     public void runTool(String... args) throws SQLException {
         String zipFileName = "backup.zip";

--- a/h2/src/main/org/h2/tools/ChangeFileEncryption.java
+++ b/h2/src/main/org/h2/tools/ChangeFileEncryption.java
@@ -67,6 +67,11 @@ public class ChangeFileEncryption extends Tool {
         }
     }
 
+    /**
+     * Creates default instance
+     */
+    public ChangeFileEncryption() {}
+
     @Override
     public void runTool(String... args) throws SQLException {
         String dir = ".";

--- a/h2/src/main/org/h2/tools/CompressTool.java
+++ b/h2/src/main/org/h2/tools/CompressTool.java
@@ -37,11 +37,11 @@ import org.h2.util.Utils;
  */
 public class CompressTool {
 
-    public static final String KANZI_OUTPUT_CLASS_NAME = "io.github.flanglet.kanzi.io.CompressedOutputStream";
-    public static final String KANZI_INPUT_CLASS_NAME = "io.github.flanglet.kanzi.io.CompressedInputStream";
-    public static final String BZIP2_OUTPUT_CLASS_NAME //
+    static final String KANZI_OUTPUT_CLASS_NAME = "io.github.flanglet.kanzi.io.CompressedOutputStream";
+    static final String KANZI_INPUT_CLASS_NAME = "io.github.flanglet.kanzi.io.CompressedInputStream";
+    static final String BZIP2_OUTPUT_CLASS_NAME //
             = "org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream";
-    public static final String BZIP2_INPUT_CLASS_NAME //
+    static final String BZIP2_INPUT_CLASS_NAME //
             = "org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream";
 
     private static final int MAX_BUFFER_SIZE = 3 * Constants.IO_BUFFER_SIZE_COMPRESS;
@@ -54,6 +54,8 @@ public class CompressTool {
 
     /**
      * Creates a BZip2 compressing output stream using reflection.
+     * @param baseOutputStream to compress
+     * @return compressed stream
      */
     public static OutputStream createBZip2OutputStream(OutputStream baseOutputStream) {
         try {
@@ -70,6 +72,8 @@ public class CompressTool {
 
     /**
      * Creates a BZip2 decompressing input stream using reflection.
+     * @param inputStream to decompress
+     * @return decompressed stream
      */
     public static InputStream createBZip2InputStream(InputStream inputStream) {
         try {
@@ -86,6 +90,9 @@ public class CompressTool {
 
     /**
      * Creates a Kanzi compressing output stream using reflection.
+     * @param baseOutputStream to compress
+     * @param executor for multithreaded execution
+     * @return compressed stream
      */
     public static OutputStream createKanziOutputStream(OutputStream baseOutputStream, ExecutorService executor) {
         try {
@@ -130,6 +137,9 @@ public class CompressTool {
 
     /**
      * Creates a Kanzi decompressing input stream using reflection.
+     * @param inputStream to decompress
+     * @param executor for multithreaded execution
+     * @return decompressed stream
      */
     public static InputStream createKanziInputStream(InputStream inputStream, ExecutorService executor) {
         try {

--- a/h2/src/main/org/h2/tools/CompressionType.java
+++ b/h2/src/main/org/h2/tools/CompressionType.java
@@ -10,15 +10,48 @@ import java.util.Locale;
 /**
  * Compression types for SQL output
  */
-public enum CompressionType {
+public enum CompressionType
+{
+    /**
+     * No compression
+     */
     NONE,
+
+    /**
+     * <A href="https://en.wikipedia.org/wiki/Gzip">GZIP compression</A>
+     */
     GZIP,
+
+    /**
+     * <A href="https://en.wikipedia.org/wiki/ZIP_(file_format)">ZIP compression</A>
+     */
     ZIP,
+
+    /**
+     * <A href="https://en.wikipedia.org/wiki/Bzip2">BZIP2 compression</A>
+     */
     BZIP2,
+
+    /**
+     * <A href="https://github.com/flanglet/kanzi">KANZI compression</A>
+     */
     KANZI,
+
+    /**
+     * <A href="https://en.wikipedia.org/wiki/Deflate">DEFLATE compression</A>
+     */
     DEFLATE,
+
+    /**
+     * <A href="https://github.com/ning/compress/wiki/LZFFormat">LZF compression</A>
+     */
     LZF;
 
+    /**
+     * Find instance of CompressionType by its name.
+     * @param type name of CompressionType
+     * @return instance of CompressionType or {@link #NONE} if provyded type is empty
+     */
     public static CompressionType from(String type) {
         return type==null || type.isEmpty()
             ? NONE

--- a/h2/src/main/org/h2/tools/Console.java
+++ b/h2/src/main/org/h2/tools/Console.java
@@ -27,6 +27,8 @@ public class Console extends Tool implements ShutdownHandler {
 
     boolean isWindows;
 
+    Console() {}
+
     /**
      * When running without options, -tcp, -web, -browser and -pg are started.
      *

--- a/h2/src/main/org/h2/tools/ConvertTraceFile.java
+++ b/h2/src/main/org/h2/tools/ConvertTraceFile.java
@@ -74,6 +74,11 @@ public class ConvertTraceFile extends Tool {
         new ConvertTraceFile().runTool(args);
     }
 
+    /**
+     * Creates default instance
+     */
+    public ConvertTraceFile() {}
+
     @Override
     public void runTool(String... args) throws SQLException {
         String traceFile = "test.trace.db";

--- a/h2/src/main/org/h2/tools/CreateCluster.java
+++ b/h2/src/main/org/h2/tools/CreateCluster.java
@@ -50,6 +50,11 @@ public class CreateCluster extends Tool {
         new CreateCluster().runTool(args);
     }
 
+    /**
+     * Creates default instance
+     */
+    public CreateCluster() {}
+
     @Override
     public void runTool(String... args) throws SQLException {
         String urlSource = null;

--- a/h2/src/main/org/h2/tools/Csv.java
+++ b/h2/src/main/org/h2/tools/Csv.java
@@ -65,6 +65,11 @@ public class Csv implements SimpleRowSource {
     private Writer output;
     private boolean endOfLine, endOfFile;
 
+    /**
+     * Creates default instance
+     */
+    public Csv() {}
+
     private int writeResultSet(ResultSet rs) throws SQLException {
         try {
             int rows = 0;

--- a/h2/src/main/org/h2/tools/DeleteDbFiles.java
+++ b/h2/src/main/org/h2/tools/DeleteDbFiles.java
@@ -41,6 +41,11 @@ public class DeleteDbFiles extends Tool {
         new DeleteDbFiles().runTool(args);
     }
 
+    /**
+     * Creates default instance
+     */
+    public DeleteDbFiles() {}
+
     @Override
     public void runTool(String... args) throws SQLException {
         String dir = ".";

--- a/h2/src/main/org/h2/tools/DirectRecover.java
+++ b/h2/src/main/org/h2/tools/DirectRecover.java
@@ -208,6 +208,11 @@ public class DirectRecover extends Recover {
     }
 
     /**
+     * Creates default instance
+     */
+    public DirectRecover() {}
+
+    /**
      * Enhanced runTool method with compression support.
      */
     @Override

--- a/h2/src/main/org/h2/tools/GUIConsole.java
+++ b/h2/src/main/org/h2/tools/GUIConsole.java
@@ -57,6 +57,11 @@ public class GUIConsole extends Console implements ActionListener, MouseListener
     private Object tray;
     private Object trayIcon;
 
+    /**
+     * Creates default instance
+     */
+    public GUIConsole() {}
+
     @Override
     protected String getMainClassName() {
         return Console.class.getName();

--- a/h2/src/main/org/h2/tools/Recover.java
+++ b/h2/src/main/org/h2/tools/Recover.java
@@ -105,6 +105,11 @@ public class Recover extends Tool implements DataHandler {
     }
 
     /**
+     * Creates default instance
+     */
+    public Recover() {}
+
+    /**
      * Dumps the contents of a database file to a human readable text file. This
      * text file can be used to recover most of the data. This tool does not
      * open the database and can be used even if the database files are

--- a/h2/src/main/org/h2/tools/Restore.java
+++ b/h2/src/main/org/h2/tools/Restore.java
@@ -46,6 +46,11 @@ public class Restore extends Tool {
         new Restore().runTool(args);
     }
 
+    /**
+     * Creates default instance
+     */
+    public Restore() {}
+
     @Override
     public void runTool(String... args) throws SQLException {
         String zipFileName = "backup.zip";

--- a/h2/src/main/org/h2/tools/RunScript.java
+++ b/h2/src/main/org/h2/tools/RunScript.java
@@ -67,6 +67,11 @@ public class RunScript extends Tool {
     }
 
     /**
+     * Creates default instance
+     */
+    public RunScript() {}
+
+    /**
      * Executes the contents of a SQL script file against a database.
      * This tool is usually used to create a database from script.
      * It can also be used to analyze performance problems by running

--- a/h2/src/main/org/h2/tools/Script.java
+++ b/h2/src/main/org/h2/tools/Script.java
@@ -44,6 +44,11 @@ public class Script extends Tool {
         new Script().runTool(args);
     }
 
+    /**
+     * Creates default instance
+     */
+    public Script() {}
+
     @Override
     public void runTool(String... args) throws SQLException {
         String url = null;

--- a/h2/src/main/org/h2/tools/Shell.java
+++ b/h2/src/main/org/h2/tools/Shell.java
@@ -81,6 +81,11 @@ public class Shell extends Tool implements Runnable {
     }
 
     /**
+     * Creates default instance
+     */
+    public Shell() {}
+
+    /**
      * Sets the standard error stream.
      *
      * @param err the new standard error stream

--- a/h2/src/main/org/h2/tools/TriggerAdapter.java
+++ b/h2/src/main/org/h2/tools/TriggerAdapter.java
@@ -44,6 +44,12 @@ public abstract class TriggerAdapter implements Trigger {
      */
     protected int type;
 
+
+    /**
+     * Creates default instance
+     */
+    public TriggerAdapter() {}
+
     /**
      * This method is called by the database engine once when initializing the
      * trigger. It is called when the trigger is created, as well as when the

--- a/h2/src/main/org/h2/tools/ZeroBytesEOFInputStream.java
+++ b/h2/src/main/org/h2/tools/ZeroBytesEOFInputStream.java
@@ -21,6 +21,10 @@ public class ZeroBytesEOFInputStream extends InputStream {
     private static final int MAX_ZERO_READS = 10;
     private boolean eofReached = false;
 
+    /**
+     * Creates ZeroBytesEOFInputStream instance
+     * @param wrapped stream
+     */
     public ZeroBytesEOFInputStream(InputStream wrapped) {
         this.wrapped = wrapped;
     }

--- a/h2/src/main/org/h2/util/Utils.java
+++ b/h2/src/main/org/h2/util/Utils.java
@@ -751,17 +751,21 @@ public class Utils {
         return time;
     }
 
+    public static final ThreadGroup H2_THREAD_GROUP = new ThreadGroup("H2-background");
+
     public static ThreadPoolExecutor createSingleThreadExecutor(String threadName) {
         return createSingleThreadExecutor(threadName, new LinkedBlockingQueue<>());
     }
 
     public static ThreadPoolExecutor createSingleThreadExecutor(String threadName, BlockingQueue<Runnable> workQueue) {
         return new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, workQueue,
-                                        r -> {
-                                            Thread thread = new Thread(r, threadName);
-                                            thread.setDaemon(true);
-                                            return thread;
-                                        });
+                                        r -> createBackgroundThread(threadName, r));
+    }
+
+    public static Thread createBackgroundThread(String threadName, Runnable r) {
+        Thread thread = new Thread(H2_THREAD_GROUP, r, threadName);
+        thread.setDaemon(true);
+        return thread;
     }
 
     /**
@@ -791,6 +795,10 @@ public class Utils {
                 executor.awaitTermination(1, TimeUnit.DAYS);
             } catch (InterruptedException ignore) {/**/}
         }
+    }
+
+    public static boolean isBackgroundThread() {
+        return Thread.currentThread().getThreadGroup() == H2_THREAD_GROUP;
     }
 
     /**

--- a/h2/src/main/org/h2/value/VersionedValue.java
+++ b/h2/src/main/org/h2/value/VersionedValue.java
@@ -13,6 +13,7 @@ package org.h2.value;
  */
 public abstract class VersionedValue<T> {
 
+    public static final long NO_ENTRY_ID = -1L;
     public static final long NO_OPERATION_ID = 0L;
 
     protected VersionedValue() {}
@@ -23,6 +24,10 @@ public abstract class VersionedValue<T> {
 
     public long getOperationId() {
         return NO_OPERATION_ID;
+    }
+
+    public long getEntryId() {
+        return NO_ENTRY_ID;
     }
 
     @SuppressWarnings("unchecked")

--- a/h2/src/main/org/h2/value/VersionedValue.java
+++ b/h2/src/main/org/h2/value/VersionedValue.java
@@ -11,7 +11,9 @@ package org.h2.value;
  * Also for uncommitted values it contains operationId - a combination of
  * transactionId and logId.
  */
-public class VersionedValue<T> {
+public abstract class VersionedValue<T> {
+
+    public static final long NO_OPERATION_ID = 0L;
 
     protected VersionedValue() {}
 
@@ -20,7 +22,7 @@ public class VersionedValue<T> {
     }
 
     public long getOperationId() {
-        return 0L;
+        return NO_OPERATION_ID;
     }
 
     @SuppressWarnings("unchecked")

--- a/h2/src/test/org/h2/test/db/TestMultiThread.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThread.java
@@ -15,6 +15,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -391,17 +392,20 @@ public class TestMultiThread extends TestDb implements Runnable {
 
     private final class ConcurrentUpdate2 extends Thread {
         private final String column;
+        private final CountDownLatch latch;
 
         Throwable exception;
 
-        ConcurrentUpdate2(String column) {
+        ConcurrentUpdate2(String column, CountDownLatch latch) {
             this.column = column;
+            this.latch = latch;
         }
 
         @Override
         public void run() {
             try (Connection c = getConnection("concurrentUpdate2;LOCK_TIMEOUT=10000")) {
                 PreparedStatement ps = c.prepareStatement("UPDATE TEST SET V = ? WHERE " + column + " = ?");
+                latch.countDown();
                 for (int test = 0; test < 1000; test++) {
                     for (int i = 0; i < 16; i++) {
                         ps.setInt(1, test);
@@ -429,8 +433,9 @@ public class TestMultiThread extends TestDb implements Runnable {
                     ps.executeUpdate();
                 }
             }
-            ConcurrentUpdate2 a = new ConcurrentUpdate2("A");
-            ConcurrentUpdate2 b = new ConcurrentUpdate2("B");
+            CountDownLatch latch = new CountDownLatch(2);
+            ConcurrentUpdate2 a = new ConcurrentUpdate2("A", latch);
+            ConcurrentUpdate2 b = new ConcurrentUpdate2("B", latch);
             a.start();
             b.start();
             a.join();

--- a/h2/src/test/org/h2/test/db/TestMultiThread.java
+++ b/h2/src/test/org/h2/test/db/TestMultiThread.java
@@ -406,9 +406,10 @@ public class TestMultiThread extends TestDb implements Runnable {
             try (Connection c = getConnection("concurrentUpdate2;LOCK_TIMEOUT=10000")) {
                 PreparedStatement ps = c.prepareStatement("UPDATE TEST SET V = ? WHERE " + column + " = ?");
                 latch.countDown();
-                for (int test = 0; test < 1000; test++) {
+                latch.await();
+                for (int test = 1; test < 1000; test++) {
                     for (int i = 0; i < 16; i++) {
-                        ps.setInt(1, test);
+                        ps.setInt(1, "A".equals(column) ? -test : test);
                         ps.setInt(2, i);
                         assertEquals(16, ps.executeUpdate());
                     }

--- a/h2/src/test/org/h2/test/synth/TestDiskFull.java
+++ b/h2/src/test/org/h2/test/synth/TestDiskFull.java
@@ -37,7 +37,10 @@ public class TestDiskFull extends TestDb {
         fs.setPartialWrites(true);
         try {
             test(Integer.MAX_VALUE);
-            int max = Integer.MAX_VALUE - fs.getDiskFullCount() + 10;
+            // Since test() run seems to be non-repeatable (due to randomness in thead scheduling?)
+            // this need to be limited to make testing time reasonable
+            int max = Math.min(1000, Integer.MAX_VALUE - fs.getDiskFullCount() + 10);
+            println("write op count: " + max);
             for (int i = 0; i < max; i++) {
                 test(i);
             }


### PR DESCRIPTION
This MVStore update contains performance improvements and bug fixes, mostly around the fact that chunk production is pipelined and chunk meta data can not be saved before it's space allocated, and even as chunk may become dead  before it's saved.

As for performance improvements: 
- Tree locking strategy is adjusted. 
- B-tree path is reused after a failed update attempt, so if failure is due to a change in some unrelated tree region, no key searches will be performed on retry.
- Blocking transactions are resumed earlier, after blocker transaction commits, not when it is closed, as it was before. 
- Post-commit clean-up is updating leaf page once, even if it contains multiple entries updated by a committed transaction. 
- Rows in non-clustered primary index are updated in place, instead of removal and subsequent insertion. This also avoid secondary indexes updates when key columns were not modified. The same goes for clustered primary index case when primary key is not modified.