### PR TITLE
Populate MaterializedView columns for INFORMATION_SCHEMA.COLUMNS

### DIFF
--- a/h2/src/docsrc/html/changelog.html
+++ b/h2/src/docsrc/html/changelog.html
@@ -21,7 +21,8 @@ Change Log
 
 <h2>Next Version (unreleased)</h2>
 <ul>
-<li>nothing here yet</li>
+<li>Issue #4376: Reading INFORMATION_SCHEMA.COLUMNS fails with a NullPointerException while a materialized view exists
+</li>
 </ul>
 
 <h2>Version 2.5.250 (2026-08-29)</h2>

--- a/h2/src/main/org/h2/table/MaterializedView.java
+++ b/h2/src/main/org/h2/table/MaterializedView.java
@@ -34,12 +34,23 @@ public class MaterializedView extends Table {
         this.table = table;
         this.query = query;
         this.querySQL = querySQL;
+        copyColumnsFromUnderlyingTable();
     }
 
     public void replace(Table table, Query query, String querySQL) {
         this.table = table;
         this.query = query;
         this.querySQL = querySQL;
+        copyColumnsFromUnderlyingTable();
+    }
+
+    private void copyColumnsFromUnderlyingTable() {
+        Column[] source = table.getColumns();
+        Column[] cols = new Column[source.length];
+        for (int i = 0; i < source.length; i++) {
+            cols[i] = source[i].getClone();
+        }
+        setColumns(cols);
     }
 
     public Table getUnderlyingTable() {

--- a/h2/src/test/org/h2/test/db/TestMaterializedView.java
+++ b/h2/src/test/org/h2/test/db/TestMaterializedView.java
@@ -32,6 +32,7 @@ public class TestMaterializedView extends TestDb {
     public void test() throws SQLException {
         deleteDb("materializedview");
         test1();
+        testInformationSchemaColumns();
         deleteDb("materializedview");
     }
 
@@ -62,6 +63,37 @@ public class TestMaterializedView extends TestDb {
         });
         stat.execute("drop materialized view test_view");
         stat.execute("drop table test");
+        conn.close();
+    }
+
+    private void testInformationSchemaColumns() throws SQLException {
+        Connection conn = getConnection("materializedview");
+        Statement stat = conn.createStatement();
+        stat.execute("create table t(id int)");
+        stat.execute("create materialized view m as select id from t");
+        ResultSet rs = stat.executeQuery("select count(*) from information_schema.columns");
+        assertTrue(rs.next());
+        assertTrue(rs.getInt(1) > 0);
+        rs.close();
+        rs = stat.executeQuery("select column_name from information_schema.columns "
+                + "where table_name = 'M' order by ordinal_position");
+        assertTrue(rs.next());
+        assertEquals("ID", rs.getString(1));
+        assertFalse(rs.next());
+        rs.close();
+        rs = stat.executeQuery("select column_name from information_schema.columns "
+                + "where table_name = 'T'");
+        assertTrue(rs.next());
+        assertEquals("ID", rs.getString(1));
+        assertFalse(rs.next());
+        rs.close();
+        rs = conn.getMetaData().getColumns(null, "PUBLIC", "M", null);
+        assertTrue(rs.next());
+        assertEquals("ID", rs.getString("COLUMN_NAME"));
+        assertFalse(rs.next());
+        rs.close();
+        stat.execute("drop materialized view m");
+        stat.execute("drop table t");
         conn.close();
     }
 


### PR DESCRIPTION
Fixes #4376

`MaterializedView` never populated the `columns` array it inherits from `Table`. Queries against the view itself are resolved to the backing table, so they work, but `INFORMATION_SCHEMA.COLUMNS` (and `DatabaseMetaData.getColumns()`) iterate every table and NPE when they hit the view.

Clone columns from the underlying table in the constructor and on replace, the same way other table types call `setColumns`. Clones are required because `setColumns` reassigns `Column.setTable`.

## Tests
- `org.h2.test.db.TestMaterializedView` (executed, RED then GREEN)
- `org.h2.test.db.TestView` (executed, GREEN)
- `org.h2.test.db.TestViewDropView` (executed, GREEN)