### PR TITLE
MAX_OPEN_TRANSACTIONS reduction exposed regression bug

### DIFF
--- a/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
+++ b/h2/src/main/org/h2/mvstore/tx/TransactionStore.java
@@ -214,7 +214,7 @@ public class TransactionStore implements AutoCloseable
                         if (store.hasData(mapName)) {
                             int transactionId = StringUtils.parseUInt31(mapName, UNDO_LOG_NAME_PREFIX.length() + 1,
                                     mapName.length());
-                            if (isTransactionClosed(transactionId)) {
+                            if (transactionId <= maxTransactionId) {
                                 Object[] data = preparedTransactions.get(transactionId);
                                 int status;
                                 String name;


### PR DESCRIPTION
fix for #4346 
The reason, for ArrayIndexOutOfBoundsException there, 
is my inexplicable [change](https://github.com/h2database/h2database/commit/0c91e7016a1d1134647f8fac9c56436f494af974#diff-aa426880647dfd85757e31e57e27ac85a0f15df3763a387e25725239d03db8daL205)
Now when actual transaction registration is postponed, that check does not make sense at all. It was to protect against simultaneous existence of "undoLog.xxx" and "undoLog-xxx" maps, which is not actual any more. Instead out-of-bound transaction id need to be checked.

(sorry for bogus comment on the commit)