### PR TITLE
fix: MySQL/MariaDB two-argument DATEDIFF(expr1, expr2)

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,6 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
+<li>Issue #4351: MySQL/MariaDB modes accept two-argument DATEDIFF(expr1, expr2) (days of expr1 - expr2)
+</li>
 <li>PR #4359: Fixed casting issue: skipped Index Condition Pushdown optm for lossy conversions
 </li>
 <li>PR #4317: Fix case for ChunkNotFound. MVStore performance improvements.

--- a/h2/src/main/org/h2/command/Parser.java
+++ b/h2/src/main/org/h2/command/Parser.java
@@ -4090,6 +4090,7 @@ public final class Parser extends ParserBase {
             return new DateTimeFunction(DateTimeFunction.DATEADD, readDateTimeField(), readNextArgument(),
                     readLastArgument());
         case "DATEDIFF":
+            return readDateDiffFunction();
         case "TIMESTAMPDIFF":
             return new DateTimeFunction(DateTimeFunction.DATEDIFF, readDateTimeField(), readNextArgument(),
                     readLastArgument());
@@ -4564,6 +4565,43 @@ public final class Parser extends ParserBase {
         return f;
     }
 
+    /**
+     * Parses {@code DATEDIFF}. In MySQL and MariaDB modes the two-argument form
+     * {@code DATEDIFF(expr1, expr2)} is accepted and returns the number of days of
+     * {@code expr1 - expr2} (MySQL semantics), equivalent to
+     * {@code DATEDIFF(DAY, expr2, expr1)}. The H2 three-argument form remains supported.
+     *
+     * @return the function
+     */
+    private DateTimeFunction readDateDiffFunction() {
+        ModeEnum modeEnum = database.getMode().getEnum();
+        if (modeEnum == ModeEnum.MySQL || modeEnum == ModeEnum.MariaDB) {
+            int backup = tokenIndex;
+            int field = tryReadDateTimeField();
+            if (field >= 0) {
+                Expression start = readNextArgument();
+                if (readIf(COMMA)) {
+                    Expression end = readExpression();
+                    read(CLOSE_PAREN);
+                    return new DateTimeFunction(DateTimeFunction.DATEDIFF, field, start, end);
+                }
+                if (readIf(CLOSE_PAREN)) {
+                    // Two arguments only; first token looked like a date-time field name
+                    // (e.g. a column named DAY). Reparse as MySQL two-arg form.
+                    setTokenIndex(backup);
+                } else {
+                    throw getSyntaxError();
+                }
+            }
+            Expression expr1 = readExpression();
+            Expression expr2 = readLastArgument();
+            // MySQL: DATEDIFF(expr1, expr2) = days(expr1) - days(expr2)
+            return new DateTimeFunction(DateTimeFunction.DATEDIFF, DateTimeFunction.DAY, expr2, expr1);
+        }
+        return new DateTimeFunction(DateTimeFunction.DATEDIFF, readDateTimeField(), readNextArgument(),
+                readLastArgument());
+    }
+
     private int readDateTimeField() {
         int field = -1;
         switch (currentTokenType) {
@@ -4601,6 +4639,64 @@ public final class Parser extends ParserBase {
         }
         read();
         return field;
+    }
+
+    /**
+     * Tries to read a date-time field token without throwing if the current token is not one.
+     * Used to distinguish MySQL two-argument {@code DATEDIFF} from the H2 three-argument form.
+     *
+     * @return the field, or {@code -1} if the current token is not a date-time field
+     */
+    private int tryReadDateTimeField() {
+        int field = -1;
+        switch (currentTokenType) {
+        case IDENTIFIER:
+            if (!token.isQuoted()) {
+                field = dateTimeFieldOrNegative(currentToken);
+            }
+            break;
+        case LITERAL:
+            if (token.value(session).getValueType() == Value.VARCHAR) {
+                field = dateTimeFieldOrNegative(token.value(session).getString());
+            }
+            break;
+        case YEAR:
+            field = DateTimeFunction.YEAR;
+            break;
+        case MONTH:
+            field = DateTimeFunction.MONTH;
+            break;
+        case DAY:
+            field = DateTimeFunction.DAY;
+            break;
+        case HOUR:
+            field = DateTimeFunction.HOUR;
+            break;
+        case MINUTE:
+            field = DateTimeFunction.MINUTE;
+            break;
+        case SECOND:
+            field = DateTimeFunction.SECOND;
+            break;
+        default:
+            return -1;
+        }
+        if (field < 0) {
+            return -1;
+        }
+        read();
+        return field;
+    }
+
+    private static int dateTimeFieldOrNegative(String name) {
+        try {
+            return DateTimeFunction.getField(name);
+        } catch (DbException e) {
+            if (e.getErrorCode() == ErrorCode.INVALID_VALUE_2) {
+                return -1;
+            }
+            throw e;
+        }
     }
 
     private WindowFunction readWindowFunction(String name) {

--- a/h2/src/main/org/h2/res/help.csv
+++ b/h2/src/main/org/h2/res/help.csv
@@ -6059,12 +6059,16 @@ DATEADD(MONTH, 1, DATE '2001-01-31')
 
 "Functions (Time and Date)","DATEDIFF","
 @h2@ { DATEDIFF | TIMESTAMPDIFF } @h2@ (datetimeField, aDateAndTime, bDateAndTime)
+| @c@ { DATEDIFF(aDateAndTime, bDateAndTime) }
 ","
 Returns the number of crossed unit boundaries between two date/time values.
 This method returns a long.
 The datetimeField indicates the unit.
 Only TIMEZONE_HOUR, TIMEZONE_MINUTE, and TIMEZONE_SECOND fields use the time zone offset component.
 With all other fields if date/time values have time zone offset component it is ignored.
+The two-argument form is accepted only in MySQL and MariaDB compatibility modes and returns the
+number of days of aDateAndTime - bDateAndTime (MySQL semantics), equivalent to
+DATEDIFF(DAY, bDateAndTime, aDateAndTime).
 ","
 DATEDIFF(YEAR, T1.CREATED, T2.CREATED)
 "

--- a/h2/src/test/org/h2/test/scripts/TestScript.java
+++ b/h2/src/test/org/h2/test/scripts/TestScript.java
@@ -139,7 +139,8 @@ public class TestScript extends TestDb {
         testScript("altertable-fk.sql");
         testScript("default-and-on_update.sql");
 
-        for (String s : new String[] { "add_months", "compatibility", "group_by", "strict_and_legacy"}) {
+        for (String s : new String[] { "add_months", "compatibility", "group_by", "mysql_datediff",
+                "strict_and_legacy"}) {
             testScript("compatibility/" + s + ".sql");
         }
         for (String s : new String[] { "array", "bigint", "binary", "blob",

--- a/h2/src/test/org/h2/test/scripts/compatibility/mysql_datediff.sql
+++ b/h2/src/test/org/h2/test/scripts/compatibility/mysql_datediff.sql
@@ -1,0 +1,56 @@
+-- Copyright 2004-2025 H2 Group. Multiple-Licensed under the MPL 2.0,
+-- and the EPL 1.0 (https://h2database.com/html/license.html).
+-- Initial Developer: H2 Group
+--
+-- Issue #4351: MySQL-style two-argument DATEDIFF(end, start) in MODE=MySQL / MariaDB
+
+SET MODE MySQL;
+> ok
+
+SELECT DATEDIFF('2026-06-08', '2026-06-01');
+>> 7
+
+SELECT DATEDIFF(DATE '2026-06-08', DATE '2026-06-01');
+>> 7
+
+SELECT DATEDIFF(TIMESTAMP '2026-06-08 23:59:59', TIMESTAMP '2026-06-01 00:00:00');
+>> 7
+
+SELECT DATEDIFF('2026-06-01', '2026-06-08');
+>> -7
+
+SELECT DATEDIFF('2026-06-01', '2026-06-01');
+>> 0
+
+-- H2 three-argument form still works in MySQL mode
+SELECT DATEDIFF(DAY, DATE '2026-06-01', DATE '2026-06-08');
+>> 7
+
+SELECT DATEDIFF('DAY', DATE '2026-06-01', DATE '2026-06-08');
+>> 7
+
+SELECT DATEDIFF(YEAR, TIMESTAMP '2003-12-01 10:20:30', TIMESTAMP '2004-01-01 10:00:00');
+>> 1
+
+-- TIMESTAMPDIFF stays three-argument (MySQL native signature)
+SELECT TIMESTAMPDIFF(DAY, DATE '2026-06-01', DATE '2026-06-08');
+>> 7
+
+SET MODE MariaDB;
+> ok
+
+SELECT DATEDIFF('2026-06-08', '2026-06-01');
+>> 7
+
+SELECT DATEDIFF(DAY, DATE '2026-06-01', DATE '2026-06-08');
+>> 7
+
+SET MODE Regular;
+> ok
+
+-- Two-argument form is not accepted outside MySQL/MariaDB modes
+SELECT DATEDIFF('2026-06-08', '2026-06-01');
+> exception INVALID_VALUE_2
+
+SELECT DATEDIFF(DAY, DATE '2026-06-01', DATE '2026-06-08');
+>> 7


### PR DESCRIPTION
## Summary

Fixes #4351.

In `MODE=MySQL` and `MODE=MariaDB`, accept MySQL's two-argument form:

```sql
SELECT DATEDIFF(expr1, expr2);  -- days of expr1 - expr2
```

This matches [MySQL DATEDIFF](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_datediff) and is equivalent to H2's:

```sql
SELECT DATEDIFF(DAY, expr2, expr1);
```

The H2 three-argument form `DATEDIFF(unit, start, end)` continues to work in these modes. `TIMESTAMPDIFF` remains three-argument only (also MySQL's native signature).

## Changes

- `Parser.readDateDiffFunction()`: in MySQL/MariaDB modes, distinguish two-arg vs three-arg forms; map two-arg to `DATEDIFF(DAY, expr2, expr1)`.
- Docs: `help.csv` + changelog entry.
- Tests: `compatibility/mysql_datediff.sql` (registered in `TestScript`).

## Test plan

- [x] Focused JDBC checks (MySQL / MariaDB / Regular modes), including prepared `DATEDIFF(?, ?)`
- [x] `mysql_datediff.sql` via TestScript harness (JDK 21)
- [x] Three-arg H2 form and `TIMESTAMPDIFF` still work under MODE=MySQL
- [x] Two-arg form still rejected under Regular mode (`INVALID_VALUE_2` on date-time field)