### PR TITLE
fix: preserve QUALIFY when pushing global conditions into derived tables

### DIFF
--- a/h2/src/main/org/h2/command/query/Select.java
+++ b/h2/src/main/org/h2/command/query/Select.java
@@ -1648,6 +1648,13 @@ public class Select extends Query {
         }
         comp = comp.optimize(session);
         if (isWindowQuery) {
+            // After prepareExpressions(), QUALIFY was moved into expressions and
+            // the qualify field was cleared. Restore it before attaching a
+            // global condition so outer WHERE pushdown into derived tables /
+            // views / CTEs does not drop the original QUALIFY (issue #4366).
+            if (qualify == null && qualifyIndex >= 0) {
+                qualify = expressions.get(qualifyIndex);
+            }
             qualify = addGlobalCondition(qualify, comp);
         } else if (isGroupQuery) {
             for (int i = 0; groupIndex != null && i < groupIndex.length; i++) {

--- a/h2/src/test/org/h2/test/scripts/functions/window/row_number.sql
+++ b/h2/src/test/org/h2/test/scripts/functions/window/row_number.sql
@@ -243,3 +243,84 @@ SELECT CUME_DIST() OVER (ORDER BY 'a') FROM TEST;
 
 DROP TABLE TEST;
 > ok
+
+-- Issue #4366: QUALIFY must be preserved when a derived table / CTE / view is
+-- queried with an outer WHERE (global condition pushdown).
+CREATE TABLE QUALIFY_TEST (
+    ID INT,
+    RAIL INT,
+    ATTRIBUTE DECIMAL(4, 2)
+);
+> ok
+
+INSERT INTO QUALIFY_TEST(ID, RAIL, ATTRIBUTE) VALUES
+    (1, 1, 1.11),
+    (1, 2, 2.22),
+    (1, 3, 3.33),
+    (2, 1, 4.44),
+    (2, 2, 5.55);
+> update count: 5
+
+SELECT * FROM QUALIFY_TEST
+    QUALIFY 1 = ROW_NUMBER() OVER (PARTITION BY ID ORDER BY RAIL DESC)
+    ORDER BY ID;
+> ID RAIL ATTRIBUTE
+> -- ---- ---------
+> 1  3    3.33
+> 2  2    5.55
+> rows (ordered): 2
+
+-- Derived table with outer WHERE (global condition pushdown)
+SELECT * FROM (
+    SELECT * FROM QUALIFY_TEST
+        QUALIFY 1 = ROW_NUMBER() OVER (PARTITION BY ID ORDER BY RAIL DESC)
+) T WHERE T.ID = 1;
+> ID RAIL ATTRIBUTE
+> -- ---- ---------
+> 1  3    3.33
+> rows: 1
+
+-- CTE with outer WHERE
+WITH TEMP AS (
+    SELECT * FROM QUALIFY_TEST
+        QUALIFY 1 = ROW_NUMBER() OVER (PARTITION BY ID ORDER BY RAIL DESC)
+)
+SELECT * FROM TEMP WHERE TEMP.ID = 1;
+> ID RAIL ATTRIBUTE
+> -- ---- ---------
+> 1  3    3.33
+> rows: 1
+
+-- VIEW with outer WHERE
+CREATE VIEW QUALIFY_VIEW AS
+    SELECT * FROM QUALIFY_TEST
+        QUALIFY 1 = ROW_NUMBER() OVER (PARTITION BY ID ORDER BY RAIL DESC);
+> ok
+
+SELECT * FROM QUALIFY_VIEW WHERE ID = 1;
+> ID RAIL ATTRIBUTE
+> -- ---- ---------
+> 1  3    3.33
+> rows: 1
+
+SELECT * FROM QUALIFY_VIEW WHERE ID = 2;
+> ID RAIL ATTRIBUTE
+> -- ---- ---------
+> 2  2    5.55
+> rows: 1
+
+-- Range condition pushdown (multiple global conditions)
+SELECT * FROM (
+    SELECT * FROM QUALIFY_TEST
+        QUALIFY 1 = ROW_NUMBER() OVER (PARTITION BY ID ORDER BY RAIL DESC)
+) T WHERE T.ID >= 1 AND T.ID <= 1;
+> ID RAIL ATTRIBUTE
+> -- ---- ---------
+> 1  3    3.33
+> rows: 1
+
+DROP VIEW QUALIFY_VIEW;
+> ok
+
+DROP TABLE QUALIFY_TEST;
+> ok


### PR DESCRIPTION
## Summary

Fixes #4366: `QUALIFY` in a CTE, view, or derived table was ignored when the outer query applied a `WHERE` filter.

### Cause

After `prepareExpressions()`, the `QUALIFY` expression is moved into `expressions[qualifyIndex]` and the `qualify` field is cleared (same pattern as `HAVING` / `havingIndex`).

When an outer `WHERE` is pushed into the nested query as a global condition (`Select.addGlobalCondition` for window queries), only the `qualify` field was updated. With `qualify == null`, the original `QUALIFY` predicate was dropped and replaced by the pushed condition alone. `getPlanSQL()` then recompiled the nested query without the window filter.

### Fix

Restore the original `QUALIFY` from `expressions[qualifyIndex]` when `qualify` is still null before attaching the global condition (only on the first push so multiple range conditions still accumulate).

### Tests

Added script coverage in `functions/window/row_number.sql` for:

- base `QUALIFY` query
- derived table + outer `WHERE`
- CTE + outer `WHERE` (issue repro)
- view + outer `WHERE`
- range pushdown (`>=` / `<=`, multiple global conditions)

## Test plan

- [x] `functions/window/row_number.sql` via focused `TestScript` (JDK 21)
- [x] Manual shell repro of issue #4366 CTE / derived / view cases

```text
./build.sh jar
# focused: TestScript testScript("functions/window/row_number.sql")
```