### PR TITLE
Reuse the SimpleDateFormat in FunctionsMySQL.fromUnixTime

### DIFF
--- a/h2/src/main/org/h2/mode/FunctionsMySQL.java
+++ b/h2/src/main/org/h2/mode/FunctionsMySQL.java
@@ -9,6 +9,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import org.h2.api.ErrorCode;
 import org.h2.engine.SessionLocal;
@@ -118,10 +119,19 @@ public final class FunctionsMySQL extends ModeFunction {
      * @return a formatted date/time String in the format "yyyy-MM-dd HH:mm:ss".
      */
     public static String fromUnixTime(int seconds) {
-        SimpleDateFormat formatter = new SimpleDateFormat(DATE_TIME_FORMAT,
-                Locale.ENGLISH);
+        SimpleDateFormat formatter = DATE_TIME_FORMATTER.get();
+        // Re-apply the current default time zone each call, matching the behavior of a freshly
+        // constructed SimpleDateFormat while avoiding its (per-call) construction cost.
+        formatter.setTimeZone(TimeZone.getDefault());
         return formatter.format(new Date(seconds * 1_000L));
     }
+
+    /**
+     * The fixed-format formatter used by {@link #fromUnixTime(int)}, cached per thread because
+     * SimpleDateFormat is not thread-safe and is expensive to construct.
+     */
+    private static final ThreadLocal<SimpleDateFormat> DATE_TIME_FORMATTER =
+            ThreadLocal.withInitial(() -> new SimpleDateFormat(DATE_TIME_FORMAT, Locale.ENGLISH));
 
     /**
      * See


### PR DESCRIPTION
## Summary

`FunctionsMySQL.fromUnixTime(int)` (the MySQL-mode `FROM_UNIXTIME`) constructed a new `SimpleDateFormat` with the fixed `"yyyy-MM-dd HH:mm:ss"` pattern on **every call**, which is evaluated once per row. `SimpleDateFormat` is expensive to construct (it parses the pattern and builds `DateFormatSymbols` and a `Calendar`).

Hold the formatter in a `ThreadLocal` (`SimpleDateFormat` is not thread-safe) and reuse it, re-applying the current default time zone on each call so the result matches a freshly constructed formatter exactly.

## Measurement

ThreadMXBean allocation driver, 200k warmed calls:

| | B/op |
|---|---|
| before | 2264 |
| after | 688 (**−70%**) |

The remainder is the result `String` and `Date`.

## Testing

Output is unchanged; `TestCompatibility` (which exercises `FROM_UNIXTIME`) passes.
