### PR TITLE
MVStore: fix data race causing spurious "Position 0" during chunk rewriting

### DIFF
--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -9,6 +9,8 @@ import static org.h2.engine.Constants.MEMORY_ARRAY;
 import static org.h2.engine.Constants.MEMORY_OBJECT;
 import static org.h2.engine.Constants.MEMORY_POINTER;
 import static org.h2.mvstore.DataUtils.PAGE_TYPE_LEAF;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -1043,22 +1045,34 @@ public abstract class Page<K,V> implements Cloneable {
         @SuppressWarnings("rawtypes")
         static final PageReference EMPTY = new PageReference<>(null, 0, 0);
 
+        private static final VarHandle PAGE;
+        static {
+            try {
+                PAGE = MethodHandles.lookup().findVarHandle(PageReference.class, "page", Page.class);
+            } catch (ReflectiveOperationException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+
         /**
          * The position, if known, or 0.
-         *
-         * Written before {@link #page} is cleared; both fields are volatile because chunk
-         * rewriting (FileStore.rewriteChunks) traverses pages without holding the
-         * serialization lock, and the volatile write that clears {@code page} is the
-         * release/acquire edge that makes {@code pos} visible to such readers. Without it,
-         * a reader may observe {@code page == null} together with a stale {@code pos == 0}
-         * and fail with "Position 0" although the tree is consistent.
+         * <p>
+         * Always stamped with the saved position (by {@link #resetPos()}) before
+         * {@link #page} is cleared, and never reset to 0 afterwards.
          */
-        private volatile long pos;
+        private long pos;
 
         /**
          * The page, if in memory, or null.
+         * <p>
+         * Cleared with a release write and read with an acquire read, because a tree
+         * traversal reads {@link #pos} only when this field is null, and such traversals
+         * run concurrently with the serialization thread clearing it. The release/acquire
+         * pair is what publishes {@link #pos}: without it a reader may observe
+         * {@code page == null} together with a stale {@code pos == 0} and fail with
+         * "Position 0" although the tree is consistent.
          */
-        private volatile Page<K,V> page;
+        private Page<K,V> page;
 
         /**
          * The descendant count for this child page.
@@ -1092,8 +1106,9 @@ public abstract class Page<K,V> implements Cloneable {
             this.count = count;
         }
 
+        @SuppressWarnings("unchecked")
         public Page<K,V> getPage() {
-            return page;
+            return (Page<K,V>) PAGE.getAcquire(this);
         }
 
         /**
@@ -1102,15 +1117,15 @@ public abstract class Page<K,V> implements Cloneable {
          * Reference is cleared only if corresponding page was already saved on a disk.
          */
         void clearPageReference() {
-            if (page != null) {
-                page.releaseSavedPages();
-                if (page.isSaved()) {
-                    assert pos == page.getPos();
-                    assert count == page.getTotalCount() : count + " != " + page.getTotalCount();
-                    // (re)stamp pos before the volatile write to 'page' publishes it: readers
-                    // that observe page == null must never observe an unsaved pos
-                    pos = page.getPos();
-                    page = null;
+            Page<K,V> p = page;
+            if (p != null) {
+                p.releaseSavedPages();
+                if (p.isSaved()) {
+                    assert pos == p.getPos();
+                    assert count == p.getTotalCount() : count + " != " + p.getTotalCount();
+                    // 'pos' was stamped by resetPos() earlier on this thread; the release
+                    // write below publishes it to any reader that observes the cleared page
+                    PAGE.setRelease(this, (Page<K,V>) null);
                 }
             }
         }

--- a/h2/src/main/org/h2/mvstore/Page.java
+++ b/h2/src/main/org/h2/mvstore/Page.java
@@ -1045,13 +1045,20 @@ public abstract class Page<K,V> implements Cloneable {
 
         /**
          * The position, if known, or 0.
+         *
+         * Written before {@link #page} is cleared; both fields are volatile because chunk
+         * rewriting (FileStore.rewriteChunks) traverses pages without holding the
+         * serialization lock, and the volatile write that clears {@code page} is the
+         * release/acquire edge that makes {@code pos} visible to such readers. Without it,
+         * a reader may observe {@code page == null} together with a stale {@code pos == 0}
+         * and fail with "Position 0" although the tree is consistent.
          */
-        private long pos;
+        private volatile long pos;
 
         /**
          * The page, if in memory, or null.
          */
-        private Page<K,V> page;
+        private volatile Page<K,V> page;
 
         /**
          * The descendant count for this child page.
@@ -1100,6 +1107,9 @@ public abstract class Page<K,V> implements Cloneable {
                 if (page.isSaved()) {
                     assert pos == page.getPos();
                     assert count == page.getTotalCount() : count + " != " + page.getTotalCount();
+                    // (re)stamp pos before the volatile write to 'page' publishes it: readers
+                    // that observe page == null must never observe an unsaved pos
+                    pos = page.getPos();
                     page = null;
                 }
             }


### PR DESCRIPTION
### Symptom

A scheduled `MVStore.compact(targetFillRate, write)` on a store under concurrent read/write load occasionally fails and closes the store. Observed in production on 2.4.240; by code inspection the race is still present on master.

```
org.h2.mvstore.MVStoreException: Position 0 [2.4.240/6]
	at org.h2.mvstore.DataUtils.newMVStoreException(DataUtils.java:996)
	at org.h2.mvstore.FileStore.readPage(FileStore.java:1957)
	at org.h2.mvstore.MVStore.readPage(MVStore.java:1143)
	at org.h2.mvstore.MVMap.readPage(MVMap.java:632)
	at org.h2.mvstore.Page$NonLeaf.getChildPage(Page.java:1158)
	at org.h2.mvstore.CursorPos.traverseDown(CursorPos.java:61)
	at org.h2.mvstore.MVMap.operate(MVMap.java:1754)
	at org.h2.mvstore.MVMap.rewritePage(MVMap.java:690)
	at org.h2.mvstore.FileStore.rewriteChunks(FileStore.java:1928)
	at org.h2.mvstore.FileStore.compactRewrite(FileStore.java:1902)
	at org.h2.mvstore.FileStore.rewriteChunks(FileStore.java:1863)
	at org.h2.mvstore.FileStore.lambda$compact$0(FileStore.java:880)
	at org.h2.mvstore.MVStore.tryExecuteUnderStoreLock(MVStore.java:1059)
	at org.h2.mvstore.FileStore.compact(FileStore.java:880)
	at org.h2.mvstore.MVStore.compact(MVStore.java:1124)
```

`tryExecuteUnderStoreLock` catches the `MVStoreException` and calls `panic(e)`, which closes the store. Every subsequent operation then fails with "This store is closed" until the process restarts. The file itself is consistent — reopening it works — so the corruption verdict is spurious and the impact is availability.

### Mechanism

- The inner `FileStore.rewriteChunks(Set, boolean)` deliberately releases `serializationLock` around each `map.rewritePage(pagePos)` so map writers are not blocked during compaction. The traversal under `rewritePage` → `operate` → `traverseDown` → `NonLeaf.getChildPage` therefore runs with nothing ordering it against the serialization thread.
- On the serialization thread (under `serializationLock`), saving pages performs, in program order, `PageReference.resetPos()` (stamps `pos` with the saved position) and later `releaseSavedPages()` → `clearPageReference()` (sets `page = null`).
- `PageReference.pos` and `PageReference.page` are plain fields, unlike `Page.pos`, which is volatile with a CAS updater. There is no happens-before edge between those cleanup writes and the traversing thread's reads.
- `getChildPage` reads `page`, and if it is null, reads `pos`. That `pos` load is only control-dependent on the `page` load, so it may be hoisted; the reader can observe `page == null` together with the pre-stamp `pos == 0` even on x86 (the production occurrence was on an Intel host). `readPage` then throws `ERROR_FILE_CORRUPT` "Position 0" for the unsaved position.

### Fix

Make both `PageReference` fields volatile and (re)stamp `pos` before the write that clears `page`, so the volatile store to `page` is the release edge that publishes `pos`. A reader that observes `page == null` can then never observe an unsaved `pos`.

The extra cost is a pair of volatile accesses on paths that are not hot enough to matter. I have this running in production on top of master.

Happy to adjust the approach if you would prefer the ordering enforced elsewhere (e.g. VarHandle release/acquire rather than volatile, or having the traversal re-read under the lock).