### PR TITLE
Fix getCostRangeIndex() giving partial-match indexes an unfair sort discount

### DIFF
--- a/h2/src/main/org/h2/index/Index.java
+++ b/h2/src/main/org/h2/index/Index.java
@@ -667,6 +667,12 @@ public abstract class Index extends SchemaObject {
         }
         if (sortOrder != null && !isScanIndex && filters != null && filter == 0) {
             int coveringCount = 0;
+            // Unlike running out of index columns, or a direction/null-ordering mismatch on
+            // an otherwise-matching column (still usable via a reverse index scan), landing
+            // on a sort column the index doesn't have at that position at all means the rows
+            // still need a real sort from that point on, so it must disqualify the discount
+            // below rather than just cap coveringCount at whatever matched so far.
+            boolean mismatched = false;
             int[] sortTypes = sortOrder.getSortTypesWithNullOrdering();
             int sortOrderLength = sortTypes.length;
             TableFilter tableFilter = filters[0];
@@ -682,10 +688,12 @@ public abstract class Index extends SchemaObject {
                 }
                 Column col = sortOrder.getColumn(i, tableFilter);
                 if (col == null) {
+                    mismatched = true;
                     break;
                 }
                 IndexColumn idxCol = indexColumns[i];
                 if (!col.equals(idxCol.column)) {
+                    mismatched = true;
                     break;
                 }
                 boolean mismatch = false;
@@ -719,7 +727,7 @@ public abstract class Index extends SchemaObject {
                 }
                 coveringCount++;
             }
-            if (coveringCount > 0) {
+            if (!mismatched && coveringCount > 0) {
                 // "coveringCount" makes sure that when we have two
                 // or more covering indexes, we choose the one
                 // that covers more.

--- a/h2/src/test/org/h2/test/scripts/queries/query-optimisations.sql
+++ b/h2/src/test/org/h2/test/scripts/queries/query-optimisations.sql
@@ -351,3 +351,26 @@ SELECT COUNT(*) FROM T1 WHERE C0 > 2.5;
 
 DROP TABLE T1;
 > ok
+
+-- Issue #4353: don't give an index that only covers the leading column(s) of
+-- the ORDER BY nearly the same sort discount as an index that covers all of
+-- them, since rows still need a real sort within each group sharing the
+-- leading column's value
+--
+CREATE TABLE TEST(A INT, B INT, C INT, D INT);
+> ok
+
+CREATE INDEX TEST_IDX_1 ON TEST(A, B);
+> ok
+
+CREATE UNIQUE INDEX TEST_IDX_2 ON TEST(A, C, D);
+> ok
+
+INSERT INTO TEST VALUES (1, 1, 1, 1), (1, 2, 2, 2);
+> update count: 2
+
+EXPLAIN SELECT * FROM TEST WHERE A = 1 ORDER BY A, C, D FETCH FIRST 10 ROWS ONLY;
+>> SELECT "PUBLIC"."TEST"."A", "PUBLIC"."TEST"."B", "PUBLIC"."TEST"."C", "PUBLIC"."TEST"."D" FROM "PUBLIC"."TEST" /* PUBLIC.TEST_IDX_2: A = 1 */ WHERE "A" = 1 ORDER BY 1, 3, 4 FETCH FIRST 10 ROWS ONLY /* index sorted */
+
+DROP TABLE TEST;
+> ok


### PR DESCRIPTION
This is a follow up to #4353.

I dug into why the optimizer sometimes picks a much worse index when there's an `ORDER BY` on several columns. The regression traces back to #4163, specifically the rewrite of the sort-order matching loop in `Index.getCostRangeIndex()`.

Before that change, if any sort column failed to match the index at the right position, the whole "this index already gives us the right order" discount was skipped, so the cost fell back to the normal row-count-scaling sort cost. After the rewrite, the loop just breaks on a mismatch without invalidating the `coveringCount` picked up before the break, and the discount is applied as long as `coveringCount > 0`. That means an index that only matches the first column of a multi-column `ORDER BY` gets almost the same discount as one that matches the whole thing, even though the first one still needs a real sort inside every group that shares that first column's value.

On a table with a few million rows and a couple of competing indexes (one that fully satisfies a 3-column `ORDER BY`, one that only shares the leading column), this is enough to make the optimizer consistently pick the wrong one, since the discount was the only thing meaningfully separating their costs.

The fix only disqualifies the discount when the index has a genuinely different column at that sort position. A pure direction/null-ordering mismatch on the same column is left alone, since that's the legitimate reverse-scan case #4163 added, and there's an existing test in `indexes.sql` that depends on getting partial credit there.

I reproduced this with a small standalone test built from the schema in #4353's example (one non-unique 2-column index, one unique 3-column index that fully covers the `ORDER BY`, a few thousand groups of a few hundred rows each): before this patch the optimizer picked the worse index in every single run, after the patch it picked the right one every time.

Ran the existing suite (`TestIndex`, `TestScript`, `TestOptimizations`, `TestTableEngines`) against the patched build with no regressions.