### PR TITLE
Reuse the Collator in StringUtils.startsWithIgnoringCase

### DIFF
--- a/h2/src/main/org/h2/util/StringUtils.java
+++ b/h2/src/main/org/h2/util/StringUtils.java
@@ -1405,10 +1405,19 @@ public class StringUtils {
     public static boolean startsWithIgnoringCase(String text, String prefix) {
         if (text.length() < prefix.length()) {
             return false;
-        } else {
-            Collator collator = Collator.getInstance();
-            collator.setStrength(Collator.PRIMARY);
-            return collator.equals(text.substring(0, prefix.length()), prefix);
         }
+        return PRIMARY_COLLATOR.get().equals(text.substring(0, prefix.length()), prefix);
     }
+
+    /**
+     * Primary-strength collator for {@link #startsWithIgnoringCase(String, String)}, held per thread.
+     * Collator is not thread-safe and {@link Collator#getInstance()} is expensive (it allocated a fresh
+     * collator, on the order of a kilobyte, on every call); reusing one per thread avoids that allocation
+     * while preserving the previous default-locale, PRIMARY-strength comparison.
+     */
+    private static final ThreadLocal<Collator> PRIMARY_COLLATOR = ThreadLocal.withInitial(() -> {
+        Collator collator = Collator.getInstance();
+        collator.setStrength(Collator.PRIMARY);
+        return collator;
+    });
 }


### PR DESCRIPTION
## Summary

`StringUtils.startsWithIgnoringCase` created a fresh `Collator` via `Collator.getInstance()` and set its strength on **every call**, then discarded it. `Collator.getInstance()` is expensive and allocates on the order of a kilobyte per call. This method backs database-object autocomplete (`DbContextRule`), where it is invoked in a loop over candidate names, so the cost is paid repeatedly per completion request.

Hold the primary-strength `Collator` in a `ThreadLocal` (`Collator` is not thread-safe) and reuse it. The default-locale, `PRIMARY`-strength comparison is unchanged.

## Measurement

ThreadMXBean allocation driver, 200k warmed calls:

| | B/op |
|---|---|
| before | 1152 |
| after | 720 (**−37%**) |

The remainder is internal to `Collator.equals`.

## Testing

`TestStringUtils` and `TestBnf` pass.
