### PR TITLE
MVStore: Store continues operating after background-thread panic, causing database corruption

### DIFF
--- a/h2/benchmark_11.html
+++ b/h2/benchmark_11.html
@@ -1,0 +1,19 @@
+<table><tr><th>Test Case</th><th>Unit</th><th>H2 (C/S)</th><th>HSQLDB (C/S)</th></tr>
+<tr><td>Simple: Init</td><td>ms</td><td>10311</td><td>13590</td></tr>
+<tr><td>Simple: Query (random)</td><td>ms</td><td>1549</td><td>1863</td></tr>
+<tr><td>Simple: Query (sequential)</td><td>ms</td><td>11371</td><td>12734</td></tr>
+<tr><td>Simple: Update (sequential)</td><td>ms</td><td>4261</td><td>5977</td></tr>
+<tr><td>Simple: Delete (sequential)</td><td>ms</td><td>6097</td><td>7743</td></tr>
+<tr><td>Simple: Memory Usage</td><td>MB</td><td>17</td><td>16</td></tr>
+<tr><td>BenchA: Init</td><td>ms</td><td>9065</td><td>11900</td></tr>
+<tr><td>BenchA: Transactions</td><td>ms</td><td>5792</td><td>7593</td></tr>
+<tr><td>BenchA: Memory Usage</td><td>MB</td><td>14</td><td>18</td></tr>
+<tr><td>BenchB: Init</td><td>ms</td><td>10772</td><td>14173</td></tr>
+<tr><td>BenchB: Transactions</td><td>ms</td><td>343</td><td>3550</td></tr>
+<tr><td>BenchB: Memory Usage</td><td>MB</td><td>18</td><td>13</td></tr>
+<tr><td>BenchC: Init</td><td>ms</td><td>6402</td><td>7474</td></tr>
+<tr><td>BenchC: Transactions</td><td>ms</td><td>2181</td><td>2569</td></tr>
+<tr><td>BenchC: Memory Usage</td><td>MB</td><td>20</td><td>22</td></tr>
+<tr><td>Executed statements</td><td>#</td><td>2222032</td><td>2222032</td></tr>
+<tr><td>Total time</td><td>ms</td><td>68144</td><td>89166</td></tr>
+<tr><td>Statements per second</td><td>#/s</td><td>32607</td><td>24920</td></tr></table>

--- a/h2/src/main/org/h2/mvstore/FileStore.java
+++ b/h2/src/main/org/h2/mvstore/FileStore.java
@@ -1429,6 +1429,13 @@ public abstract class FileStore<C extends Chunk<C>>
     private void serializeAndStore(boolean syncRun, ArrayList<Page<?,?>> changed, long time, long version) {
         serializationLock.lock();
         try {
+            // Bail out if the store panicked (e.g. failed storeBuffer on the
+            // bufferSaveExecutor).  Without this check, queued serialization
+            // work would proceed, creating chunks that reference page positions
+            // from the failed chunk — corrupting the file.
+            if (mvStore.getPanicException() != null) {
+                return;
+            }
             int chunkId = lastChunkId;
             if (chunkId != 0) {
                 chunkId &= Chunk.MAX_ID;
@@ -1535,7 +1542,7 @@ public abstract class FileStore<C extends Chunk<C>>
     private void storeBuffer(C c, WriteBuffer buff) {
         saveChunkLock.lock();
         try {
-            if (closed) {
+            if (closed || mvStore.getPanicException() != null) {
                 throw DataUtils.newMVStoreException(DataUtils.ERROR_WRITING_FAILED, "This fileStore is closed");
             }
 
@@ -1862,7 +1869,7 @@ public abstract class FileStore<C extends Chunk<C>>
      */
     void writeInBackground() {
         try {
-            if (mvStore.isOpen() && !isReadOnly()) {
+            if (mvStore.isOpen() && mvStore.getPanicException() == null && !isReadOnly()) {
                 // could also commit when there are many unsaved pages,
                 // but according to a test it doesn't really help
                 long time = getTimeSinceCreation();

--- a/h2/src/main/org/h2/mvstore/MVStore.java
+++ b/h2/src/main/org/h2/mvstore/MVStore.java
@@ -12,7 +12,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -216,7 +216,17 @@ public final class MVStore implements AutoCloseable {
      * Ordered collection of all version usage counters for all versions starting
      * from oldestVersionToKeep and up to current.
      */
-    private final Deque<TxCounter> versions = new LinkedList<>();
+    private final Deque<TxCounter> versions = new ConcurrentLinkedDeque<>();
+
+    /**
+     * Lock protecting compound operations on the versions deque.
+     * Individual ConcurrentLinkedDeque operations are thread-safe, but the
+     * peek-then-poll pattern in dropUnusedVersions() requires atomicity.
+     * This lock also serializes onVersionChange() calls that may originate
+     * from the serialization executor thread (without storeLock) against
+     * dropUnusedVersions() calls from user threads (via deregisterVersionUsage).
+     */
+    private final ReentrantLock versionsLock = new ReentrantLock();
 
     /**
      * Counter of open transactions for the latest (current) store version
@@ -1476,10 +1486,15 @@ public final class MVStore implements AutoCloseable {
             DataUtils.checkArgument(isKnownVersion(version), "Unknown version {0}", version);
 
             TxCounter txCounter;
-            while ((txCounter = versions.peekLast()) != null && txCounter.version >= version) {
-                versions.removeLast();
+            versionsLock.lock();
+            try {
+                while ((txCounter = versions.peekLast()) != null && txCounter.version >= version) {
+                    versions.removeLast();
+                }
+                currentTxCounter = new TxCounter(version);
+            } finally {
+                versionsLock.unlock();
             }
-            currentTxCounter = new TxCounter(version);
             if (oldestVersionToKeep.get() > version) {
                 oldestVersionToKeep.set(version);
             }
@@ -1727,7 +1742,7 @@ public final class MVStore implements AutoCloseable {
     }
 
     private boolean isOpenOrStopping() {
-        return state <= STATE_STOPPING;
+        return state <= STATE_STOPPING && panicException.get() == null;
     }
 
     /**
@@ -1869,23 +1884,33 @@ public final class MVStore implements AutoCloseable {
     }
 
     void onVersionChange(long version) {
-        metaChanged = false;
-        TxCounter txCounter = currentTxCounter;
-        assert txCounter.get() >= 0;
-        versions.add(txCounter);
-        currentTxCounter = new TxCounter(version);
-        txCounter.decrementAndGet();
-        dropUnusedVersions();
+        versionsLock.lock();
+        try {
+            metaChanged = false;
+            TxCounter txCounter = currentTxCounter;
+            assert txCounter.get() >= 0;
+            versions.add(txCounter);
+            currentTxCounter = new TxCounter(version);
+            txCounter.decrementAndGet();
+            dropUnusedVersions();
+        } finally {
+            versionsLock.unlock();
+        }
     }
 
     private void dropUnusedVersions() {
-        TxCounter txCounter;
-        while ((txCounter = versions.peek()) != null
-                && txCounter.get() < 0) {
-            versions.poll();
+        versionsLock.lock();
+        try {
+            TxCounter txCounter;
+            while ((txCounter = versions.peek()) != null
+                    && txCounter.get() < 0) {
+                versions.poll();
+            }
+            long oldestVersionToKeep = (txCounter != null ? txCounter : currentTxCounter).version;
+            setOldestVersionToKeep(oldestVersionToKeep);
+        } finally {
+            versionsLock.unlock();
         }
-        long oldestVersionToKeep = (txCounter != null ? txCounter : currentTxCounter).version;
-        setOldestVersionToKeep(oldestVersionToKeep);
     }
 
     public void countNewPage(boolean leaf) {


### PR DESCRIPTION
## Environment
 
- H2 server mode, single JVM, 20 concurrent MVStore-backed databases
- Each database has multiple parallel read/write connections, running large reporting tasks, all at the same time
- JDK 21 (Eclipse Temurin), Linux x86-64
- Corruption observed intermittently (2–3 of 20 databases per batch run)
- All corrupted databases recoverable via `MVStoreTool` without data loss
- Corruption correlates strongly with running `SCRIPT ... COMPRESSION GZIP` against one database while the others are under write load
 
## Bug 1 (critical): `isOpenOrStopping()` does not check `panicException`
 
### Problem
 
When `storeBuffer()` fails on the `bufferSaveExecutor` thread (e.g. due to OOM or I/O error under memory pressure from a concurrent `SCRIPT` export), `panic()` is called.  However, because the executor thread is in the `H2-background` `ThreadGroup`, `Utils.isBackgroundThread()` returns `true` and `closeImmediately()` is **not called**.  The store remains in state `STATE_OPEN` with `panicException` set.
 
`isOpenOrStopping()` only checks `state <= STATE_STOPPING` — it does not check `panicException`.  As a result, the background writer's next `tryCommit()` cycle passes the `isOpenOrStopping()` guard, enters `store()`, increments `currentVersion`, and writes a new chunk.  This new chunk references page positions that were assigned during `serializeToBuffer()` but never actually written to disk (because the preceding `storeBuffer()` failed).  The store header is updated to point to this new chunk.
 
On the next open, H2 follows the store header to the new chunk, which references pages at invalid file positions — producing errors such as `File corrupted in chunk N, expected page length X..Y, got Z` or `Chunk N no longer exists`.
 
### Corruption sequence
 
```
1. Script.process() on database A → heap pressure across the JVM
2. Database B's bufferSaveExecutor: storeBuffer() fails (OOM/IOException)
3. panic() sets panicException, but does NOT close (background thread)
4. releaseSavedPages() already ran — pages have positions in the failed chunk
5. isOpenOrStopping() returns true (only checks state, not panicException)
6. Background writer calls tryCommit() → store() → storeNow() → success
7. New chunk written, referencing ghost page positions → store header updated
8. File is now structurally corrupt
```
 
### Fix (4 one-line changes)
 
**`MVStore.java` — `isOpenOrStopping()`:**
```java
private boolean isOpenOrStopping() {
    return state <= STATE_STOPPING && panicException.get() == null;
}
```
 
**`FileStore.java` — `serializeAndStore()`** (bail out of queued work):
```java
if (mvStore.getPanicException() != null) {
    return;
}
```
 
**`FileStore.java` — `storeBuffer()`** (bail out of queued work):
```java
if (closed || mvStore.getPanicException() != null) {
    throw DataUtils.newMVStoreException(DataUtils.ERROR_WRITING_FAILED, "This fileStore is closed");
}
```
 
**`FileStore.java` — `writeInBackground()`** (stop background writer loop):
```java
if (mvStore.isOpen() && mvStore.getPanicException() == null && !isReadOnly()) {
```
 
### Reproducer (deterministic)

[mvstore-race-test.tar.gz](https://github.com/user-attachments/files/26436381/mvstore-race-test.tar.gz)
 
A JUnit 5 test calls `store.panic()` from a thread in the `H2-background` `ThreadGroup` (simulating `bufferSaveExecutor` failure), then verifies that the background writer does not advance the version:
 
```
UNPATCHED:
  Version before panic  : 1
  Version after wait    : 2        ← BUG: background writer committed after panic

gradle clean test --no-build-cache -PlocalH2=/home/are/data/src/h2database/h2/bin/h2-mvstore-2.4.249-unpatched.jar -Dmvstore.test.dir=/home/are/tmp
  
PATCHED:
  Version before panic  : 1
  Version after wait    : 1        ← correct: commit blocked

gradle clean test --no-build-cache -PlocalH2=/run/media/are/test/h2database/h2/bin/h2-mvstore-2.4.249-SNAPSHOT.jar -Dmvstore.test.dir=/home/are/tmp
```
 

 
---
 
## Bug 2 (defensive): `LinkedList<TxCounter> versions` is not thread-safe
 
### Problem
 
The `versions` deque in `MVStore` (line 219) is a plain `LinkedList`, which is not thread-safe.  It is concurrently accessed by:
 
- The **serialization executor** thread: `onVersionChange()` → `versions.add()` / `dropUnusedVersions()` → `versions.peek()` / `poll()`
- **User threads**: `deregisterVersionUsage()` → `dropUnusedVersions()` → `versions.peek()` / `poll()`
 
The serialization executor does not hold `storeLock` (it was released before the executor ran via async `tryCommit()`), so `storeLock` cannot protect this access.
 
### Practical impact
 
Stress testing at 1.4 billion operations with up to 400,000 invariant checks showed zero observable corruption on x86-64 / HotSpot JDK 21.  Individual reference writes are atomic on this platform, so the `LinkedList` node pointer corruption that could theoretically cause `oldestVersionToKeep` to skip ahead does not manifest in practice.  However, this is a genuine thread-safety violation that could manifest on other architectures (e.g. ARM with weaker memory ordering) or future JVM implementations.
 
### Fix
 
```java
// Before:
private final Deque<TxCounter> versions = new LinkedList<>();
 
// After:
private final Deque<TxCounter> versions = new ConcurrentLinkedDeque<>();
private final ReentrantLock versionsLock = new ReentrantLock();
```
 
The `versionsLock` protects the compound peek-then-poll pattern in `dropUnusedVersions()` and the add-then-decrement-then-poll pattern in `onVersionChange()`.  Three call sites are wrapped: `onVersionChange()`, `dropUnusedVersions()`, and the `rollbackTo()` versions-access loop.
 
Performance impact is negligible — the lock is acquired once per commit and once per transaction close, both paths dominated by disk I/O.

I have not been able to trigger this second issue in my tests but it may be a good thing to fix this too.