### PR TITLE
Test for chunk not found

### DIFF
--- a/h2/src/test/org/h2/test/TestAll.java
+++ b/h2/src/test/org/h2/test/TestAll.java
@@ -140,6 +140,7 @@ import org.h2.test.store.TestKillProcessWhileWriting;
 import org.h2.test.store.TestMVRTree;
 import org.h2.test.store.TestMVStore;
 import org.h2.test.store.TestMVStoreBenchmark;
+import org.h2.test.store.TestMVStoreChunkNotFound;
 import org.h2.test.store.TestMVStoreConcurrent;
 import org.h2.test.store.TestMVStoreStopCompact;
 import org.h2.test.store.TestMVStoreTool;
@@ -916,6 +917,7 @@ kill -9 `jps -l | grep "org.h2.test." | cut -d " " -f 1`
         addTest(new TestMVRTree());
         addTest(new TestMVStore());
         addTest(new TestMVStoreBenchmark());
+        addTest(new TestMVStoreChunkNotFound());
         addTest(new TestMVStoreStopCompact());
         addTest(new TestMVStoreTool());
         addTest(new TestObjectDataType());

--- a/h2/src/test/org/h2/test/store/TestMVStoreChunkNotFound.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreChunkNotFound.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2004-2025 H2 Group. Multiple-Licensed under the MPL 2.0,
+ * and the EPL 1.0 (https://h2database.com/html/license.html).
+ * Initial Developer: H2 Group
+ */
+package org.h2.test.store;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
+import org.h2.store.fs.FileUtils;
+import org.h2.test.TestBase;
+
+/**
+ * Test that an open cursor does not fail with "Chunk not found" while the
+ * store is compacted during iteration.
+ */
+public class TestMVStoreChunkNotFound extends TestBase {
+
+    /**
+     * Run just this test.
+     *
+     * @param a ignored
+     */
+    public static void main(String... a) throws Exception {
+        TestBase.createCaller().init().testFromMain();
+    }
+
+    @Override
+    public void test() throws Exception {
+        String fileName = getBaseDir() + "/testChunkNotFound.h3";
+        FileUtils.createDirectories(getBaseDir());
+        FileUtils.delete(fileName);
+        try {
+            int items = 4_000;
+            String payload = "x".repeat(50);
+            println("writing " + items + " entries");
+            try (MVStore store = openStore(fileName)) {
+                MVMap<String, String> map = store.openMap("data");
+                for (int i = 0; i < items; i++) {
+                    map.put(Integer.toString(i), payload + i);
+                    if (i % 1000 == 0) {
+                        store.commit();
+                    }
+                }
+                // overwrite every other key so every chunk is about half dead
+                for (int i = 0; i < items; i += 2) {
+                    map.put(Integer.toString(i), i + payload);
+                    if (i % 1000 == 0) {
+                        store.commit();
+                    }
+                }
+                store.commit();
+                println("wrote entries, fill rate: " + store.getFileStore().getChunksFillRate() + "%");
+            }
+            // reopen so iteration has to read pages from disk
+            println("reopening store and iterating");
+            try (MVStore store = openStore(fileName)) {
+                MVMap<String, String> map = store.openMap("data");
+                MVMap<String, String> side = store.openMap("side");
+                int iterated = 0;
+                Iterator<Map.Entry<String, String>> it = map.entrySet().iterator();
+                while (it.hasNext()) {
+                    it.next();
+                    iterated++;
+                    if (iterated % 1000 == 0) {
+                        // advance the store version and compact
+                        // while the cursor is open
+                        side.put("tick", Integer.toString(iterated));
+                        store.commit();
+                        boolean compacted = store.compact(95, 16 * 1024 * 1024);
+                        println("iterated=" + iterated + " compacted=" + compacted + " fill=" + store.getFileStore().getChunksFillRate() + "%");
+                    }
+                }
+                println("done, iterated=" + iterated);
+                assertEquals(items, iterated);
+            }
+        } finally {
+            FileUtils.delete(fileName);
+        }
+    }
+
+    private static MVStore openStore(String fileName) {
+        MVStore store = new MVStore.Builder()
+                .fileName(fileName)
+                .compress()
+                .cacheSize(1)
+                .autoCompactFillRate(50)
+                .autoCommitDisabled()
+                .open();
+        store.setVersionsToKeep(0);
+        store.setRetentionTime(0);
+        return store;
+    }
+}
+

--- a/h2/src/test/org/h2/test/store/TestMVStoreChunkNotFound.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreChunkNotFound.java
@@ -85,10 +85,6 @@ public class TestMVStoreChunkNotFound extends TestBase {
     private static MVStore openStore(String fileName) {
         MVStore store = new MVStore.Builder()
                 .fileName(fileName)
-                .compress()
-                .cacheSize(1)
-                .autoCompactFillRate(50)
-                .autoCommitDisabled()
                 .open();
         store.setVersionsToKeep(0);
         store.setRetentionTime(0);

--- a/h2/src/test/org/h2/test/store/TestMVStoreChunkNotFound.java
+++ b/h2/src/test/org/h2/test/store/TestMVStoreChunkNotFound.java
@@ -59,7 +59,6 @@ public class TestMVStoreChunkNotFound extends TestBase {
             println("reopening store and iterating");
             try (MVStore store = openStore(fileName)) {
                 MVMap<String, String> map = store.openMap("data");
-                MVMap<String, String> side = store.openMap("side");
                 int iterated = 0;
                 Iterator<Map.Entry<String, String>> it = map.entrySet().iterator();
                 while (it.hasNext()) {
@@ -68,7 +67,6 @@ public class TestMVStoreChunkNotFound extends TestBase {
                     if (iterated % 1000 == 0) {
                         // advance the store version and compact
                         // while the cursor is open
-                        side.put("tick", Integer.toString(iterated));
                         store.commit();
                         boolean compacted = store.compact(95, 16 * 1024 * 1024);
                         println("iterated=" + iterated + " compacted=" + compacted + " fill=" + store.getFileStore().getChunksFillRate() + "%");


### PR DESCRIPTION
Test PR to reproduce a chunk not found error:

```
Exception in thread "main" org.h2.mvstore.MVStoreException: Chunk 6 not found [2.4.240/9]
	at org.h2.mvstore.DataUtils.newMVStoreException(DataUtils.java:996)
	at org.h2.mvstore.FileStore.getChunk(FileStore.java:2015)
	at org.h2.mvstore.FileStore.readPage(FileStore.java:1962)
	at org.h2.mvstore.MVStore.readPage(MVStore.java:1143)
	at org.h2.mvstore.MVMap.readPage(MVMap.java:632)
	at org.h2.mvstore.Page$NonLeaf.getChildPage(Page.java:1158)
	at org.h2.mvstore.Cursor.hasNext(Cursor.java:64)
	at org.h2.mvstore.MVMap$2$1.hasNext(MVMap.java:745)
	at org.h2.test.store.TestMVStoreChunkNotFound.test(TestMVStoreChunkNotFound.java:65)
	at org.h2.test.TestBase.testFromMain(TestBase.java:479)
	at org.h2.test.store.TestMVStoreChunkNotFound.main(TestMVStoreChunkNotFound.java:28)
```

I have confirmed the test fails off `master` as well.

I'm not familiar with the codebase enough to actually attempt a fix.