### PR TITLE
Support SQL Server filtered index

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -6504,6 +6504,9 @@ public final class Parser extends ParserBase {
                 if (readIf(UNIQUE)) {
                     nullsDistinct = readNullsDistinct(database.getMode().nullsDistinct);
                 }
+                // SQL Server compatibility: parse and ignore NONCLUSTERED/CLUSTERED
+                readIfCompat("NONCLUSTERED");
+                readIfCompat("CLUSTERED");
                 if (readIfCompat("HASH")) {
                     hash = true;
                 } else if (nullsDistinct == null && readIf("SPATIAL")) {
@@ -6568,6 +6571,25 @@ public final class Parser extends ParserBase {
                 }
             }
             command.setIndexColumns(columns);
+            // SQL Server compatibility: WHERE col IS NOT NULL on single-column unique index
+            // converts to NULLS DISTINCT (allows multiple NULLs, unique only on non-null values)
+            if (nullsDistinct != null && columns.length == 1 && readIf(WHERE)) {
+                String filterCol = readIdentifier();
+                read("IS");
+                if (readIf(NOT)) {
+                    read(NULL);
+                    // Verify the WHERE column matches the index column
+                    if (filterCol.equalsIgnoreCase(columns[0].columnName)) {
+                        nullsDistinct = NullsDistinct.DISTINCT;
+                    } else {
+                        throw DbException.getSyntaxError(sqlCommand, token.start(),
+                                "WHERE column must match index column");
+                    }
+                } else {
+                    throw DbException.getSyntaxError(sqlCommand, token.start(),
+                            "only WHERE column IS NOT NULL is supported");
+                }
+            }
             command.setUnique(nullsDistinct, uniqueColumnCount);
             return command;
         }

--- a/h2/src/test/org/h2/test/scripts/ddl/createIndex.sql
+++ b/h2/src/test/org/h2/test/scripts/ddl/createIndex.sql
@@ -78,3 +78,56 @@ INSERT INTO TEST VALUES (1, NULL, NULL);
 
 DROP TABLE TEST;
 > ok
+
+-- SQL Server compatibility: NONCLUSTERED/CLUSTERED keywords and WHERE col IS NOT NULL
+
+SET MODE MSSQLServer;
+> ok
+
+CREATE TABLE TEST(ID INT, NAME VARCHAR(100));
+> ok
+
+-- NONCLUSTERED keyword should be parsed and ignored
+CREATE UNIQUE NONCLUSTERED INDEX IDX1 ON TEST(ID);
+> ok
+
+-- CLUSTERED keyword should be parsed and ignored
+CREATE UNIQUE CLUSTERED INDEX IDX2 ON TEST(NAME);
+> ok
+
+-- WHERE col IS NOT NULL on single-column unique index converts to NULLS DISTINCT
+CREATE UNIQUE NONCLUSTERED INDEX IDX3 ON TEST(ID) WHERE ID IS NOT NULL;
+> ok
+
+SELECT INDEX_NAME, NULLS_DISTINCT FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_NAME = 'TEST' ORDER BY INDEX_NAME;
+> INDEX_NAME NULLS_DISTINCT
+> ---------- --------------
+> IDX1       NO
+> IDX2       NO
+> IDX3       YES
+> rows (ordered): 3
+
+DROP INDEX IDX1;
+> ok
+
+-- Test that NULLS DISTINCT behavior works: multiple NULLs allowed
+INSERT INTO TEST VALUES (1, 'a'), (2, 'b'), (NULL, 'c'), (NULL, 'd');
+> update count: 4
+
+-- Duplicate non-null value should fail
+INSERT INTO TEST VALUES (1, 'e');
+> exception DUPLICATE_KEY_1
+
+-- WHERE column must match index column
+CREATE UNIQUE INDEX IDX_BAD ON TEST(ID) WHERE NAME IS NOT NULL;
+> exception SYNTAX_ERROR_2
+
+-- WHERE col IS NULL is not supported
+CREATE UNIQUE INDEX IDX_BAD2 ON TEST(ID) WHERE ID IS NULL;
+> exception SYNTAX_ERROR_2
+
+DROP TABLE TEST;
+> ok
+
+SET MODE Regular;
+> ok


### PR DESCRIPTION
This supports a limited form of SQL Server's filtered index: https://learn.microsoft.com/en-us/sql/relational-databases/indexes/create-filtered-indexes?view=sql-server-ver17#create-a-filtered-index-with-transact-sql

```sql
CREATE NONCLUSTERED INDEX IndexName
ON Table (ChildID) WHERE ChildID IS NOT NULL;
```

SQL Server supports more generic filtering, but for these we would need to change H2's index handling. As H2 already has NullsDistinct, supporting the limited form only needs adjustments in the parser.

This is especially useful together with Hibernate, which, given a JPA entity like this:

```java
public class User {
  @OneToOne
  private Address address;
}
```

generates SQL like this:

```sql
create unique nonclustered index sadadasdasdsad
on User (ID_USER_ADDRESS) where ID_USER_ADDRESS is not null;
```