### PR TITLE
Fixed: Server should be stopped everytime db init fails

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>PR #4363: Fixed: Server should be stopped everytime db init fails
+</li>
 <li>PR #4359: Fixed casting issue: skipped Index Condition Pushdown optm for lossy conversions
 </li>
 <li>PR #4317: Fix case for ChunkNotFound. MVStore performance improvements.

--- a/h2/src/main/org/h2/engine/Database.java
+++ b/h2/src/main/org/h2/engine/Database.java
@@ -392,13 +392,12 @@ public final class Database implements DataHandler, CastDataProvider {
                     e.fillInStackTrace();
                 }
                 if (e instanceof DbException) {
-                    if (((DbException) e).getErrorCode() == ErrorCode.DATABASE_ALREADY_OPEN_1) {
-                        stopServer();
-                    } else {
+                    if (((DbException) e).getErrorCode() != ErrorCode.DATABASE_ALREADY_OPEN_1) {
                         // only write if the database is not already in use
                         trace.error(e, "opening {0}", databaseName);
                     }
                 }
+                stopServer();
                 traceSystem.close();
                 closeOpenFilesAndUnlock();
             } catch (Throwable ex) {

--- a/h2/src/test/org/h2/test/unit/TestAutoReconnect.java
+++ b/h2/src/test/org/h2/test/unit/TestAutoReconnect.java
@@ -53,6 +53,7 @@ public class TestAutoReconnect extends TestDb {
 
     @Override
     public void test() throws Exception {
+        testFailedInitServerLeak();
         testWrongUrl();
         autoServer = true;
         testReconnect();
@@ -179,6 +180,26 @@ public class TestAutoReconnect extends TestDb {
             connServer.close();
         } else {
             server.stop();
+        }
+    }
+
+    private void testFailedInitServerLeak() throws Exception {
+        deleteDb(getTestName());
+        String dbName = getBaseDir() + "/" + getTestName();
+
+        //Fetching active servers via Reflection
+        java.lang.reflect.Field serversField = org.h2.server.TcpServer.class.getDeclaredField("SERVERS");
+        serversField.setAccessible(true);
+        java.util.Map<?, ?> servers = (java.util.Map<?, ?>) serversField.get(null);
+
+        int serversBefore = servers.size();
+        // Throws UnsupportedOperationException
+        try {
+            assertThrows(ErrorCode.GENERAL_ERROR_1,
+                    () -> getConnection("jdbc:h2:" + dbName + ";AUTO_SERVER=TRUE;MV_STORE=FALSE"));
+        } finally {
+            assertEquals(serversBefore, servers.size());
+            deleteDb(getTestName());
         }
     }
 


### PR DESCRIPTION
Fixes #4362 

**Issue**
While opening a DB file with AUTO_SERVER mode and during that if some exception was thrown and db INIT was failed, the background TCP Server initiated was never stopped. It can stop in some cases of exception like IOException etc. which was somehow handled deeper in the codebase, but still it fails to stop in many cases.

**FIX**
No matter what if db fails to start then server should always be stopped. So in the catch block of Database() function in Database.java i updated to stopServer() always called irrespective of the exception thrown.

**TEST**
I added a unit test in TestAutoReconnect.java in which we deliberately call to open a db file with MV_STORE = FALSE flag and we will land with UnsupportedOperationException, and i used java Reflection to look into active Servers to assert initial and final count.