### PR TITLE
Fix SCRIPT tool COLUMNS option placement

### DIFF
--- a/h2/src/main/org/h2/tools/Script.java
+++ b/h2/src/main/org/h2/tools/Script.java
@@ -74,7 +74,8 @@ public class Script extends Tool {
                 for (; i < args.length; i++) {
                     String a = args[i];
                     String upper = StringUtils.toUpperEnglish(a);
-                    if ("SIMPLE".equals(upper) || upper.startsWith("NO") || "DROP".equals(upper)) {
+                    if ("SIMPLE".equals(upper) || "COLUMNS".equals(upper) || upper.startsWith("NO")
+                            || "DROP".equals(upper)) {
                         buff1.append(' ');
                         buff1.append(args[i]);
                     } else if ("BLOCKSIZE".equals(upper)) {

--- a/h2/src/test/org/h2/test/unit/TestTools.java
+++ b/h2/src/test/org/h2/test/unit/TestTools.java
@@ -58,6 +58,7 @@ import org.h2.tools.Script;
 import org.h2.tools.Server;
 import org.h2.tools.SimpleResultSet;
 import org.h2.tools.SimpleResultSet.SimpleArray;
+import org.h2.util.IOUtils;
 import org.h2.util.JdbcUtils;
 import org.h2.util.Task;
 import org.h2.value.ValueUuid;
@@ -991,6 +992,21 @@ public class TestTools extends TestDb {
         Script.main("-url", url, "-user", user, "-password", password,
                 "-script", fileName, "-options", "simple", "blocksize",
                 "8192");
+
+        // test parsing of COLUMNS option before TO
+        DeleteDbFiles.main("-dir", getBaseDir(), "-db", "testScriptRunscript",
+                "-quiet");
+        conn = getConnection(url, user, password);
+        conn.createStatement().execute(
+                "CREATE TABLE TEST(ID INT PRIMARY KEY, NAME VARCHAR)");
+        conn.createStatement().execute("INSERT INTO TEST VALUES(1, 'Hello')");
+        conn.close();
+        Script.main("-url", url, "-user", user, "-password", password,
+                "-script", fileName, "-options", "simple", "columns");
+        String script = IOUtils.readStringAndClose(
+                IOUtils.getReader(FileUtils.newInputStream(fileName)), -1);
+        assertContains(script,
+                "INSERT INTO \"PUBLIC\".\"TEST\"(\"ID\", \"NAME\")");
     }
 
     private void testBackupRestore() throws SQLException {


### PR DESCRIPTION
﻿Fixes #4321.

This fixes the SCRIPT tool option placement for `COLUMNS`, so generated SQL uses `SCRIPT SIMPLE COLUMNS TO ...` instead of placing `COLUMNS` after the target path.

The regression test covers the command-line tool path and verifies that the generated script includes column names.

Tests:

```text
.\build.bat compile
java -cp ... org.h2.tools.Script ... -options simple columns
git diff --check
```
