### PR TITLE
Fixed casting issue: skipped Index Condition Pushdown optm for lossy conversions

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #4359: Fixed casting issue: skipped Index Condition Pushdown optm for lossy conversions
+</li>
 <li>PR #4317: Fix case for ChunkNotFound. MVStore performance improvements.
 </li>
 <li>Issue #4302: org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: Check constraint invalid

--- a/h2/src/main/org/h2/expression/condition/Comparison.java
+++ b/h2/src/main/org/h2/expression/condition/Comparison.java
@@ -413,8 +413,10 @@ public final class Comparison extends Condition {
         }
         
         if (DataType.isNumericType(cType) && DataType.isNumericType(hType)) {
-            boolean cIsInt = cType == Value.TINYINT || cType == Value.SMALLINT || cType == Value.INTEGER || cType == Value.BIGINT;
-            boolean hIsInt = hType == Value.TINYINT || hType == Value.SMALLINT || hType == Value.INTEGER || hType == Value.BIGINT;
+            boolean cIsInt = cType == Value.TINYINT || cType == Value.SMALLINT 
+                    || cType == Value.INTEGER || cType == Value.BIGINT;
+            boolean hIsInt = hType == Value.TINYINT || hType == Value.SMALLINT 
+                    || hType == Value.INTEGER || hType == Value.BIGINT;
             
             if (cIsInt && !hIsInt) {
                 return false;

--- a/h2/src/main/org/h2/expression/condition/Comparison.java
+++ b/h2/src/main/org/h2/expression/condition/Comparison.java
@@ -401,6 +401,28 @@ public final class Comparison extends Condition {
         }
     }
 
+    public static boolean isSafeIndexCondition(TypeInfo colType, TypeInfo higherType) {
+        if (!TypeInfo.haveSameOrdering(colType, higherType)) {
+            return false;
+        }
+        int cType = colType.getValueType();
+        int hType = higherType.getValueType();
+        
+        if (cType == hType) {
+            return true;
+        }
+        
+        if (DataType.isNumericType(cType) && DataType.isNumericType(hType)) {
+            boolean cIsInt = cType == Value.TINYINT || cType == Value.SMALLINT || cType == Value.INTEGER || cType == Value.BIGINT;
+            boolean hIsInt = hType == Value.TINYINT || hType == Value.SMALLINT || hType == Value.INTEGER || hType == Value.BIGINT;
+            
+            if (cIsInt && !hIsInt) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     static void createIndexConditions(TableFilter filter, Expression left, Expression right, int compareType) {
         if (compareType == NOT_EQUAL || compareType == NOT_EQUAL_NULL_SAFE) {
             return;
@@ -459,13 +481,15 @@ public final class Comparison extends Condition {
         case SPATIAL_INTERSECTS:
             if (l != null) {
                 TypeInfo colType = l.getType();
-                if (TypeInfo.haveSameOrdering(colType, TypeInfo.getHigherType(colType, right.getType()))) {
+                TypeInfo higherType = TypeInfo.getHigherType(colType, right.getType());
+                if (isSafeIndexCondition(colType, higherType)) {
                     filter.addIndexCondition(IndexCondition.get(compareType, l, right));
                 }
             } else {
                 @SuppressWarnings("null")
                 TypeInfo colType = r.getType();
-                if (TypeInfo.haveSameOrdering(colType, TypeInfo.getHigherType(colType, left.getType()))) {
+                TypeInfo higherType = TypeInfo.getHigherType(colType, left.getType());
+                if (isSafeIndexCondition(colType, higherType)) {
                     filter.addIndexCondition(IndexCondition.get(getReversedCompareType(compareType), r, left));
                 }
             }

--- a/h2/src/main/org/h2/expression/condition/ConditionIn.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionIn.java
@@ -122,8 +122,8 @@ abstract class ConditionIn extends Condition {
         TypeInfo colType = left.getType();
         ExpressionVisitor visitor = ExpressionVisitor.getNotFromResolverVisitor(filter);
         for (Expression e : valueList) {
-            if (!e.isEverything(visitor)
-                    || !TypeInfo.haveSameOrdering(colType, TypeInfo.getHigherType(colType, e.getType()))) {
+            TypeInfo higherType = TypeInfo.getHigherType(colType, e.getType());
+            if (!e.isEverything(visitor) || !Comparison.isSafeIndexCondition(colType, higherType)) {
                 return;
             }
         }

--- a/h2/src/main/org/h2/expression/condition/ConditionInArray.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInArray.java
@@ -186,7 +186,7 @@ public class ConditionInArray extends Condition {
                     for (int i = 0; i < count; i++) {
                         type = TypeInfo.getHigherType(type, values[i].getType());
                     }
-                    if (TypeInfo.haveSameOrdering(colType, type)) {
+                    if (Comparison.isSafeIndexCondition(colType, type)) {
                         Expression[] valueList = new Expression[count];
                         for (int i = 0; i < count; i++) {
                             valueList[i] = ValueExpression.get(values[i]);
@@ -201,8 +201,8 @@ public class ConditionInArray extends Condition {
                 TypeInfo arrayType = right.getType();
                 if (arrayType.getValueType() == Value.ARRAY) {
                     TypeInfo colType = l.getType();
-                    if (TypeInfo.haveSameOrdering(colType,
-                            TypeInfo.getHigherType(colType, (TypeInfo) arrayType.getExtTypeInfo()))) {
+                    TypeInfo higherType = TypeInfo.getHigherType(colType, (TypeInfo) arrayType.getExtTypeInfo());
+                    if (Comparison.isSafeIndexCondition(colType, higherType)) {
                         filter.addIndexCondition(IndexCondition.getInArray(l, right));
                     }
                 }

--- a/h2/src/main/org/h2/expression/condition/ConditionInConstantSet.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInConstantSet.java
@@ -166,7 +166,8 @@ public final class ConditionInConstantSet extends ConditionIn {
     private static void createIndexConditions(TableFilter filter, ExpressionColumn l, ArrayList<Expression> valueList,
             TypeInfo type) {
         TypeInfo colType = l.getType();
-        if (TypeInfo.haveSameOrdering(colType, TypeInfo.getHigherType(colType, type))) {
+        TypeInfo higherType = TypeInfo.getHigherType(colType, type);
+        if (Comparison.isSafeIndexCondition(colType, higherType)) {
             filter.addIndexCondition(IndexCondition.getInList(l, valueList));
         }
     }

--- a/h2/src/main/org/h2/expression/condition/ConditionInList.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInList.java
@@ -174,8 +174,8 @@ public final class ConditionInList extends ConditionIn {
         ExpressionVisitor visitor = ExpressionVisitor.getNotFromResolverVisitor(filter);
         TypeInfo colType = l.getType();
         for (Expression e : valueList) {
-            if (!e.isEverything(visitor)
-                    || !TypeInfo.haveSameOrdering(colType, TypeInfo.getHigherType(colType, e.getType()))) {
+            TypeInfo higherType = TypeInfo.getHigherType(colType, e.getType());
+            if (!e.isEverything(visitor) || !Comparison.isSafeIndexCondition(colType, higherType)) {
                 return;
             }
         }

--- a/h2/src/main/org/h2/expression/condition/ConditionInQuery.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionInQuery.java
@@ -233,7 +233,8 @@ public final class ConditionInQuery extends PredicateWithSubquery {
         }
         TypeInfo colType = left.getType();
         TypeInfo queryType = query.getExpressions().get(0).getType();
-        if (!TypeInfo.haveSameOrdering(colType, TypeInfo.getHigherType(colType, queryType))) {
+        TypeInfo higherType = TypeInfo.getHigherType(colType, queryType);
+        if (!Comparison.isSafeIndexCondition(colType, higherType)) {
             return;
         }
         int leftType = colType.getValueType();

--- a/h2/src/test/org/h2/test/scripts/predicates/in.sql
+++ b/h2/src/test/org/h2/test/scripts/predicates/in.sql
@@ -509,3 +509,36 @@ EXPLAIN SELECT * FROM D WHERE (A, C) IN ((1, 1), (1, 2), (1, 3), (2, 1), (2, 2),
 
 DROP TABLE D;
 > ok
+
+CREATE TABLE T1(C0 INT, C1 INT) AS VALUES (1, 1), (2, 2), (3, 3);
+> ok
+
+CREATE TABLE T2(C0 DOUBLE) AS VALUES 1.0, 0.5, 2.5;
+> ok
+
+SELECT COUNT(*) FROM T1 WHERE C0 IN (SELECT C0 FROM T2);
+> COUNT(*)
+> --------
+> 1
+> rows: 1
+
+SELECT COUNT(*) FROM T1 WHERE C0 IN (1.0, 0.5, 2.5);
+> COUNT(*)
+> --------
+> 1
+> rows: 1
+
+SELECT COUNT(*) FROM T1 WHERE C0 IN (1.0, 0.5, 2.5 + (RAND() * 0));
+> COUNT(*)
+> --------
+> 1
+> rows: 1
+
+SELECT COUNT(*) FROM T1 WHERE (C0, C1) IN ((1.0, 1.0), (0.5, 0.5), (2.5, 2.5));
+> COUNT(*)
+> --------
+> 1
+> rows: 1
+
+DROP TABLE T1, T2;
+> ok

--- a/h2/src/test/org/h2/test/scripts/predicates/quantified-comparison-with-array.sql
+++ b/h2/src/test/org/h2/test/scripts/predicates/quantified-comparison-with-array.sql
@@ -299,3 +299,15 @@ SELECT V, A, CASE V WHEN = ANY(A) THEN 1 WHEN > ANY(A) THEN 2 WHEN < ANY(A) THEN
 > null [null]       4
 > null null         4
 > rows: 35
+
+CREATE TABLE T3(C0 INT) AS VALUES 1, 2, 3;
+> ok
+
+SELECT COUNT(*) FROM T3 WHERE C0 = ANY(ARRAY[1.0, 0.5, 2.5]);
+> COUNT(*)
+> --------
+> 1
+> rows: 1
+
+DROP TABLE T3;
+> ok

--- a/h2/src/test/org/h2/test/scripts/queries/query-optimisations.sql
+++ b/h2/src/test/org/h2/test/scripts/queries/query-optimisations.sql
@@ -334,3 +334,20 @@ EXPLAIN SELECT * FROM T1 JOIN T2 USING(ID) WHERE (C1, C2) IN ((1, 1), (1, 3));
 DROP TABLE T1, T2;
 > ok
 
+CREATE TABLE T1(C0 INT) AS VALUES 1, 2, 3;
+> ok
+
+SELECT COUNT(*) FROM T1 WHERE C0 = 0.5;
+> COUNT(*)
+> --------
+> 0
+> rows: 1
+
+SELECT COUNT(*) FROM T1 WHERE C0 > 2.5;
+> COUNT(*)
+> --------
+> 1
+> rows: 1
+
+DROP TABLE T1;
+> ok


### PR DESCRIPTION
Fixes #4350 

**Issue**
In query:

CREATE TABLE t2(c0 INT);
CREATE TABLE t3(c0 DOUBLE);
INSERT INTO t2 VALUES (1), (2);
INSERT INTO t3 VALUES (1.0), (0.5);
SELECT COUNT(*) AS wrong_cnt
FROM (SELECT t2.c0 AS subq1_c1 FROM t2) AS subq1
WHERE subq1.subq1_c1 IN (SELECT t3.c0 FROM t3);

The output should be 1 cause(1 == 1.0) but count(*) was returning 2, at first it seems a casting issue but i figured that the after parser AST is created and then sent over to get "getprepared()" we have an optimization called **Index Condition Pushdown** which pushes the t3 row over the t2 and creates a scanIndex on t2, so instead of linearly scanning and validating IN for every row in t2 it does a reverse scan, it iterates in t3 and asks whether this is present in t2 index or not

IndexCursor.java nextCursor() function

```
else if (inResult != null) {
            while (inResult.next()) {
                Value v = inResult.currentRow()[0];
                if (v != ValueNull.INSTANCE) {
                    if (inColumn instanceof Column[]) {
                        v = Column.convert(session, (Column[]) inColumn, (ValueRow) v);
                    } else {
                        v = ((Column) inColumn).convert(session, v);
                    }
                    find(v);
                    break;
```


 and if present then it return that row of t2 and then later ConditionQuery.java again do the IN query. 

So the bug was lying in this reverse checking, while iterating in t3 it first converts the double to int and then asks t2. So t3[1.0 , 0.5] 1.0 -> 1 and 1 exits in 1 so that row in t2 is given to ConditionQuery.java to be processed and then again 0.5 -> 1 and it asks t2 again and yes 1 exists so it gives 1 again and processed again and hence 2 from t2 didnt got a chance of being processed and 1 got processed twice.

**FIX**
So what i thought was of to skip this "Index Condition Pushdown Optimization" for lossy conversions just like other majority Databases do, you can read their ICP docs.

I created a helper "isSafeIndexCondition" function in comparison.java which still validates the original logic of "havingsameOrdering" (they are of same family) and added this check : Left expression (here t2) if have same type as higherType among t2,t3 then we can create index (if t2 was double then creating index was safe). 

NOTE:- But here comes a **performance edge case** in Integer Family:  Even though SmallInNT is of lowerType than standard Int, if t2 was SMALLINT and t3 was BIGINT, index creation was also safe here because they belonged to the same integer family and hence conversion was not lossy. So we can safely create the index. And this check also handles if t2 was smallerType and t3 was higherType just like the issue.

All these files i made changes in somehow creates the index so i added validation in them with our helper "isSafeIndexCondition"  from Comparison.java.

**TESTS**
I added test for all the files i have changed, and test cover all the cases of ConditioIn, ConditionInQuery, ConditinInList, ConditioInQuery, ConditioInArray, and Standard Comparisons of >, = etc.


**NOTE:**
During testing, I found a pre existing bug for static row lists like WHERE (INT, VARCHAR) IN ((DOUBLE, VARCHAR)). The DB should not create an index for this lossy compound row. This check should  take place recursively inside haveSameOrdering(TypeInfo t1, TypeInfo t2) in TypeInfo.java, but it currently passes as true and gives wrong answers when pushing the lossy values into the index.

(Note: This doesn't affect IN (SELECT) subqueries because ConditionInQuery currently has a hardcoded limitation that aborts all multi column pushdowns).

My changes doesnt covers this case because it should be done in haveSameOrdering for ROW and can be fixed in a separate pr.