### PR TITLE
fix: LIKE ESCAPE '' matches in Oracle mode (Hibernate)

### DIFF
--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -3240,7 +3240,20 @@ public final class Parser extends ParserBase {
 
     private Expression readLikePredicate(Expression left, LikeType likeType, boolean not, boolean whenOperand) {
         Expression right = readConcat();
-        Expression esc = readIf("ESCAPE") ? readConcat() : null;
+        Expression esc = null;
+        if (readIf("ESCAPE")) {
+            // Detect ESCAPE '' before it is converted to NULL by
+            // treatEmptyStringsAsNull (e.g. MODE=Oracle), so that it can be
+            // restored below and treated as "no escape character" instead of
+            // making the predicate UNKNOWN (Hibernate compatibility).
+            boolean emptyStringEscape = database.getMode().treatEmptyStringsAsNull
+                    && token instanceof Token.CharacterStringToken
+                    && ((Token.CharacterStringToken) token).string.isEmpty();
+            esc = readConcat();
+            if (emptyStringEscape && esc == ValueExpression.NULL) {
+                esc = ValueExpression.get(ValueVarchar.EMPTY);
+            }
+        }
         recompileAlways = true;
         return new CompareLike(database, left, not, whenOperand, right, esc, likeType);
     }

--- a/h2/src/main/org/h2/expression/condition/CompareLike.java
+++ b/h2/src/main/org/h2/expression/condition/CompareLike.java
@@ -174,7 +174,7 @@ public final class CompareLike extends Condition {
                 return TypedValueExpression.UNKNOWN;
             }
             Value e = escape == null ? null : escape.getValue(session);
-            if (e == ValueNull.INSTANCE) {
+            if (isUnknownEscape(session, e)) {
                 return TypedValueExpression.UNKNOWN;
             }
             String p = r.getString();
@@ -199,9 +199,23 @@ public final class CompareLike extends Condition {
         return this;
     }
 
+    /**
+     * Returns whether ESCAPE makes the LIKE predicate UNKNOWN.
+     * Standard: ESCAPE NULL → UNKNOWN. H2 allows ESCAPE '' as "no escape
+     * character"; under treatEmptyStringsAsNull (Oracle) that becomes NULL,
+     * so NULL is treated as no escape there (Hibernate compatibility).
+     */
+    private static boolean isUnknownEscape(SessionLocal session, Value e) {
+        return e == ValueNull.INSTANCE && !session.getMode().treatEmptyStringsAsNull;
+    }
+
     private Character getEscapeChar(Value e) {
         if (e == null) {
             return getEscapeChar(defaultEscape);
+        }
+        if (e == ValueNull.INSTANCE) {
+            // Empty ESCAPE under treatEmptyStringsAsNull (see isUnknownEscape)
+            return null;
         }
         String es = e.getString();
         Character esc;
@@ -241,7 +255,7 @@ public final class CompareLike extends Condition {
         String p = right.getValue(session).getString();
         if (!isInit) {
             Value e = escape == null ? null : escape.getValue(session);
-            if (e == ValueNull.INSTANCE) {
+            if (isUnknownEscape(session, e)) {
                 // should already be optimized
                 throw DbException.getInternalError();
             }
@@ -317,7 +331,7 @@ public final class CompareLike extends Condition {
             }
             String p = r.getString();
             Value e = escape == null ? null : escape.getValue(session);
-            if (e == ValueNull.INSTANCE) {
+            if (isUnknownEscape(session, e)) {
                 return ValueNull.INSTANCE;
             }
             initPattern(p, getEscapeChar(e));

--- a/h2/src/main/org/h2/expression/condition/CompareLike.java
+++ b/h2/src/main/org/h2/expression/condition/CompareLike.java
@@ -174,7 +174,7 @@ public final class CompareLike extends Condition {
                 return TypedValueExpression.UNKNOWN;
             }
             Value e = escape == null ? null : escape.getValue(session);
-            if (isUnknownEscape(session, e)) {
+            if (e == ValueNull.INSTANCE) {
                 return TypedValueExpression.UNKNOWN;
             }
             String p = r.getString();
@@ -199,23 +199,9 @@ public final class CompareLike extends Condition {
         return this;
     }
 
-    /**
-     * Returns whether ESCAPE makes the LIKE predicate UNKNOWN.
-     * Standard: ESCAPE NULL → UNKNOWN. H2 allows ESCAPE '' as "no escape
-     * character"; under treatEmptyStringsAsNull (Oracle) that becomes NULL,
-     * so NULL is treated as no escape there (Hibernate compatibility).
-     */
-    private static boolean isUnknownEscape(SessionLocal session, Value e) {
-        return e == ValueNull.INSTANCE && !session.getMode().treatEmptyStringsAsNull;
-    }
-
     private Character getEscapeChar(Value e) {
         if (e == null) {
             return getEscapeChar(defaultEscape);
-        }
-        if (e == ValueNull.INSTANCE) {
-            // Empty ESCAPE under treatEmptyStringsAsNull (see isUnknownEscape)
-            return null;
         }
         String es = e.getString();
         Character esc;
@@ -255,7 +241,7 @@ public final class CompareLike extends Condition {
         String p = right.getValue(session).getString();
         if (!isInit) {
             Value e = escape == null ? null : escape.getValue(session);
-            if (isUnknownEscape(session, e)) {
+            if (e == ValueNull.INSTANCE) {
                 // should already be optimized
                 throw DbException.getInternalError();
             }
@@ -331,7 +317,7 @@ public final class CompareLike extends Condition {
             }
             String p = r.getString();
             Value e = escape == null ? null : escape.getValue(session);
-            if (isUnknownEscape(session, e)) {
+            if (e == ValueNull.INSTANCE) {
                 return ValueNull.INSTANCE;
             }
             initPattern(p, getEscapeChar(e));

--- a/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
+++ b/h2/src/test/org/h2/test/db/TestCompatibilityOracle.java
@@ -39,6 +39,7 @@ public class TestCompatibilityOracle extends TestDb {
     public void test() throws Exception {
         testNotNullSyntax();
         testTreatEmptyStringsAsNull();
+        testLikeEscapeEmpty();
         testDecimalScale();
         testPoundSymbolInColumnName();
         testToDate();
@@ -47,6 +48,45 @@ public class TestCompatibilityOracle extends TestDb {
         testSequenceNextval();
         testVarchar();
         deleteDb("oracle");
+    }
+
+    /**
+     * ESCAPE '' means no escape character (H2 extension used by Hibernate).
+     * Under MODE=Oracle empty strings become NULL; LIKE must still match.
+     */
+    private void testLikeEscapeEmpty() throws SQLException {
+        deleteDb("oracle");
+        Connection conn = getConnection("oracle;MODE=Oracle");
+        Statement stat = conn.createStatement();
+        stat.execute("CREATE TABLE T (NAME VARCHAR(255) NOT NULL)");
+        stat.execute("INSERT INTO T VALUES ('hello')");
+        stat.execute("INSERT INTO T VALUES ('hello%world')");
+
+        assertResult("1", stat, "SELECT COUNT(*) FROM T WHERE NAME = 'hello'");
+        assertResult("1", stat, "SELECT COUNT(*) FROM T WHERE NAME LIKE 'hello'");
+        // Hibernate emits LIKE ... ESCAPE '' when no escape is specified
+        assertResult("1", stat, "SELECT COUNT(*) FROM T WHERE NAME LIKE 'hello' ESCAPE ''");
+        assertResult("2", stat, "SELECT COUNT(*) FROM T WHERE NAME LIKE 'hel%' ESCAPE ''");
+        assertResult("2", stat, "SELECT COUNT(*) FROM T WHERE NAME LIKE 'hello%' ESCAPE ''");
+        // backslash is not special when escape is empty (default \ would escape %)
+        assertResult("0", stat, "SELECT COUNT(*) FROM T WHERE NAME LIKE 'hello\\%' ESCAPE ''");
+
+        PreparedStatement ps = conn.prepareStatement(
+                "SELECT COUNT(*) FROM T WHERE NAME LIKE ? ESCAPE ''");
+        ps.setString(1, "hello");
+        ResultSet rs = ps.executeQuery();
+        rs.next();
+        assertEquals(1, rs.getInt(1));
+        rs.close();
+        ps.setString(1, "hel%");
+        rs = ps.executeQuery();
+        rs.next();
+        assertEquals(2, rs.getInt(1));
+        rs.close();
+        ps.close();
+
+        stat.execute("DROP TABLE T");
+        conn.close();
     }
 
     private void testNotNullSyntax() throws SQLException {


### PR DESCRIPTION
## Fixes

Fixes #4367

## Problem

With `MODE=Oracle`, `treatEmptyStringsAsNull` turns `ESCAPE ''` into `ESCAPE NULL`. The SQL standard requires `LIKE ... ESCAPE NULL` to be UNKNOWN, so every Hibernate-generated `col LIKE ? ESCAPE ''` returns no rows.

H2 allows `ESCAPE ''` as an extension meaning “no escape character” (no default `\`). Hibernate relies on that for standard-compatible LIKE without an escape.

## Change

In `CompareLike`, when the ESCAPE expression evaluates to NULL and the mode has `treatEmptyStringsAsNull`, treat it as “no escape character” (same as empty string in regular mode) instead of making the predicate UNKNOWN.

- No ESCAPE clause still uses the database default escape (`\`)
- `ESCAPE ''` / empty under Oracle mode → no escape character
- Other modes: `ESCAPE NULL` still UNKNOWN

## Test

- `TestCompatibilityOracle.testLikeEscapeEmpty` — literals and bound patterns with `ESCAPE ''` under `MODE=Oracle`
- Manual repro from the issue: `LIKE ... ESCAPE ''` matches under Oracle mode

```
./build.sh compile
java -cp temp:... org.h2.test.db.TestCompatibilityOracle
```